### PR TITLE
Trim whitespace from process names

### DIFF
--- a/app/api_topology_test.go
+++ b/app/api_topology_test.go
@@ -43,14 +43,14 @@ func TestAPITopologyApplications(t *testing.T) {
 		// Let's not unit-test the specific content of the detail tables
 	}
 	{
-		body := getRawJSON(t, ts, fmt.Sprintf("/api/topology/applications/%s/%s", expected.ClientProcessID, expected.ServerProcessID))
+		body := getRawJSON(t, ts, fmt.Sprintf("/api/topology/applications/%s/%s", expected.ClientProcess1ID, expected.ServerProcessID))
 		var edge APIEdge
 		if err := json.Unmarshal(body, &edge); err != nil {
 			t.Fatalf("JSON parse error: %s", err)
 		}
 		want := render.AggregateMetadata{
-			"egress_bytes":  30,
-			"ingress_bytes": 300,
+			"egress_bytes":  10,
+			"ingress_bytes": 100,
 		}
 		if !reflect.DeepEqual(want, edge.Metadata) {
 			t.Error("\n" + test.Diff(want, edge.Metadata))
@@ -129,7 +129,7 @@ func TestAPITopologyWebsocket(t *testing.T) {
 	if err := json.Unmarshal(p, &d); err != nil {
 		t.Fatalf("JSON parse error: %s", err)
 	}
-	equals(t, 5, len(d.Add))
+	equals(t, 6, len(d.Add))
 	equals(t, 0, len(d.Update))
 	equals(t, 0, len(d.Remove))
 }

--- a/probe/process/walker.go
+++ b/probe/process/walker.go
@@ -62,7 +62,7 @@ var Walk = func(procRoot string, f func(*Process)) error {
 
 		comm := "(unknown)"
 		if commBuf, err := ReadFile(path.Join(procRoot, filename, "comm")); err == nil {
-			comm = string(commBuf)
+			comm = strings.TrimSpace(string(commBuf))
 		}
 
 		f(&Process{

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -32,27 +32,44 @@ var (
 		AggregateMetadata: render.AggregateMetadata{},
 	}
 
-	ClientProcessID       = render.MakeProcessID(test.ClientHostID, test.ClientPID)
+	ClientProcess1ID      = render.MakeProcessID(test.ClientHostID, test.Client1PID)
+	ClientProcess2ID      = render.MakeProcessID(test.ClientHostID, test.Client2PID)
 	ServerProcessID       = render.MakeProcessID(test.ServerHostID, test.ServerPID)
 	nonContainerProcessID = render.MakeProcessID(test.ServerHostID, test.NonContainerPID)
 
 	RenderedProcesses = render.RenderableNodes{
-		ClientProcessID: {
-			ID:         ClientProcessID,
+		ClientProcess1ID: {
+			ID:         ClientProcess1ID,
 			LabelMajor: "curl",
-			LabelMinor: fmt.Sprintf("%s (%s)", test.ClientHostID, test.ClientPID),
-			Rank:       test.ClientPID,
+			LabelMinor: fmt.Sprintf("%s (%s)", test.ClientHostID, test.Client1PID),
+			Rank:       test.Client1PID,
 			Pseudo:     false,
 			Adjacency:  report.MakeIDList(ServerProcessID),
 			Origins: report.MakeIDList(
 				test.Client54001NodeID,
-				test.Client54002NodeID,
-				test.ClientProcessNodeID,
+				test.ClientProcess1NodeID,
 				test.ClientHostNodeID,
 			),
 			AggregateMetadata: render.AggregateMetadata{
-				render.KeyBytesIngress: 300,
-				render.KeyBytesEgress:  30,
+				render.KeyBytesIngress: 100,
+				render.KeyBytesEgress:  10,
+			},
+		},
+		ClientProcess2ID: {
+			ID:         ClientProcess2ID,
+			LabelMajor: "curl",
+			LabelMinor: fmt.Sprintf("%s (%s)", test.ClientHostID, test.Client2PID),
+			Rank:       test.Client2PID,
+			Pseudo:     false,
+			Adjacency:  report.MakeIDList(ServerProcessID),
+			Origins: report.MakeIDList(
+				test.Client54002NodeID,
+				test.ClientProcess2NodeID,
+				test.ClientHostNodeID,
+			),
+			AggregateMetadata: render.AggregateMetadata{
+				render.KeyBytesIngress: 200,
+				render.KeyBytesEgress:  20,
 			},
 		},
 		ServerProcessID: {
@@ -62,7 +79,8 @@ var (
 			Rank:       test.ServerPID,
 			Pseudo:     false,
 			Adjacency: report.MakeIDList(
-				ClientProcessID,
+				ClientProcess1ID,
+				ClientProcess2ID,
 				unknownPseudoNode1ID,
 				unknownPseudoNode2ID,
 				render.TheInternetID,
@@ -106,7 +124,8 @@ var (
 			Origins: report.MakeIDList(
 				test.Client54001NodeID,
 				test.Client54002NodeID,
-				test.ClientProcessNodeID,
+				test.ClientProcess1NodeID,
+				test.ClientProcess2NodeID,
 				test.ClientHostNodeID,
 			),
 			AggregateMetadata: render.AggregateMetadata{
@@ -165,7 +184,8 @@ var (
 				test.ClientContainerNodeID,
 				test.Client54001NodeID,
 				test.Client54002NodeID,
-				test.ClientProcessNodeID,
+				test.ClientProcess1NodeID,
+				test.ClientProcess2NodeID,
 				test.ClientHostNodeID,
 			),
 			AggregateMetadata: render.AggregateMetadata{
@@ -219,7 +239,8 @@ var (
 				test.ClientContainerNodeID,
 				test.Client54001NodeID,
 				test.Client54002NodeID,
-				test.ClientProcessNodeID,
+				test.ClientProcess1NodeID,
+				test.ClientProcess2NodeID,
 				test.ClientHostNodeID,
 			),
 			AggregateMetadata: render.AggregateMetadata{

--- a/test/report_fixture.go
+++ b/test/report_fixture.go
@@ -21,7 +21,8 @@ var (
 	ClientHostName = ClientHostID
 	ServerHostName = ServerHostID
 
-	ClientPID       = "10001"
+	Client1PID      = "10001"
+	Client2PID      = "30020"
 	ServerPID       = "215"
 	NonContainerPID = "1234"
 
@@ -36,7 +37,8 @@ var (
 	UnknownClient3NodeID = report.MakeEndpointNodeID(ServerHostID, "10.10.10.11", "54020")    // Check this one isn't deduped
 	RandomClientNodeID   = report.MakeEndpointNodeID(ServerHostID, "51.52.53.54", "12345")    // this should become an internet node
 
-	ClientProcessNodeID       = report.MakeProcessNodeID(ClientHostID, ClientPID)
+	ClientProcess1NodeID      = report.MakeProcessNodeID(ClientHostID, Client1PID)
+	ClientProcess2NodeID      = report.MakeProcessNodeID(ClientHostID, Client2PID)
 	ServerProcessNodeID       = report.MakeProcessNodeID(ServerHostID, ServerPID)
 	NonContainerProcessNodeID = report.MakeProcessNodeID(ServerHostID, NonContainerPID)
 
@@ -72,13 +74,13 @@ var (
 				Client54001NodeID: report.NodeMetadata{
 					"addr":            ClientIP,
 					"port":            ClientPort54001,
-					"pid":             ClientPID,
+					"pid":             Client1PID,
 					report.HostNodeID: ClientHostNodeID,
 				},
 				Client54002NodeID: report.NodeMetadata{
 					"addr":            ClientIP,
 					"port":            ClientPort54002,
-					"pid":             ClientPID, // should be same as above!
+					"pid":             Client2PID,
 					report.HostNodeID: ClientHostNodeID,
 				},
 				Server80NodeID: report.NodeMetadata{
@@ -130,8 +132,14 @@ var (
 		Process: report.Topology{
 			Adjacency: report.Adjacency{},
 			NodeMetadatas: report.NodeMetadatas{
-				ClientProcessNodeID: report.NodeMetadata{
-					"pid":              ClientPID,
+				ClientProcess1NodeID: report.NodeMetadata{
+					"pid":              Client1PID,
+					"comm":             "curl",
+					docker.ContainerID: ClientContainerID,
+					report.HostNodeID:  ClientHostNodeID,
+				},
+				ClientProcess2NodeID: report.NodeMetadata{
+					"pid":              Client2PID,
 					"comm":             "curl",
 					docker.ContainerID: ClientContainerID,
 					report.HostNodeID:  ClientHostNodeID,


### PR DESCRIPTION
This causes detailed node lookups for the grouped-by-process-name view to fail.  Also, add a test for process walker trimmming whitespace, and a test the process-by-name view gives the right result.

Works around #281, but I believe there is an underlying UI bug where URLs aren't escaped properly.