### PR TITLE
Add Containers topology

### DIFF
--- a/app/api_topologies_test.go
+++ b/app/api_topologies_test.go
@@ -15,7 +15,7 @@ func TestAPITopology(t *testing.T) {
 	if err := json.Unmarshal(body, &topos); err != nil {
 		t.Fatalf("JSON parse error: %s", err)
 	}
-	equals(t, 2, len(topos))
+	equals(t, 3, len(topos))
 	for _, topo := range topos {
 		is200(t, ts, topo.URL)
 		if topo.GroupedURL != "" {

--- a/app/router.go
+++ b/app/router.go
@@ -47,5 +47,6 @@ var topologyRegistry = map[string]struct {
 	hasGrouped bool
 }{
 	"applications": {"Applications", selectProcess, report.ProcessPID, true},
+	"containers":   {"Containers", selectProcess, report.ProcessContainer, true},
 	"hosts":        {"Hosts", selectNetwork, report.NetworkHostname, false},
 }

--- a/app/scope_test.go
+++ b/app/scope_test.go
@@ -69,7 +69,6 @@ func checkRequest(t *testing.T, ts *httptest.Server, method, path string, body [
 
 // getRawJSON GETs a file, checks it is JSON, and returns the non-parsed body
 func getRawJSON(t *testing.T, ts *httptest.Server, path string) []byte {
-
 	res, body := checkGet(t, ts, path)
 
 	if res.StatusCode != 200 {

--- a/probe/docker_process_mapper.go
+++ b/probe/docker_process_mapper.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"time"
 
@@ -135,7 +136,7 @@ func (m *dockerMapper) idMapper() processMapper {
 
 func (m *dockerMapper) nameMapper() processMapper {
 	return &dockerProcessMapper{m, "docker_name", func(c *docker.Container) string {
-		return c.Name
+		return strings.TrimPrefix(c.Name, "/")
 	}}
 }
 

--- a/report/mapping_test.go
+++ b/report/mapping_test.go
@@ -51,6 +51,38 @@ func TestUngroupedMapping(t *testing.T) {
 			wantMinor: "hosta (42)",
 			wantRank:  "42",
 		},
+		{
+			f:  ProcessContainer,
+			id: "foo-id",
+			meta: NodeMetadata{
+				"pid":    "42",
+				"name":   "curl",
+				"domain": "hosta",
+			},
+			wantOK:    true,
+			wantID:    "uncontained",
+			wantMajor: "Uncontained",
+			wantMinor: "",
+			wantRank:  "uncontained",
+		},
+		{
+			f:  ProcessContainer,
+			id: "bar-id",
+			meta: NodeMetadata{
+				"pid":               "42",
+				"name":              "curl",
+				"domain":            "hosta",
+				"docker_id":         "d321fe0",
+				"docker_name":       "walking_sparrow",
+				"docker_image_id":   "1101fff",
+				"docker_image_name": "org/app:latest",
+			},
+			wantOK:    true,
+			wantID:    "d321fe0",
+			wantMajor: "walking_sparrow",
+			wantMinor: "hosta",
+			wantRank:  "1101fff",
+		},
 	} {
 		identity := fmt.Sprintf("(%d %s %v)", i, c.id, c.meta)
 


### PR DESCRIPTION
- In the default view, nodes from the same container instance (docker ID) are merged
- In the grouped view, nodes from the same container image (docker image ID) are merged

Closes #91.

/cc @tomwilkie 