### PR TITLE
Works with boot2docker.

### DIFF
--- a/scope
+++ b/scope
@@ -99,7 +99,7 @@ weave_dns_present() {
 }
 
 set_docker_bridge_ip() {
-    DOCKER_BRIDGE_IP=$(ip -4 addr show dev $DOCKER_BRIDGE | grep -m1 -o 'inet [.0-9]*')
+    DOCKER_BRIDGE_IP=$(docker run --rm --net=host --entrypoint /bin/sh $SCOPE_IMAGE -c "ip -f inet address show dev $DOCKER_BRIDGE" | grep -m1 -o 'inet \([.0-9]\)*')
     DOCKER_BRIDGE_IP=${DOCKER_BRIDGE_IP#inet }
 }
 

--- a/scope
+++ b/scope
@@ -95,7 +95,7 @@ weave_dns_add() {
 }
 
 weave_dns_present() {
-    docker run --rm gliderlabs/alpine nc -z $DOCKER_BRIDGE_IP 53 || is_running $WEAVEDNS_CONTAINER_NAME
+    docker run --rm --entrypoint /bin/sh $SCOPE_IMAGE -c "nc -z $DOCKER_BRIDGE_IP 53" || is_running $WEAVEDNS_CONTAINER_NAME
 }
 
 set_docker_bridge_ip() {
@@ -168,7 +168,7 @@ case "$COMMAND" in
             -v /var/run/docker.sock:/var/run/docker.sock \
             $WEAVESCOPE_DOCKER_ARGS $SCOPE_IMAGE $WEAVESCOPE_DNS_ARGS $SCOPE_ARGS --probe.docker true "$@")
 
-        IP_ADDRS=$(docker run --rm --net=host gliderlabs/alpine /bin/sh -c "$IP_ADDR_CMD")
+        IP_ADDRS=$(docker run --rm --net=host --entrypoint /bin/sh $SCOPE_IMAGE -c "$IP_ADDR_CMD")
         if command_exists weave && is_running $WEAVE_CONTAINER_NAME && weave_dns_present; then
             if [ -z "$IP_ADDRS" ]; then
                 echo "Could not determine local IP address; Weave DNS integration will not work correctly."


### PR DESCRIPTION
The DOCKER_BRIDGE_IP is set on the remote host, so it will be found
correctly on boot2docker.

When a container dies, the logs show:
```
2015/08/27 15:38:51 docker container: error reading event, did container stop? read unix /var/run/docker.sock: use of closed network connection
2015/08/27 15:38:51 docker container: stopped collecting stats for 44514f936c6631ac4fd95fe434f47a94faa04c94cecbcd540c7387c1648a24fc
```
Which is a bit messy, but not an issue.

Closes #353