### PR TITLE
Use conntrack to detect short lived connections.

### DIFF
--- a/common/exec/exec.go
+++ b/common/exec/exec.go
@@ -1,0 +1,28 @@
+package exec
+
+import (
+	"io"
+	"os"
+	"os/exec"
+)
+
+// Cmd is a hook for mocking
+type Cmd interface {
+	StdoutPipe() (io.ReadCloser, error)
+	Start() error
+	Wait() error
+	Process() *os.Process
+}
+
+// Command is a hook for mocking
+var Command = func(name string, args ...string) Cmd {
+	return &realCmd{exec.Command(name, args...)}
+}
+
+type realCmd struct {
+	*exec.Cmd
+}
+
+func (c *realCmd) Process() *os.Process {
+	return c.Cmd.Process
+}

--- a/probe/endpoint/conntrack.go
+++ b/probe/endpoint/conntrack.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/weaveworks/scope/test/exec"
+	"github.com/weaveworks/scope/common/exec"
 )
 
 // Constants exported for testing

--- a/probe/endpoint/conntrack.go
+++ b/probe/endpoint/conntrack.go
@@ -1,0 +1,225 @@
+package endpoint
+
+import (
+	"bufio"
+	"encoding/xml"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/weaveworks/scope/test/exec"
+)
+
+// Constants exported for testing
+const (
+	modules          = "/proc/modules"
+	conntrackModule  = "nf_conntrack"
+	XMLHeader        = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+	ConntrackOpenTag = "<conntrack>\n"
+	TimeWait         = "TIME_WAIT"
+	TCP              = "tcp"
+	New              = "new"
+	Update           = "update"
+	Destroy          = "destroy"
+)
+
+// Layer3 - these structs are for the parsed conntrack output
+type Layer3 struct {
+	XMLName xml.Name `xml:"layer3"`
+	SrcIP   string   `xml:"src"`
+	DstIP   string   `xml:"dst"`
+}
+
+// Layer4 - these structs are for the parsed conntrack output
+type Layer4 struct {
+	XMLName xml.Name `xml:"layer4"`
+	SrcPort int      `xml:"sport"`
+	DstPort int      `xml:"dport"`
+	Proto   string   `xml:"protoname,attr"`
+}
+
+// Meta - these structs are for the parsed conntrack output
+type Meta struct {
+	XMLName   xml.Name `xml:"meta"`
+	Direction string   `xml:"direction,attr"`
+	Layer3    Layer3   `xml:"layer3"`
+	Layer4    Layer4   `xml:"layer4"`
+	ID        int64    `xml:"id"`
+	State     string   `xml:"state"`
+}
+
+// Flow - these structs are for the parsed conntrack output
+type Flow struct {
+	XMLName xml.Name `xml:"flow"`
+	Metas   []Meta   `xml:"meta"`
+	Type    string   `xml:"type,attr"`
+
+	Original, Reply, Independent *Meta `xml:"-"`
+}
+
+// Conntracker uses the conntrack command to track network connections
+type Conntracker struct {
+	sync.Mutex
+	cmd           exec.Cmd
+	activeFlows   map[int64]Flow // active flows in state != TIME_WAIT
+	bufferedFlows []Flow         // flows coming out of activeFlows spend 1 walk cycle here
+}
+
+// NewConntracker creates and starts a new Conntracter
+func NewConntracker(args ...string) (*Conntracker, error) {
+	if !ConntrackModulePresent() {
+		return nil, fmt.Errorf("No conntrack module")
+	}
+	result := &Conntracker{
+		activeFlows: map[int64]Flow{},
+	}
+	go result.run(args...)
+	return result, nil
+}
+
+// ConntrackModulePresent returns true if the kernel has the conntrack module
+// present.  It is made public for mocking.
+var ConntrackModulePresent = func() bool {
+	f, err := os.Open(modules)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, conntrackModule) {
+			return true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		log.Printf("conntrack error: %v", err)
+	}
+
+	log.Printf("conntrack: failed to find module %s", conntrackModule)
+	return false
+}
+
+// NB this is not re-entrant!
+func (c *Conntracker) run(args ...string) {
+	args = append([]string{"-E", "-o", "xml"}, args...)
+	cmd := exec.Command("conntrack", args...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		log.Printf("conntrack error: %v", err)
+		return
+	}
+	if err := cmd.Start(); err != nil {
+		log.Printf("conntrack error: %v", err)
+		return
+	}
+
+	c.Lock()
+	c.cmd = cmd
+	c.Unlock()
+	defer func() {
+		if err := cmd.Wait(); err != nil {
+			log.Printf("conntrack error: %v", err)
+		}
+	}()
+
+	// Swallow the first two lines
+	reader := bufio.NewReader(stdout)
+	if line, err := reader.ReadString('\n'); err != nil {
+		log.Printf("conntrack error: %v", err)
+		return
+	} else if line != XMLHeader {
+		log.Printf("conntrack invalid output: '%s'", line)
+		return
+	}
+	if line, err := reader.ReadString('\n'); err != nil {
+		log.Printf("conntrack error: %v", err)
+		return
+	} else if line != ConntrackOpenTag {
+		log.Printf("conntrack invalid output: '%s'", line)
+		return
+	}
+
+	// Now loop on the output stream
+	decoder := xml.NewDecoder(reader)
+	for {
+		var f Flow
+		if err := decoder.Decode(&f); err != nil {
+			log.Printf("conntrack error: %v", err)
+		}
+		c.handleFlow(f)
+	}
+}
+
+// Stop stop stop
+func (c *Conntracker) Stop() {
+	c.Lock()
+	defer c.Unlock()
+	if c.cmd == nil {
+		return
+	}
+
+	if p := c.cmd.Process(); p != nil {
+		p.Kill()
+	}
+}
+
+func (c *Conntracker) handleFlow(f Flow) {
+	// A flow consists of 3 'metas' - the 'original' 4 tuple (as seen by this
+	// host) and the 'reply' 4 tuple, which is what it has been rewritten to.
+	// This code finds those metas, which are identified by a Direction
+	// attribute.
+	for i := range f.Metas {
+		meta := &f.Metas[i]
+		switch meta.Direction {
+		case "original":
+			f.Original = meta
+		case "reply":
+			f.Reply = meta
+		case "independent":
+			f.Independent = meta
+		}
+	}
+
+	// For not, I'm only interested in tcp connections - there is too much udp
+	// traffic going on (every container talking to weave dns, for example) to
+	// render nicely. TODO: revisit this.
+	if f.Original.Layer4.Proto != TCP {
+		return
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	switch f.Type {
+	case New, Update:
+		if f.Independent.State != TimeWait {
+			c.activeFlows[f.Independent.ID] = f
+		} else if _, ok := c.activeFlows[f.Independent.ID]; ok {
+			delete(c.activeFlows, f.Independent.ID)
+			c.bufferedFlows = append(c.bufferedFlows, f)
+		}
+	case Destroy:
+		if _, ok := c.activeFlows[f.Independent.ID]; ok {
+			delete(c.activeFlows, f.Independent.ID)
+			c.bufferedFlows = append(c.bufferedFlows, f)
+		}
+	}
+}
+
+// WalkFlows calls f with all active flows and flows that have come and gone
+// since the last call to WalkFlows
+func (c *Conntracker) WalkFlows(f func(Flow)) {
+	c.Lock()
+	defer c.Unlock()
+	for _, flow := range c.activeFlows {
+		f(flow)
+	}
+	for _, flow := range c.bufferedFlows {
+		f(flow)
+	}
+	c.bufferedFlows = c.bufferedFlows[:0]
+}

--- a/probe/endpoint/conntrack_test.go
+++ b/probe/endpoint/conntrack_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/weaveworks/scope/common/exec"
 	. "github.com/weaveworks/scope/probe/endpoint"
 	"github.com/weaveworks/scope/test"
-	"github.com/weaveworks/scope/test/exec"
+	testExec "github.com/weaveworks/scope/test/exec"
 )
 
 func makeFlow(id int64, srcIP, dstIP string, srcPort, dstPort int, ty, state string) Flow {
@@ -72,7 +73,7 @@ func TestConntracker(t *testing.T) {
 
 	reader, writer := io.Pipe()
 	exec.Command = func(name string, args ...string) exec.Cmd {
-		return exec.NewMockCmd(reader)
+		return testExec.NewMockCmd(reader)
 	}
 
 	conntracker, err := NewConntracker()

--- a/probe/endpoint/conntrack_test.go
+++ b/probe/endpoint/conntrack_test.go
@@ -1,0 +1,142 @@
+package endpoint_test
+
+import (
+	"bufio"
+	"encoding/xml"
+	"io"
+	"testing"
+	"time"
+
+	. "github.com/weaveworks/scope/probe/endpoint"
+	"github.com/weaveworks/scope/test"
+	"github.com/weaveworks/scope/test/exec"
+)
+
+func makeFlow(id int64, srcIP, dstIP string, srcPort, dstPort int, ty, state string) Flow {
+	return Flow{
+		XMLName: xml.Name{
+			Local: "flow",
+		},
+		Type: ty,
+		Metas: []Meta{
+			{
+				XMLName: xml.Name{
+					Local: "meta",
+				},
+				Direction: "original",
+				Layer3: Layer3{
+					XMLName: xml.Name{
+						Local: "layer3",
+					},
+					SrcIP: srcIP,
+					DstIP: dstIP,
+				},
+				Layer4: Layer4{
+					XMLName: xml.Name{
+						Local: "layer4",
+					},
+					SrcPort: srcPort,
+					DstPort: dstPort,
+					Proto:   TCP,
+				},
+			},
+			{
+				XMLName: xml.Name{
+					Local: "meta",
+				},
+				Direction: "independent",
+				ID:        id,
+				State:     state,
+				Layer3: Layer3{
+					XMLName: xml.Name{
+						Local: "layer3",
+					},
+				},
+				Layer4: Layer4{
+					XMLName: xml.Name{
+						Local: "layer4",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestConntracker(t *testing.T) {
+	oldExecCmd, oldConntrackPresent := exec.Command, ConntrackModulePresent
+	defer func() { exec.Command, ConntrackModulePresent = oldExecCmd, oldConntrackPresent }()
+
+	ConntrackModulePresent = func() bool {
+		return true
+	}
+
+	reader, writer := io.Pipe()
+	exec.Command = func(name string, args ...string) exec.Cmd {
+		return exec.NewMockCmd(reader)
+	}
+
+	conntracker, err := NewConntracker()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bw := bufio.NewWriter(writer)
+	if _, err := bw.WriteString(XMLHeader); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := bw.WriteString(ConntrackOpenTag); err != nil {
+		t.Fatal(err)
+	}
+	if err := bw.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	have := func() interface{} {
+		result := []Flow{}
+		conntracker.WalkFlows(func(f Flow) {
+			f.Original = nil
+			f.Reply = nil
+			f.Independent = nil
+			result = append(result, f)
+		})
+		return result
+	}
+	ts := 100 * time.Millisecond
+
+	// First, assert we have no flows
+	test.Poll(t, ts, []Flow{}, have)
+
+	// Now add some flows
+	xmlEncoder := xml.NewEncoder(bw)
+	writeFlow := func(f Flow) {
+		if err := xmlEncoder.Encode(f); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := bw.WriteString("\n"); err != nil {
+			t.Fatal(err)
+		}
+		if err := bw.Flush(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	flow1 := makeFlow(1, "1.2.3.4", "2.3.4.5", 2, 3, New, "")
+	writeFlow(flow1)
+	test.Poll(t, ts, []Flow{flow1}, have)
+
+	// Now check when we remove the flow, we still get it in the next Walk
+	flow1.Type = Destroy
+	writeFlow(flow1)
+	test.Poll(t, ts, []Flow{flow1}, have)
+	test.Poll(t, ts, []Flow{}, have)
+
+	// This time we're not going to remove it, but put it in state TIME_WAIT
+	flow1.Type = New
+	writeFlow(flow1)
+	test.Poll(t, ts, []Flow{flow1}, have)
+
+	flow1.Metas[1].State = TimeWait
+	writeFlow(flow1)
+	test.Poll(t, ts, []Flow{flow1}, have)
+	test.Poll(t, ts, []Flow{}, have)
+}

--- a/probe/endpoint/nat.go
+++ b/probe/endpoint/nat.go
@@ -1,53 +1,10 @@
 package endpoint
 
 import (
-	"bufio"
-	"encoding/xml"
-	"io"
-	"log"
-	"os"
-	"os/exec"
 	"strconv"
-	"strings"
 
 	"github.com/weaveworks/scope/report"
 )
-
-const (
-	modules         = "/proc/modules"
-	conntrackModule = "nf_conntrack"
-)
-
-// these structs are for the parsed conntrack output
-type layer3 struct {
-	XMLName xml.Name `xml:"layer3"`
-	SrcIP   string   `xml:"src"`
-	DstIP   string   `xml:"dst"`
-}
-
-type layer4 struct {
-	XMLName xml.Name `xml:"layer4"`
-	SrcPort int      `xml:"sport"`
-	DstPort int      `xml:"dport"`
-	Proto   string   `xml:"protoname,attr"`
-}
-
-type meta struct {
-	XMLName   xml.Name `xml:"meta"`
-	Direction string   `xml:"direction,attr"`
-	Layer3    layer3   `xml:"layer3"`
-	Layer4    layer4   `xml:"layer4"`
-}
-
-type flow struct {
-	XMLName xml.Name `xml:"flow"`
-	Metas   []meta   `xml:"meta"`
-}
-
-type conntrack struct {
-	XMLName xml.Name `xml:"conntrack"`
-	Flows   []flow   `xml:"flow"`
-}
 
 // This is our 'abstraction' of the endpoint that have been rewritten by NAT.
 // Original is the private IP that has been rewritten.
@@ -59,111 +16,51 @@ type endpointMapping struct {
 	rewrittenPort int
 }
 
-// natTable returns a list of endpoints that have been remapped by NAT.
-func natTable() ([]endpointMapping, error) {
-	var conntrack conntrack
-	cmd := exec.Command("conntrack", "-L", "--any-nat", "-o", "xml")
-	stdout, err := cmd.StdoutPipe()
+type natmapper struct {
+	*Conntracker
+}
+
+func newNATMapper() (*natmapper, error) {
+	ct, err := NewConntracker("--any-nat")
 	if err != nil {
 		return nil, err
 	}
-	if err := cmd.Start(); err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err := cmd.Wait(); err != nil {
-			log.Printf("conntrack error: %v", err)
-		}
-	}()
-	if err := xml.NewDecoder(stdout).Decode(&conntrack); err != nil {
-		if err == io.EOF {
-			return []endpointMapping{}, nil
-		}
-		return nil, err
-	}
+	return &natmapper{ct}, nil
+}
 
-	output := []endpointMapping{}
-	for _, flow := range conntrack.Flows {
-		// A flow consists of 3 'metas' - the 'original' 4 tuple (as seen by this
-		// host) and the 'reply' 4 tuple, which is what it has been rewritten to.
-		// This code finds those metas, which are identified by a Direction
-		// attribute.
-		original, reply := meta{}, meta{}
-		for _, meta := range flow.Metas {
-			if meta.Direction == "original" {
-				original = meta
-			} else if meta.Direction == "reply" {
-				reply = meta
-			}
+func toMapping(f Flow) *endpointMapping {
+	var mapping endpointMapping
+	if f.Original.Layer3.SrcIP == f.Reply.Layer3.DstIP {
+		mapping = endpointMapping{
+			originalIP:    f.Reply.Layer3.SrcIP,
+			originalPort:  f.Reply.Layer4.SrcPort,
+			rewrittenIP:   f.Original.Layer3.DstIP,
+			rewrittenPort: f.Original.Layer4.DstPort,
 		}
-
-		if original.Layer4.Proto != "tcp" {
-			continue
+	} else {
+		mapping = endpointMapping{
+			originalIP:    f.Original.Layer3.SrcIP,
+			originalPort:  f.Original.Layer4.SrcPort,
+			rewrittenIP:   f.Reply.Layer3.DstIP,
+			rewrittenPort: f.Reply.Layer4.DstPort,
 		}
-
-		var conn endpointMapping
-		if original.Layer3.SrcIP == reply.Layer3.DstIP {
-			conn = endpointMapping{
-				originalIP:    reply.Layer3.SrcIP,
-				originalPort:  reply.Layer4.SrcPort,
-				rewrittenIP:   original.Layer3.DstIP,
-				rewrittenPort: original.Layer4.DstPort,
-			}
-		} else {
-			conn = endpointMapping{
-				originalIP:    original.Layer3.SrcIP,
-				originalPort:  original.Layer4.SrcPort,
-				rewrittenIP:   reply.Layer3.DstIP,
-				rewrittenPort: reply.Layer4.DstPort,
-			}
-		}
-
-		output = append(output, conn)
 	}
 
-	return output, nil
+	return &mapping
 }
 
 // applyNAT duplicates NodeMetadatas in the endpoint topology of a
 // report, based on the NAT table as returns by natTable.
-func applyNAT(rpt report.Report, scope string) error {
-	mappings, err := natTable()
-	if err != nil {
-		return err
-	}
-
-	for _, mapping := range mappings {
+func (n *natmapper) applyNAT(rpt report.Report, scope string) {
+	n.WalkFlows(func(f Flow) {
+		mapping := toMapping(f)
 		realEndpointID := report.MakeEndpointNodeID(scope, mapping.originalIP, strconv.Itoa(mapping.originalPort))
 		copyEndpointID := report.MakeEndpointNodeID(scope, mapping.rewrittenIP, strconv.Itoa(mapping.rewrittenPort))
 		nmd, ok := rpt.Endpoint.NodeMetadatas[realEndpointID]
 		if !ok {
-			continue
+			return
 		}
 
 		rpt.Endpoint.NodeMetadatas[copyEndpointID] = nmd.Copy()
-	}
-
-	return nil
-}
-
-func conntrackModulePresent() bool {
-	f, err := os.Open(modules)
-	if err != nil {
-		return false
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, conntrackModule) {
-			return true
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		log.Printf("conntrack error: %v", err)
-	}
-
-	log.Printf("conntrack: failed to find module %s", conntrackModule)
-	return false
+	})
 }

--- a/probe/endpoint/reporter_test.go
+++ b/probe/endpoint/reporter_test.go
@@ -19,7 +19,6 @@ var (
 	fixRemotePortB   = uint16(12346)
 	fixProcessPID    = uint(4242)
 	fixProcessName   = "nginx"
-	fixProcessPIDB   = uint(4243)
 
 	fixConnections = []procspy.Connection{
 		{
@@ -55,9 +54,9 @@ var (
 			LocalAddress:  fixLocalAddress,
 			LocalPort:     fixLocalPort,
 			RemoteAddress: fixRemoteAddress,
-			RemotePort:    fixRemotePort,
+			RemotePort:    fixRemotePortB,
 			Proc: procspy.Proc{
-				PID:  fixProcessPIDB,
+				PID:  fixProcessPID,
 				Name: fixProcessName,
 			},
 		},
@@ -72,7 +71,7 @@ func TestSpyNoProcesses(t *testing.T) {
 		nodeName = "frenchs-since-1904"   // TODO rename to hostNmae
 	)
 
-	reporter := endpoint.NewReporter(nodeID, nodeName, false)
+	reporter := endpoint.NewReporter(nodeID, nodeName, false, false)
 	r, _ := reporter.Report()
 	//buf, _ := json.MarshalIndent(r, "", "    ")
 	//t.Logf("\n%s\n", buf)
@@ -109,7 +108,7 @@ func TestSpyWithProcesses(t *testing.T) {
 		nodeName = "fishermans-friend" // TODO rename to hostNmae
 	)
 
-	reporter := endpoint.NewReporter(nodeID, nodeName, false)
+	reporter := endpoint.NewReporter(nodeID, nodeName, true, false)
 	r, _ := reporter.Report()
 	// buf, _ := json.MarshalIndent(r, "", "    ") ; t.Logf("\n%s\n", buf)
 

--- a/probe/overlay/weave.go
+++ b/probe/overlay/weave.go
@@ -11,9 +11,9 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/weaveworks/scope/common/exec"
 	"github.com/weaveworks/scope/probe/docker"
 	"github.com/weaveworks/scope/report"
-	"github.com/weaveworks/scope/test/exec"
 )
 
 const (

--- a/probe/overlay/weave.go
+++ b/probe/overlay/weave.go
@@ -4,17 +4,16 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"net"
 	"net/http"
 	"net/url"
-	"os/exec"
 	"regexp"
 	"strings"
 
 	"github.com/weaveworks/scope/probe/docker"
 	"github.com/weaveworks/scope/report"
+	"github.com/weaveworks/scope/test/exec"
 )
 
 const (
@@ -35,16 +34,6 @@ const (
 
 var weavePsMatch = regexp.MustCompile(`^([0-9a-f]{12}) ((?:[0-9a-f][0-9a-f]\:){5}(?:[0-9a-f][0-9a-f]))(.*)$`)
 var ipMatch = regexp.MustCompile(`([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})(/[0-9]+)`)
-
-// Cmd is a hook for mocking
-type Cmd interface {
-	StdoutPipe() (io.ReadCloser, error)
-	Start() error
-	Wait() error
-}
-
-// ExecCommand is a hook for mocking
-var ExecCommand = func(name string, args ...string) Cmd { return exec.Command(name, args...) }
 
 // Weave represents a single Weave router, presumably on the same host
 // as the probe. It is both a Reporter and a Tagger: it produces an Overlay
@@ -114,7 +103,7 @@ type psEntry struct {
 
 func (w Weave) ps() ([]psEntry, error) {
 	var result []psEntry
-	cmd := ExecCommand("weave", "--local", "ps")
+	cmd := exec.Command("weave", "--local", "ps")
 	out, err := cmd.StdoutPipe()
 	if err != nil {
 		return result, err

--- a/probe/overlay/weave_test.go
+++ b/probe/overlay/weave_test.go
@@ -7,18 +7,19 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/weaveworks/scope/common/exec"
 	"github.com/weaveworks/scope/probe/docker"
 	"github.com/weaveworks/scope/probe/overlay"
 	"github.com/weaveworks/scope/report"
 	"github.com/weaveworks/scope/test"
-	"github.com/weaveworks/scope/test/exec"
+	testExec "github.com/weaveworks/scope/test/exec"
 )
 
 func TestWeaveTaggerOverlayTopology(t *testing.T) {
 	oldExecCmd := exec.Command
 	defer func() { exec.Command = oldExecCmd }()
 	exec.Command = func(name string, args ...string) exec.Cmd {
-		return exec.NewMockCmdString(fmt.Sprintf("%s %s %s/24\n", mockContainerID, mockContainerMAC, mockContainerIP))
+		return testExec.NewMockCmdString(fmt.Sprintf("%s %s %s/24\n", mockContainerID, mockContainerMAC, mockContainerIP))
 	}
 
 	s := httptest.NewServer(http.HandlerFunc(mockWeaveRouter))

--- a/render/mapping.go
+++ b/render/mapping.go
@@ -25,12 +25,12 @@ const (
 )
 
 // LeafMapFunc is anything which can take an arbitrary NodeMetadata, which is
-// always one-to-one with nodes in a topology, and return a specific
-// representation of the referenced node, in the form of a node ID and a
-// human-readable major and minor labels.
+// always one-to-one with nodes in a topology, and return a set of RenderableNodes
+// - specific representations of the referenced node, in the form of a map of node
+// ID to a human-readable major and minor labels.
 //
 // A single NodeMetadata can yield arbitrary many representations, including
-// representations that reduce the cardinality of the set of nodes.
+// representations that reduce (or even increase) the cardinality of the set of nodes.
 type LeafMapFunc func(report.NodeMetadata) RenderableNodes
 
 // PseudoFunc creates RenderableNode representing pseudo nodes given the
@@ -41,13 +41,13 @@ type LeafMapFunc func(report.NodeMetadata) RenderableNodes
 type PseudoFunc func(srcNodeID, dstNodeID string, srcIsClient bool, local report.Networks) (RenderableNode, bool)
 
 // MapFunc is anything which can take an arbitrary RenderableNode and
-// return another RenderableNode.
+// return a set of other RenderableNodes.
 //
-// As with LeafMapFunc, if the final output parameter is false, the node
+// As with LeafMapFunc, if the output is empty, the node
 // shall be omitted from the rendered topology.
 type MapFunc func(RenderableNode) RenderableNodes
 
-// MapEndpointIdentity maps an endpoint topology node to an endpoint
+// MapEndpointIdentity maps an endpoint topology node to a single endpoint
 // renderable node. As it is only ever run on endpoint topology nodes, we
 // expect that certain keys are present.
 func MapEndpointIdentity(m report.NodeMetadata) RenderableNodes {

--- a/render/mapping_test.go
+++ b/render/mapping_test.go
@@ -72,7 +72,7 @@ type testcase struct {
 }
 
 func testMap(t *testing.T, f render.LeafMapFunc, input testcase) {
-	if _, have := f(input.md); input.ok != have {
+	if have := f(input.md); input.ok != (len(have) > 0) {
 		t.Errorf("%v: want %v, have %v", input.md, input.ok, have)
 	}
 }

--- a/render/render.go
+++ b/render/render.go
@@ -195,16 +195,14 @@ func (m LeafMap) Render(rpt report.Report) RenderableNodes {
 
 		srcRenderableIDs, ok := source2mapped[srcNodeID]
 		if !ok {
-			// One of the entries in dsts must be a non-pseudo node
-			var existingDstNodeID string
+			// One of the entries in dsts must be a non-pseudo node, unless
+			// it was dropped by the mapping function.
 			for _, dstNodeID := range dsts {
 				if _, ok := source2mapped[dstNodeID]; ok {
-					existingDstNodeID = dstNodeID
+					srcRenderableIDs = mkPseudoNode(srcNodeID, dstNodeID, true)
 					break
 				}
 			}
-
-			srcRenderableIDs = mkPseudoNode(srcNodeID, existingDstNodeID, true)
 		}
 		if len(srcRenderableIDs) == 0 {
 			continue

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -52,8 +52,8 @@ func TestReduceEdge(t *testing.T) {
 func TestMapRender1(t *testing.T) {
 	// 1. Check when we return false, the node gets filtered out
 	mapper := render.Map{
-		MapFunc: func(nodes render.RenderableNode) (render.RenderableNode, bool) {
-			return render.RenderableNode{}, false
+		MapFunc: func(nodes render.RenderableNode) render.RenderableNodes {
+			return render.RenderableNodes{}
 		},
 		Renderer: mockRenderer{RenderableNodes: render.RenderableNodes{
 			"foo": {ID: "foo"},
@@ -69,8 +69,8 @@ func TestMapRender1(t *testing.T) {
 func TestMapRender2(t *testing.T) {
 	// 2. Check we can remap two nodes into one
 	mapper := render.Map{
-		MapFunc: func(nodes render.RenderableNode) (render.RenderableNode, bool) {
-			return render.RenderableNode{ID: "bar"}, true
+		MapFunc: func(nodes render.RenderableNode) render.RenderableNodes {
+			return render.RenderableNodes{"bar": render.RenderableNode{ID: "bar"}}
 		},
 		Renderer: mockRenderer{RenderableNodes: render.RenderableNodes{
 			"foo": {ID: "foo"},
@@ -89,8 +89,9 @@ func TestMapRender2(t *testing.T) {
 func TestMapRender3(t *testing.T) {
 	// 3. Check we can remap adjacencies
 	mapper := render.Map{
-		MapFunc: func(nodes render.RenderableNode) (render.RenderableNode, bool) {
-			return render.RenderableNode{ID: "_" + nodes.ID}, true
+		MapFunc: func(nodes render.RenderableNode) render.RenderableNodes {
+			id := "_" + nodes.ID
+			return render.RenderableNodes{id: render.RenderableNode{ID: id}}
 		},
 		Renderer: mockRenderer{RenderableNodes: render.RenderableNodes{
 			"foo": {ID: "foo", Adjacency: report.MakeIDList("baz")},
@@ -125,13 +126,14 @@ func TestMapEdge(t *testing.T) {
 		}
 	}
 
-	identity := func(nmd report.NodeMetadata) (render.RenderableNode, bool) {
-		return render.NewRenderableNode(nmd.Metadata["id"], "", "", "", nmd), true
+	identity := func(nmd report.NodeMetadata) render.RenderableNodes {
+		return render.RenderableNodes{nmd.Metadata["id"]: render.NewRenderableNode(nmd.Metadata["id"], "", "", "", nmd)}
 	}
 
 	mapper := render.Map{
-		MapFunc: func(n render.RenderableNode) (render.RenderableNode, bool) {
-			return render.RenderableNode{ID: "_" + n.ID}, true
+		MapFunc: func(nodes render.RenderableNode) render.RenderableNodes {
+			id := "_" + nodes.ID
+			return render.RenderableNodes{id: render.RenderableNode{ID: id}}
 		},
 		Renderer: render.LeafMap{
 			Selector: selector,

--- a/render/topologies.go
+++ b/render/topologies.go
@@ -99,10 +99,33 @@ var ContainerRenderer = MakeReduce(
 			},
 		},
 	},
+
 	LeafMap{
 		Selector: report.SelectContainer,
 		Mapper:   MapContainerIdentity,
 		Pseudo:   PanicPseudoNode,
+	},
+
+	// This mapper brings in short lived connections by joining with container IPs.
+	// We need to be careful to ensure we only include each edge once.  Edges brought in
+	// by the above renders will have a pid, so its enough to filter out any nodes with
+	// pids.
+	Map{
+		MapFunc: MapIP2Container,
+		Renderer: FilterUnconnected(
+			MakeReduce(
+				LeafMap{
+					Selector: report.SelectContainer,
+					Mapper:   MapContainer2IP,
+					Pseudo:   PanicPseudoNode,
+				},
+				LeafMap{
+					Selector: report.SelectEndpoint,
+					Mapper:   MapEndpoint2IP,
+					Pseudo:   IPPseudoNode,
+				},
+			),
+		),
 	},
 )
 

--- a/test/exec/exec.go
+++ b/test/exec/exec.go
@@ -5,36 +5,16 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
+
+	"github.com/weaveworks/scope/common/exec"
 )
-
-// Cmd is a hook for mocking
-type Cmd interface {
-	StdoutPipe() (io.ReadCloser, error)
-	Start() error
-	Wait() error
-	Process() *os.Process
-}
-
-// Command is a hook for mocking
-var Command = func(name string, args ...string) Cmd {
-	return &realCmd{exec.Command(name, args...)}
-}
-
-type realCmd struct {
-	*exec.Cmd
-}
-
-func (c *realCmd) Process() *os.Process {
-	return c.Cmd.Process
-}
 
 type mockCmd struct {
 	io.ReadCloser
 }
 
 // NewMockCmdString creates a new mock Cmd which has s on its stdout pipe
-func NewMockCmdString(s string) Cmd {
+func NewMockCmdString(s string) exec.Cmd {
 	return &mockCmd{
 		struct {
 			io.Reader
@@ -47,7 +27,7 @@ func NewMockCmdString(s string) Cmd {
 }
 
 // NewMockCmd creates a new mock Cmd with rc as its stdout pipe
-func NewMockCmd(rc io.ReadCloser) Cmd {
+func NewMockCmd(rc io.ReadCloser) exec.Cmd {
 	return &mockCmd{rc}
 }
 

--- a/test/exec/exec.go
+++ b/test/exec/exec.go
@@ -1,0 +1,68 @@
+package exec
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+)
+
+// Cmd is a hook for mocking
+type Cmd interface {
+	StdoutPipe() (io.ReadCloser, error)
+	Start() error
+	Wait() error
+	Process() *os.Process
+}
+
+// Command is a hook for mocking
+var Command = func(name string, args ...string) Cmd {
+	return &realCmd{exec.Command(name, args...)}
+}
+
+type realCmd struct {
+	*exec.Cmd
+}
+
+func (c *realCmd) Process() *os.Process {
+	return c.Cmd.Process
+}
+
+type mockCmd struct {
+	io.ReadCloser
+}
+
+// NewMockCmdString creates a new mock Cmd which has s on its stdout pipe
+func NewMockCmdString(s string) Cmd {
+	return &mockCmd{
+		struct {
+			io.Reader
+			io.Closer
+		}{
+			bytes.NewBufferString(s),
+			ioutil.NopCloser(nil),
+		},
+	}
+}
+
+// NewMockCmd creates a new mock Cmd with rc as its stdout pipe
+func NewMockCmd(rc io.ReadCloser) Cmd {
+	return &mockCmd{rc}
+}
+
+func (c *mockCmd) Start() error {
+	return nil
+}
+
+func (c *mockCmd) Wait() error {
+	return nil
+}
+
+func (c *mockCmd) StdoutPipe() (io.ReadCloser, error) {
+	return c.ReadCloser, nil
+}
+
+func (c *mockCmd) Process() *os.Process {
+	return nil
+}

--- a/test/poll.go
+++ b/test/poll.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -20,6 +21,7 @@ func Poll(t *testing.T, d time.Duration, want interface{}, have func() interface
 	}
 	h := have()
 	if !reflect.DeepEqual(want, h) {
-		t.Fatal(Diff(want, h))
+		_, file, line, _ := runtime.Caller(1)
+		t.Fatalf("%s:%d: %s", file, line, Diff(want, h))
 	}
 }


### PR DESCRIPTION
Fixes #356

Status: Good to go.  Review feedback welcome.

Steps are:
1. Refactor the rendering pipeline such that mappers can emit multiple nodes
2. Use conntrack to populate the endpoint table (in addition to procspy).  NB nodes from conntrack _will not_ have a pid
3. Enhance the container render with an extra pipeline which joins containers to endpoints via their IP addresses
