### PR TITLE
Emit the urls at which the weave scope UI is reachable on scope launch.

### DIFF
--- a/scope
+++ b/scope
@@ -153,6 +153,11 @@ case "$COMMAND" in
 		fi
 
 		echo $CONTAINER
+
+		echo "Weave Scope is reachable at the following URL(s):" >&2
+		for ip in $(hostname -I); do
+			echo "  * http://$ip:4040/" >&2
+		done
 		;;
 
 	stop)


### PR DESCRIPTION
Fixes #149 

The text is outputted on stderr, so $(scope launch) just gives you the uuid of the container.