### PR TITLE
In Docker, {app,probe} -> {scope-app,scope-probe}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,9 +34,11 @@ coverage.html
 scope.tar
 scope_ui_build.tar
 app/app
+app/scope-app
 probe/probe
-docker/app
-docker/probe
+probe/scope-probe
+docker/scope-app
+docker/scope-probe
 experimental/bridge/bridge
 experimental/demoprobe/demoprobe
 experimental/fixprobe/fixprobe

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@
 SUDO=sudo
 DOCKER_SQUASH=$(shell which docker-squash)
 DOCKERHUB_USER=weaveworks
-APP_EXE=app/app
-PROBE_EXE=probe/probe
+APP_EXE=app/scope-app
+PROBE_EXE=probe/scope-probe
 FIXPROBE_EXE=experimental/fixprobe/fixprobe
 SCOPE_IMAGE=$(DOCKERHUB_USER)/scope
 SCOPE_EXPORT=scope.tar

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /home/weave
 RUN echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >>/etc/apk/repositories && \
 	apk add --update runit conntrack-tools && \
 	rm -rf /var/cache/apk/*
-COPY ./app ./probe ./entrypoint.sh /home/weave/
+COPY ./scope-app ./scope-probe ./entrypoint.sh /home/weave/
 COPY ./run-app /etc/service/app/run
 COPY ./run-probe /etc/service/probe/run
 EXPOSE 4040

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -44,8 +44,8 @@ while true; do
 done
 
 mkdir -p /etc/weave
-echo "$APP_ARGS" >/etc/weave/app.args
-echo "$PROBE_ARGS" >/etc/weave/probe.args
+echo "$APP_ARGS" >/etc/weave/scope-app.args
+echo "$PROBE_ARGS" >/etc/weave/scope-probe.args
 
 if [ -n "$DNS_SERVER" -a -n "$SEARCHPATH" ]; then
     echo "domain $SEARCHPATH" >/etc/resolv.conf

--- a/docker/run-app
+++ b/docker/run-app
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec /home/weave/app $(cat /etc/weave/app.args) $(cat /etc/weave/probes)
+exec /home/weave/scope-app $(cat /etc/weave/scope-app.args) $(cat /etc/weave/probes)

--- a/docker/run-probe
+++ b/docker/run-probe
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec /home/weave/probe $(cat /etc/weave/probe.args)
+exec /home/weave/scope-probe $(cat /etc/weave/probe.args)


### PR DESCRIPTION
A "more correct" way of doing this would be renaming the app and probe directories to scope-app and scope-probe, but that makes importing the packages under probe very ugly. I think this strikes a reasonable balance: when doing the blessed build via `make`, we produce special scope-app and scope-probe binaries, and reference them in the various Docker scripts.

LMKWYT.