### PR TITLE
Docker tagger uses event API

### DIFF
--- a/probe/main.go
+++ b/probe/main.go
@@ -66,7 +66,10 @@ func main() {
 
 	taggers := []tag.Tagger{tag.NewTopologyTagger()}
 	if *dockerTagger {
-		t := tag.NewDockerTagger(*procRoot, *dockerInterval)
+		t, err := tag.NewDockerTagger(*procRoot, *dockerInterval)
+		if err != nil {
+			log.Fatal(err)
+		}
 		defer t.Stop()
 		taggers = append(taggers, t)
 	}

--- a/probe/tag/docker_tagger.go
+++ b/probe/tag/docker_tagger.go
@@ -3,11 +3,17 @@ package tag
 import (
 	"log"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/weaveworks/scope/report"
+)
+
+const (
+	dockerEventStart = "start"
+	dockerEventStop  = "stop"
 )
 
 var (
@@ -24,74 +30,104 @@ type dockerClient interface {
 	ListContainers(docker.ListContainersOptions) ([]docker.APIContainers, error)
 	InspectContainer(string) (*docker.Container, error)
 	ListImages(docker.ListImagesOptions) ([]docker.APIImages, error)
+	AddEventListener(chan<- *docker.APIEvents) error
+	RemoveEventListener(chan *docker.APIEvents) error
 }
 
 type dockerTagger struct {
 	sync.RWMutex
-	procRoot   string
-	containers map[int]*docker.Container
-	images     map[string]*docker.APIImages
-	quit       chan struct{}
+	containersByID  map[string]*docker.Container
+	containersByPID map[int]*docker.Container
+	imagesByID      map[string]*docker.APIImages
+
+	procRoot string
+	pidTree  *pidTree
+	interval time.Duration
+	quit     chan struct{}
 }
 
 // NewDockerTagger returns a tagger that tags Docker container information to
 // nodes with a process_node_id.
-func NewDockerTagger(procRoot string, interval time.Duration) Tagger {
-	t := dockerTagger{
-		procRoot:   procRoot,
-		containers: map[int]*docker.Container{},
-		images:     map[string]*docker.APIImages{},
-		quit:       make(chan struct{}),
+func NewDockerTagger(procRoot string, interval time.Duration) (Tagger, error) {
+	pidTree, err := newPIDTree(procRoot)
+	if err != nil {
+		return nil, err
 	}
-	t.update()
-	go t.loop(interval)
-	return &t
+
+	t := dockerTagger{
+		containersByID:  map[string]*docker.Container{},
+		containersByPID: map[int]*docker.Container{},
+		imagesByID:      map[string]*docker.APIImages{},
+
+		procRoot: procRoot,
+		pidTree:  pidTree,
+		interval: interval,
+		quit:     make(chan struct{}),
+	}
+	go t.loop()
+	return &t, nil
 }
 
 func (t *dockerTagger) Tag(r report.Report, ts report.TopologySelector, id string) report.NodeMetadata {
-	// Cross-reference the process.
+	// Look up the specified node
 	myNodeMetadata, ok := ts(r).NodeMetadatas[id]
 	if !ok {
-		//log.Printf("dockerTagger: %q: missing", id)
 		return report.NodeMetadata{}
 	}
+
+	// Hopefully it has a process node ID
 	processNodeID, ok := myNodeMetadata["process_node_id"]
 	if !ok {
-		//log.Printf("dockerTagger: %q: no process node ID", id)
 		return report.NodeMetadata{}
 	}
+
+	// Hopefully that's a valid node in the process topology
 	processNodeMetadata, ok := r.Process.NodeMetadatas[processNodeID]
 	if !ok {
-		//log.Printf("dockerTagger: %q: process node ID missing", id)
 		return report.NodeMetadata{}
 	}
+
+	// Hopefully that process node has a PID
 	pidStr, ok := processNodeMetadata["pid"]
 	if !ok {
-		//log.Printf("dockerTagger: %q: process node has no PID", id)
 		return report.NodeMetadata{}
 	}
 	pid, err := strconv.ParseUint(pidStr, 10, 64)
 	if err != nil {
-		//log.Printf("dockerTagger: %q: bad process node PID (%v)", id, err)
 		return report.NodeMetadata{}
 	}
 
+	// Use the PID to look up the container
+	var (
+		container *docker.Container
+		candidate = int(pid)
+	)
 	t.RLock()
-	container, ok := t.containers[int(pid)]
+	for {
+		container, ok = t.containersByPID[candidate]
+		if ok {
+			break // found
+		}
+		candidate, err = t.pidTree.getParent(candidate)
+		if err != nil {
+			break // oh well
+		}
+	}
 	t.RUnlock()
 
-	if !ok {
-		return report.NodeMetadata{}
+	if err != nil || container == nil {
+		return report.NodeMetadata{} // not found :(
 	}
 
+	// Build the metadata
 	md := report.NodeMetadata{
 		"docker_container_id":   container.ID,
-		"docker_container_name": container.Name,
+		"docker_container_name": strings.TrimPrefix(container.Name, "/"),
 		"docker_image_id":       container.Image,
 	}
 
 	t.RLock()
-	image, ok := t.images[container.Image]
+	image, ok := t.imagesByID[container.Image]
 	t.RUnlock()
 
 	if ok && len(image.RepoTags) > 0 {
@@ -105,68 +141,164 @@ func (t *dockerTagger) Stop() {
 	close(t.quit)
 }
 
-func (t *dockerTagger) loop(d time.Duration) {
-	for range time.Tick(d) {
-		t.update()
+func (t *dockerTagger) loop() {
+	if !t.update() {
+		return
+	}
+	ticker := time.Tick(t.interval)
+	for {
+		select {
+		case <-ticker:
+			if !t.update() {
+				return
+			}
+		case <-t.quit:
+			return
+		}
 	}
 }
 
-func (t *dockerTagger) update() {
-	pidTree, err := newPIDTree(t.procRoot)
-	if err != nil {
-		log.Printf("docker tagger: %s", err)
-		return
-	}
-
+// Return false to stop the owning loop gorouting.
+func (t *dockerTagger) update() bool {
 	endpoint := "unix:///var/run/docker.sock"
 	client, err := newDockerClient(endpoint)
 	if err != nil {
-		log.Printf("docker tagger: %s", err)
-		return
+		log.Printf("docker tagger: %v", err)
+		return true
 	}
 
-	containers, err := client.ListContainers(docker.ListContainersOptions{All: true})
+	events := make(chan *docker.APIEvents)
+	if err := client.AddEventListener(events); err != nil {
+		log.Printf("docker tagger: %v", err)
+		return true
+	}
+	defer func() {
+		if err := client.RemoveEventListener(events); err != nil {
+			log.Printf("docker tagger: %v", err)
+		}
+	}()
+
+	if err := t.updateContainers(client); err != nil {
+		log.Printf("docker tagger: %v", err)
+		return true
+	}
+
+	if err := t.updateImages(client); err != nil {
+		log.Printf("docker tagger: %v", err)
+		return true
+	}
+
+	otherUpdates := time.Tick(t.interval)
+	for {
+		select {
+		case event := <-events:
+			t.handleEvent(event, client)
+
+		case <-otherUpdates:
+			if err := t.updatePIDTree(); err != nil {
+				log.Printf("docker tagger: %v", err)
+				continue
+			}
+
+			if err := t.updateImages(client); err != nil {
+				log.Printf("docker tagger: %v", err)
+				continue
+			}
+
+		case <-t.quit:
+			return false
+		}
+	}
+}
+
+func (t *dockerTagger) updateContainers(client dockerClient) error {
+	apiContainers, err := client.ListContainers(docker.ListContainersOptions{All: true})
 	if err != nil {
-		log.Printf("docker tagger: %s", err)
-		return
+		return err
 	}
 
-	pmap := map[int]*docker.Container{}
-	for _, container := range containers {
-		info, err := client.InspectContainer(container.ID)
+	containers := []*docker.Container{}
+	for _, apiContainer := range apiContainers {
+		container, err := client.InspectContainer(apiContainer.ID)
 		if err != nil {
-			log.Printf("docker tagger: %s", err)
+			log.Printf("docker tagger: %v", err)
 			continue
 		}
-
-		if !info.State.Running {
+		if !container.State.Running {
 			continue
 		}
-
-		pids, err := pidTree.allChildren(info.State.Pid)
-		if err != nil {
-			log.Printf("docker tagger: %s", err)
-			continue
-		}
-		for _, pid := range pids {
-			pmap[pid] = info
-		}
-	}
-
-	imageList, err := client.ListImages(docker.ListImagesOptions{})
-	if err != nil {
-		log.Printf("docker tagger: %s", err)
-		return
-	}
-
-	imageMap := map[string]*docker.APIImages{}
-	for i := range imageList {
-		image := &imageList[i]
-		imageMap[image.ID] = image
+		containers = append(containers, container)
 	}
 
 	t.Lock()
-	t.containers = pmap
-	t.images = imageMap
+	for _, container := range containers {
+		t.containersByID[container.ID] = container
+		t.containersByPID[container.State.Pid] = container
+	}
 	t.Unlock()
+
+	return nil
+}
+
+func (t *dockerTagger) updateImages(client dockerClient) error {
+	images, err := client.ListImages(docker.ListImagesOptions{})
+	if err != nil {
+		return err
+	}
+
+	t.Lock()
+	for i := range images {
+		image := &images[i]
+		t.imagesByID[image.ID] = image
+	}
+	t.Unlock()
+
+	return nil
+}
+
+func (t *dockerTagger) handleEvent(event *docker.APIEvents, client dockerClient) {
+	switch event.Status {
+	case dockerEventStop:
+		containerID := event.ID
+
+		t.Lock()
+		if container, ok := t.containersByID[containerID]; ok {
+			delete(t.containersByID, containerID)
+			delete(t.containersByPID, container.State.Pid)
+		} else {
+			log.Printf("docker tagger: container %s not found", containerID)
+		}
+		t.Unlock()
+
+	case dockerEventStart:
+		containerID := event.ID
+		container, err := client.InspectContainer(containerID)
+		if err != nil {
+			log.Printf("docker tagger: %v", err)
+			return
+		}
+
+		if !container.State.Running {
+			log.Printf("docker tagger: container %s not running", containerID)
+			return
+		}
+
+		t.Lock()
+		t.containersByID[containerID] = container
+		t.containersByPID[container.State.Pid] = container
+		t.Unlock()
+	}
+}
+
+func (t *dockerTagger) updatePIDTree() error {
+	pidTree, err := newPIDTree(t.procRoot)
+	if err != nil {
+		return err
+	}
+
+	t.Lock()
+	t.pidTree = pidTree
+	t.Unlock()
+
+	return nil
 }

--- a/probe/tag/pidtree.go
+++ b/probe/tag/pidtree.go
@@ -62,6 +62,14 @@ func newRealPIDTree(procRoot string) (*pidTree, error) {
 	return &pt, nil
 }
 
+func (pt *pidTree) getParent(pid int) (int, error) {
+	proc, ok := pt.processes[pid]
+	if !ok {
+		return -1, fmt.Errorf("PID %d not found", pid)
+	}
+	return proc.ppid, nil
+}
+
 // allChildren returns a flat list of child PIDs, including the given PID.
 func (pt *pidTree) allChildren(pid int) ([]int, error) {
 	proc, ok := pt.processes[pid]


### PR DESCRIPTION
This is a pull request into the new-report branch. It just brings the docker mapper event API changes into the new docker tagger. We don't necessarily have to merge it this way, it's just so you can see the diff.