### PR TITLE
Don't fail if CACHE_DIR has a missing component

### DIFF
--- a/bin/rebuild-ui-build-image
+++ b/bin/rebuild-ui-build-image
@@ -5,7 +5,7 @@ set -eux
 CACHE_DIR=$HOME/docker/
 
 rebuild() {
-	rm $CACHE_DIR/*
+	rm $CACHE_DIR/* || true
 	make scope_ui_build.tar
 	mkdir -p $CACHE_DIR
 	mv scope_ui_build.tar $CACHE_DIR/image-$CIRCLE_SHA1

--- a/scope
+++ b/scope
@@ -152,7 +152,9 @@ case "$COMMAND" in
 
         # If Weave is running, we want to expose a Weave IP to the host
         # network namespace, so Scope can use it.
-        weave_expose
+        if is_running $WEAVE_CONTAINER_NAME; then
+            weave_expose
+        fi
 
         # If WeaveDNS is running, we want to automatically tell the scope
         # image to use weave dns.  We can't use --dns with --net=host, so we
@@ -168,11 +170,14 @@ case "$COMMAND" in
 
         IP_ADDRS=$(docker run --net=host gliderlabs/alpine /bin/sh -c "$IP_ADDR_CMD")
         if is_running $DNS_CONTAINER_NAME; then
-            if [ -z "$IP_ADDRS" ]; then
-                echo "Could not determine local IP address; Weave DNS integration will not work correctly."
-                exit 1
+            if is_running $WEAVE_CONTAINER_NAME; then
+                if [ -z "$IP_ADDRS" ]; then
+                    echo "Could not determine local IP address; Weave DNS integration will not work correctly."
+                    exit 1
+                fi
+
+                weave_dns_add $CONTAINER $FQDN $IP_ADDRS
             fi
-            weave_dns_add $CONTAINER $FQDN $IP_ADDRS
         fi
 
         echo $CONTAINER


### PR DESCRIPTION
A [build on Circle failed](https://circleci.com/gh/weaveworks/scope/624) as follows:

```
bin/rebuild-ui-build-image
+ CACHE_DIR=/home/ubuntu/docker/
++ cached_image_rev
++ find /home/ubuntu/docker/ -name 'image-*' -type f
++ sed 's/[^\-]*\-//'
find: `/home/ubuntu/docker/': No such file or directory
+ cached_revision=
+ '[' -z '' ']'
+ rebuild
+ rm '/home/ubuntu/docker//*'

bin/rebuild-ui-build-image returned exit code 1

rm: cannot remove `/home/ubuntu/docker//*': No such file or directory 

Action failed: bin/rebuild-ui-build-image
```

This changeset allows the build to proceed even if the CACHE_DIR isn't properly set up. Maybe there is a smarter way?