### PR TITLE
Prevent multiple connections for the same app.

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"log/syslog"
+	"math/rand"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -60,11 +61,11 @@ func main() {
 		log.SetOutput(f)
 	}
 
-	log.Printf("app starting, version %s", version)
+	id := strconv.FormatInt(rand.Int63(), 16)
+	log.Printf("app starting, version %s, id %s", version, id)
 
 	// Collector deals with the probes, and generates merged reports.
-	xfer.MaxBackoff = 10 * time.Second
-	c := xfer.NewCollector(*batch)
+	c := xfer.NewCollector(*batch, id)
 	defer c.Stop()
 
 	r := newStaticResolver(probes, c.Add)

--- a/experimental/bridge/main.go
+++ b/experimental/bridge/main.go
@@ -49,7 +49,7 @@ func main() {
 
 	// Collector deals with the probes, and generates a single merged report
 	// every second.
-	c := xfer.NewCollector(*batch)
+	c := xfer.NewCollector(*batch, "id")
 	for _, addr := range fixedAddresses {
 		c.Add(addr)
 	}

--- a/experimental/graphviz/main.go
+++ b/experimental/graphviz/main.go
@@ -26,7 +26,7 @@ func main() {
 	flag.Parse()
 
 	xfer.MaxBackoff = 10 * time.Second
-	c := xfer.NewCollector(*batch)
+	c := xfer.NewCollector(*batch, "id")
 	for _, addr := range strings.Split(*probes, ",") {
 		c.Add(addr)
 	}

--- a/experimental/oneshot/main.go
+++ b/experimental/oneshot/main.go
@@ -28,7 +28,7 @@ func main() {
 
 	// Collector deals with the probes, and generates merged reports.
 	xfer.MaxBackoff = 1 * time.Second
-	c := xfer.NewCollector(1 * time.Second)
+	c := xfer.NewCollector(1*time.Second, "id")
 	for _, addr := range strings.Split(*probes, ",") {
 		c.Add(addr)
 	}

--- a/xfer/collector_test.go
+++ b/xfer/collector_test.go
@@ -22,7 +22,7 @@ func TestCollector(t *testing.T) {
 	defer func() { tick = oldTick }()
 
 	// Build a collector
-	collector := NewCollector(time.Second)
+	collector := NewCollector(time.Second, "id")
 	defer collector.Stop()
 
 	concreteCollector, ok := collector.(*realCollector)
@@ -54,7 +54,7 @@ func TestCollector(t *testing.T) {
 }
 
 func TestCollectorQuitWithActiveConnections(t *testing.T) {
-	c := NewCollector(time.Second)
+	c := NewCollector(time.Second, "id")
 	c.Add("1.2.3.4:56789")
 	c.Stop()
 }

--- a/xfer/merge_test.go
+++ b/xfer/merge_test.go
@@ -31,7 +31,7 @@ func TestMerge(t *testing.T) {
 	defer p2.Close()
 
 	batchTime := 100 * time.Millisecond
-	c := xfer.NewCollector(batchTime)
+	c := xfer.NewCollector(batchTime, "id")
 	c.Add(p1Addr)
 	c.Add(p2Addr)
 	defer c.Stop()

--- a/xfer/publisher_test.go
+++ b/xfer/publisher_test.go
@@ -37,6 +37,11 @@ func TestTCPPublisher(t *testing.T) {
 	defer conn.Close()
 	time.Sleep(time.Millisecond)
 
+	// Send handshake
+	if err := gob.NewEncoder(conn).Encode(xfer.HandshakeRequest{ID: "foo"}); err != nil {
+		t.Fatal(err)
+	}
+
 	// Publish a message
 	p.Publish(report.Report{})
 
@@ -69,11 +74,18 @@ func TestPublisherClosesDuplicateConnections(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer conn.Close()
+	if err := gob.NewEncoder(conn).Encode(xfer.HandshakeRequest{ID: "foo"}); err != nil {
+		t.Fatal(err)
+	}
 	time.Sleep(time.Millisecond)
 
 	// Try to connect the same listener
 	dupconn, err := net.Dial("tcp4", "127.0.0.1"+port)
 	if err != nil {
+		t.Fatal(err)
+	}
+	// Send handshake
+	if err := gob.NewEncoder(dupconn).Encode(xfer.HandshakeRequest{ID: "foo"}); err != nil {
 		t.Fatal(err)
 	}
 	defer dupconn.Close()


### PR DESCRIPTION
- Apps generate a unique, random id on startup and send this to probes when connecting
- Probes dedupe connections based on this id

Fixes #195 