### PR TITLE
Fix new node metadata

### DIFF
--- a/experimental/demoprobe/generate.go
+++ b/experimental/demoprobe/generate.go
@@ -71,7 +71,7 @@ func DemoReport(nodeCount int) report.Report {
 
 		// Endpoint topology
 		if _, ok := r.Endpoint.NodeMetadatas[srcPortID]; !ok {
-			r.Endpoint.NodeMetadatas[srcPortID] = report.NewNodeMetadata(map[string]string{
+			r.Endpoint.NodeMetadatas[srcPortID] = report.MakeNodeMetadataWith(map[string]string{
 				process.PID: "4000",
 				"name":      c.srcProc,
 				"domain":    "node-" + src,
@@ -79,7 +79,7 @@ func DemoReport(nodeCount int) report.Report {
 		}
 		r.Endpoint.Adjacency[srcID] = r.Endpoint.Adjacency[srcID].Add(dstPortID)
 		if _, ok := r.Endpoint.NodeMetadatas[dstPortID]; !ok {
-			r.Endpoint.NodeMetadatas[dstPortID] = report.NewNodeMetadata(map[string]string{
+			r.Endpoint.NodeMetadatas[dstPortID] = report.MakeNodeMetadataWith(map[string]string{
 				process.PID: "4000",
 				"name":      c.dstProc,
 				"domain":    "node-" + dst,
@@ -101,20 +101,20 @@ func DemoReport(nodeCount int) report.Report {
 
 		// Address topology
 		if _, ok := r.Address.NodeMetadatas[srcAddressID]; !ok {
-			r.Address.NodeMetadatas[srcAddressID] = report.NewNodeMetadata(map[string]string{
+			r.Address.NodeMetadatas[srcAddressID] = report.MakeNodeMetadataWith(map[string]string{
 				docker.Name: src,
 			})
 		}
 		r.Address.Adjacency[nodeSrcAddressID] = r.Address.Adjacency[nodeSrcAddressID].Add(dstAddressID)
 		if _, ok := r.Address.NodeMetadatas[dstAddressID]; !ok {
-			r.Address.NodeMetadatas[dstAddressID] = report.NewNodeMetadata(map[string]string{
+			r.Address.NodeMetadatas[dstAddressID] = report.MakeNodeMetadataWith(map[string]string{
 				docker.Name: dst,
 			})
 		}
 		r.Address.Adjacency[nodeDstAddressID] = r.Address.Adjacency[nodeDstAddressID].Add(srcAddressID)
 
 		// Host data
-		r.Host.NodeMetadatas["hostX"] = report.NewNodeMetadata(map[string]string{
+		r.Host.NodeMetadatas["hostX"] = report.MakeNodeMetadataWith(map[string]string{
 			"ts":             time.Now().UTC().Format(time.RFC3339Nano),
 			"host_name":      "host-x",
 			"local_networks": localNet.String(),

--- a/experimental/genreport/generate.go
+++ b/experimental/genreport/generate.go
@@ -69,7 +69,7 @@ func DemoReport(nodeCount int) report.Report {
 
 		// Endpoint topology
 		if _, ok := r.Endpoint.NodeMetadatas[srcPortID]; !ok {
-			r.Endpoint.NodeMetadatas[srcPortID] = report.NewNodeMetadata(map[string]string{
+			r.Endpoint.NodeMetadatas[srcPortID] = report.MakeNodeMetadataWith(map[string]string{
 				"pid":    "4000",
 				"name":   c.srcProc,
 				"domain": "node-" + src,
@@ -77,7 +77,7 @@ func DemoReport(nodeCount int) report.Report {
 		}
 		r.Endpoint.Adjacency[srcID] = r.Endpoint.Adjacency[srcID].Add(dstPortID)
 		if _, ok := r.Endpoint.NodeMetadatas[dstPortID]; !ok {
-			r.Endpoint.NodeMetadatas[dstPortID] = report.NewNodeMetadata(map[string]string{
+			r.Endpoint.NodeMetadatas[dstPortID] = report.MakeNodeMetadataWith(map[string]string{
 				"pid":    "4000",
 				"name":   c.dstProc,
 				"domain": "node-" + dst,
@@ -99,20 +99,20 @@ func DemoReport(nodeCount int) report.Report {
 
 		// Address topology
 		if _, ok := r.Address.NodeMetadatas[srcAddressID]; !ok {
-			r.Address.NodeMetadatas[srcAddressID] = report.NewNodeMetadata(map[string]string{
+			r.Address.NodeMetadatas[srcAddressID] = report.MakeNodeMetadataWith(map[string]string{
 				"name": src,
 			})
 		}
 		r.Address.Adjacency[nodeSrcAddressID] = r.Address.Adjacency[nodeSrcAddressID].Add(dstAddressID)
 		if _, ok := r.Address.NodeMetadatas[dstAddressID]; !ok {
-			r.Address.NodeMetadatas[dstAddressID] = report.NewNodeMetadata(map[string]string{
+			r.Address.NodeMetadatas[dstAddressID] = report.MakeNodeMetadataWith(map[string]string{
 				"name": dst,
 			})
 		}
 		r.Address.Adjacency[nodeDstAddressID] = r.Address.Adjacency[nodeDstAddressID].Add(srcAddressID)
 
 		// Host data
-		r.Host.NodeMetadatas["hostX"] = report.NewNodeMetadata(map[string]string{
+		r.Host.NodeMetadatas["hostX"] = report.MakeNodeMetadataWith(map[string]string{
 			"ts":             time.Now().UTC().Format(time.RFC3339Nano),
 			"host_name":      "host-x",
 			"local_networks": localNet.String(),

--- a/probe/docker/container.go
+++ b/probe/docker/container.go
@@ -205,7 +205,7 @@ func (c *container) GetNodeMetadata() report.NodeMetadata {
 	c.RLock()
 	defer c.RUnlock()
 
-	result := report.NewNodeMetadata(map[string]string{
+	result := report.MakeNodeMetadataWith(map[string]string{
 		ContainerID:      c.ID(),
 		ContainerName:    strings.TrimPrefix(c.container.Name, "/"),
 		ContainerPorts:   c.ports(),
@@ -218,7 +218,7 @@ func (c *container) GetNodeMetadata() report.NodeMetadata {
 		return result
 	}
 
-	result.Merge(report.NewNodeMetadata(map[string]string{
+	result.Merge(report.MakeNodeMetadataWith(map[string]string{
 		NetworkRxDropped: strconv.FormatUint(c.latestStats.Network.RxDropped, 10),
 		NetworkRxBytes:   strconv.FormatUint(c.latestStats.Network.RxBytes, 10),
 		NetworkRxErrors:  strconv.FormatUint(c.latestStats.Network.RxErrors, 10),

--- a/probe/docker/registry_test.go
+++ b/probe/docker/registry_test.go
@@ -38,7 +38,7 @@ func (c *mockContainer) StartGatheringStats() error {
 func (c *mockContainer) StopGatheringStats() {}
 
 func (c *mockContainer) GetNodeMetadata() report.NodeMetadata {
-	return report.NewNodeMetadata(map[string]string{
+	return report.MakeNodeMetadataWith(map[string]string{
 		docker.ContainerID:   c.c.ID,
 		docker.ContainerName: c.c.Name,
 		docker.ImageID:       c.c.Image,

--- a/probe/docker/reporter.go
+++ b/probe/docker/reporter.go
@@ -49,7 +49,7 @@ func (r *Reporter) containerImageTopology() report.Topology {
 	result := report.NewTopology()
 
 	r.registry.WalkImages(func(image *docker_client.APIImages) {
-		nmd := report.NewNodeMetadata(map[string]string{
+		nmd := report.MakeNodeMetadataWith(map[string]string{
 			ImageID: image.ID,
 		})
 

--- a/probe/docker/reporter_test.go
+++ b/probe/docker/reporter_test.go
@@ -53,7 +53,7 @@ func TestReporter(t *testing.T) {
 		Adjacency:     report.Adjacency{},
 		EdgeMetadatas: report.EdgeMetadatas{},
 		NodeMetadatas: report.NodeMetadatas{
-			report.MakeContainerNodeID("", "ping"): report.NewNodeMetadata(map[string]string{
+			report.MakeContainerNodeID("", "ping"): report.MakeNodeMetadataWith(map[string]string{
 				docker.ContainerID:   "ping",
 				docker.ContainerName: "pong",
 				docker.ImageID:       "baz",
@@ -64,7 +64,7 @@ func TestReporter(t *testing.T) {
 		Adjacency:     report.Adjacency{},
 		EdgeMetadatas: report.EdgeMetadatas{},
 		NodeMetadatas: report.NodeMetadatas{
-			report.MakeContainerNodeID("", "baz"): report.NewNodeMetadata(map[string]string{
+			report.MakeContainerNodeID("", "baz"): report.MakeNodeMetadataWith(map[string]string{
 				docker.ImageID:   "baz",
 				docker.ImageName: "bang",
 			}),

--- a/probe/docker/tagger.go
+++ b/probe/docker/tagger.go
@@ -79,7 +79,7 @@ func (t *Tagger) tag(tree process.Tree, topology *report.Topology) {
 			continue
 		}
 
-		md := report.NewNodeMetadata(map[string]string{
+		md := report.MakeNodeMetadataWith(map[string]string{
 			ContainerID: c.ID(),
 		})
 

--- a/probe/docker/tagger_test.go
+++ b/probe/docker/tagger_test.go
@@ -34,16 +34,16 @@ func TestTagger(t *testing.T) {
 	var (
 		pid1NodeID       = report.MakeProcessNodeID("somehost.com", "1")
 		pid2NodeID       = report.MakeProcessNodeID("somehost.com", "2")
-		wantNodeMetadata = report.NewNodeMetadata(map[string]string{docker.ContainerID: "ping"})
+		wantNodeMetadata = report.MakeNodeMetadataWith(map[string]string{docker.ContainerID: "ping"})
 	)
 
 	input := report.MakeReport()
-	input.Process.NodeMetadatas[pid1NodeID] = report.NewNodeMetadata(map[string]string{"pid": "1"})
-	input.Process.NodeMetadatas[pid2NodeID] = report.NewNodeMetadata(map[string]string{"pid": "2"})
+	input.Process.NodeMetadatas[pid1NodeID] = report.MakeNodeMetadataWith(map[string]string{"pid": "1"})
+	input.Process.NodeMetadatas[pid2NodeID] = report.MakeNodeMetadataWith(map[string]string{"pid": "2"})
 
 	want := report.MakeReport()
-	want.Process.NodeMetadatas[pid1NodeID] = report.NewNodeMetadata(map[string]string{"pid": "1"}).Merge(wantNodeMetadata)
-	want.Process.NodeMetadatas[pid2NodeID] = report.NewNodeMetadata(map[string]string{"pid": "2"}).Merge(wantNodeMetadata)
+	want.Process.NodeMetadatas[pid1NodeID] = report.MakeNodeMetadataWith(map[string]string{"pid": "1"}).Merge(wantNodeMetadata)
+	want.Process.NodeMetadatas[pid2NodeID] = report.MakeNodeMetadataWith(map[string]string{"pid": "2"}).Merge(wantNodeMetadata)
 
 	tagger := docker.NewTagger(mockRegistryInstance, nil)
 	have, err := tagger.Tag(input)

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -86,7 +86,7 @@ func (r *Reporter) addConnection(rpt *report.Report, c *procspy.Connection) {
 	rpt.Address.Adjacency[adjacencyID] = rpt.Address.Adjacency[adjacencyID].Add(remoteAddressNodeID)
 
 	if _, ok := rpt.Address.NodeMetadatas[localAddressNodeID]; !ok {
-		rpt.Address.NodeMetadatas[localAddressNodeID] = report.NewNodeMetadata(map[string]string{
+		rpt.Address.NodeMetadatas[localAddressNodeID] = report.MakeNodeMetadataWith(map[string]string{
 			"name": r.hostName, // TODO this is ambiguous, be more specific
 			Addr:   c.LocalAddress.String(),
 		})
@@ -106,7 +106,7 @@ func (r *Reporter) addConnection(rpt *report.Report, c *procspy.Connection) {
 
 		if _, ok := rpt.Endpoint.NodeMetadatas[localEndpointNodeID]; !ok {
 			// First hit establishes NodeMetadata for scoped local address + port
-			md := report.NewNodeMetadata(map[string]string{
+			md := report.MakeNodeMetadataWith(map[string]string{
 				Addr:        c.LocalAddress.String(),
 				Port:        strconv.Itoa(int(c.LocalPort)),
 				process.PID: fmt.Sprint(c.Proc.PID),

--- a/probe/host/reporter.go
+++ b/probe/host/reporter.go
@@ -75,7 +75,7 @@ func (r *Reporter) Report() (report.Report, error) {
 		return rep, err
 	}
 
-	rep.Host.NodeMetadatas[report.MakeHostNodeID(r.hostID)] = report.NewNodeMetadata(map[string]string{
+	rep.Host.NodeMetadatas[report.MakeHostNodeID(r.hostID)] = report.MakeNodeMetadataWith(map[string]string{
 		Timestamp:     Now(),
 		HostName:      r.hostName,
 		LocalNetworks: strings.Join(localCIDRs, " "),

--- a/probe/host/reporter_test.go
+++ b/probe/host/reporter_test.go
@@ -46,7 +46,7 @@ func TestReporter(t *testing.T) {
 	host.InterfaceAddrs = func() ([]net.Addr, error) { _, ipnet, _ := net.ParseCIDR(network); return []net.Addr{ipnet}, nil }
 
 	want := report.MakeReport()
-	want.Host.NodeMetadatas[report.MakeHostNodeID(hostID)] = report.NewNodeMetadata(map[string]string{
+	want.Host.NodeMetadatas[report.MakeHostNodeID(hostID)] = report.MakeNodeMetadataWith(map[string]string{
 		host.Timestamp:     now,
 		host.HostName:      hostname,
 		host.LocalNetworks: network,

--- a/probe/host/tagger.go
+++ b/probe/host/tagger.go
@@ -17,7 +17,7 @@ func NewTagger(hostID string) Tagger {
 
 // Tag implements Tagger.
 func (t Tagger) Tag(r report.Report) (report.Report, error) {
-	md := report.NewNodeMetadata(map[string]string{report.HostNodeID: t.hostNodeID})
+	md := report.MakeNodeMetadataWith(map[string]string{report.HostNodeID: t.hostNodeID})
 	for _, topology := range r.Topologies() {
 		for nodeID := range topology.NodeMetadatas {
 			topology.NodeMetadatas[nodeID].Merge(md)

--- a/probe/host/tagger_test.go
+++ b/probe/host/tagger_test.go
@@ -13,12 +13,12 @@ func TestTagger(t *testing.T) {
 	var (
 		hostID         = "foo"
 		endpointNodeID = report.MakeEndpointNodeID(hostID, "1.2.3.4", "56789") // hostID ignored
-		nodeMetadata   = report.NewNodeMetadata(map[string]string{"foo": "bar"})
+		nodeMetadata   = report.MakeNodeMetadataWith(map[string]string{"foo": "bar"})
 	)
 
 	r := report.MakeReport()
 	r.Endpoint.NodeMetadatas[endpointNodeID] = nodeMetadata
-	want := nodeMetadata.Merge(report.NewNodeMetadata(map[string]string{
+	want := nodeMetadata.Merge(report.MakeNodeMetadataWith(map[string]string{
 		report.HostNodeID: report.MakeHostNodeID(hostID),
 	}))
 	rpt, _ := host.NewTagger(hostID).Tag(r)

--- a/probe/overlay/weave.go
+++ b/probe/overlay/weave.go
@@ -70,7 +70,7 @@ func (w Weave) Report() (report.Report, error) {
 	}
 
 	for _, peer := range status.Peers {
-		r.Overlay.NodeMetadatas[report.MakeOverlayNodeID(peer.Name)] = report.NewNodeMetadata(map[string]string{
+		r.Overlay.NodeMetadatas[report.MakeOverlayNodeID(peer.Name)] = report.MakeNodeMetadataWith(map[string]string{
 			WeavePeerName:     peer.Name,
 			WeavePeerNickName: peer.NickName,
 		})

--- a/probe/overlay/weave_test.go
+++ b/probe/overlay/weave_test.go
@@ -29,7 +29,7 @@ func TestWeaveTaggerOverlayTopology(t *testing.T) {
 		Adjacency:     report.Adjacency{},
 		EdgeMetadatas: report.EdgeMetadatas{},
 		NodeMetadatas: report.NodeMetadatas{
-			report.MakeOverlayNodeID(mockWeavePeerName): report.NewNodeMetadata(map[string]string{
+			report.MakeOverlayNodeID(mockWeavePeerName): report.MakeNodeMetadataWith(map[string]string{
 				overlay.WeavePeerName:     mockWeavePeerName,
 				overlay.WeavePeerNickName: mockWeavePeerNickName,
 			}),

--- a/probe/process/reporter.go
+++ b/probe/process/reporter.go
@@ -45,7 +45,7 @@ func (r *Reporter) processTopology() (report.Topology, error) {
 	err := r.walker.Walk(func(p Process) {
 		pidstr := strconv.Itoa(p.PID)
 		nodeID := report.MakeProcessNodeID(r.scope, pidstr)
-		t.NodeMetadatas[nodeID] = report.NewNodeMetadata(map[string]string{
+		t.NodeMetadatas[nodeID] = report.MakeNodeMetadataWith(map[string]string{
 			PID:     pidstr,
 			Comm:    p.Comm,
 			Cmdline: p.Cmdline,

--- a/probe/process/reporter_test.go
+++ b/probe/process/reporter_test.go
@@ -36,27 +36,27 @@ func TestReporter(t *testing.T) {
 		Adjacency:     report.Adjacency{},
 		EdgeMetadatas: report.EdgeMetadatas{},
 		NodeMetadatas: report.NodeMetadatas{
-			report.MakeProcessNodeID("", "1"): report.NewNodeMetadata(map[string]string{
+			report.MakeProcessNodeID("", "1"): report.MakeNodeMetadataWith(map[string]string{
 				process.PID:     "1",
 				process.Comm:    "init",
 				process.Cmdline: "",
 				process.Threads: "0",
 			}),
-			report.MakeProcessNodeID("", "2"): report.NewNodeMetadata(map[string]string{
+			report.MakeProcessNodeID("", "2"): report.MakeNodeMetadataWith(map[string]string{
 				process.PID:     "2",
 				process.Comm:    "bash",
 				process.PPID:    "1",
 				process.Cmdline: "",
 				process.Threads: "0",
 			}),
-			report.MakeProcessNodeID("", "3"): report.NewNodeMetadata(map[string]string{
+			report.MakeProcessNodeID("", "3"): report.MakeNodeMetadataWith(map[string]string{
 				process.PID:     "3",
 				process.Comm:    "apache",
 				process.PPID:    "1",
 				process.Cmdline: "",
 				process.Threads: "2",
 			}),
-			report.MakeProcessNodeID("", "4"): report.NewNodeMetadata(map[string]string{
+			report.MakeProcessNodeID("", "4"): report.MakeNodeMetadataWith(map[string]string{
 				process.PID:     "4",
 				process.Comm:    "ping",
 				process.PPID:    "2",

--- a/probe/tag_report.go
+++ b/probe/tag_report.go
@@ -50,7 +50,7 @@ func (topologyTagger) Tag(r report.Report) (report.Report, error) {
 		"host":            &(r.Host),
 		"overlay":         &(r.Overlay),
 	} {
-		md := report.NewNodeMetadata(map[string]string{Topology: val})
+		md := report.MakeNodeMetadataWith(map[string]string{Topology: val})
 		for nodeID := range topology.NodeMetadatas {
 			(*topology).NodeMetadatas[nodeID].Merge(md)
 		}

--- a/probe/tag_report_test.go
+++ b/probe/tag_report_test.go
@@ -11,8 +11,8 @@ func TestApply(t *testing.T) {
 	var (
 		endpointNodeID       = "c"
 		addressNodeID        = "d"
-		endpointNodeMetadata = report.NewNodeMetadata(map[string]string{"5": "6"})
-		addressNodeMetadata  = report.NewNodeMetadata(map[string]string{"7": "8"})
+		endpointNodeMetadata = report.MakeNodeMetadataWith(map[string]string{"5": "6"})
+		addressNodeMetadata  = report.MakeNodeMetadataWith(map[string]string{"7": "8"})
 	)
 
 	r := report.MakeReport()
@@ -25,8 +25,8 @@ func TestApply(t *testing.T) {
 		from report.Topology
 		via  string
 	}{
-		{endpointNodeMetadata.Copy().Merge(report.NewNodeMetadata(map[string]string{"topology": "endpoint"})), r.Endpoint, endpointNodeID},
-		{addressNodeMetadata.Copy().Merge(report.NewNodeMetadata(map[string]string{"topology": "address"})), r.Address, addressNodeID},
+		{endpointNodeMetadata.Copy().Merge(report.MakeNodeMetadataWith(map[string]string{"topology": "endpoint"})), r.Endpoint, endpointNodeID},
+		{addressNodeMetadata.Copy().Merge(report.MakeNodeMetadataWith(map[string]string{"topology": "address"})), r.Address, addressNodeID},
 	} {
 		if want, have := tuple.want, tuple.from.NodeMetadatas[tuple.via]; !reflect.DeepEqual(want, have) {
 			t.Errorf("want %+v, have %+v", want, have)
@@ -37,7 +37,7 @@ func TestApply(t *testing.T) {
 func TestTagMissingID(t *testing.T) {
 	const nodeID = "not-found"
 	r := report.MakeReport()
-	want := report.NewNodeMetadata(map[string]string{})
+	want := report.MakeNodeMetadata()
 	rpt, _ := newTopologyTagger().Tag(r)
 	have := rpt.Endpoint.NodeMetadatas[nodeID].Copy()
 	if !reflect.DeepEqual(want, have) {

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -17,18 +17,21 @@ var (
 		ID:                unknownPseudoNode1ID,
 		LabelMajor:        "10.10.10.10",
 		Pseudo:            true,
+		NodeMetadata:      report.MakeNodeMetadata(),
 		AggregateMetadata: render.AggregateMetadata{},
 	}
 	unknownPseudoNode2 = render.RenderableNode{
 		ID:                unknownPseudoNode2ID,
 		LabelMajor:        "10.10.10.11",
 		Pseudo:            true,
+		NodeMetadata:      report.MakeNodeMetadata(),
 		AggregateMetadata: render.AggregateMetadata{},
 	}
 	theInternetNode = render.RenderableNode{
 		ID:                render.TheInternetID,
 		LabelMajor:        render.TheInternetMajor,
 		Pseudo:            true,
+		NodeMetadata:      report.MakeNodeMetadata(),
 		AggregateMetadata: render.AggregateMetadata{},
 	}
 
@@ -50,6 +53,7 @@ var (
 				test.ClientProcess1NodeID,
 				test.ClientHostNodeID,
 			),
+			NodeMetadata: report.MakeNodeMetadata(),
 			AggregateMetadata: render.AggregateMetadata{
 				render.KeyBytesIngress: 100,
 				render.KeyBytesEgress:  10,
@@ -67,6 +71,7 @@ var (
 				test.ClientProcess2NodeID,
 				test.ClientHostNodeID,
 			),
+			NodeMetadata: report.MakeNodeMetadata(),
 			AggregateMetadata: render.AggregateMetadata{
 				render.KeyBytesIngress: 200,
 				render.KeyBytesEgress:  20,
@@ -90,6 +95,7 @@ var (
 				test.ServerProcessNodeID,
 				test.ServerHostNodeID,
 			),
+			NodeMetadata: report.MakeNodeMetadata(),
 			AggregateMetadata: render.AggregateMetadata{
 				render.KeyBytesIngress: 150,
 				render.KeyBytesEgress:  1500,
@@ -106,6 +112,7 @@ var (
 				test.NonContainerProcessNodeID,
 				test.ServerHostNodeID,
 			),
+			NodeMetadata:      report.MakeNodeMetadata(),
 			AggregateMetadata: render.AggregateMetadata{},
 		},
 		unknownPseudoNode1ID: unknownPseudoNode1,
@@ -128,6 +135,7 @@ var (
 				test.ClientProcess2NodeID,
 				test.ClientHostNodeID,
 			),
+			NodeMetadata: report.MakeNodeMetadata(),
 			AggregateMetadata: render.AggregateMetadata{
 				render.KeyBytesIngress: 300,
 				render.KeyBytesEgress:  30,
@@ -150,6 +158,7 @@ var (
 				test.ServerProcessNodeID,
 				test.ServerHostNodeID,
 			),
+			NodeMetadata: report.MakeNodeMetadata(),
 			AggregateMetadata: render.AggregateMetadata{
 				render.KeyBytesIngress: 150,
 				render.KeyBytesEgress:  1500,
@@ -165,6 +174,7 @@ var (
 				test.NonContainerProcessNodeID,
 				test.ServerHostNodeID,
 			),
+			NodeMetadata:      report.MakeNodeMetadata(),
 			AggregateMetadata: render.AggregateMetadata{},
 		},
 		unknownPseudoNode1ID: unknownPseudoNode1,
@@ -188,6 +198,7 @@ var (
 				test.ClientProcess2NodeID,
 				test.ClientHostNodeID,
 			),
+			NodeMetadata: report.MakeNodeMetadata(),
 			AggregateMetadata: render.AggregateMetadata{
 				render.KeyBytesIngress: 300,
 				render.KeyBytesEgress:  30,
@@ -206,6 +217,7 @@ var (
 				test.ServerProcessNodeID,
 				test.ServerHostNodeID,
 			),
+			NodeMetadata: report.MakeNodeMetadata(),
 			AggregateMetadata: render.AggregateMetadata{
 				render.KeyBytesIngress: 150,
 				render.KeyBytesEgress:  1500,
@@ -221,6 +233,7 @@ var (
 				test.NonContainerProcessNodeID,
 				test.ServerHostNodeID,
 			),
+			NodeMetadata:      report.MakeNodeMetadata(),
 			AggregateMetadata: render.AggregateMetadata{},
 		},
 		render.TheInternetID: theInternetNode,
@@ -243,6 +256,7 @@ var (
 				test.ClientProcess2NodeID,
 				test.ClientHostNodeID,
 			),
+			NodeMetadata: report.MakeNodeMetadata(),
 			AggregateMetadata: render.AggregateMetadata{
 				render.KeyBytesIngress: 300,
 				render.KeyBytesEgress:  30,
@@ -261,6 +275,7 @@ var (
 				test.Server80NodeID,
 				test.ServerProcessNodeID,
 				test.ServerHostNodeID),
+			NodeMetadata: report.MakeNodeMetadata(),
 			AggregateMetadata: render.AggregateMetadata{
 				render.KeyBytesIngress: 150,
 				render.KeyBytesEgress:  1500,
@@ -276,6 +291,7 @@ var (
 				test.NonContainerProcessNodeID,
 				test.ServerHostNodeID,
 			),
+			NodeMetadata:      report.MakeNodeMetadata(),
 			AggregateMetadata: render.AggregateMetadata{},
 		},
 		render.TheInternetID: theInternetNode,
@@ -298,6 +314,7 @@ var (
 				test.ServerHostNodeID,
 				test.ServerAddressNodeID,
 			),
+			NodeMetadata: report.MakeNodeMetadata(),
 			AggregateMetadata: render.AggregateMetadata{
 				render.KeyMaxConnCountTCP: 3,
 			},
@@ -313,6 +330,7 @@ var (
 				test.ClientHostNodeID,
 				test.ClientAddressNodeID,
 			),
+			NodeMetadata: report.MakeNodeMetadata(),
 			AggregateMetadata: render.AggregateMetadata{
 				render.KeyMaxConnCountTCP: 3,
 			},
@@ -321,12 +339,14 @@ var (
 			ID:                pseudoHostID1,
 			LabelMajor:        "10.10.10.10",
 			Pseudo:            true,
+			NodeMetadata:      report.MakeNodeMetadata(),
 			AggregateMetadata: render.AggregateMetadata{},
 		},
 		pseudoHostID2: {
 			ID:                pseudoHostID2,
 			LabelMajor:        "10.10.10.11",
 			Pseudo:            true,
+			NodeMetadata:      report.MakeNodeMetadata(),
 			AggregateMetadata: render.AggregateMetadata{},
 		},
 		render.TheInternetID: theInternetNode,

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -110,8 +110,8 @@ func TestMapEdge(t *testing.T) {
 	selector := func(_ report.Report) report.Topology {
 		return report.Topology{
 			NodeMetadatas: report.NodeMetadatas{
-				"foo": report.NewNodeMetadata(map[string]string{"id": "foo"}),
-				"bar": report.NewNodeMetadata(map[string]string{"id": "bar"}),
+				"foo": report.MakeNodeMetadataWith(map[string]string{"id": "foo"}),
+				"bar": report.MakeNodeMetadataWith(map[string]string{"id": "bar"}),
 			},
 			Adjacency: report.Adjacency{
 				">foo": report.MakeIDList("bar"),

--- a/render/renderable_node.go
+++ b/render/renderable_node.go
@@ -82,7 +82,7 @@ func newDerivedNode(id string, node RenderableNode) RenderableNode {
 		Pseudo:            node.Pseudo,
 		AggregateMetadata: node.AggregateMetadata,
 		Origins:           node.Origins,
-		NodeMetadata:      report.NewNodeMetadata(map[string]string{}),
+		NodeMetadata:      report.MakeNodeMetadata(),
 	}
 }
 
@@ -94,7 +94,7 @@ func newPseudoNode(id, major, minor string) RenderableNode {
 		Rank:              "",
 		Pseudo:            true,
 		AggregateMetadata: AggregateMetadata{},
-		NodeMetadata:      report.NewNodeMetadata(map[string]string{}),
+		NodeMetadata:      report.MakeNodeMetadata(),
 	}
 }
 
@@ -107,6 +107,6 @@ func newDerivedPseudoNode(id, major string, node RenderableNode) RenderableNode 
 		Pseudo:            true,
 		AggregateMetadata: node.AggregateMetadata,
 		Origins:           node.Origins,
-		NodeMetadata:      report.NewNodeMetadata(map[string]string{}),
+		NodeMetadata:      report.MakeNodeMetadata(),
 	}
 }

--- a/render/theinternet_test.go
+++ b/render/theinternet_test.go
@@ -14,8 +14,8 @@ import (
 func TestReportLocalNetworks(t *testing.T) {
 	r := report.MakeReport()
 	r.Merge(report.Report{Host: report.Topology{NodeMetadatas: report.NodeMetadatas{
-		"nonets": report.NewNodeMetadata(map[string]string{}),
-		"foo":    report.NewNodeMetadata(map[string]string{host.LocalNetworks: "10.0.0.1/8 192.168.1.1/24 10.0.0.1/8 badnet/33"}),
+		"nonets": report.MakeNodeMetadata(),
+		"foo":    report.MakeNodeMetadataWith(map[string]string{host.LocalNetworks: "10.0.0.1/8 192.168.1.1/24 10.0.0.1/8 badnet/33"}),
 	}}})
 	want := report.Networks([]*net.IPNet{
 		mustParseCIDR("10.0.0.1/8"),

--- a/render/topologies_test.go
+++ b/render/topologies_test.go
@@ -13,7 +13,7 @@ import (
 func trimNodeMetadata(rns render.RenderableNodes) render.RenderableNodes {
 	result := render.RenderableNodes{}
 	for id, rn := range rns {
-		rn.NodeMetadata = report.NodeMetadata{}
+		rn.NodeMetadata = report.MakeNodeMetadata()
 		result[id] = rn
 	}
 	return result

--- a/report/merge_test.go
+++ b/report/merge_test.go
@@ -228,14 +228,14 @@ func TestMergeNodeMetadatas(t *testing.T) {
 		"Empty a": {
 			a: report.NodeMetadatas{},
 			b: report.NodeMetadatas{
-				":192.168.1.1:12345": report.NewNodeMetadata(map[string]string{
+				":192.168.1.1:12345": report.MakeNodeMetadataWith(map[string]string{
 					PID:    "23128",
 					Name:   "curl",
 					Domain: "node-a.local",
 				}),
 			},
 			want: report.NodeMetadatas{
-				":192.168.1.1:12345": report.NewNodeMetadata(map[string]string{
+				":192.168.1.1:12345": report.MakeNodeMetadataWith(map[string]string{
 					PID:    "23128",
 					Name:   "curl",
 					Domain: "node-a.local",
@@ -244,7 +244,7 @@ func TestMergeNodeMetadatas(t *testing.T) {
 		},
 		"Empty b": {
 			a: report.NodeMetadatas{
-				":192.168.1.1:12345": report.NewNodeMetadata(map[string]string{
+				":192.168.1.1:12345": report.MakeNodeMetadataWith(map[string]string{
 					PID:    "23128",
 					Name:   "curl",
 					Domain: "node-a.local",
@@ -252,7 +252,7 @@ func TestMergeNodeMetadatas(t *testing.T) {
 			},
 			b: report.NodeMetadatas{},
 			want: report.NodeMetadatas{
-				":192.168.1.1:12345": report.NewNodeMetadata(map[string]string{
+				":192.168.1.1:12345": report.MakeNodeMetadataWith(map[string]string{
 					PID:    "23128",
 					Name:   "curl",
 					Domain: "node-a.local",
@@ -261,26 +261,26 @@ func TestMergeNodeMetadatas(t *testing.T) {
 		},
 		"Simple merge": {
 			a: report.NodeMetadatas{
-				":192.168.1.1:12345": report.NewNodeMetadata(map[string]string{
+				":192.168.1.1:12345": report.MakeNodeMetadataWith(map[string]string{
 					PID:    "23128",
 					Name:   "curl",
 					Domain: "node-a.local",
 				}),
 			},
 			b: report.NodeMetadatas{
-				":192.168.1.2:12345": report.NewNodeMetadata(map[string]string{
+				":192.168.1.2:12345": report.MakeNodeMetadataWith(map[string]string{
 					PID:    "42",
 					Name:   "curl",
 					Domain: "node-a.local",
 				}),
 			},
 			want: report.NodeMetadatas{
-				":192.168.1.1:12345": report.NewNodeMetadata(map[string]string{
+				":192.168.1.1:12345": report.MakeNodeMetadataWith(map[string]string{
 					PID:    "23128",
 					Name:   "curl",
 					Domain: "node-a.local",
 				}),
-				":192.168.1.2:12345": report.NewNodeMetadata(map[string]string{
+				":192.168.1.2:12345": report.MakeNodeMetadataWith(map[string]string{
 					PID:    "42",
 					Name:   "curl",
 					Domain: "node-a.local",
@@ -289,21 +289,21 @@ func TestMergeNodeMetadatas(t *testing.T) {
 		},
 		"Merge conflict": {
 			a: report.NodeMetadatas{
-				":192.168.1.1:12345": report.NewNodeMetadata(map[string]string{
+				":192.168.1.1:12345": report.MakeNodeMetadataWith(map[string]string{
 					PID:    "23128",
 					Name:   "curl",
 					Domain: "node-a.local",
 				}),
 			},
 			b: report.NodeMetadatas{
-				":192.168.1.1:12345": report.NewNodeMetadata(map[string]string{ // <-- same ID
+				":192.168.1.1:12345": report.MakeNodeMetadataWith(map[string]string{ // <-- same ID
 					PID:    "0",
 					Name:   "curl",
 					Domain: "node-a.local",
 				}),
 			},
 			want: report.NodeMetadatas{
-				":192.168.1.1:12345": report.NewNodeMetadata(map[string]string{
+				":192.168.1.1:12345": report.MakeNodeMetadataWith(map[string]string{
 					PID:    "23128",
 					Name:   "curl",
 					Domain: "node-a.local",

--- a/report/topology.go
+++ b/report/topology.go
@@ -46,8 +46,13 @@ type NodeMetadata struct {
 	Metadata map[string]string
 }
 
-// NewNodeMetadata creates a new NodeMetadata with the supplied Metadata.
-func NewNodeMetadata(m map[string]string) NodeMetadata {
+// MakeNodeMetadata creates a new NodeMetadata with no initial metadata.
+func MakeNodeMetadata() NodeMetadata {
+	return MakeNodeMetadataWith(map[string]string{})
+}
+
+// MakeNodeMetadataWith creates a new NodeMetadata with the supplied map.
+func MakeNodeMetadataWith(m map[string]string) NodeMetadata {
 	return NodeMetadata{
 		Metadata: m,
 	}
@@ -55,7 +60,7 @@ func NewNodeMetadata(m map[string]string) NodeMetadata {
 
 // Copy returns a value copy, useful for tests.
 func (nm NodeMetadata) Copy() NodeMetadata {
-	cp := NewNodeMetadata(map[string]string{})
+	cp := MakeNodeMetadata()
 	for k, v := range nm.Metadata {
 		cp.Metadata[k] = v
 	}

--- a/test/report_fixture.go
+++ b/test/report_fixture.go
@@ -87,19 +87,19 @@ var (
 				// NodeMetadata is arbitrary. We're free to put only precisely what we
 				// care to test into the fixture. Just be sure to include the bits
 				// that the mapping funcs extract :)
-				Client54001NodeID: report.NewNodeMetadata(map[string]string{
+				Client54001NodeID: report.MakeNodeMetadataWith(map[string]string{
 					endpoint.Addr:     ClientIP,
 					endpoint.Port:     ClientPort54001,
 					process.PID:       Client1PID,
 					report.HostNodeID: ClientHostNodeID,
 				}),
-				Client54002NodeID: report.NewNodeMetadata(map[string]string{
+				Client54002NodeID: report.MakeNodeMetadataWith(map[string]string{
 					endpoint.Addr:     ClientIP,
 					endpoint.Port:     ClientPort54002,
 					process.PID:       Client2PID,
 					report.HostNodeID: ClientHostNodeID,
 				}),
-				Server80NodeID: report.NewNodeMetadata(map[string]string{
+				Server80NodeID: report.MakeNodeMetadataWith(map[string]string{
 					endpoint.Addr:     ServerIP,
 					endpoint.Port:     ServerPort,
 					process.PID:       ServerPID,
@@ -148,25 +148,25 @@ var (
 		Process: report.Topology{
 			Adjacency: report.Adjacency{},
 			NodeMetadatas: report.NodeMetadatas{
-				ClientProcess1NodeID: report.NewNodeMetadata(map[string]string{
+				ClientProcess1NodeID: report.MakeNodeMetadataWith(map[string]string{
 					process.PID:        Client1PID,
 					"comm":             Client1Comm,
 					docker.ContainerID: ClientContainerID,
 					report.HostNodeID:  ClientHostNodeID,
 				}),
-				ClientProcess2NodeID: report.NewNodeMetadata(map[string]string{
+				ClientProcess2NodeID: report.MakeNodeMetadataWith(map[string]string{
 					process.PID:        Client2PID,
 					"comm":             Client2Comm,
 					docker.ContainerID: ClientContainerID,
 					report.HostNodeID:  ClientHostNodeID,
 				}),
-				ServerProcessNodeID: report.NewNodeMetadata(map[string]string{
+				ServerProcessNodeID: report.MakeNodeMetadataWith(map[string]string{
 					process.PID:        ServerPID,
 					"comm":             ServerComm,
 					docker.ContainerID: ServerContainerID,
 					report.HostNodeID:  ServerHostNodeID,
 				}),
-				NonContainerProcessNodeID: report.NewNodeMetadata(map[string]string{
+				NonContainerProcessNodeID: report.MakeNodeMetadataWith(map[string]string{
 					process.PID:       NonContainerPID,
 					"comm":            NonContainerComm,
 					report.HostNodeID: ServerHostNodeID,
@@ -176,13 +176,13 @@ var (
 		},
 		Container: report.Topology{
 			NodeMetadatas: report.NodeMetadatas{
-				ClientContainerNodeID: report.NewNodeMetadata(map[string]string{
+				ClientContainerNodeID: report.MakeNodeMetadataWith(map[string]string{
 					docker.ContainerID:   ClientContainerID,
 					docker.ContainerName: "client",
 					docker.ImageID:       ClientContainerImageID,
 					report.HostNodeID:    ClientHostNodeID,
 				}),
-				ServerContainerNodeID: report.NewNodeMetadata(map[string]string{
+				ServerContainerNodeID: report.MakeNodeMetadataWith(map[string]string{
 					docker.ContainerID:   ServerContainerID,
 					docker.ContainerName: "server",
 					docker.ImageID:       ServerContainerImageID,
@@ -192,12 +192,12 @@ var (
 		},
 		ContainerImage: report.Topology{
 			NodeMetadatas: report.NodeMetadatas{
-				ClientContainerImageNodeID: report.NewNodeMetadata(map[string]string{
+				ClientContainerImageNodeID: report.MakeNodeMetadataWith(map[string]string{
 					docker.ImageID:    ClientContainerImageID,
 					docker.ImageName:  ClientContainerImageName,
 					report.HostNodeID: ClientHostNodeID,
 				}),
-				ServerContainerImageNodeID: report.NewNodeMetadata(map[string]string{
+				ServerContainerImageNodeID: report.MakeNodeMetadataWith(map[string]string{
 					docker.ImageID:    ServerContainerImageID,
 					docker.ImageName:  ServerContainerImageName,
 					report.HostNodeID: ServerHostNodeID,
@@ -211,11 +211,11 @@ var (
 					ClientAddressNodeID, UnknownAddress1NodeID, UnknownAddress2NodeID, RandomAddressNodeID), // no backlinks to unknown/random
 			},
 			NodeMetadatas: report.NodeMetadatas{
-				ClientAddressNodeID: report.NewNodeMetadata(map[string]string{
+				ClientAddressNodeID: report.MakeNodeMetadataWith(map[string]string{
 					endpoint.Addr:     ClientIP,
 					report.HostNodeID: ClientHostNodeID,
 				}),
-				ServerAddressNodeID: report.NewNodeMetadata(map[string]string{
+				ServerAddressNodeID: report.MakeNodeMetadataWith(map[string]string{
 					endpoint.Addr:     ServerIP,
 					report.HostNodeID: ServerHostNodeID,
 				}),
@@ -234,14 +234,14 @@ var (
 		Host: report.Topology{
 			Adjacency: report.Adjacency{},
 			NodeMetadatas: report.NodeMetadatas{
-				ClientHostNodeID: report.NewNodeMetadata(map[string]string{
+				ClientHostNodeID: report.MakeNodeMetadataWith(map[string]string{
 					"host_name":       ClientHostName,
 					"local_networks":  "10.10.10.0/24",
 					"os":              "Linux",
 					"load":            "0.01 0.01 0.01",
 					report.HostNodeID: ClientHostNodeID,
 				}),
-				ServerHostNodeID: report.NewNodeMetadata(map[string]string{
+				ServerHostNodeID: report.MakeNodeMetadataWith(map[string]string{
 					"host_name":       ServerHostName,
 					"local_networks":  "10.10.10.0/24",
 					"os":              "Linux",

--- a/xfer/collector_internal_test.go
+++ b/xfer/collector_internal_test.go
@@ -47,7 +47,7 @@ func TestCollector(t *testing.T) {
 	r := report.Report{
 		Address: report.Topology{
 			NodeMetadatas: report.NodeMetadatas{
-				report.MakeAddressNodeID("a", "b"): report.NodeMetadata{},
+				report.MakeAddressNodeID("a", "b"): report.MakeNodeMetadata(),
 			},
 		},
 	}

--- a/xfer/merge_test.go
+++ b/xfer/merge_test.go
@@ -41,12 +41,12 @@ func TestMerge(t *testing.T) {
 
 	{
 		r := report.MakeReport()
-		r.Host.NodeMetadatas[k1] = report.NewNodeMetadata(map[string]string{"host_name": "test1"})
+		r.Host.NodeMetadatas[k1] = report.MakeNodeMetadataWith(map[string]string{"host_name": "test1"})
 		p1.Publish(r)
 	}
 	{
 		r := report.MakeReport()
-		r.Host.NodeMetadatas[k2] = report.NewNodeMetadata(map[string]string{"host_name": "test2"})
+		r.Host.NodeMetadatas[k2] = report.MakeNodeMetadataWith(map[string]string{"host_name": "test2"})
 		p2.Publish(r)
 	}
 


### PR DESCRIPTION
Fix a couple of dangling issues with the NewNodeMetadata constructor pattern from a ~week ago.

Extracted from an upcoming branch.