### PR TITLE
ID constructors

### DIFF
--- a/app/mock_reporter_test.go
+++ b/app/mock_reporter_test.go
@@ -18,34 +18,34 @@ func (s StaticReport) Report() report.Report {
 	var testReport = report.Report{
 		Process: report.Topology{
 			Adjacency: report.Adjacency{
-				"hostA|;192.168.1.1;12345": []string{";192.168.1.2;80"},
-				"hostA|;192.168.1.1;12346": []string{";192.168.1.2;80"},
-				"hostA|;192.168.1.1;8888":  []string{";1.2.3.4;22"},
-				"hostB|;192.168.1.2;80":    []string{";192.168.1.1;12345"},
+				report.MakeAdjacencyID("hostA", report.MakeEndpointNodeID("hostA", "192.168.1.1", "12345")): report.NewIDList(report.MakeEndpointNodeID("hostB", "192.168.1.2", "80")),
+				report.MakeAdjacencyID("hostA", report.MakeEndpointNodeID("hostA", "192.168.1.1", "12346")): report.NewIDList(report.MakeEndpointNodeID("hostB", "192.168.1.2", "80")),
+				report.MakeAdjacencyID("hostA", report.MakeEndpointNodeID("hostA", "192.168.1.1", "8888")):  report.NewIDList(report.MakeEndpointNodeID("", "1.2.3.4", "22")),
+				report.MakeAdjacencyID("hostB", report.MakeEndpointNodeID("hostB", "192.168.1.2", "80")):    report.NewIDList(report.MakeEndpointNodeID("hostA", "192.168.1.1", "12345")),
 			},
 			EdgeMetadatas: report.EdgeMetadatas{
-				";192.168.1.1;12345|;192.168.1.2;80": report.EdgeMetadata{
+				report.MakeEdgeID(report.MakeEndpointNodeID("hostA", "192.168.1.1", "12345"), report.MakeEndpointNodeID("hostB", "192.168.1.2", "80")): report.EdgeMetadata{
 					WithBytes:        true,
 					BytesEgress:      12,
 					BytesIngress:     0,
 					WithConnCountTCP: true,
 					MaxConnCountTCP:  200,
 				},
-				";192.168.1.1;12346|;192.168.1.2;80": report.EdgeMetadata{
+				report.MakeEdgeID(report.MakeEndpointNodeID("hostA", "192.168.1.1", "12346"), report.MakeEndpointNodeID("hostB", "192.168.1.2", "80")): report.EdgeMetadata{
 					WithBytes:        true,
 					BytesEgress:      12,
 					BytesIngress:     0,
 					WithConnCountTCP: true,
 					MaxConnCountTCP:  201,
 				},
-				";192.168.1.1;8888|;1.2.3.4;80": report.EdgeMetadata{
+				report.MakeEdgeID(report.MakeEndpointNodeID("hostA", "192.168.1.1", "8888"), report.MakeEndpointNodeID("", "1.2.3.4", "80")): report.EdgeMetadata{
 					WithBytes:        true,
 					BytesEgress:      200,
 					BytesIngress:     0,
 					WithConnCountTCP: true,
 					MaxConnCountTCP:  202,
 				},
-				";192.168.1.2;80|;192.168.1.1;12345": report.EdgeMetadata{
+				report.MakeEdgeID(report.MakeEndpointNodeID("hostB", "192.168.1.2", "80"), report.MakeEndpointNodeID("hostA", "192.168.1.1", "12345")): report.EdgeMetadata{
 					WithBytes:        true,
 					BytesEgress:      0,
 					BytesIngress:     12,
@@ -54,22 +54,22 @@ func (s StaticReport) Report() report.Report {
 				},
 			},
 			NodeMetadatas: report.NodeMetadatas{
-				";192.168.1.1;12345": report.NodeMetadata{
+				report.MakeEndpointNodeID("hostA", "192.168.1.1", "12345"): report.NodeMetadata{
 					"pid":    "23128",
 					"name":   "curl",
 					"domain": "node-a.local",
 				},
-				";192.168.1.1;12346": report.NodeMetadata{ // <-- same as :12345
+				report.MakeEndpointNodeID("hostA", "192.168.1.1", "12346"): report.NodeMetadata{ // <-- same as :12345
 					"pid":    "23128",
 					"name":   "curl",
 					"domain": "node-a.local",
 				},
-				";192.168.1.1;8888": report.NodeMetadata{
+				report.MakeEndpointNodeID("hostA", "192.168.1.1", "8888"): report.NodeMetadata{
 					"pid":    "55100",
 					"name":   "ssh",
 					"domain": "node-a.local",
 				},
-				";192.168.1.2;80": report.NodeMetadata{
+				report.MakeEndpointNodeID("hostB", "192.168.1.2", "80"): report.NodeMetadata{
 					"pid":    "215",
 					"name":   "apache",
 					"domain": "node-b.local",
@@ -79,25 +79,25 @@ func (s StaticReport) Report() report.Report {
 
 		Network: report.Topology{
 			Adjacency: report.Adjacency{
-				"hostA|;192.168.1.1": []string{";192.168.1.2", ";1.2.3.4"},
-				"hostB|;192.168.1.2": []string{";192.168.1.1"},
+				report.MakeAdjacencyID("hostA", report.MakeAddressNodeID("hostA", "192.168.1.1")): report.NewIDList(report.MakeAddressNodeID("hostB", "192.168.1.2"), report.MakeAddressNodeID("", "1.2.3.4")),
+				report.MakeAdjacencyID("hostB", report.MakeAddressNodeID("hostB", "192.168.1.2")): report.NewIDList(report.MakeAddressNodeID("hostA", "192.168.1.1")),
 			},
 			EdgeMetadatas: report.EdgeMetadatas{
-				";192.168.1.1|;192.168.1.2": report.EdgeMetadata{
+				report.MakeEdgeID(report.MakeAddressNodeID("hostA", "192.168.1.1"), report.MakeAddressNodeID("hostB", "192.168.1.2")): report.EdgeMetadata{
 					WithBytes:        true,
 					BytesEgress:      12,
 					BytesIngress:     0,
 					WithConnCountTCP: true,
 					MaxConnCountTCP:  14,
 				},
-				";192.168.1.1|;1.2.3.4": report.EdgeMetadata{
+				report.MakeEdgeID(report.MakeAddressNodeID("hostA", "192.168.1.1"), report.MakeAddressNodeID("", "1.2.3.4")): report.EdgeMetadata{
 					WithBytes:        true,
 					BytesEgress:      200,
 					BytesIngress:     0,
 					WithConnCountTCP: true,
 					MaxConnCountTCP:  15,
 				},
-				";192.168.1.2|;192.168.1.1": report.EdgeMetadata{
+				report.MakeEdgeID(report.MakeAddressNodeID("hostB", "192.168.1.2"), report.MakeAddressNodeID("hostA", "192.168.1.1")): report.EdgeMetadata{
 					WithBytes:        true,
 					BytesEgress:      0,
 					BytesIngress:     12,
@@ -106,10 +106,10 @@ func (s StaticReport) Report() report.Report {
 				},
 			},
 			NodeMetadatas: report.NodeMetadatas{
-				";192.168.1.1": report.NodeMetadata{
+				report.MakeAddressNodeID("hostA", "192.168.1.1"): report.NodeMetadata{
 					"name": "host-a",
 				},
-				";192.168.1.2": report.NodeMetadata{
+				report.MakeAddressNodeID("hostB", "192.168.1.2"): report.NodeMetadata{
 					"name": "host-b",
 				},
 			},

--- a/experimental/bridge/main.go
+++ b/experimental/bridge/main.go
@@ -132,7 +132,7 @@ func discover(c collector, p publisher, fixed []string) {
 
 		for _, adjacent := range r.Network.Adjacency {
 			for _, a := range adjacent {
-				ip := report.AddressIP(a) // address id -> IP
+				ip := report.AddressIDAddresser(a) // address id -> IP
 				if ip == nil {
 					continue
 				}

--- a/experimental/demoprobe/generate.go
+++ b/experimental/demoprobe/generate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"strconv"
 	"time"
 
 	"github.com/weaveworks/scope/report"
@@ -56,14 +57,14 @@ func DemoReport(nodeCount int) report.Report {
 			src              = hosts[rand.Intn(len(hosts))]
 			dst              = hosts[rand.Intn(len(hosts))]
 			srcPort          = rand.Intn(50000) + 10000
-			srcPortID        = fmt.Sprintf("%s%s%s%d", report.ScopeDelim, src, report.ScopeDelim, srcPort)
-			dstPortID        = fmt.Sprintf("%s%s%s%d", report.ScopeDelim, dst, report.ScopeDelim, c.dstPort)
-			srcID            = "hostX" + report.IDDelim + srcPortID
-			dstID            = "hostX" + report.IDDelim + dstPortID
-			srcAddressID     = fmt.Sprintf("%s%s", report.ScopeDelim, src)
-			dstAddressID     = fmt.Sprintf("%s%s", report.ScopeDelim, dst)
-			nodeSrcAddressID = "hostX" + report.IDDelim + srcAddressID
-			nodeDstAddressID = "hostX" + report.IDDelim + dstAddressID
+			srcPortID        = report.MakeEndpointNodeID("", src, strconv.Itoa(srcPort))
+			dstPortID        = report.MakeEndpointNodeID("", dst, strconv.Itoa(c.dstPort))
+			srcID            = report.MakeAdjacencyID("hostX", srcPortID)
+			dstID            = report.MakeAdjacencyID("hostX", dstPortID)
+			srcAddressID     = report.MakeAddressNodeID("", src)
+			dstAddressID     = report.MakeAddressNodeID("", dst)
+			nodeSrcAddressID = report.MakeAdjacencyID("hostX", srcAddressID)
+			nodeDstAddressID = report.MakeAdjacencyID("hostX", dstAddressID)
 		)
 
 		// Process topology
@@ -84,8 +85,8 @@ func DemoReport(nodeCount int) report.Report {
 		}
 		r.Process.Adjacency[dstID] = r.Process.Adjacency[dstID].Add(srcPortID)
 		var (
-			edgeKeyEgress  = srcPortID + report.IDDelim + dstPortID
-			edgeKeyIngress = dstPortID + report.IDDelim + srcPortID
+			edgeKeyEgress  = report.MakeEdgeID(srcPortID, dstPortID)
+			edgeKeyIngress = report.MakeEdgeID(dstPortID, srcPortID)
 		)
 		r.Process.EdgeMetadatas[edgeKeyEgress] = report.EdgeMetadata{
 			WithConnCountTCP: true,

--- a/experimental/genreport/generate.go
+++ b/experimental/genreport/generate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"strconv"
 	"time"
 
 	"github.com/weaveworks/scope/report"
@@ -56,14 +57,14 @@ func DemoReport(nodeCount int) report.Report {
 			src              = hosts[rand.Intn(len(hosts))]
 			dst              = hosts[rand.Intn(len(hosts))]
 			srcPort          = rand.Intn(50000) + 10000
-			srcPortID        = fmt.Sprintf("%s%s%s%d", report.ScopeDelim, src, report.ScopeDelim, srcPort)
-			dstPortID        = fmt.Sprintf("%s%s%s%d", report.ScopeDelim, dst, report.ScopeDelim, c.dstPort)
-			srcID            = "hostX" + report.IDDelim + srcPortID
-			dstID            = "hostX" + report.IDDelim + dstPortID
-			srcAddressID     = fmt.Sprintf("%s%s", report.ScopeDelim, src)
-			dstAddressID     = fmt.Sprintf("%s%s", report.ScopeDelim, dst)
-			nodeSrcAddressID = "hostX" + report.IDDelim + srcAddressID
-			nodeDstAddressID = "hostX" + report.IDDelim + dstAddressID
+			srcPortID        = report.MakeEndpointNodeID("", src, strconv.Itoa(srcPort))
+			dstPortID        = report.MakeEndpointNodeID("", dst, strconv.Itoa(c.dstPort))
+			srcID            = report.MakeAdjacencyID("hostX", srcPortID)
+			dstID            = report.MakeAdjacencyID("hostX", dstPortID)
+			srcAddressID     = report.MakeAddressNodeID("", src)
+			dstAddressID     = report.MakeAddressNodeID("", dst)
+			nodeSrcAddressID = report.MakeAdjacencyID("hostX", srcAddressID)
+			nodeDstAddressID = report.MakeAdjacencyID("hostX", dstAddressID)
 		)
 
 		// Process topology
@@ -84,8 +85,8 @@ func DemoReport(nodeCount int) report.Report {
 		}
 		r.Process.Adjacency[dstID] = r.Process.Adjacency[dstID].Add(srcPortID)
 		var (
-			edgeKeyEgress  = srcPortID + report.IDDelim + dstPortID
-			edgeKeyIngress = dstPortID + report.IDDelim + srcPortID
+			edgeKeyEgress  = report.MakeEdgeID(srcPortID, dstPortID)
+			edgeKeyIngress = report.MakeEdgeID(dstPortID, srcPortID)
 		)
 		r.Process.EdgeMetadatas[edgeKeyEgress] = report.EdgeMetadata{
 			WithConnCountTCP: true,

--- a/report/fixture_test.go
+++ b/report/fixture_test.go
@@ -1,0 +1,29 @@
+package report_test
+
+import (
+	"github.com/weaveworks/scope/report"
+)
+
+var (
+	clientHostID     = "client.host.com"
+	clientHostName   = clientHostID
+	clientHostNodeID = report.MakeHostNodeID(clientHostID)
+	clientAddress    = "10.10.10.20"
+	serverHostID     = "server.host.com"
+	serverHostName   = serverHostID
+	serverHostNodeID = report.MakeHostNodeID(serverHostID)
+	serverAddress    = "10.10.10.1"
+	unknownHostID    = ""              // by definition, we don't know it
+	unknownAddress   = "172.16.93.112" // will be a pseudonode, no corresponding host
+
+	client54001EndpointNodeID = report.MakeEndpointNodeID(clientHostID, clientAddress, "54001") // i.e. curl
+	client54002EndpointNodeID = report.MakeEndpointNodeID(clientHostID, clientAddress, "54002") // also curl
+	server80EndpointNodeID    = report.MakeEndpointNodeID(serverHostID, serverAddress, "80")    // i.e. apache
+	unknown1EndpointNodeID    = report.MakeEndpointNodeID(unknownHostID, unknownAddress, "10001")
+	unknown2EndpointNodeID    = report.MakeEndpointNodeID(unknownHostID, unknownAddress, "10002")
+	unknown3EndpointNodeID    = report.MakeEndpointNodeID(unknownHostID, unknownAddress, "10003")
+
+	clientAddressNodeID  = report.MakeAddressNodeID(clientHostID, clientAddress)
+	serverAddressNodeID  = report.MakeAddressNodeID(serverHostID, serverAddress)
+	unknownAddressNodeID = report.MakeAddressNodeID(unknownHostID, unknownAddress)
+)

--- a/report/id.go
+++ b/report/id.go
@@ -1,29 +1,117 @@
 package report
 
 import (
+	"fmt"
 	"net"
 	"strings"
 )
 
-// IDAddresser is used to get the IP address from an addressID. Or nil.
-type IDAddresser func(string) net.IP
+// TheInternet is used as a node ID to indicate a remote IP.
+const TheInternet = "theinternet"
 
-// AddressIPPort translates "scope;ip;port" to the IP address. These are used
-// by Process topologies.
-func AddressIPPort(id string) net.IP {
-	parts := strings.SplitN(id, ScopeDelim, 3)
-	if len(parts) != 3 {
-		return nil // hmm
-	}
-	return net.ParseIP(parts[1])
+// Delimiters are used to separate parts of node IDs, to guarantee uniqueness
+// in particular contexts.
+const (
+	// ScopeDelim is a general-purpose delimiter used within node IDs to
+	// separate different contextual scopes. Different topologies have
+	// different key structures.
+	ScopeDelim = ";"
+
+	// EdgeDelim separates two node IDs when they need to exist in the same key.
+	// Concretely, it separates node IDs in keys that represent edges.
+	EdgeDelim = "|"
+)
+
+// MakeAdjacencyID produces an adjacency ID from composite parts.
+func MakeAdjacencyID(hostID, srcNodeID string) string {
+	// Here we rely on the fact that every possible source node ID has the
+	// host ID as the first scope-delimited field, and therefore don't
+	// duplicate that information.
+	return ">" + srcNodeID
 }
 
-// AddressIP translates "scope;ip" to the IP address. These are used by
-// Network topologies.
-func AddressIP(id string) net.IP {
-	parts := strings.SplitN(id, ScopeDelim, 2)
-	if len(parts) != 2 {
-		return nil // hmm
+// ParseAdjacencyID splits an adjacency ID to its composite parts.
+func ParseAdjacencyID(adjacencyID string) (hostID, srcNodeID string, ok bool) {
+	if !strings.HasPrefix(adjacencyID, ">") {
+		return "", "", false
 	}
-	return net.ParseIP(parts[1])
+	// This relies on every node ID having hostID as its first scoped field.
+	adjacencyID = adjacencyID[1:]
+	fields := strings.SplitN(adjacencyID, ScopeDelim, 2)
+	if len(fields) != 2 {
+		return "", "", false
+	}
+	return fields[0], adjacencyID, true
+}
+
+// MakeEdgeID produces an edge ID from composite parts.
+func MakeEdgeID(srcNodeID, dstNodeID string) string {
+	return srcNodeID + EdgeDelim + dstNodeID
+}
+
+// ParseEdgeID splits an edge ID to its composite parts.
+func ParseEdgeID(edgeID string) (srcNodeID, dstNodeID string, ok bool) {
+	fields := strings.SplitN(edgeID, EdgeDelim, 2)
+	if len(fields) != 2 {
+		return "", "", false
+	}
+	return fields[0], fields[1], true
+}
+
+// MakeEndpointNodeID produces an endpoint node ID from its composite parts.
+func MakeEndpointNodeID(hostID, address, port string) string {
+	return MakeAddressNodeID(hostID, address) + ScopeDelim + port
+}
+
+// MakeAddressNodeID produces an address node ID from its composite parts.
+func MakeAddressNodeID(hostID, address string) string {
+	return hostID + ScopeDelim + address
+}
+
+// MakeProcessNodeID produces a process node ID from its composite parts.
+func MakeProcessNodeID(hostID, pid string) string {
+	return hostID + ScopeDelim + pid
+}
+
+// MakeHostNodeID produces a host node ID from its composite parts.
+func MakeHostNodeID(hostID string) string {
+	// hostIDs come from the probe and are presumed to be globally-unique.
+	// But, suffix something to elicit failures if we try to use probe host
+	// IDs directly as node IDs in the host topology.
+	return hostID + ScopeDelim + "<host>"
+}
+
+// MakePseudoNodeID produces a pseudo node ID from its composite parts.
+func MakePseudoNodeID(parts ...string) string {
+	return strings.Join(append([]string{"pseudo"}, parts...), ScopeDelim)
+}
+
+// IDAddresser tries to convert a node ID to a net.IP, if possible.
+type IDAddresser func(string) net.IP
+
+// EndpointIDAddresser converts an endpoint node ID to an IP.
+func EndpointIDAddresser(id string) net.IP {
+	fields := strings.SplitN(id, ScopeDelim, 3)
+	if len(fields) != 3 {
+		//log.Printf("EndpointIDAddresser: bad input %q", id)
+		return nil
+	}
+	return net.ParseIP(fields[1])
+}
+
+// AddressIDAddresser converts an address node ID to an IP.
+func AddressIDAddresser(id string) net.IP {
+	fields := strings.SplitN(id, ScopeDelim, 2)
+	if len(fields) != 2 {
+		//log.Printf("AddressIDAddresser: bad input %q", id)
+		return nil
+	}
+	return net.ParseIP(fields[1])
+}
+
+// PanicIDAddresser will panic if it's ever called. It's used in topologies
+// where there are never any edges, and so it's nonsensical to try and extract
+// IPs from the node IDs.
+func PanicIDAddresser(id string) net.IP {
+	panic(fmt.Sprintf("PanicIDAddresser called on %q", id))
 }

--- a/report/id_test.go
+++ b/report/id_test.go
@@ -1,0 +1,147 @@
+package report_test
+
+import (
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/weaveworks/scope/report"
+)
+
+func TestAdjacencyID(t *testing.T) {
+	for _, bad := range []string{
+		client54001EndpointNodeID,
+		client54002EndpointNodeID,
+		unknown1EndpointNodeID,
+		unknown2EndpointNodeID,
+		unknown3EndpointNodeID,
+		clientAddressNodeID,
+		serverAddressNodeID,
+		unknownAddressNodeID,
+		clientHostNodeID,
+		serverHostNodeID,
+		">1.2.3.4",
+		">",
+		";",
+		"",
+	} {
+		if hostID, srcNodeID, ok := report.ParseAdjacencyID(bad); ok {
+			t.Errorf("%q: expected failure, but got (%q, %q)", bad, hostID, srcNodeID)
+		}
+	}
+
+	for input, want := range map[string]struct{ hostID, srcNodeID string }{
+		report.MakeAdjacencyID("a", report.MakeEndpointNodeID("a", "b", "c")): {"a", report.MakeEndpointNodeID("a", "b", "c")},
+		report.MakeAdjacencyID("a", report.MakeAddressNodeID("a", "b")):       {"a", report.MakeAddressNodeID("a", "b")},
+		report.MakeAdjacencyID("a", report.MakeProcessNodeID("a", "b")):       {"a", report.MakeProcessNodeID("a", "b")},
+		report.MakeAdjacencyID("a", report.MakeHostNodeID("a")):               {"a", report.MakeHostNodeID("a")},
+		">host.com;1.2.3.4":                                                   {"host.com", "host.com;1.2.3.4"},
+		">a;b;c":                                                              {"a", "a;b;c"},
+		">a;b":                                                                {"a", "a;b"},
+		">a;":                                                                 {"a", "a;"},
+		">;b":                                                                 {"", ";b"},
+		">;":                                                                  {"", ";"},
+	} {
+		hostID, srcNodeID, ok := report.ParseAdjacencyID(input)
+		if !ok {
+			t.Errorf("%q: not OK", input)
+			continue
+		}
+		if want, have := want.hostID, hostID; want != have {
+			t.Errorf("%q: want %q, have %q", input, want, have)
+		}
+		if want, have := want.srcNodeID, srcNodeID; want != have {
+			t.Errorf("%q: want %q, have %q", input, want, have)
+		}
+	}
+}
+
+func TestEdgeID(t *testing.T) {
+	for _, bad := range []string{
+		client54001EndpointNodeID,
+		client54002EndpointNodeID,
+		unknown1EndpointNodeID,
+		unknown2EndpointNodeID,
+		unknown3EndpointNodeID,
+		clientAddressNodeID,
+		serverAddressNodeID,
+		unknownAddressNodeID,
+		clientHostNodeID,
+		serverHostNodeID,
+		">1.2.3.4",
+		">",
+		";",
+		"",
+	} {
+		if srcNodeID, dstNodeID, ok := report.ParseEdgeID(bad); ok {
+			t.Errorf("%q: expected failure, but got (%q, %q)", bad, srcNodeID, dstNodeID)
+		}
+	}
+
+	for input, want := range map[string]struct{ srcNodeID, dstNodeID string }{
+		report.MakeEdgeID("a", report.MakeEndpointNodeID("a", "b", "c")): {"a", report.MakeEndpointNodeID("a", "b", "c")},
+		report.MakeEdgeID("a", report.MakeAddressNodeID("a", "b")):       {"a", report.MakeAddressNodeID("a", "b")},
+		report.MakeEdgeID("a", report.MakeProcessNodeID("a", "b")):       {"a", report.MakeProcessNodeID("a", "b")},
+		report.MakeEdgeID("a", report.MakeHostNodeID("a")):               {"a", report.MakeHostNodeID("a")},
+		"host.com|1.2.3.4":                                               {"host.com", "1.2.3.4"},
+		"a|b;c":                                                          {"a", "b;c"},
+		"a|b":                                                            {"a", "b"},
+		"a|":                                                             {"a", ""},
+		"|b":                                                             {"", "b"},
+		"|":                                                              {"", ""},
+	} {
+		srcNodeID, dstNodeID, ok := report.ParseEdgeID(input)
+		if !ok {
+			t.Errorf("%q: not OK", input)
+			continue
+		}
+		if want, have := want.srcNodeID, srcNodeID; want != have {
+			t.Errorf("%q: want %q, have %q", input, want, have)
+		}
+		if want, have := want.dstNodeID, dstNodeID; want != have {
+			t.Errorf("%q: want %q, have %q", input, want, have)
+		}
+	}
+}
+
+func TestEndpointIDAddresser(t *testing.T) {
+	if nodeID := "1.2.4.5"; report.EndpointIDAddresser(nodeID) != nil {
+		t.Errorf("%q: bad node ID parsed as good", nodeID)
+	}
+	var (
+		nodeID = report.MakeEndpointNodeID(clientHostID, clientAddress, "12345")
+		want   = net.ParseIP(clientAddress)
+		have   = report.EndpointIDAddresser(nodeID)
+	)
+	if !reflect.DeepEqual(want, have) {
+		t.Errorf("want %s, have %s", want, have)
+	}
+}
+
+func TestAddressIDAddresser(t *testing.T) {
+	if nodeID := "1.2.4.5"; report.AddressIDAddresser(nodeID) != nil {
+		t.Errorf("%q: bad node ID parsed as good", nodeID)
+	}
+	var (
+		nodeID = report.MakeAddressNodeID(clientHostID, clientAddress)
+		want   = net.ParseIP(clientAddress)
+		have   = report.AddressIDAddresser(nodeID)
+	)
+	if !reflect.DeepEqual(want, have) {
+		t.Errorf("want %s, have %s", want, have)
+	}
+}
+
+func TestPanicIDAddresser(t *testing.T) {
+	if panicked := func() (recovered bool) {
+		defer func() {
+			if r := recover(); r != nil {
+				recovered = true
+			}
+		}()
+		report.PanicIDAddresser("irrelevant")
+		return false
+	}(); !panicked {
+		t.Errorf("expected panic, didn't get it")
+	}
+}

--- a/report/mapping_functions.go
+++ b/report/mapping_functions.go
@@ -151,7 +151,7 @@ func GenericPseudoNode(src string, srcMapped RenderableNode, dst string) (Mapped
 		srcNodeAddr, srcNodePort := trySplitAddr(src)
 		dstNodeAddr, _ := trySplitAddr(dst)
 
-		outputID = strings.Join([]string{"pseudo:", dstNodeAddr, srcNodeAddr, srcNodePort}, ScopeDelim)
+		outputID = MakePseudoNodeID(dstNodeAddr, srcNodeAddr, srcNodePort)
 		maj, min = dstNodeAddr, ""
 	}
 
@@ -174,7 +174,7 @@ func GenericGroupedPseudoNode(src string, srcMapped RenderableNode, dst string) 
 		// When grouping, emit one pseudo node per (srcNodeAddress, dstNodeAddr)
 		dstNodeAddr, _ := trySplitAddr(dst)
 
-		outputID = strings.Join([]string{"pseudo:", dstNodeAddr, srcMapped.ID}, ScopeDelim)
+		outputID = MakePseudoNodeID(dstNodeAddr, srcMapped.ID)
 		maj, min = dstNodeAddr, ""
 	}
 
@@ -193,6 +193,12 @@ func InternetOnlyPseudoNode(_ string, _ RenderableNode, dst string) (MappedNode,
 	return MappedNode{}, false
 }
 
+// trySplitAddr is basically ParseArbitraryNodeID, since its callsites
+// (pseudo funcs) just have opaque node IDs and don't know what topology they
+// come from. Without changing how pseudo funcs work, we can't make it much
+// smarter.
+//
+// TODO change how pseudofuncs work, and eliminate this helper.
 func trySplitAddr(addr string) (string, string) {
 	fields := strings.SplitN(addr, ScopeDelim, 3)
 	if len(fields) == 3 {

--- a/report/mapping_test.go
+++ b/report/mapping_test.go
@@ -15,7 +15,7 @@ func TestUngroupedMapping(t *testing.T) {
 	}{
 		{
 			f:  NetworkHostname,
-			id: ScopeDelim + "1.2.3.4",
+			id: MakeAddressNodeID("", "1.2.3.4"),
 			meta: NodeMetadata{
 				"name": "my.host",
 			},
@@ -27,7 +27,7 @@ func TestUngroupedMapping(t *testing.T) {
 		},
 		{
 			f:  NetworkHostname,
-			id: ScopeDelim + "1.2.3.4",
+			id: MakeAddressNodeID("", "1.2.3.4"),
 			meta: NodeMetadata{
 				"name": "localhost",
 			},

--- a/report/report.go
+++ b/report/report.go
@@ -93,8 +93,8 @@ func MakeReport() Report {
 func (r Report) SquashRemote() Report {
 	localNets := r.HostMetadatas.LocalNets()
 	return Report{
-		Process:       Squash(r.Process, AddressIPPort, localNets),
-		Network:       Squash(r.Network, AddressIP, localNets),
+		Process:       Squash(r.Process, EndpointIDAddresser, localNets),
+		Network:       Squash(r.Network, AddressIDAddresser, localNets),
 		HostMetadatas: r.HostMetadatas,
 	}
 }

--- a/report/squash_test.go
+++ b/report/squash_test.go
@@ -166,7 +166,7 @@ func TestSquashTopology(t *testing.T) {
 		NodeMetadatas: reportToSquash().Process.NodeMetadatas,
 	}
 
-	have := Squash(reportToSquash().Process, AddressIPPort, reportToSquash().HostMetadatas.LocalNets())
+	have := Squash(reportToSquash().Process, EndpointIDAddresser, reportToSquash().HostMetadatas.LocalNets())
 	if !reflect.DeepEqual(want, have) {
 		t.Errorf("want\n\t%#v, have\n\t%#v", want, have)
 	}

--- a/xfer/collector_test.go
+++ b/xfer/collector_test.go
@@ -43,7 +43,7 @@ func TestCollector(t *testing.T) {
 
 	// Push a report through everything
 	reports <- report.Report{Network: report.Topology{NodeMetadatas: report.NodeMetadatas{"a": report.NodeMetadata{}}}}
-	poll(t, time.Millisecond, func() bool { return len(concreteCollector.peek().Network.NodeMetadatas) == 1 }, "missed the report")
+	poll(t, 10*time.Millisecond, func() bool { return len(concreteCollector.peek().Network.NodeMetadatas) == 1 }, "missed the report")
 	go func() { publish <- time.Now() }()
 	if want, have := 1, len((<-collector.Reports()).Network.NodeMetadatas); want != have {
 		t.Errorf("want %d, have %d", want, have)


### PR DESCRIPTION
Use constructor functions to produce IDs in reports/topologies/tests. Remove manual, error-prone, and sometimes arbitrary string concatenation.

This is broken up into individual commits so you can see the progression, and if you have specific questions about a choice. I'll of course squash & rebase before merging.