### PR TITLE
Wait longer for resolver goroutine to stop.

### DIFF
--- a/probe/resolver_test.go
+++ b/probe/resolver_test.go
@@ -85,7 +85,7 @@ func TestResolver(t *testing.T) {
 	go func() { r.Stop(); close(done) }()
 	select {
 	case <-done:
-	case <-time.After(time.Millisecond):
+	case <-time.After(100*time.Millisecond):
 		t.Errorf("didn't Stop in time")
 	}
 }


### PR DESCRIPTION
Fixes #427 

1 millisecond is too little; a GC could take way longer.