### PR TITLE
Increase timeouts to prevent flakiness.

### DIFF
--- a/xfer/merge_test.go
+++ b/xfer/merge_test.go
@@ -66,7 +66,7 @@ func TestMerge(t *testing.T) {
 
 	select {
 	case <-success:
-	case <-time.After(batchTime):
+	case <-time.After(2 * batchTime):
 		t.Errorf("collector didn't capture both reports")
 	}
 }


### PR DESCRIPTION
Fixes #251 

Ran in a loop and would hit these failure about 1 in 10 times.  With this change, didn't hit them in 100 runs.