### PR TITLE
Make scope build on circle ci.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,6 +29,8 @@ dependencies:
     - bin/setup-circleci-secrets "$SECRET_PASSWORD"
     - mkdir -p $(dirname $SRCDIR)
     - cp -r $(pwd)/ $SRCDIR
+    - cd $(dirname $SRCDIR); ln -s weave scope
+    - cd $(dirname $SRCDIR); git clone ssh://git@github.com/weaveworks/procspy.git
 
 test:
   override:


### PR DESCRIPTION
Scope repo is the Weave repo, but we use /scope imports in places.  Symlink for now.
