### PR TITLE
Tag containers with Weave and Docker IPs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ probe/probe
 probe/scope-probe
 docker/scope-app
 docker/scope-probe
+docker/docker*
+docker/weave
 experimental/bridge/bridge
 experimental/demoprobe/demoprobe
 experimental/fixprobe/fixprobe

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,23 @@ SCOPE_EXPORT=scope.tar
 SCOPE_UI_BUILD_EXPORT=scope_ui_build.tar
 SCOPE_UI_BUILD_IMAGE=$(DOCKERHUB_USER)/scope-ui-build
 SCOPE_VERSION=$(shell git rev-parse --short HEAD)
+DOCKER_VERSION=1.3.1
+DOCKER_DISTRIB=docker/docker-$(DOCKER_VERSION).tgz
+DOCKER_DISTRIB_URL=https://get.docker.com/builds/Linux/x86_64/docker-$(DOCKER_VERSION).tgz
 
 all: $(SCOPE_EXPORT)
 
-$(SCOPE_EXPORT): $(APP_EXE) $(PROBE_EXE) docker/*
+$(DOCKER_DISTRIB):
+	curl -o $(DOCKER_DISTRIB) $(DOCKER_DISTRIB_URL)
+
+docker/weave:
+	curl -L git.io/weave -o docker/weave
+	chmod u+x docker/weave
+
+$(SCOPE_EXPORT): $(APP_EXE) $(PROBE_EXE) $(DOCKER_DISTRIB) docker/weave docker/entrypoint.sh docker/Dockerfile docker/run-app docker/run-probe
 	@if [ -z '$(DOCKER_SQUASH)' ]; then echo "Please install docker-squash by running 'make deps'." && exit 1; fi
 	cp $(APP_EXE) $(PROBE_EXE) docker/
+	cp $(DOCKER_DISTRIB) docker/docker.tgz
 	$(SUDO) docker build -t $(SCOPE_IMAGE) docker/
 	$(SUDO) docker save $(SCOPE_IMAGE):latest | sudo $(DOCKER_SQUASH) -t $(SCOPE_IMAGE) | tee $@ | $(SUDO) docker load
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,8 +2,10 @@ FROM gliderlabs/alpine
 MAINTAINER Weaveworks Inc <help@weave.works>
 WORKDIR /home/weave
 RUN echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >>/etc/apk/repositories && \
-	apk add --update runit conntrack-tools && \
+	apk add --update runit conntrack-tools iproute2 util-linux && \
 	rm -rf /var/cache/apk/*
+ADD ./docker.tgz /
+ADD ./weave /usr/bin/
 COPY ./scope-app ./scope-probe ./entrypoint.sh /home/weave/
 COPY ./run-app /etc/service/app/run
 COPY ./run-probe /etc/service/probe/run

--- a/probe/docker/container.go
+++ b/probe/docker/container.go
@@ -244,3 +244,8 @@ func (c *container) GetNodeMetadata() report.NodeMetadata {
 	}))
 	return result
 }
+
+// ExtractContainerIPs returns the list of container IPs given a NodeMetadata from the Container topology.
+func ExtractContainerIPs(nmd report.NodeMetadata) []string {
+	return strings.Fields(nmd.Metadata[ContainerIPs])
+}

--- a/probe/docker/container.go
+++ b/probe/docker/container.go
@@ -26,6 +26,7 @@ const (
 	ContainerCommand = "docker_container_command"
 	ContainerPorts   = "docker_container_ports"
 	ContainerCreated = "docker_container_created"
+	ContainerIPs     = "docker_container_ips"
 
 	NetworkRxDropped = "network_rx_dropped"
 	NetworkRxBytes   = "network_rx_bytes"
@@ -212,6 +213,8 @@ func (c *container) GetNodeMetadata() report.NodeMetadata {
 		ContainerCreated: c.container.Created.Format(time.RFC822),
 		ContainerCommand: c.container.Path + " " + strings.Join(c.container.Args, " "),
 		ImageID:          c.container.Image,
+		ContainerIPs: strings.Join(append(c.container.NetworkSettings.SecondaryIPAddresses,
+			c.container.NetworkSettings.IPAddress), " "),
 	})
 
 	if c.latestStats == nil {

--- a/probe/docker/registry_test.go
+++ b/probe/docker/registry_test.go
@@ -103,6 +103,9 @@ var (
 		Name:  "pong",
 		Image: "baz",
 		State: client.State{Pid: 1, Running: true},
+		NetworkSettings: &client.NetworkSettings{
+			IPAddress: "1.2.3.4",
+		},
 	}
 	container2 = &client.Container{
 		ID:    "wiff",

--- a/probe/overlay/weave.go
+++ b/probe/overlay/weave.go
@@ -150,7 +150,7 @@ func (w Weave) tagContainer(r report.Report, containerIDPrefix, macAddress strin
 			continue
 		}
 
-		existingIPs := report.MakeIDList(strings.Fields(nmd.Metadata[docker.ContainerIPs])...)
+		existingIPs := report.MakeIDList(docker.ExtractContainerIPs(nmd)...)
 		existingIPs = existingIPs.Add(ips...)
 		nmd.Metadata[docker.ContainerIPs] = strings.Join(existingIPs, " ")
 		nmd.Metadata[WeaveMACAddress] = macAddress

--- a/render/detailed_node.go
+++ b/render/detailed_node.go
@@ -301,13 +301,16 @@ func containerOriginTable(nmd report.NodeMetadata, addHostTag bool) (Table, bool
 		{docker.ContainerPorts, "Ports"},
 		{docker.ContainerCreated, "Created"},
 		{docker.ContainerCommand, "Command"},
-		{docker.ContainerIPs, "IP Addresses"},
 		{overlay.WeaveMACAddress, "Weave MAC"},
 		{overlay.WeaveDNSHostname, "Weave DNS Hostname"},
 	} {
 		if val, ok := nmd.Metadata[tuple.key]; ok && val != "" {
 			rows = append(rows, Row{Key: tuple.human, ValueMajor: val, ValueMinor: ""})
 		}
+	}
+
+	for _, ip := range docker.ExtractContainerIPs(nmd) {
+		rows = append(rows, Row{Key: "IP Address", ValueMajor: ip, ValueMinor: ""})
 	}
 
 	if val, ok := nmd.Metadata[docker.MemoryUsage]; ok {

--- a/render/detailed_node.go
+++ b/render/detailed_node.go
@@ -297,13 +297,15 @@ func containerOriginTable(nmd report.NodeMetadata, addHostTag bool) (Table, bool
 	rows := []Row{}
 	for _, tuple := range []struct{ key, human string }{
 		{docker.ContainerID, "ID"},
-		{overlay.WeaveDNSHostname, "Weave DNS Hostname"},
 		{docker.ImageID, "Image ID"},
 		{docker.ContainerPorts, "Ports"},
 		{docker.ContainerCreated, "Created"},
 		{docker.ContainerCommand, "Command"},
+		{docker.ContainerIPs, "IP Addresses"},
+		{overlay.WeaveMACAddress, "Weave MAC"},
+		{overlay.WeaveDNSHostname, "Weave DNS Hostname"},
 	} {
-		if val, ok := nmd.Metadata[tuple.key]; ok {
+		if val, ok := nmd.Metadata[tuple.key]; ok && val != "" {
 			rows = append(rows, Row{Key: tuple.human, ValueMajor: val, ValueMinor: ""})
 		}
 	}


### PR DESCRIPTION
Fixes #326

This change involved periodically invoking ```weave ps```, which requires the weave script to be installed in our container, which requires the Docker CLI to be installed in out container.