### PR TITLE
Trim node titles in graph

### DIFF
--- a/client/app/scripts/charts/node.js
+++ b/client/app/scripts/charts/node.js
@@ -66,10 +66,27 @@ const Node = React.createClass({
         <circle r={scale(0.5)} className="border" stroke={color}></circle>
         <circle r={scale(0.45)} className="shadow"></circle>
         <circle r={Math.max(2, scale(0.125))} className="node"></circle>
-        <text className="node-label" textAnchor="middle" x={textOffsetX} y={textOffsetY}>{this.props.label}</text>
-        <text className="node-sublabel" textAnchor="middle" x={textOffsetX} y={textOffsetY + 17}>{this.props.subLabel}</text>
+        <text className="node-label" textAnchor="middle" x={textOffsetX} y={textOffsetY}>
+          {this.ellipsis(this.props.label, 14)}
+        </text>
+        <text className="node-sublabel" textAnchor="middle" x={textOffsetX} y={textOffsetY + 17}>
+          {this.ellipsis(this.props.subLabel, 12)}
+        </text>
       </g>
     );
+  },
+
+  ellipsis: function(text, fontSize) {
+    const maxWidth = this.props.scale(4);
+    const averageCharLength = fontSize / 1.5;
+    const allowedChars = maxWidth / averageCharLength;
+    let truncatedText = text;
+    let trimmedText = text;
+    while (text && trimmedText.length > 1 && trimmedText.length > allowedChars) {
+      trimmedText = trimmedText.slice(0, -1);
+      truncatedText = trimmedText + '...';
+    }
+    return truncatedText;
   },
 
   handleMouseEnter: function(ev) {


### PR DESCRIPTION
Trim node titles in graph via JS

fix for #413

Sadly, the title attribute to show something on hover does not work in
SVG. So we might need another solution for that.