### PR TITLE
Don't panic tests on Darwin.

### DIFF
--- a/probe/docker/container.go
+++ b/probe/docker/container.go
@@ -122,7 +122,7 @@ func (c *container) StartGatheringStats() error {
 			return
 		}
 
-		dial, err := net.Dial(url.Scheme, url.Path)
+		dial, err := DialStub(url.Scheme, url.Path)
 		if err != nil {
 			log.Printf("docker container: %v", err)
 			return

--- a/probe/docker/container_test.go
+++ b/probe/docker/container_test.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"encoding/json"
 	"io"
+	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 	"runtime"
@@ -31,6 +33,8 @@ func (c *mockConnection) Close() error {
 }
 
 func TestContainer(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+
 	oldDialStub, oldNewClientConnStub := docker.DialStub, docker.NewClientConnStub
 	defer func() { docker.DialStub, docker.NewClientConnStub = oldDialStub, oldNewClientConnStub }()
 

--- a/probe/process/walker_test.go
+++ b/probe/process/walker_test.go
@@ -8,6 +8,17 @@ import (
 	"github.com/weaveworks/scope/test"
 )
 
+func TestBasicWalk(t *testing.T) {
+	// Don't panic or error.
+	var (
+		procRoot = "/proc"
+		procFunc = func(process.Process) {}
+	)
+	if err := process.NewWalker(procRoot).Walk(procFunc); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCache(t *testing.T) {
 	processes := []process.Process{
 		{PID: 1, PPID: 0, Comm: "init"},


### PR DESCRIPTION
The Docker container test only makes sense to run on Linux. Previously, it would panic on Darwin.

This PR is extracted from the sniff branch.