### PR TITLE
Makes scope works with boot2docker (Mac OSX)

### DIFF
--- a/scope
+++ b/scope
@@ -98,8 +98,11 @@ weave_dns_present() {
 }
 
 set_docker_bridge_ip() {
-    DOCKER_BRIDGE_IP=$(ip -4 addr show dev $DOCKER_BRIDGE | grep -m1 -o 'inet [.0-9]*')
-    DOCKER_BRIDGE_IP=${DOCKER_BRIDGE_IP#inet }
+    if [ -z ${DOCKER_BRIDGE_IP+x} ]
+    then
+        DOCKER_BRIDGE_IP=$(ip -4 addr show dev $DOCKER_BRIDGE | grep -m1 -o 'inet [.0-9]*')
+        DOCKER_BRIDGE_IP=${DOCKER_BRIDGE_IP#inet }
+    fi
 }
 
 # Call url $4 with http verb $3 on container $1 at port $2


### PR DESCRIPTION
In order for scope to work with boot2docker, the variable DOCKER_BRIDGE_IP can now be preset to the ip returned by the command 'boot2docker ip'.

DOCKER_BRIDGE_IP=$(boot2docker ip) scope launch <- now works with boot2docker)
scope launch <- usual behavior.