### PR TITLE
Fix some variable names

### DIFF
--- a/experimental/demoprobe/generate.go
+++ b/experimental/demoprobe/generate.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/weaveworks/scope/probe/docker"
+	"github.com/weaveworks/scope/probe/process"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -71,17 +72,17 @@ func DemoReport(nodeCount int) report.Report {
 		// Endpoint topology
 		if _, ok := r.Endpoint.NodeMetadatas[srcPortID]; !ok {
 			r.Endpoint.NodeMetadatas[srcPortID] = report.NewNodeMetadata(map[string]string{
-				docker.PID:    "4000",
-				docker.Name:   c.srcProc,
-				docker.Domain: "node-" + src,
+				process.PID: "4000",
+				"name":      c.srcProc,
+				"domain":    "node-" + src,
 			})
 		}
 		r.Endpoint.Adjacency[srcID] = r.Endpoint.Adjacency[srcID].Add(dstPortID)
 		if _, ok := r.Endpoint.NodeMetadatas[dstPortID]; !ok {
 			r.Endpoint.NodeMetadatas[dstPortID] = report.NewNodeMetadata(map[string]string{
-				docker.PID:    "4000",
-				docker.Name:   c.dstProc,
-				docker.Domain: "node-" + dst,
+				process.PID: "4000",
+				"name":      c.dstProc,
+				"domain":    "node-" + dst,
 			})
 		}
 		r.Endpoint.Adjacency[dstID] = r.Endpoint.Adjacency[dstID].Add(srcPortID)

--- a/probe/docker/tagger.go
+++ b/probe/docker/tagger.go
@@ -7,15 +7,11 @@ import (
 	"github.com/weaveworks/scope/report"
 )
 
-// These constants are keys used in node metadata
-// TODO: use these constants in report/{mapping.go, detailed_node.go} - pending some circular references
+// Node metadata keys.
 const (
-	Addr        = "addr"
 	ContainerID = "docker_container_id"
-	Domain      = "domain"
-	Name        = "name"
-	PID         = "pid"
-	Port        = "port"
+	Domain      = "domain" // TODO this is ambiguous, be more specific
+	Name        = "name"   // TODO this is ambiguous, be more specific
 )
 
 // These vars are exported for testing.
@@ -50,7 +46,7 @@ func (t *Tagger) Tag(r report.Report) (report.Report, error) {
 
 func (t *Tagger) tag(tree process.Tree, topology *report.Topology) {
 	for nodeID, nodeMetadata := range topology.NodeMetadatas {
-		pidStr, ok := nodeMetadata.Metadata["pid"]
+		pidStr, ok := nodeMetadata.Metadata[process.PID]
 		if !ok {
 			continue
 		}

--- a/render/detailed_node.go
+++ b/render/detailed_node.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/weaveworks/scope/probe/docker"
+	"github.com/weaveworks/scope/probe/endpoint"
 	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/probe/process"
 	"github.com/weaveworks/scope/report"
@@ -125,7 +126,7 @@ func OriginTable(r report.Report, originID string) (Table, bool) {
 
 func connectionDetailsRows(endpointTopology report.Topology, originID string, nmd report.NodeMetadata) []Row {
 	rows := []Row{}
-	local := fmt.Sprintf("%s:%s", nmd.Metadata[docker.Addr], nmd.Metadata[docker.Port])
+	local := fmt.Sprintf("%s:%s", nmd.Metadata[endpoint.Addr], nmd.Metadata[endpoint.Port])
 	adjacencies := endpointTopology.Adjacency[report.MakeAdjacencyID(originID)]
 	sort.Strings(adjacencies)
 	for _, adj := range adjacencies {
@@ -150,7 +151,7 @@ func connectionDetailsTable(connectionRows []Row) Table {
 
 func addressOriginTable(nmd report.NodeMetadata) (Table, bool) {
 	rows := []Row{}
-	if val, ok := nmd.Metadata["addr"]; ok {
+	if val, ok := nmd.Metadata[endpoint.Addr]; ok {
 		rows = append(rows, Row{"Address", val, ""})
 	}
 	return Table{

--- a/render/mapping.go
+++ b/render/mapping.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 
 	"github.com/weaveworks/scope/probe/docker"
+	"github.com/weaveworks/scope/probe/endpoint"
 	"github.com/weaveworks/scope/probe/host"
+	"github.com/weaveworks/scope/probe/process"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -49,9 +51,9 @@ type MapFunc func(RenderableNode) (RenderableNode, bool)
 // assume the presence of certain keys.
 func MapEndpointIdentity(m report.NodeMetadata) (RenderableNode, bool) {
 	var (
-		id      = MakeEndpointID(report.ExtractHostID(m), m.Metadata["addr"], m.Metadata["port"])
-		major   = fmt.Sprintf("%s:%s", m.Metadata["addr"], m.Metadata["port"])
-		pid, ok = m.Metadata["pid"]
+		id      = MakeEndpointID(report.ExtractHostID(m), m.Metadata[endpoint.Addr], m.Metadata[endpoint.Port])
+		major   = fmt.Sprintf("%s:%s", m.Metadata[endpoint.Addr], m.Metadata[endpoint.Port])
+		pid, ok = m.Metadata[process.PID]
 		minor   = report.ExtractHostID(m)
 		rank    = major
 	)
@@ -68,9 +70,9 @@ func MapEndpointIdentity(m report.NodeMetadata) (RenderableNode, bool) {
 // presence of certain keys.
 func MapProcessIdentity(m report.NodeMetadata) (RenderableNode, bool) {
 	var (
-		id    = MakeProcessID(report.ExtractHostID(m), m.Metadata["pid"])
+		id    = MakeProcessID(report.ExtractHostID(m), m.Metadata[process.PID])
 		major = m.Metadata["comm"]
-		minor = fmt.Sprintf("%s (%s)", report.ExtractHostID(m), m.Metadata["pid"])
+		minor = fmt.Sprintf("%s (%s)", report.ExtractHostID(m), m.Metadata[process.PID])
 		rank  = m.Metadata["comm"]
 	)
 
@@ -109,8 +111,8 @@ func MapContainerImageIdentity(m report.NodeMetadata) (RenderableNode, bool) {
 // assume the presence of certain keys.
 func MapAddressIdentity(m report.NodeMetadata) (RenderableNode, bool) {
 	var (
-		id    = MakeAddressID(report.ExtractHostID(m), m.Metadata["addr"])
-		major = m.Metadata["addr"]
+		id    = MakeAddressID(report.ExtractHostID(m), m.Metadata[endpoint.Addr])
+		major = m.Metadata[endpoint.Addr]
 		minor = report.ExtractHostID(m)
 		rank  = major
 	)
@@ -154,7 +156,7 @@ func MapEndpoint2Process(n RenderableNode) (RenderableNode, bool) {
 		return n, true
 	}
 
-	pid, ok := n.NodeMetadata.Metadata["pid"]
+	pid, ok := n.NodeMetadata.Metadata[process.PID]
 	if !ok {
 		return RenderableNode{}, false
 	}

--- a/test/report_fixture.go
+++ b/test/report_fixture.go
@@ -2,6 +2,8 @@ package test
 
 import (
 	"github.com/weaveworks/scope/probe/docker"
+	"github.com/weaveworks/scope/probe/endpoint"
+	"github.com/weaveworks/scope/probe/process"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -86,21 +88,21 @@ var (
 				// care to test into the fixture. Just be sure to include the bits
 				// that the mapping funcs extract :)
 				Client54001NodeID: report.NewNodeMetadata(map[string]string{
-					"addr":            ClientIP,
-					"port":            ClientPort54001,
-					"pid":             Client1PID,
+					endpoint.Addr:     ClientIP,
+					endpoint.Port:     ClientPort54001,
+					process.PID:       Client1PID,
 					report.HostNodeID: ClientHostNodeID,
 				}),
 				Client54002NodeID: report.NewNodeMetadata(map[string]string{
-					"addr":            ClientIP,
-					"port":            ClientPort54002,
-					"pid":             Client2PID,
+					endpoint.Addr:     ClientIP,
+					endpoint.Port:     ClientPort54002,
+					process.PID:       Client2PID,
 					report.HostNodeID: ClientHostNodeID,
 				}),
 				Server80NodeID: report.NewNodeMetadata(map[string]string{
-					"addr":            ServerIP,
-					"port":            ServerPort,
-					"pid":             ServerPID,
+					endpoint.Addr:     ServerIP,
+					endpoint.Port:     ServerPort,
+					process.PID:       ServerPID,
 					report.HostNodeID: ServerHostNodeID,
 				}),
 			},
@@ -147,25 +149,25 @@ var (
 			Adjacency: report.Adjacency{},
 			NodeMetadatas: report.NodeMetadatas{
 				ClientProcess1NodeID: report.NewNodeMetadata(map[string]string{
-					"pid":              Client1PID,
+					process.PID:        Client1PID,
 					"comm":             Client1Comm,
 					docker.ContainerID: ClientContainerID,
 					report.HostNodeID:  ClientHostNodeID,
 				}),
 				ClientProcess2NodeID: report.NewNodeMetadata(map[string]string{
-					"pid":              Client2PID,
+					process.PID:        Client2PID,
 					"comm":             Client2Comm,
 					docker.ContainerID: ClientContainerID,
 					report.HostNodeID:  ClientHostNodeID,
 				}),
 				ServerProcessNodeID: report.NewNodeMetadata(map[string]string{
-					"pid":              ServerPID,
+					process.PID:        ServerPID,
 					"comm":             ServerComm,
 					docker.ContainerID: ServerContainerID,
 					report.HostNodeID:  ServerHostNodeID,
 				}),
 				NonContainerProcessNodeID: report.NewNodeMetadata(map[string]string{
-					"pid":             NonContainerPID,
+					process.PID:       NonContainerPID,
 					"comm":            NonContainerComm,
 					report.HostNodeID: ServerHostNodeID,
 				}),
@@ -210,11 +212,11 @@ var (
 			},
 			NodeMetadatas: report.NodeMetadatas{
 				ClientAddressNodeID: report.NewNodeMetadata(map[string]string{
-					"addr":            ClientIP,
+					endpoint.Addr:     ClientIP,
 					report.HostNodeID: ClientHostNodeID,
 				}),
 				ServerAddressNodeID: report.NewNodeMetadata(map[string]string{
-					"addr":            ServerIP,
+					endpoint.Addr:     ServerIP,
 					report.HostNodeID: ServerHostNodeID,
 				}),
 			},


### PR DESCRIPTION
Also, don't use docker.Addr as a synonym for 'addr' string literal. 

This PR extracted from the sniff branch.