### PR TITLE
Add ContainerImage topology and use it to build the Container By Image graph.

### DIFF
--- a/app/router.go
+++ b/app/router.go
@@ -65,7 +65,7 @@ var topologyRegistry = map[string]topologyView{
 	"containers-by-image": {
 		human:    "by image",
 		parent:   "containers",
-		renderer: render.LeafMap{Selector: report.SelectEndpoint, Mapper: render.ProcessContainerImage, Pseudo: render.InternetOnlyPseudoNode},
+		renderer: render.ContainerImageRenderer,
 	},
 	"hosts": {
 		human:    "Hosts",

--- a/probe/main.go
+++ b/probe/main.go
@@ -130,6 +130,7 @@ func main() {
 
 				if dockerTagger != nil {
 					r.Container.Merge(dockerTagger.ContainerTopology(hostID))
+					r.ContainerImage.Merge(dockerTagger.ContainerImageTopology(hostID))
 				}
 
 				if weaveTagger != nil {

--- a/render/detailed_node.go
+++ b/render/detailed_node.go
@@ -93,6 +93,9 @@ func OriginTable(r report.Report, originID string) (Table, bool) {
 	if nmd, ok := r.Container.NodeMetadatas[originID]; ok {
 		return containerOriginTable(nmd)
 	}
+	if nmd, ok := r.ContainerImage.NodeMetadatas[originID]; ok {
+		return containerImageOriginTable(nmd)
+	}
 	if nmd, ok := r.Host.NodeMetadatas[originID]; ok {
 		return hostOriginTable(nmd)
 	}
@@ -155,7 +158,6 @@ func containerOriginTable(nmd report.NodeMetadata) (Table, bool) {
 		{"docker_container_id", "Container ID"},
 		{"docker_container_name", "Container name"},
 		{"docker_image_id", "Container image ID"},
-		{"docker_image_name", "Container image name"},
 	} {
 		if val, ok := nmd[tuple.key]; ok {
 			rows = append(rows, Row{Key: tuple.human, ValueMajor: val, ValueMinor: ""})
@@ -163,6 +165,23 @@ func containerOriginTable(nmd report.NodeMetadata) (Table, bool) {
 	}
 	return Table{
 		Title:   "Origin Container",
+		Numeric: false,
+		Rows:    rows,
+	}, len(rows) > 0
+}
+
+func containerImageOriginTable(nmd report.NodeMetadata) (Table, bool) {
+	rows := []Row{}
+	for _, tuple := range []struct{ key, human string }{
+		{"docker_image_id", "Container image ID"},
+		{"docker_image_name", "Container image name"},
+	} {
+		if val, ok := nmd[tuple.key]; ok {
+			rows = append(rows, Row{Key: tuple.human, ValueMajor: val, ValueMinor: ""})
+		}
+	}
+	return Table{
+		Title:   "Origin Container Image",
 		Numeric: false,
 		Rows:    rows,
 	}, len(rows) > 0

--- a/render/detailed_node_test.go
+++ b/render/detailed_node_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/weaveworks/scope/render"
+	"github.com/weaveworks/scope/test"
 )
 
 func TestOriginTable(t *testing.T) {
@@ -51,7 +52,7 @@ func TestOriginTable(t *testing.T) {
 			continue
 		}
 		if !reflect.DeepEqual(want, have) {
-			t.Errorf("%q: %s", originID, diff(want, have))
+			t.Errorf("%q: %s", originID, test.Diff(want, have))
 		}
 	}
 }
@@ -95,6 +96,7 @@ func TestMakeDetailedNode(t *testing.T) {
 				Rows: []render.Row{
 					{"Container ID", "5e4d3c2b1a", ""},
 					{"Container name", "server", ""},
+					{"Container image ID", "imageid456", ""},
 				},
 			},
 			{
@@ -109,6 +111,6 @@ func TestMakeDetailedNode(t *testing.T) {
 		},
 	}
 	if !reflect.DeepEqual(want, have) {
-		t.Errorf("%s", diff(want, have))
+		t.Errorf("%s", test.Diff(want, have))
 	}
 }

--- a/render/topologies.go
+++ b/render/topologies.go
@@ -45,3 +45,17 @@ var ContainerRenderer = MakeReduce(
 		Pseudo:   GenericPseudoNode,
 	},
 )
+
+// ContainerImageRenderer is a Renderer which produces a renderable container
+// image graph by merging the container graph and the container image topology.
+var ContainerImageRenderer = MakeReduce(
+	Map{
+		MapFunc:  MapContainer2ContainerImage,
+		Renderer: ContainerRenderer,
+	},
+	LeafMap{
+		Selector: report.SelectContainerImage,
+		Mapper:   MapContainerImageIdentity,
+		Pseudo:   GenericPseudoNode,
+	},
+)

--- a/render/topology_diff_test.go
+++ b/render/topology_diff_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/weaveworks/scope/render"
+	"github.com/weaveworks/scope/test"
 )
 
 // ByID is a sort interface for a RenderableNode slice.
@@ -87,7 +88,7 @@ func TestTopoDiff(t *testing.T) {
 		sort.Sort(ByID(c.have.Add))
 		sort.Sort(ByID(c.have.Update))
 		if !reflect.DeepEqual(c.want, c.have) {
-			t.Errorf("%s - %s", c.label, diff(c.want, c.have))
+			t.Errorf("%s - %s", c.label, test.Diff(c.want, c.have))
 		}
 	}
 }

--- a/report/merge.go
+++ b/report/merge.go
@@ -10,6 +10,7 @@ func (r *Report) Merge(other Report) {
 	r.Address.Merge(other.Address)
 	r.Process.Merge(other.Process)
 	r.Container.Merge(other.Container)
+	r.ContainerImage.Merge(other.ContainerImage)
 	r.Host.Merge(other.Host)
 	r.Overlay.Merge(other.Overlay)
 }

--- a/report/report.go
+++ b/report/report.go
@@ -23,9 +23,14 @@ type Report struct {
 	Process Topology
 
 	// Container nodes represent all Docker containers on hosts running probes.
-	// Metadata includes things like Docker image, name etc.
+	// Metadata includes things like containter id, name, image id etc.
 	// Edges are not present.
 	Container Topology
+
+	// ContainerImages nodes represent all Docker containers images on
+	// hosts running probes. Metadata includes things like image id, name etc.
+	// Edges are not present.
+	ContainerImage Topology
 
 	// Host nodes are physical hosts that run probes. Metadata includes things
 	// like operating system, load, etc. The information is scraped by the
@@ -68,15 +73,21 @@ func SelectContainer(r Report) Topology {
 	return r.Container
 }
 
+// SelectContainerImage selects the container image topology.
+func SelectContainerImage(r Report) Topology {
+	return r.ContainerImage
+}
+
 // MakeReport makes a clean report, ready to Merge() other reports into.
 func MakeReport() Report {
 	return Report{
-		Endpoint:  NewTopology(),
-		Address:   NewTopology(),
-		Process:   NewTopology(),
-		Container: NewTopology(),
-		Host:      NewTopology(),
-		Overlay:   NewTopology(),
+		Endpoint:       NewTopology(),
+		Address:        NewTopology(),
+		Process:        NewTopology(),
+		Container:      NewTopology(),
+		ContainerImage: NewTopology(),
+		Host:           NewTopology(),
+		Overlay:        NewTopology(),
 	}
 }
 
@@ -88,6 +99,7 @@ func (r Report) Squash() Report {
 	r.Address = r.Address.Squash(AddressIDAddresser, localNetworks)
 	r.Process = r.Process.Squash(PanicIDAddresser, localNetworks)
 	r.Container = r.Container.Squash(PanicIDAddresser, localNetworks)
+	r.ContainerImage = r.ContainerImage.Squash(PanicIDAddresser, localNetworks)
 	r.Host = r.Host.Squash(PanicIDAddresser, localNetworks)
 	r.Overlay = r.Overlay.Squash(PanicIDAddresser, localNetworks)
 	return r
@@ -123,7 +135,8 @@ func (r Report) LocalNetworks() []*net.IPNet {
 
 // Topologies returns a slice of Topologies in this report
 func (r Report) Topologies() []Topology {
-	return []Topology{r.Endpoint, r.Address, r.Process, r.Container, r.Host}
+	return []Topology{r.Endpoint, r.Address, r.Process, r.Container,
+		r.ContainerImage, r.Host, r.Overlay}
 }
 
 // Validate checks the report for various inconsistencies.

--- a/test/diff.go
+++ b/test/diff.go
@@ -1,0 +1,22 @@
+package test
+
+import (
+	"github.com/davecgh/go-spew/spew"
+	"github.com/pmezard/go-difflib/difflib"
+)
+
+func init() {
+	spew.Config.SortKeys = true // :\
+}
+
+// Diff diff diff
+func Diff(want, have interface{}) string {
+	text, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(spew.Sdump(want)),
+		B:        difflib.SplitLines(spew.Sdump(have)),
+		FromFile: "want",
+		ToFile:   "have",
+		Context:  3,
+	})
+	return "\n" + text
+}


### PR DESCRIPTION
This makes container image details show the containers (and processes) correctly.

Fixes #230 

Also:
- introduces a 'test' package, moved Diff function there.
- adds some tests for this new rendered view.