### PR TITLE
Fix a subtle bug in render mapping

### DIFF
--- a/render/mapping_test.go
+++ b/render/mapping_test.go
@@ -1,0 +1,78 @@
+package render_test
+
+import (
+	"testing"
+
+	"github.com/weaveworks/scope/probe/docker"
+	"github.com/weaveworks/scope/probe/endpoint"
+	"github.com/weaveworks/scope/probe/process"
+	"github.com/weaveworks/scope/render"
+	"github.com/weaveworks/scope/report"
+)
+
+func TestMapEndpointIdentity(t *testing.T) {
+	for _, input := range []testcase{
+		{report.MakeNodeMetadata(), false},
+		{report.MakeNodeMetadataWith(map[string]string{endpoint.Addr: "1.2.3.4"}), false},
+		{report.MakeNodeMetadataWith(map[string]string{endpoint.Port: "1234"}), false},
+		{report.MakeNodeMetadataWith(map[string]string{endpoint.Addr: "1.2.3.4", endpoint.Port: "1234"}), true},
+		{report.MakeNodeMetadataWith(map[string]string{report.HostNodeID: report.MakeHostNodeID("foo"), endpoint.Addr: "10.0.0.1", endpoint.Port: "20001"}), true},
+	} {
+		testMap(t, render.MapEndpointIdentity, input)
+	}
+}
+
+func TestMapProcessIdentity(t *testing.T) {
+	for _, input := range []testcase{
+		{report.MakeNodeMetadata(), false},
+		{report.MakeNodeMetadataWith(map[string]string{process.PID: "201"}), true},
+	} {
+		testMap(t, render.MapProcessIdentity, input)
+	}
+}
+
+func TestMapContainerIdentity(t *testing.T) {
+	for _, input := range []testcase{
+		{report.MakeNodeMetadata(), false},
+		{report.MakeNodeMetadataWith(map[string]string{docker.ContainerID: "a1b2c3"}), true},
+	} {
+		testMap(t, render.MapContainerIdentity, input)
+	}
+}
+
+func TestMapContainerImageIdentity(t *testing.T) {
+	for _, input := range []testcase{
+		{report.MakeNodeMetadata(), false},
+		{report.MakeNodeMetadataWith(map[string]string{docker.ImageID: "a1b2c3"}), true},
+	} {
+		testMap(t, render.MapContainerImageIdentity, input)
+	}
+}
+
+func TestMapAddressIdentity(t *testing.T) {
+	for _, input := range []testcase{
+		{report.MakeNodeMetadata(), false},
+		{report.MakeNodeMetadataWith(map[string]string{endpoint.Addr: "192.168.1.1"}), true},
+	} {
+		testMap(t, render.MapAddressIdentity, input)
+	}
+}
+
+func TestMapHostIdentity(t *testing.T) {
+	for _, input := range []testcase{
+		{report.MakeNodeMetadata(), true}, // TODO it's questionable if this is actually correct
+	} {
+		testMap(t, render.MapHostIdentity, input)
+	}
+}
+
+type testcase struct {
+	md report.NodeMetadata
+	ok bool
+}
+
+func testMap(t *testing.T, f render.LeafMapFunc, input testcase) {
+	if _, have := f(input.md); input.ok != have {
+		t.Errorf("%v: want %v, have %v", input.md, input.ok, have)
+	}
+}

--- a/report/topology.go
+++ b/report/topology.go
@@ -89,7 +89,6 @@ func (t Topology) Validate() error {
 		}
 		if _, ok := t.NodeMetadatas[srcNodeID]; !ok {
 			errs = append(errs, fmt.Sprintf("node metadata missing for source node ID %q (from edge %q)", srcNodeID, edgeID))
-			continue
 		}
 		dstNodeIDs, ok := t.Adjacency[MakeAdjacencyID(srcNodeID)]
 		if !ok {
@@ -98,7 +97,6 @@ func (t Topology) Validate() error {
 		}
 		if !dstNodeIDs.Contains(dstNodeID) {
 			errs = append(errs, fmt.Sprintf("adjacency destination missing for destination node ID %q (from edge %q)", dstNodeID, edgeID))
-			continue
 		}
 	}
 
@@ -111,20 +109,22 @@ func (t Topology) Validate() error {
 		}
 		if _, ok := t.NodeMetadatas[nodeID]; !ok {
 			errs = append(errs, fmt.Sprintf("node metadata missing for source node %q (from adjacency %q)", nodeID, adjacencyID))
-			continue
 		}
 	}
 
-	// Check all node metadata keys are parse-able (i.e. contain a scope)
+	// Check all node metadatas are valid, and the keys are parseable, i.e.
+	// contain a scope.
 	for nodeID := range t.NodeMetadatas {
+		if t.NodeMetadatas[nodeID].Metadata == nil {
+			errs = append(errs, fmt.Sprintf("node ID %q has nil metadata", nodeID))
+		}
 		if _, _, ok := ParseNodeID(nodeID); !ok {
 			errs = append(errs, fmt.Sprintf("invalid node ID %q", nodeID))
-			continue
 		}
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf(strings.Join(errs, "; "))
+		return fmt.Errorf("%d error(s): %s", len(errs), strings.Join(errs, "; "))
 	}
 
 	return nil


### PR DESCRIPTION
During rendering, RenderableNodes are created by Map funcs, which take only NodeMetadata. Previously, it was simply assumed that the relevant keys for a given Map func would be present in the metadata. If that implicit invariant failed, the returned RenderableNode would be invalid, with e.g. an ID of
"hostid::". That, in turn, would trigger undefined behavior later on in the rendering workflow.

This bug was detected by creating a partial node metadata for a non-local endpoint node. That node was detected during the first phase of rendering, and given an invalid renderable node ID of "myhostname::", which prevented it from attaching to TheInternet pseudonode. It eventually got removed from the  set
of valid nodes, which meant nodes that were adjacent to it suddenly became orphans, and got filtered out by the FilterUnconnected step of the rendering pipeline.

With this change, every map func checks for the presence of mandatory fields, i.e. the fields that compose the resulting renderable node's ID.