### PR TITLE
Make edge direction flow from client->server.

### DIFF
--- a/app/api_topology_test.go
+++ b/app/api_topology_test.go
@@ -132,7 +132,7 @@ func TestAPITopologyHosts(t *testing.T) {
 		// Let's not unit-test the specific content of the detail tables
 	}
 	{
-		body := getRawJSON(t, ts, fmt.Sprintf("/api/topology/hosts/%s/%s", expected.ServerHostRenderedID, expected.ClientHostRenderedID))
+		body := getRawJSON(t, ts, fmt.Sprintf("/api/topology/hosts/%s/%s", expected.ClientHostRenderedID, expected.ServerHostRenderedID))
 		var edge APIEdge
 		if err := json.Unmarshal(body, &edge); err != nil {
 			t.Fatalf("JSON parse error: %s", err)

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -80,18 +80,18 @@ func (r *Reporter) addConnection(rpt *report.Report, c *procspy.Connection) {
 		localIsClient       = int(c.LocalPort) > int(c.RemotePort)
 		localAddressNodeID  = report.MakeAddressNodeID(r.hostID, c.LocalAddress.String())
 		remoteAddressNodeID = report.MakeAddressNodeID(r.hostID, c.RemoteAddress.String())
-		adjecencyID         = ""
+		adjacencyID         = ""
 		edgeID              = ""
 	)
 
 	if localIsClient {
-		adjecencyID = report.MakeAdjacencyID(localAddressNodeID)
-		rpt.Address.Adjacency[adjecencyID] = rpt.Address.Adjacency[adjecencyID].Add(remoteAddressNodeID)
+		adjacencyID = report.MakeAdjacencyID(localAddressNodeID)
+		rpt.Address.Adjacency[adjacencyID] = rpt.Address.Adjacency[adjacencyID].Add(remoteAddressNodeID)
 
 		edgeID = report.MakeEdgeID(localAddressNodeID, remoteAddressNodeID)
 	} else {
-		adjecencyID = report.MakeAdjacencyID(remoteAddressNodeID)
-		rpt.Address.Adjacency[adjecencyID] = rpt.Address.Adjacency[adjecencyID].Add(localAddressNodeID)
+		adjacencyID = report.MakeAdjacencyID(remoteAddressNodeID)
+		rpt.Address.Adjacency[adjacencyID] = rpt.Address.Adjacency[adjacencyID].Add(localAddressNodeID)
 
 		edgeID = report.MakeEdgeID(remoteAddressNodeID, localAddressNodeID)
 	}
@@ -109,18 +109,18 @@ func (r *Reporter) addConnection(rpt *report.Report, c *procspy.Connection) {
 		var (
 			localEndpointNodeID  = report.MakeEndpointNodeID(r.hostID, c.LocalAddress.String(), strconv.Itoa(int(c.LocalPort)))
 			remoteEndpointNodeID = report.MakeEndpointNodeID(r.hostID, c.RemoteAddress.String(), strconv.Itoa(int(c.RemotePort)))
-			adjecencyID          = ""
+			adjacencyID          = ""
 			edgeID               = ""
 		)
 
 		if localIsClient {
-			adjecencyID = report.MakeAdjacencyID(localEndpointNodeID)
-			rpt.Endpoint.Adjacency[adjecencyID] = rpt.Endpoint.Adjacency[adjecencyID].Add(remoteEndpointNodeID)
+			adjacencyID = report.MakeAdjacencyID(localEndpointNodeID)
+			rpt.Endpoint.Adjacency[adjacencyID] = rpt.Endpoint.Adjacency[adjacencyID].Add(remoteEndpointNodeID)
 
 			edgeID = report.MakeEdgeID(localEndpointNodeID, remoteEndpointNodeID)
 		} else {
-			adjecencyID = report.MakeAdjacencyID(remoteEndpointNodeID)
-			rpt.Endpoint.Adjacency[adjecencyID] = rpt.Endpoint.Adjacency[adjecencyID].Add(localEndpointNodeID)
+			adjacencyID = report.MakeAdjacencyID(remoteEndpointNodeID)
+			rpt.Endpoint.Adjacency[adjacencyID] = rpt.Endpoint.Adjacency[adjacencyID].Add(localEndpointNodeID)
 
 			edgeID = report.MakeEdgeID(remoteEndpointNodeID, localEndpointNodeID)
 		}

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -77,13 +77,24 @@ func (r *Reporter) Report() (report.Report, error) {
 
 func (r *Reporter) addConnection(rpt *report.Report, c *procspy.Connection) {
 	var (
+		localIsClient       = int(c.LocalPort) > int(c.RemotePort)
 		localAddressNodeID  = report.MakeAddressNodeID(r.hostID, c.LocalAddress.String())
 		remoteAddressNodeID = report.MakeAddressNodeID(r.hostID, c.RemoteAddress.String())
-		adjecencyID         = report.MakeAdjacencyID(localAddressNodeID)
-		edgeID              = report.MakeEdgeID(localAddressNodeID, remoteAddressNodeID)
+		adjecencyID         = ""
+		edgeID              = ""
 	)
 
-	rpt.Address.Adjacency[adjecencyID] = rpt.Address.Adjacency[adjecencyID].Add(remoteAddressNodeID)
+	if localIsClient {
+		adjecencyID = report.MakeAdjacencyID(localAddressNodeID)
+		rpt.Address.Adjacency[adjecencyID] = rpt.Address.Adjacency[adjecencyID].Add(remoteAddressNodeID)
+
+		edgeID = report.MakeEdgeID(localAddressNodeID, remoteAddressNodeID)
+	} else {
+		adjecencyID = report.MakeAdjacencyID(remoteAddressNodeID)
+		rpt.Address.Adjacency[adjecencyID] = rpt.Address.Adjacency[adjecencyID].Add(localAddressNodeID)
+
+		edgeID = report.MakeEdgeID(remoteAddressNodeID, localAddressNodeID)
+	}
 
 	if _, ok := rpt.Address.NodeMetadatas[localAddressNodeID]; !ok {
 		rpt.Address.NodeMetadatas[localAddressNodeID] = report.MakeNodeMetadataWith(map[string]string{
@@ -98,11 +109,21 @@ func (r *Reporter) addConnection(rpt *report.Report, c *procspy.Connection) {
 		var (
 			localEndpointNodeID  = report.MakeEndpointNodeID(r.hostID, c.LocalAddress.String(), strconv.Itoa(int(c.LocalPort)))
 			remoteEndpointNodeID = report.MakeEndpointNodeID(r.hostID, c.RemoteAddress.String(), strconv.Itoa(int(c.RemotePort)))
-			adjecencyID          = report.MakeAdjacencyID(localEndpointNodeID)
-			edgeID               = report.MakeEdgeID(localEndpointNodeID, remoteEndpointNodeID)
+			adjecencyID          = ""
+			edgeID               = ""
 		)
 
-		rpt.Endpoint.Adjacency[adjecencyID] = rpt.Endpoint.Adjacency[adjecencyID].Add(remoteEndpointNodeID)
+		if localIsClient {
+			adjecencyID = report.MakeAdjacencyID(localEndpointNodeID)
+			rpt.Endpoint.Adjacency[adjecencyID] = rpt.Endpoint.Adjacency[adjecencyID].Add(remoteEndpointNodeID)
+
+			edgeID = report.MakeEdgeID(localEndpointNodeID, remoteEndpointNodeID)
+		} else {
+			adjecencyID = report.MakeAdjacencyID(remoteEndpointNodeID)
+			rpt.Endpoint.Adjacency[adjecencyID] = rpt.Endpoint.Adjacency[adjecencyID].Add(localEndpointNodeID)
+
+			edgeID = report.MakeEdgeID(remoteEndpointNodeID, localEndpointNodeID)
+		}
 
 		if _, ok := rpt.Endpoint.NodeMetadatas[localEndpointNodeID]; !ok {
 			// First hit establishes NodeMetadata for scoped local address + port

--- a/probe/endpoint/reporter_test.go
+++ b/probe/endpoint/reporter_test.go
@@ -85,14 +85,14 @@ func TestSpyNoProcesses(t *testing.T) {
 	var (
 		scopedLocal  = report.MakeAddressNodeID(nodeID, fixLocalAddress.String())
 		scopedRemote = report.MakeAddressNodeID(nodeID, fixRemoteAddress.String())
-		localKey     = report.MakeAdjacencyID(scopedLocal)
+		remoteKey    = report.MakeAdjacencyID(scopedRemote)
 	)
 
-	if want, have := 1, len(r.Address.Adjacency[localKey]); want != have {
+	if want, have := 1, len(r.Address.Adjacency[remoteKey]); want != have {
 		t.Fatalf("want %d, have %d", want, have)
 	}
 
-	if want, have := scopedRemote, r.Address.Adjacency[localKey][0]; want != have {
+	if want, have := scopedLocal, r.Address.Adjacency[remoteKey][0]; want != have {
 		t.Fatalf("want %q, have %q", want, have)
 	}
 
@@ -116,14 +116,14 @@ func TestSpyWithProcesses(t *testing.T) {
 	var (
 		scopedLocal  = report.MakeEndpointNodeID(nodeID, fixLocalAddress.String(), strconv.Itoa(int(fixLocalPort)))
 		scopedRemote = report.MakeEndpointNodeID(nodeID, fixRemoteAddress.String(), strconv.Itoa(int(fixRemotePort)))
-		localKey     = report.MakeAdjacencyID(scopedLocal)
+		remoteKey    = report.MakeAdjacencyID(scopedRemote)
 	)
 
-	if want, have := 1, len(r.Endpoint.Adjacency[localKey]); want != have {
+	if want, have := 1, len(r.Endpoint.Adjacency[remoteKey]); want != have {
 		t.Fatalf("want %d, have %d", want, have)
 	}
 
-	if want, have := scopedRemote, r.Endpoint.Adjacency[localKey][0]; want != have {
+	if want, have := scopedLocal, r.Endpoint.Adjacency[remoteKey][0]; want != have {
 		t.Fatalf("want %q, have %q", want, have)
 	}
 

--- a/render/detailed_node_test.go
+++ b/render/detailed_node_test.go
@@ -94,8 +94,8 @@ func TestMakeDetailedHostNode(t *testing.T) {
 				Rank:    0,
 				Rows: []render.Row{
 					{
-						Key:        "Local",
-						ValueMajor: "Remote",
+						Key:        "Client",
+						ValueMajor: "Server",
 						ValueMinor: "",
 					},
 					{

--- a/render/detailed_node_test.go
+++ b/render/detailed_node_test.go
@@ -1,7 +1,7 @@
 package render_test
 
 import (
-	//	"fmt"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -121,15 +121,15 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 		LabelMinor: test.ServerHostName,
 		Pseudo:     false,
 		Tables: []render.Table{
-			//			{
-			//				Title:   "Connections",
-			//				Numeric: true,
-			//				Rank:    100,
-			//				Rows: []render.Row{
-			//					{"Egress packet rate", "75", "packets/sec"},
-			//					{"Egress byte rate", "750", "Bps"},
-			//				},
-			//			},
+			{
+				Title:   "Connections",
+				Numeric: true,
+				Rank:    100,
+				Rows: []render.Row{
+					{"Egress packet rate", "105", "packets/sec"},
+					{"Egress byte rate", "1.0", "KBps"},
+				},
+			},
 			{
 				Title:   "Origin Container",
 				Numeric: false,
@@ -159,43 +159,43 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 					{"Operating system", "Linux", ""},
 				},
 			},
-			//			{
-			//				Title:   "Connection Details",
-			//				Numeric: false,
-			//				Rows: []render.Row{
-			//					{"Local", "Remote", ""},
-			//					{
-			//						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
-			//						fmt.Sprintf("%s:%s", test.UnknownClient1IP, test.ClientPort54010),
-			//						"",
-			//					},
-			//					{
-			//						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
-			//						fmt.Sprintf("%s:%s", test.UnknownClient1IP, test.ClientPort54020),
-			//						"",
-			//					},
-			//					{
-			//						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
-			//						fmt.Sprintf("%s:%s", test.UnknownClient3IP, test.ClientPort54020),
-			//						"",
-			//					},
-			//					{
-			//						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
-			//						fmt.Sprintf("%s:%s", test.ClientIP, test.ClientPort54001),
-			//						"",
-			//					},
-			//					{
-			//						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
-			//						fmt.Sprintf("%s:%s", test.ClientIP, test.ClientPort54002),
-			//						"",
-			//					},
-			//					{
-			//						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
-			//						fmt.Sprintf("%s:%s", test.RandomClientIP, test.ClientPort12345),
-			//						"",
-			//					},
-			//				},
-			//			},
+			{
+				Title:   "Connection Details",
+				Numeric: false,
+				Rows: []render.Row{
+					{"Client", "Server", ""},
+					{
+						fmt.Sprintf("%s:%s", test.UnknownClient1IP, test.ClientPort54010),
+						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
+						"",
+					},
+					{
+						fmt.Sprintf("%s:%s", test.UnknownClient1IP, test.ClientPort54020),
+						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
+						"",
+					},
+					{
+						fmt.Sprintf("%s:%s", test.UnknownClient3IP, test.ClientPort54020),
+						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
+						"",
+					},
+					{
+						fmt.Sprintf("%s:%s", test.ClientIP, test.ClientPort54001),
+						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
+						"",
+					},
+					{
+						fmt.Sprintf("%s:%s", test.ClientIP, test.ClientPort54002),
+						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
+						"",
+					},
+					{
+						fmt.Sprintf("%s:%s", test.RandomClientIP, test.ClientPort12345),
+						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
+						"",
+					},
+				},
+			},
 		},
 	}
 	if !reflect.DeepEqual(want, have) {

--- a/render/detailed_node_test.go
+++ b/render/detailed_node_test.go
@@ -1,7 +1,7 @@
 package render_test
 
 import (
-	"fmt"
+	//	"fmt"
 	"reflect"
 	"testing"
 
@@ -121,15 +121,15 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 		LabelMinor: test.ServerHostName,
 		Pseudo:     false,
 		Tables: []render.Table{
-			{
-				Title:   "Connections",
-				Numeric: true,
-				Rank:    100,
-				Rows: []render.Row{
-					{"Egress packet rate", "75", "packets/sec"},
-					{"Egress byte rate", "750", "Bps"},
-				},
-			},
+			//			{
+			//				Title:   "Connections",
+			//				Numeric: true,
+			//				Rank:    100,
+			//				Rows: []render.Row{
+			//					{"Egress packet rate", "75", "packets/sec"},
+			//					{"Egress byte rate", "750", "Bps"},
+			//				},
+			//			},
 			{
 				Title:   "Origin Container",
 				Numeric: false,
@@ -159,43 +159,43 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 					{"Operating system", "Linux", ""},
 				},
 			},
-			{
-				Title:   "Connection Details",
-				Numeric: false,
-				Rows: []render.Row{
-					{"Local", "Remote", ""},
-					{
-						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
-						fmt.Sprintf("%s:%s", test.UnknownClient1IP, test.ClientPort54010),
-						"",
-					},
-					{
-						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
-						fmt.Sprintf("%s:%s", test.UnknownClient1IP, test.ClientPort54020),
-						"",
-					},
-					{
-						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
-						fmt.Sprintf("%s:%s", test.UnknownClient3IP, test.ClientPort54020),
-						"",
-					},
-					{
-						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
-						fmt.Sprintf("%s:%s", test.ClientIP, test.ClientPort54001),
-						"",
-					},
-					{
-						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
-						fmt.Sprintf("%s:%s", test.ClientIP, test.ClientPort54002),
-						"",
-					},
-					{
-						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
-						fmt.Sprintf("%s:%s", test.RandomClientIP, test.ClientPort12345),
-						"",
-					},
-				},
-			},
+			//			{
+			//				Title:   "Connection Details",
+			//				Numeric: false,
+			//				Rows: []render.Row{
+			//					{"Local", "Remote", ""},
+			//					{
+			//						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
+			//						fmt.Sprintf("%s:%s", test.UnknownClient1IP, test.ClientPort54010),
+			//						"",
+			//					},
+			//					{
+			//						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
+			//						fmt.Sprintf("%s:%s", test.UnknownClient1IP, test.ClientPort54020),
+			//						"",
+			//					},
+			//					{
+			//						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
+			//						fmt.Sprintf("%s:%s", test.UnknownClient3IP, test.ClientPort54020),
+			//						"",
+			//					},
+			//					{
+			//						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
+			//						fmt.Sprintf("%s:%s", test.ClientIP, test.ClientPort54001),
+			//						"",
+			//					},
+			//					{
+			//						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
+			//						fmt.Sprintf("%s:%s", test.ClientIP, test.ClientPort54002),
+			//						"",
+			//					},
+			//					{
+			//						fmt.Sprintf("%s:%s", test.ServerIP, test.ServerPort),
+			//						fmt.Sprintf("%s:%s", test.RandomClientIP, test.ClientPort12345),
+			//						"",
+			//					},
+			//				},
+			//			},
 		},
 	}
 	if !reflect.DeepEqual(want, have) {

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -13,28 +13,45 @@ var (
 	uncontainedServerID  = render.MakePseudoNodeID(render.UncontainedID, test.ServerHostName)
 	unknownPseudoNode1ID = render.MakePseudoNodeID("10.10.10.10", test.ServerIP, "80")
 	unknownPseudoNode2ID = render.MakePseudoNodeID("10.10.10.11", test.ServerIP, "80")
-	unknownPseudoNode1   = render.RenderableNode{
-		ID:           unknownPseudoNode1ID,
-		LabelMajor:   "10.10.10.10",
-		Pseudo:       true,
-		NodeMetadata: report.MakeNodeMetadata(),
-		EdgeMetadata: report.EdgeMetadata{},
+	unknownPseudoNode1   = func(adjacency report.IDList) render.RenderableNode {
+		return render.RenderableNode{
+			ID:           unknownPseudoNode1ID,
+			LabelMajor:   "10.10.10.10",
+			Pseudo:       true,
+			NodeMetadata: report.MakeNodeMetadata(),
+			EdgeMetadata: report.EdgeMetadata{
+				EgressPacketCount: newu64(40),
+				EgressByteCount:   newu64(400),
+			},
+			Adjacency: adjacency,
+		}
 	}
-	unknownPseudoNode2 = render.RenderableNode{
-		ID:           unknownPseudoNode2ID,
-		LabelMajor:   "10.10.10.11",
-		Pseudo:       true,
-		NodeMetadata: report.MakeNodeMetadata(),
-		EdgeMetadata: report.EdgeMetadata{},
+	unknownPseudoNode2 = func(adjacency report.IDList) render.RenderableNode {
+		return render.RenderableNode{
+			ID:           unknownPseudoNode2ID,
+			LabelMajor:   "10.10.10.11",
+			Pseudo:       true,
+			NodeMetadata: report.MakeNodeMetadata(),
+			EdgeMetadata: report.EdgeMetadata{
+				EgressPacketCount: newu64(50),
+				EgressByteCount:   newu64(500),
+			},
+			Adjacency: adjacency,
+		}
 	}
-	theInternetNode = render.RenderableNode{
-		ID:           render.TheInternetID,
-		LabelMajor:   render.TheInternetMajor,
-		Pseudo:       true,
-		NodeMetadata: report.MakeNodeMetadata(),
-		EdgeMetadata: report.EdgeMetadata{},
+	theInternetNode = func(adjacency report.IDList) render.RenderableNode {
+		return render.RenderableNode{
+			ID:           render.TheInternetID,
+			LabelMajor:   render.TheInternetMajor,
+			Pseudo:       true,
+			NodeMetadata: report.MakeNodeMetadata(),
+			EdgeMetadata: report.EdgeMetadata{
+				EgressPacketCount: newu64(60),
+				EgressByteCount:   newu64(600),
+			},
+			Adjacency: adjacency,
+		}
 	}
-
 	ClientProcess1ID      = render.MakeProcessID(test.ClientHostID, test.Client1PID)
 	ClientProcess2ID      = render.MakeProcessID(test.ClientHostID, test.Client2PID)
 	ServerProcessID       = render.MakeProcessID(test.ServerHostID, test.ServerPID)
@@ -83,23 +100,14 @@ var (
 			LabelMinor: fmt.Sprintf("%s (%s)", test.ServerHostID, test.ServerPID),
 			Rank:       test.ServerComm,
 			Pseudo:     false,
-			Adjacency: report.MakeIDList(
-				ClientProcess1ID,
-				ClientProcess2ID,
-				unknownPseudoNode1ID,
-				unknownPseudoNode2ID,
-				render.TheInternetID,
-			),
+			Adjacency:  report.MakeIDList(),
 			Origins: report.MakeIDList(
 				test.Server80NodeID,
 				test.ServerProcessNodeID,
 				test.ServerHostNodeID,
 			),
 			NodeMetadata: report.MakeNodeMetadata(),
-			EdgeMetadata: report.EdgeMetadata{
-				EgressPacketCount: newu64(150),
-				EgressByteCount:   newu64(1500),
-			},
+			EdgeMetadata: report.EdgeMetadata{},
 		},
 		nonContainerProcessID: {
 			ID:         nonContainerProcessID,
@@ -115,9 +123,9 @@ var (
 			NodeMetadata: report.MakeNodeMetadata(),
 			EdgeMetadata: report.EdgeMetadata{},
 		},
-		unknownPseudoNode1ID: unknownPseudoNode1,
-		unknownPseudoNode2ID: unknownPseudoNode2,
-		render.TheInternetID: theInternetNode,
+		unknownPseudoNode1ID: unknownPseudoNode1(report.MakeIDList(ServerProcessID)),
+		unknownPseudoNode2ID: unknownPseudoNode2(report.MakeIDList(ServerProcessID)),
+		render.TheInternetID: theInternetNode(report.MakeIDList(ServerProcessID)),
 	}
 
 	RenderedProcessNames = render.RenderableNodes{
@@ -147,22 +155,14 @@ var (
 			LabelMinor: "",
 			Rank:       "apache",
 			Pseudo:     false,
-			Adjacency: report.MakeIDList(
-				"curl",
-				unknownPseudoNode1ID,
-				unknownPseudoNode2ID,
-				render.TheInternetID,
-			),
+			Adjacency:  report.MakeIDList(),
 			Origins: report.MakeIDList(
 				test.Server80NodeID,
 				test.ServerProcessNodeID,
 				test.ServerHostNodeID,
 			),
 			NodeMetadata: report.MakeNodeMetadata(),
-			EdgeMetadata: report.EdgeMetadata{
-				EgressPacketCount: newu64(150),
-				EgressByteCount:   newu64(1500),
-			},
+			EdgeMetadata: report.EdgeMetadata{},
 		},
 		"bash": {
 			ID:         "bash",
@@ -177,9 +177,9 @@ var (
 			NodeMetadata: report.MakeNodeMetadata(),
 			EdgeMetadata: report.EdgeMetadata{},
 		},
-		unknownPseudoNode1ID: unknownPseudoNode1,
-		unknownPseudoNode2ID: unknownPseudoNode2,
-		render.TheInternetID: theInternetNode,
+		unknownPseudoNode1ID: unknownPseudoNode1(report.MakeIDList("apache")),
+		unknownPseudoNode2ID: unknownPseudoNode2(report.MakeIDList("apache")),
+		render.TheInternetID: theInternetNode(report.MakeIDList("apache")),
 	}
 
 	RenderedContainers = render.RenderableNodes{
@@ -210,7 +210,7 @@ var (
 			LabelMinor: test.ServerHostName,
 			Rank:       test.ServerContainerImageID,
 			Pseudo:     false,
-			Adjacency:  report.MakeIDList(test.ClientContainerID, render.TheInternetID),
+			Adjacency:  report.MakeIDList(),
 			Origins: report.MakeIDList(
 				test.ServerContainerNodeID,
 				test.Server80NodeID,
@@ -218,10 +218,7 @@ var (
 				test.ServerHostNodeID,
 			),
 			NodeMetadata: report.MakeNodeMetadata(),
-			EdgeMetadata: report.EdgeMetadata{
-				EgressPacketCount: newu64(150),
-				EgressByteCount:   newu64(1500),
-			},
+			EdgeMetadata: report.EdgeMetadata{},
 		},
 		uncontainedServerID: {
 			ID:         uncontainedServerID,
@@ -236,7 +233,7 @@ var (
 			NodeMetadata: report.MakeNodeMetadata(),
 			EdgeMetadata: report.EdgeMetadata{},
 		},
-		render.TheInternetID: theInternetNode,
+		render.TheInternetID: theInternetNode(report.MakeIDList(test.ServerContainerID)),
 	}
 
 	RenderedContainerImages = render.RenderableNodes{
@@ -268,7 +265,7 @@ var (
 			LabelMinor: "",
 			Rank:       test.ServerContainerImageName,
 			Pseudo:     false,
-			Adjacency:  report.MakeIDList(test.ClientContainerImageName, render.TheInternetID),
+			Adjacency:  report.MakeIDList(),
 			Origins: report.MakeIDList(
 				test.ServerContainerImageNodeID,
 				test.ServerContainerNodeID,
@@ -276,10 +273,7 @@ var (
 				test.ServerProcessNodeID,
 				test.ServerHostNodeID),
 			NodeMetadata: report.MakeNodeMetadata(),
-			EdgeMetadata: report.EdgeMetadata{
-				EgressPacketCount: newu64(150),
-				EgressByteCount:   newu64(1500),
-			},
+			EdgeMetadata: report.EdgeMetadata{},
 		},
 		uncontainedServerID: {
 			ID:         uncontainedServerID,
@@ -294,7 +288,7 @@ var (
 			NodeMetadata: report.MakeNodeMetadata(),
 			EdgeMetadata: report.EdgeMetadata{},
 		},
-		render.TheInternetID: theInternetNode,
+		render.TheInternetID: theInternetNode(report.MakeIDList(test.ServerContainerImageName)),
 	}
 
 	ServerHostRenderedID = render.MakeHostID(test.ServerHostID)
@@ -309,15 +303,13 @@ var (
 			LabelMinor: "hostname.com", // after first .
 			Rank:       "hostname.com",
 			Pseudo:     false,
-			Adjacency:  report.MakeIDList(ClientHostRenderedID, render.TheInternetID, pseudoHostID1, pseudoHostID2),
+			Adjacency:  report.MakeIDList(),
 			Origins: report.MakeIDList(
 				test.ServerHostNodeID,
 				test.ServerAddressNodeID,
 			),
 			NodeMetadata: report.MakeNodeMetadata(),
-			EdgeMetadata: report.EdgeMetadata{
-				MaxConnCountTCP: newu64(3),
-			},
+			EdgeMetadata: report.EdgeMetadata{},
 		},
 		ClientHostRenderedID: {
 			ID:         ClientHostRenderedID,
@@ -339,6 +331,7 @@ var (
 			ID:           pseudoHostID1,
 			LabelMajor:   "10.10.10.10",
 			Pseudo:       true,
+			Adjacency:    report.MakeIDList(ServerHostRenderedID),
 			NodeMetadata: report.MakeNodeMetadata(),
 			EdgeMetadata: report.EdgeMetadata{},
 		},
@@ -346,10 +339,18 @@ var (
 			ID:           pseudoHostID2,
 			LabelMajor:   "10.10.10.11",
 			Pseudo:       true,
+			Adjacency:    report.MakeIDList(ServerHostRenderedID),
 			NodeMetadata: report.MakeNodeMetadata(),
 			EdgeMetadata: report.EdgeMetadata{},
 		},
-		render.TheInternetID: theInternetNode,
+		render.TheInternetID: {
+			ID:           render.TheInternetID,
+			LabelMajor:   render.TheInternetMajor,
+			Pseudo:       true,
+			Adjacency:    report.MakeIDList(ServerHostRenderedID),
+			NodeMetadata: report.MakeNodeMetadata(),
+			EdgeMetadata: report.EdgeMetadata{},
+		},
 	}
 )
 

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -20,8 +20,8 @@ var (
 			Pseudo:       true,
 			NodeMetadata: report.MakeNodeMetadata(),
 			EdgeMetadata: report.EdgeMetadata{
-				EgressPacketCount: newu64(40),
-				EgressByteCount:   newu64(400),
+				EgressPacketCount: newu64(70),
+				EgressByteCount:   newu64(700),
 			},
 			Adjacency: adjacency,
 		}
@@ -107,7 +107,10 @@ var (
 				test.ServerHostNodeID,
 			),
 			NodeMetadata: report.MakeNodeMetadata(),
-			EdgeMetadata: report.EdgeMetadata{},
+			EdgeMetadata: report.EdgeMetadata{
+				EgressPacketCount: newu64(210),
+				EgressByteCount:   newu64(2100),
+			},
 		},
 		nonContainerProcessID: {
 			ID:         nonContainerProcessID,
@@ -162,7 +165,10 @@ var (
 				test.ServerHostNodeID,
 			),
 			NodeMetadata: report.MakeNodeMetadata(),
-			EdgeMetadata: report.EdgeMetadata{},
+			EdgeMetadata: report.EdgeMetadata{
+				EgressPacketCount: newu64(210),
+				EgressByteCount:   newu64(2100),
+			},
 		},
 		"bash": {
 			ID:         "bash",
@@ -218,7 +224,10 @@ var (
 				test.ServerHostNodeID,
 			),
 			NodeMetadata: report.MakeNodeMetadata(),
-			EdgeMetadata: report.EdgeMetadata{},
+			EdgeMetadata: report.EdgeMetadata{
+				EgressPacketCount: newu64(210),
+				EgressByteCount:   newu64(2100),
+			},
 		},
 		uncontainedServerID: {
 			ID:         uncontainedServerID,
@@ -273,7 +282,10 @@ var (
 				test.ServerProcessNodeID,
 				test.ServerHostNodeID),
 			NodeMetadata: report.MakeNodeMetadata(),
-			EdgeMetadata: report.EdgeMetadata{},
+			EdgeMetadata: report.EdgeMetadata{
+				EgressPacketCount: newu64(210),
+				EgressByteCount:   newu64(2100),
+			},
 		},
 		uncontainedServerID: {
 			ID:         uncontainedServerID,
@@ -309,7 +321,9 @@ var (
 				test.ServerAddressNodeID,
 			),
 			NodeMetadata: report.MakeNodeMetadata(),
-			EdgeMetadata: report.EdgeMetadata{},
+			EdgeMetadata: report.EdgeMetadata{
+				MaxConnCountTCP: newu64(3),
+			},
 		},
 		ClientHostRenderedID: {
 			ID:         ClientHostRenderedID,

--- a/render/render.go
+++ b/render/render.go
@@ -177,6 +177,24 @@ func (m LeafMap) Render(rpt report.Report) RenderableNodes {
 		source2mapped[nodeID] = mapped.ID
 	}
 
+	mkPseudoNode := func(srcID, dstId string, srcIsClient bool) (string, bool) {
+		pseudoNode, ok := m.Pseudo(srcID, dstId, srcIsClient, localNetworks)
+		if !ok {
+			return "", false
+		}
+		// TODO(tomwilkie): we should propagate origin nodes for pseudo nodes.
+		// Not worth doing until they are selectable in the UI
+		// pseudoNode.Origins = pseudoNode.Origins.Add(srcID)
+		existing, ok := nodes[pseudoNode.ID]
+		if ok {
+			pseudoNode.Merge(existing)
+		}
+
+		nodes[pseudoNode.ID] = pseudoNode
+		source2mapped[pseudoNode.ID] = srcID
+		return pseudoNode.ID, true
+	}
+
 	// Walk the graph and make connections.
 	for src, dsts := range t.Adjacency {
 		srcNodeID, ok := report.ParseAdjacencyID(src)
@@ -185,11 +203,8 @@ func (m LeafMap) Render(rpt report.Report) RenderableNodes {
 			continue
 		}
 
-		var (
-			srcRenderableID, ok1 = source2mapped[srcNodeID]
-			srcRenderableNode    = nodes[srcRenderableID]
-		)
-		if !ok1 {
+		srcRenderableID, ok := source2mapped[srcNodeID]
+		if !ok {
 			// One of the entries in dsts must be a non-pseudo node
 			var existingDstNodeID string
 			for _, dstNodeID := range dsts {
@@ -199,33 +214,31 @@ func (m LeafMap) Render(rpt report.Report) RenderableNodes {
 				}
 			}
 
-			pseudoNode, ok := m.Pseudo(srcNodeID, existingDstNodeID, true, localNetworks)
+			srcRenderableID, ok = mkPseudoNode(srcNodeID, existingDstNodeID, true)
 			if !ok {
 				continue
 			}
-
-			srcRenderableID = pseudoNode.ID
-			srcRenderableNode = pseudoNode
-			nodes[srcRenderableID] = srcRenderableNode
-			source2mapped[srcNodeID] = srcRenderableID
 		}
+		srcRenderableNode := nodes[srcRenderableID]
 
 		for _, dstNodeID := range dsts {
 			dstRenderableID, ok := source2mapped[dstNodeID]
 			if !ok {
-				pseudoNode, ok := m.Pseudo(dstNodeID, srcNodeID, false, localNetworks)
+				dstRenderableID, ok = mkPseudoNode(dstNodeID, srcNodeID, false)
 				if !ok {
 					continue
 				}
-				dstRenderableID = pseudoNode.ID
-				nodes[dstRenderableID] = pseudoNode
-				source2mapped[dstNodeID] = dstRenderableID
 			}
+			dstRenderableNode := nodes[dstRenderableID]
 
 			srcRenderableNode.Adjacency = srcRenderableNode.Adjacency.Add(dstRenderableID)
-			edgeID := report.MakeEdgeID(srcNodeID, dstNodeID)
-			if md, ok := t.EdgeMetadatas[edgeID]; ok {
+
+			// We propagate edge metadata to nodes on both ends of the edges.
+			// TODO we should 'reverse' one end of the edge meta data - ingress -> egress etc.
+			if md, ok := t.EdgeMetadatas[report.MakeEdgeID(srcNodeID, dstNodeID)]; ok {
 				srcRenderableNode.EdgeMetadata.Merge(md)
+				dstRenderableNode.EdgeMetadata.Merge(md)
+				nodes[dstRenderableID] = dstRenderableNode
 			}
 		}
 

--- a/render/render.go
+++ b/render/render.go
@@ -177,8 +177,8 @@ func (m LeafMap) Render(rpt report.Report) RenderableNodes {
 		source2mapped[nodeID] = mapped.ID
 	}
 
-	mkPseudoNode := func(srcID, dstId string, srcIsClient bool) (string, bool) {
-		pseudoNode, ok := m.Pseudo(srcID, dstId, srcIsClient, localNetworks)
+	mkPseudoNode := func(srcNodeID, dstNodeID string, srcIsClient bool) (string, bool) {
+		pseudoNode, ok := m.Pseudo(srcNodeID, dstNodeID, srcIsClient, localNetworks)
 		if !ok {
 			return "", false
 		}
@@ -191,7 +191,7 @@ func (m LeafMap) Render(rpt report.Report) RenderableNodes {
 		}
 
 		nodes[pseudoNode.ID] = pseudoNode
-		source2mapped[pseudoNode.ID] = srcID
+		source2mapped[pseudoNode.ID] = srcNodeID
 		return pseudoNode.ID, true
 	}
 

--- a/test/report_fixture.go
+++ b/test/report_fixture.go
@@ -79,11 +79,12 @@ var (
 	Report = report.Report{
 		Endpoint: report.Topology{
 			Adjacency: report.Adjacency{
-				report.MakeAdjacencyID(Client54001NodeID): report.MakeIDList(Server80NodeID),
-				report.MakeAdjacencyID(Client54002NodeID): report.MakeIDList(Server80NodeID),
-				report.MakeAdjacencyID(Server80NodeID): report.MakeIDList(
-					Client54001NodeID, Client54002NodeID, UnknownClient1NodeID, UnknownClient2NodeID,
-					UnknownClient3NodeID, RandomClientNodeID),
+				report.MakeAdjacencyID(Client54001NodeID):    report.MakeIDList(Server80NodeID),
+				report.MakeAdjacencyID(Client54002NodeID):    report.MakeIDList(Server80NodeID),
+				report.MakeAdjacencyID(UnknownClient1NodeID): report.MakeIDList(Server80NodeID),
+				report.MakeAdjacencyID(UnknownClient2NodeID): report.MakeIDList(Server80NodeID),
+				report.MakeAdjacencyID(UnknownClient3NodeID): report.MakeIDList(Server80NodeID),
+				report.MakeAdjacencyID(RandomClientNodeID):   report.MakeIDList(Server80NodeID),
 			},
 			NodeMetadatas: report.NodeMetadatas{
 				// NodeMetadata is arbitrary. We're free to put only precisely what we
@@ -117,26 +118,21 @@ var (
 					EgressPacketCount: newu64(20),
 					EgressByteCount:   newu64(200),
 				},
-
-				report.MakeEdgeID(Server80NodeID, Client54001NodeID): report.EdgeMetadata{
-					EgressPacketCount: newu64(10),
-					EgressByteCount:   newu64(100),
-				},
-				report.MakeEdgeID(Server80NodeID, Client54002NodeID): report.EdgeMetadata{
-					EgressPacketCount: newu64(20),
-					EgressByteCount:   newu64(200),
-				},
-				report.MakeEdgeID(Server80NodeID, UnknownClient1NodeID): report.EdgeMetadata{
+				report.MakeEdgeID(UnknownClient1NodeID, Server80NodeID): report.EdgeMetadata{
 					EgressPacketCount: newu64(30),
 					EgressByteCount:   newu64(300),
 				},
-				report.MakeEdgeID(Server80NodeID, UnknownClient2NodeID): report.EdgeMetadata{
+				report.MakeEdgeID(UnknownClient2NodeID, Server80NodeID): report.EdgeMetadata{
 					EgressPacketCount: newu64(40),
 					EgressByteCount:   newu64(400),
 				},
-				report.MakeEdgeID(Server80NodeID, UnknownClient3NodeID): report.EdgeMetadata{
+				report.MakeEdgeID(UnknownClient3NodeID, Server80NodeID): report.EdgeMetadata{
 					EgressPacketCount: newu64(50),
 					EgressByteCount:   newu64(500),
+				},
+				report.MakeEdgeID(RandomClientNodeID, Server80NodeID): report.EdgeMetadata{
+					EgressPacketCount: newu64(60),
+					EgressByteCount:   newu64(600),
 				},
 			},
 		},
@@ -201,9 +197,10 @@ var (
 		},
 		Address: report.Topology{
 			Adjacency: report.Adjacency{
-				report.MakeAdjacencyID(ClientAddressNodeID): report.MakeIDList(ServerAddressNodeID),
-				report.MakeAdjacencyID(ServerAddressNodeID): report.MakeIDList(
-					ClientAddressNodeID, UnknownAddress1NodeID, UnknownAddress2NodeID, RandomAddressNodeID), // no backlinks to unknown/random
+				report.MakeAdjacencyID(ClientAddressNodeID):   report.MakeIDList(ServerAddressNodeID),
+				report.MakeAdjacencyID(UnknownAddress1NodeID): report.MakeIDList(ServerAddressNodeID),
+				report.MakeAdjacencyID(UnknownAddress2NodeID): report.MakeIDList(ServerAddressNodeID),
+				report.MakeAdjacencyID(RandomAddressNodeID):   report.MakeIDList(ServerAddressNodeID),
 			},
 			NodeMetadatas: report.NodeMetadatas{
 				ClientAddressNodeID: report.MakeNodeMetadataWith(map[string]string{
@@ -217,9 +214,6 @@ var (
 			},
 			EdgeMetadatas: report.EdgeMetadatas{
 				report.MakeEdgeID(ClientAddressNodeID, ServerAddressNodeID): report.EdgeMetadata{
-					MaxConnCountTCP: newu64(3),
-				},
-				report.MakeEdgeID(ServerAddressNodeID, ClientAddressNodeID): report.EdgeMetadata{
 					MaxConnCountTCP: newu64(3),
 				},
 			},


### PR DESCRIPTION
So it turns out the layout engine we use is already trying to layout the graph from top-to-bottom: https://github.com/cpettitt/dagre/wiki

This change uses a simple heuristic (client port is the higher port) to orient the edges in the graph such that they flow from client to server.

It somewhat improves the graph layout.  Before:

![screen shot 2015-08-13 at 15 51 00](https://cloud.githubusercontent.com/assets/444037/9252953/243f4ca4-41d3-11e5-8536-a5a471e618fd.png)

After:

![screen shot 2015-08-13 at 15 49 45](https://cloud.githubusercontent.com/assets/444037/9252956/291100e2-41d3-11e5-9fa8-7d0fbb9805c2.png)


