### PR TITLE
Show container image details for containers.

### DIFF
--- a/render/mapping.go
+++ b/render/mapping.go
@@ -131,8 +131,8 @@ func MapContainerIdentity(m RenderableNode, _ report.Networks) RenderableNodes {
 
 	node := NewRenderableNodeWith(id, major, minor, rank, m)
 	if imageID, ok := m.Metadata[docker.ImageID]; ok {
-		scope, _, _ := report.ParseContainerNodeID(m.ID)
-		node.Origins = node.Origins.Add(report.MakeContainerNodeID(scope, imageID))
+		hostID, _, _ := report.ParseContainerNodeID(m.ID)
+		node.Origins = node.Origins.Add(report.MakeContainerNodeID(hostID, imageID))
 	}
 	return RenderableNodes{id: node}
 }

--- a/report/id.go
+++ b/report/id.go
@@ -121,10 +121,10 @@ func ParseEndpointNodeID(endpointNodeID string) (hostID, address, port string, o
 	return fields[0], fields[1], fields[2], true
 }
 
-// ParseContainerNodeID produces the host ID, and container id from an container
+// ParseContainerNodeID produces the host and container id from an container
 // node ID.
 func ParseContainerNodeID(containerNodeID string) (hostID, containerID string, ok bool) {
-	fields := strings.SplitN(containerNodeID, ScopeDelim, 3)
+	fields := strings.SplitN(containerNodeID, ScopeDelim, 2)
 	if len(fields) != 2 {
 		return "", "", false
 	}


### PR DESCRIPTION
Fixes #398

Includes (and requires) #425 

Implementation note: #425 moves the responsibility for propagating origin ids to the mappers, which in turn rely on the RenderableNode constructors to do it properly.  This opens up the opportunity for the mappers to inject extra origin node ids, which we take advantage of here.