### PR TITLE
Make the docker image built on circle runnable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ $(PROBE_EXE): probe/*.go report/*.go xfer/*.go
 
 $(APP_EXE) $(PROBE_EXE):
 	go get -tags netgo ./$(@D)
-	go build -o $@ ./$(@D)
+	go build -ldflags "-extldflags \"-static\"" -tags netgo -o $@ ./$(@D)
 
 static: client/dist/scripts/bundle.js
 	esc -o app/static.go -prefix client/dist client/dist

--- a/circle.yml
+++ b/circle.yml
@@ -24,6 +24,8 @@ dependencies:
         mv scope_ui_build.tar $(dirname "$SCOPE_UI_BUILD");
       fi
   post:
+    - go clean -i net
+    - go install -tags netgo std
     - go get github.com/golang/lint/golint
     - go get github.com/fzipp/gocyclo
     - go get github.com/mattn/goveralls


### PR DESCRIPTION
- Use netgo tag to rebuild go std lib so resulting binaries are statically compiled.
- Couple of other tweaks to make it work.