### PR TITLE
Yet More Plumbing for multi-host setup.

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
@@ -24,12 +23,12 @@ func main() {
 	var (
 		defaultProbes = []string{fmt.Sprintf("localhost:%d", xfer.ProbePort), fmt.Sprintf("scope.weave.local:%d", xfer.ProbePort)}
 		logfile       = flag.String("log", "stderr", "stderr, syslog, or filename")
-		probes        = flag.String("probes", strings.Join(defaultProbes, ","), "list of probe endpoints, comma separated")
 		batch         = flag.Duration("batch", 1*time.Second, "batch interval")
 		window        = flag.Duration("window", 15*time.Second, "window")
 		listen        = flag.String("http.address", ":"+strconv.Itoa(xfer.AppPort), "webserver listen address")
 	)
 	flag.Parse()
+	probes := append(defaultProbes, flag.Args()...)
 
 	switch *logfile {
 	case "stderr":
@@ -62,7 +61,7 @@ func main() {
 	c := xfer.NewCollector(*batch)
 	defer c.Stop()
 
-	r := NewResolver(strings.Split(*probes, ","), c.AddAddress)
+	r := NewResolver(probes, c.AddAddress)
 	defer r.Stop()
 
 	lifo := NewReportLIFO(c, *window)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -31,4 +31,12 @@ if [ -n "$DNS_SERVER" -a -n "$SEARCHPATH" ]; then
     echo "nameserver $DNS_SERVER" >>/etc/resolv.conf
 fi
 
+# End of the command line can optionally be some
+# addresses of probes to connect to, for people not
+# using Weave DNS.  We stick these in /etc/weave/probes
+# for the run-app script to pick up.
+MANUAL_PROBES=$@
+mkdir -p /etc/weave
+echo "$MANUAL_PROBES" >/etc/weave/probes
+
 exec /sbin/runsvdir /etc/service

--- a/docker/run-app
+++ b/docker/run-app
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec /home/weave/app
+exec /home/weave/app $(cat /etc/weave/probes)

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -1,0 +1,10 @@
+
+## Multi host setup
+
+Weave Scope uses WeaveDNS to automatically discover other instances of Scope running on your network.  If you have a running WeaveDNS setup, you do not need any further steps.
+
+If you do not wish to use WeaveDNS, you can instruct Scope to cluster with other Scope instances on the command line.  Hostnames and IP addresses are acceptable, both with and without ports:
+
+```
+# weave launch scope1:4030 192.168.0.12 192.168.0.11:4030
+```

--- a/scope
+++ b/scope
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 usage() {
-    echo "$0 (launch|stop)"
+    echo "Usage:"
+    echo "scope launch [<peer> ...]"
+    echo "scope stop"
+    echo
+    echo "scope <peer>    is of the form <ip_address_or_fqdn>[:<port>]"
+    exit 1
 }
 
 SCOPE_IMAGE=weaveworks/scope
@@ -118,7 +123,6 @@ container_ip() {
 case "$COMMAND" in
 
 	launch)
-		[ $# -eq 0 ] || usage
 		check_not_running $CONTAINER_NAME $IMAGE
 
 		# If WeaveDNS is running, we want to automatically tell the scope


### PR DESCRIPTION
- Move peers from flags to args in the app
- Allow users to specify peers as IPs and hostname, both with and without ports
- Allow users to specify peers on ./scope launch, and plumb that through entrypoint.sh and run-app
- Improve ./scope usage text
- Add brief document explaining how to cluster Scope