### PR TITLE
Update for new weave status interface; 'intelligently' enable by default

### DIFF
--- a/probe/overlay/weave.go
+++ b/probe/overlay/weave.go
@@ -3,7 +3,6 @@ package overlay
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -30,14 +29,45 @@ type Weave struct {
 	url string
 }
 
+type weaveStatus struct {
+	Router struct {
+		Peers []struct {
+			Name     string `json:"name"`
+			NickName string `json:"nickname"`
+		} `json:"peers"`
+	} `json:"router"`
+}
+
 // NewWeave returns a new Weave tagger based on the Weave router at
 // address. The address should be an IP or FQDN, no port.
 func NewWeave(weaveRouterAddress string) (*Weave, error) {
-	s, err := sanitize("http://", 6784, "/status-json")(weaveRouterAddress)
+	s, err := sanitize("http://", 6784, "/report")(weaveRouterAddress)
 	if err != nil {
 		return nil, err
 	}
-	return &Weave{s}, nil
+	return &Weave{
+		url: s,
+	}, nil
+}
+
+func (w Weave) update() (weaveStatus, error) {
+	var result weaveStatus
+	req, err := http.NewRequest("GET", w.url, nil)
+	if err != nil {
+		return result, err
+	}
+	req.Header.Add("Accept", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return result, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return result, fmt.Errorf("Weave Tagger: got %d", resp.StatusCode)
+	}
+
+	return result, json.NewDecoder(resp.Body).Decode(&result)
 }
 
 // Tag implements Tagger.
@@ -50,26 +80,12 @@ func (w Weave) Tag(r report.Report) (report.Report, error) {
 // Report implements Reporter.
 func (w Weave) Report() (report.Report, error) {
 	r := report.MakeReport()
-
-	resp, err := http.Get(w.url)
+	status, err := w.update()
 	if err != nil {
-		log.Printf("Weave Tagger: %v", err)
-		return r, err
-	}
-	defer resp.Body.Close()
-
-	var status struct {
-		Peers []struct {
-			Name     string `json:"Name"`
-			NickName string `json:"NickName"`
-		} `json:"Peers"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
-		log.Printf("Weave Tagger: %v", err)
 		return r, err
 	}
 
-	for _, peer := range status.Peers {
+	for _, peer := range status.Router.Peers {
 		r.Overlay.NodeMetadatas[report.MakeOverlayNodeID(peer.Name)] = report.MakeNodeMetadataWith(map[string]string{
 			WeavePeerName:     peer.Name,
 			WeavePeerNickName: peer.NickName,

--- a/probe/overlay/weave_test.go
+++ b/probe/overlay/weave_test.go
@@ -1,7 +1,7 @@
 package overlay_test
 
 import (
-	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -44,13 +44,19 @@ const (
 	mockWeavePeerNickName = "winny"
 )
 
+var (
+	mockResponse = fmt.Sprintf(`{
+		"router": {
+			"peers": [{
+				"name": "%s",
+				"nickname": "%s"
+			}]
+		}
+	}`, mockWeavePeerName, mockWeavePeerNickName)
+)
+
 func mockWeaveRouter(w http.ResponseWriter, r *http.Request) {
-	if err := json.NewEncoder(w).Encode(map[string]interface{}{
-		"Peers": []map[string]interface{}{{
-			"Name":     mockWeavePeerName,
-			"NickName": mockWeavePeerNickName,
-		}},
-	}); err != nil {
+	if _, err := w.Write([]byte(mockResponse)); err != nil {
 		panic(err)
 	}
 }

--- a/scope
+++ b/scope
@@ -150,7 +150,10 @@ case "$COMMAND" in
 
         # If Weave is running, we want to expose a Weave IP to the host
         # network namespace, so Scope can use it.
+        SCOPE_ARGS=
         if command_exists weave && is_running $WEAVE_CONTAINER_NAME; then
+            container_ip $WEAVE_CONTAINER_NAME
+            SCOPE_ARGS="--probe.weave.router.addr=$CONTAINER_IP"
             weave_expose
         fi
 
@@ -163,7 +166,7 @@ case "$COMMAND" in
 
         CONTAINER=$(docker run --privileged -d --name=$SCOPE_CONTAINER_NAME --net=host --pid=host \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            $WEAVESCOPE_DOCKER_ARGS $SCOPE_IMAGE $WEAVESCOPE_DNS_ARGS --probe.docker true "$@")
+            $WEAVESCOPE_DOCKER_ARGS $SCOPE_IMAGE $WEAVESCOPE_DNS_ARGS $SCOPE_ARGS --probe.docker true "$@")
 
         IP_ADDRS=$(docker run --rm --net=host gliderlabs/alpine /bin/sh -c "$IP_ADDR_CMD")
         if command_exists weave && is_running $WEAVE_CONTAINER_NAME && weave_dns_present; then


### PR DESCRIPTION
Weave 1.1 has a new status json interface, and the old one has been removed.

I'm not worries about backwards compatibility, as the old code was never enabled.