### PR TITLE
Only group processes not in containers AND doing network IO into uncontained nodes.

### DIFF
--- a/app/api_topology_test.go
+++ b/app/api_topology_test.go
@@ -180,7 +180,7 @@ func TestAPITopologyWebsocket(t *testing.T) {
 	if err := json.Unmarshal(p, &d); err != nil {
 		t.Fatalf("JSON parse error: %s", err)
 	}
-	equals(t, 6, len(d.Add))
+	equals(t, 7, len(d.Add))
 	equals(t, 0, len(d.Update))
 	equals(t, 0, len(d.Remove))
 }

--- a/app/router.go
+++ b/app/router.go
@@ -127,12 +127,12 @@ var topologyRegistry = map[string]topologyView{
 	"applications": {
 		human:    "Applications",
 		parent:   "",
-		renderer: render.FilterUnconnected{Renderer: render.ProcessWithContainerNameRenderer{}},
+		renderer: render.FilterUnconnected(render.ProcessWithContainerNameRenderer{}),
 	},
 	"applications-by-name": {
 		human:    "by name",
 		parent:   "applications",
-		renderer: render.FilterUnconnected{Renderer: render.ProcessNameRenderer},
+		renderer: render.FilterUnconnected(render.ProcessNameRenderer),
 	},
 	"containers": {
 		human:    "Containers",

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -59,6 +59,7 @@ var (
 			Adjacency: adjacency,
 			Origins: report.MakeIDList(
 				test.RandomClientNodeID,
+				test.GoogleEndpointNodeID,
 			),
 		}
 	}
@@ -124,14 +125,15 @@ var (
 		},
 		nonContainerProcessID: {
 			ID:         nonContainerProcessID,
-			LabelMajor: "bash",
+			LabelMajor: test.NonContainerComm,
 			LabelMinor: fmt.Sprintf("%s (%s)", test.ServerHostID, test.NonContainerPID),
 			Rank:       test.NonContainerComm,
 			Pseudo:     false,
-			Adjacency:  report.MakeIDList(),
+			Adjacency:  report.MakeIDList(render.TheInternetID),
 			Origins: report.MakeIDList(
 				test.NonContainerProcessNodeID,
 				test.ServerHostNodeID,
+				test.NonContainerNodeID,
 			),
 			NodeMetadata: report.MakeNodeMetadata(),
 			EdgeMetadata: report.EdgeMetadata{},
@@ -180,16 +182,17 @@ var (
 				EgressByteCount:   newu64(2100),
 			},
 		},
-		"bash": {
-			ID:         "bash",
-			LabelMajor: "bash",
+		test.NonContainerComm: {
+			ID:         test.NonContainerComm,
+			LabelMajor: test.NonContainerComm,
 			LabelMinor: "1 process",
-			Rank:       "bash",
+			Rank:       test.NonContainerComm,
 			Pseudo:     false,
-			Adjacency:  report.MakeIDList(),
+			Adjacency:  report.MakeIDList(render.TheInternetID),
 			Origins: report.MakeIDList(
 				test.NonContainerProcessNodeID,
 				test.ServerHostNodeID,
+				test.NonContainerNodeID,
 			),
 			NodeMetadata: report.MakeNodeMetadata(),
 			EdgeMetadata: report.EdgeMetadata{},
@@ -246,10 +249,11 @@ var (
 			LabelMinor: test.ServerHostName,
 			Rank:       "",
 			Pseudo:     true,
-			Adjacency:  report.MakeIDList(),
+			Adjacency:  report.MakeIDList(render.TheInternetID),
 			Origins: report.MakeIDList(
 				test.NonContainerProcessNodeID,
 				test.ServerHostNodeID,
+				test.NonContainerNodeID,
 			),
 			NodeMetadata: report.MakeNodeMetadata(),
 			EdgeMetadata: report.EdgeMetadata{},
@@ -305,8 +309,9 @@ var (
 			LabelMinor: test.ServerHostName,
 			Rank:       "",
 			Pseudo:     true,
-			Adjacency:  report.MakeIDList(),
+			Adjacency:  report.MakeIDList(render.TheInternetID),
 			Origins: report.MakeIDList(
+				test.NonContainerNodeID,
 				test.NonContainerProcessNodeID,
 				test.ServerHostNodeID,
 			),

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -149,18 +149,17 @@ func TestMapEdge(t *testing.T) {
 }
 
 func TestFilterRender(t *testing.T) {
-	renderer := render.FilterUnconnected{
-		Renderer: mockRenderer{RenderableNodes: render.RenderableNodes{
-			"foo": {ID: "foo", Adjacency: report.MakeIDList("bar")},
-			"bar": {ID: "bar", Adjacency: report.MakeIDList("foo")},
-			"baz": {ID: "baz", Adjacency: report.MakeIDList()},
-		}},
-	}
+	renderer := render.FilterUnconnected(
+		mockRenderer{RenderableNodes: render.RenderableNodes{
+			"foo": {ID: "foo", Adjacency: report.MakeIDList("bar"), NodeMetadata: report.MakeNodeMetadata()},
+			"bar": {ID: "bar", Adjacency: report.MakeIDList("foo"), NodeMetadata: report.MakeNodeMetadata()},
+			"baz": {ID: "baz", Adjacency: report.MakeIDList(), NodeMetadata: report.MakeNodeMetadata()},
+		}})
 	want := render.RenderableNodes{
-		"foo": {ID: "foo", Adjacency: report.MakeIDList("bar")},
-		"bar": {ID: "bar", Adjacency: report.MakeIDList("foo")},
+		"foo": {ID: "foo", Adjacency: report.MakeIDList("bar"), NodeMetadata: report.MakeNodeMetadata()},
+		"bar": {ID: "bar", Adjacency: report.MakeIDList("foo"), NodeMetadata: report.MakeNodeMetadata()},
 	}
-	have := renderer.Render(report.MakeReport())
+	have := sterilize(renderer.Render(report.MakeReport()), true)
 	if !reflect.DeepEqual(want, have) {
 		t.Errorf("want %+v, have %+v", want, have)
 	}

--- a/test/report_fixture.go
+++ b/test/report_fixture.go
@@ -28,6 +28,7 @@ var (
 	UnknownClient2IP = "10.10.10.10"
 	UnknownClient3IP = "10.10.10.11"
 	RandomClientIP   = "51.52.53.54"
+	GoogleIP         = "8.8.8.8"
 
 	ClientHostName = ClientHostID
 	ServerHostName = ServerHostID
@@ -52,6 +53,8 @@ var (
 	UnknownClient2NodeID = report.MakeEndpointNodeID(ServerHostID, UnknownClient2IP, "54020") // to the same server, are deduped.
 	UnknownClient3NodeID = report.MakeEndpointNodeID(ServerHostID, UnknownClient3IP, "54020") // Check this one isn't deduped
 	RandomClientNodeID   = report.MakeEndpointNodeID(ServerHostID, RandomClientIP, "12345")   // this should become an internet node
+	NonContainerNodeID   = report.MakeEndpointNodeID(ServerHostID, ServerIP, "46789")
+	GoogleEndpointNodeID = report.MakeEndpointNodeID(ServerHostID, GoogleIP, "80")
 
 	ClientProcess1NodeID      = report.MakeProcessNodeID(ClientHostID, Client1PID)
 	ClientProcess2NodeID      = report.MakeProcessNodeID(ClientHostID, Client2PID)
@@ -85,6 +88,7 @@ var (
 				report.MakeAdjacencyID(UnknownClient2NodeID): report.MakeIDList(Server80NodeID),
 				report.MakeAdjacencyID(UnknownClient3NodeID): report.MakeIDList(Server80NodeID),
 				report.MakeAdjacencyID(RandomClientNodeID):   report.MakeIDList(Server80NodeID),
+				report.MakeAdjacencyID(NonContainerNodeID):   report.MakeIDList(GoogleEndpointNodeID),
 			},
 			NodeMetadatas: report.NodeMetadatas{
 				// NodeMetadata is arbitrary. We're free to put only precisely what we
@@ -106,6 +110,12 @@ var (
 					endpoint.Addr:     ServerIP,
 					endpoint.Port:     ServerPort,
 					process.PID:       ServerPID,
+					report.HostNodeID: ServerHostNodeID,
+				}),
+				NonContainerNodeID: report.MakeNodeMetadataWith(map[string]string{
+					endpoint.Addr:     ServerIP,
+					endpoint.Port:     "46789",
+					process.PID:       NonContainerPID,
 					report.HostNodeID: ServerHostNodeID,
 				}),
 			},


### PR DESCRIPTION
With the re-enablement of the selection of pseudo nodes (#249), it turns out our 'Uncontained' nodes in the containers view contains all processes.  This isn't particularly useful; we only want to show the 'Uncontained' node if there is a process on the machine with network connections with isn't in a container.

The changes to the bandwidth figures are due to #373, which is not a big deal right now as the bandwidth figures aren't enabled by default, but I'll fix that next.