### PR TITLE
Add works.weave.role=system label to the scope container.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM gliderlabs/alpine
 MAINTAINER Weaveworks Inc <help@weave.works>
+LABEL works.weave.role=system
 WORKDIR /home/weave
 RUN echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >>/etc/apk/repositories && \
 	apk add --update runit conntrack-tools iproute2 util-linux && \


### PR DESCRIPTION
Fixes #337 

See https://github.com/weaveworks/weave/pull/1290 for the discussion about naming.