### PR TITLE
Rename NodeMetadata -> Node

### DIFF
--- a/app/origin_host.go
+++ b/app/origin_host.go
@@ -22,7 +22,7 @@ type OriginHost struct {
 }
 
 func getOriginHost(t report.Topology, nodeID string) (OriginHost, bool) {
-	h, ok := t.NodeMetadatas[nodeID]
+	h, ok := t.Nodes[nodeID]
 	if !ok {
 		return OriginHost{}, false
 	}

--- a/experimental/demoprobe/main.go
+++ b/experimental/demoprobe/main.go
@@ -84,14 +84,14 @@ func demoReport(nodeCount int) report.Report {
 		)
 
 		// Endpoint topology
-		r.Endpoint = r.Endpoint.WithNode(srcPortID, report.MakeNodeMetadata().WithMetadata(map[string]string{
+		r.Endpoint = r.Endpoint.WithNode(srcPortID, report.MakeNode().WithMetadata(map[string]string{
 			process.PID: "4000",
 			"name":      c.srcProc,
 			"domain":    "node-" + src,
 		}).WithEdge(dstPortID, report.EdgeMetadata{
 			MaxConnCountTCP: newu64(uint64(rand.Intn(100) + 10)),
 		}))
-		r.Endpoint = r.Endpoint.WithNode(dstPortID, report.MakeNodeMetadata().WithMetadata(map[string]string{
+		r.Endpoint = r.Endpoint.WithNode(dstPortID, report.MakeNode().WithMetadata(map[string]string{
 			process.PID: "4000",
 			"name":      c.dstProc,
 			"domain":    "node-" + dst,
@@ -100,15 +100,15 @@ func demoReport(nodeCount int) report.Report {
 		}))
 
 		// Address topology
-		r.Address = r.Address.WithNode(srcAddressID, report.MakeNodeMetadata().WithMetadata(map[string]string{
+		r.Address = r.Address.WithNode(srcAddressID, report.MakeNode().WithMetadata(map[string]string{
 			docker.Name: src,
 		}).WithAdjacent(dstAddressID))
-		r.Address = r.Address.WithNode(srcAddressID, report.MakeNodeMetadata().WithMetadata(map[string]string{
+		r.Address = r.Address.WithNode(srcAddressID, report.MakeNode().WithMetadata(map[string]string{
 			docker.Name: dst,
 		}).WithAdjacent(srcAddressID))
 
 		// Host data
-		r.Host = r.Host.WithNode("hostX", report.MakeNodeMetadataWith(map[string]string{
+		r.Host = r.Host.WithNode("hostX", report.MakeNodeWith(map[string]string{
 			"ts":             time.Now().UTC().Format(time.RFC3339Nano),
 			"host_name":      "host-x",
 			"local_networks": localNet.String(),

--- a/experimental/genreport/generate.go
+++ b/experimental/genreport/generate.go
@@ -64,14 +64,14 @@ func DemoReport(nodeCount int) report.Report {
 		)
 
 		// Endpoint topology
-		r.Endpoint = r.Endpoint.WithNode(srcPortID, report.MakeNodeMetadata().WithMetadata(map[string]string{
+		r.Endpoint = r.Endpoint.WithNode(srcPortID, report.MakeNode().WithMetadata(map[string]string{
 			"pid":    "4000",
 			"name":   c.srcProc,
 			"domain": "node-" + src,
 		}).WithEdge(dstPortID, report.EdgeMetadata{
 			MaxConnCountTCP: newu64(uint64(rand.Intn(100) + 10)),
 		}))
-		r.Endpoint = r.Endpoint.WithNode(dstPortID, report.MakeNodeMetadata().WithMetadata(map[string]string{
+		r.Endpoint = r.Endpoint.WithNode(dstPortID, report.MakeNode().WithMetadata(map[string]string{
 			"pid":    "4000",
 			"name":   c.dstProc,
 			"domain": "node-" + dst,
@@ -80,15 +80,15 @@ func DemoReport(nodeCount int) report.Report {
 		}))
 
 		// Address topology
-		r.Address = r.Address.WithNode(srcAddressID, report.MakeNodeMetadata().WithMetadata(map[string]string{
+		r.Address = r.Address.WithNode(srcAddressID, report.MakeNode().WithMetadata(map[string]string{
 			"name": src,
 		}).WithAdjacent(dstAddressID))
-		r.Address = r.Address.WithNode(dstAddressID, report.MakeNodeMetadata().WithMetadata(map[string]string{
+		r.Address = r.Address.WithNode(dstAddressID, report.MakeNode().WithMetadata(map[string]string{
 			"name": dst,
 		}).WithAdjacent(srcAddressID))
 
 		// Host data
-		r.Host = r.Host.WithNode("hostX", report.MakeNodeMetadataWith(map[string]string{
+		r.Host = r.Host.WithNode("hostX", report.MakeNodeWith(map[string]string{
 			"ts":             time.Now().UTC().Format(time.RFC3339Nano),
 			"host_name":      "host-x",
 			"local_networks": localNet.String(),

--- a/probe/docker/container.go
+++ b/probe/docker/container.go
@@ -70,7 +70,7 @@ type Container interface {
 	ID() string
 	Image() string
 	PID() int
-	GetNodeMetadata() report.NodeMetadata
+	GetNode() report.Node
 
 	StartGatheringStats() error
 	StopGatheringStats()
@@ -202,11 +202,11 @@ func (c *container) ports() string {
 	return strings.Join(ports, ", ")
 }
 
-func (c *container) GetNodeMetadata() report.NodeMetadata {
+func (c *container) GetNode() report.Node {
 	c.RLock()
 	defer c.RUnlock()
 
-	result := report.MakeNodeMetadataWith(map[string]string{
+	result := report.MakeNodeWith(map[string]string{
 		ContainerID:      c.ID(),
 		ContainerName:    strings.TrimPrefix(c.container.Name, "/"),
 		ContainerPorts:   c.ports(),
@@ -222,7 +222,7 @@ func (c *container) GetNodeMetadata() report.NodeMetadata {
 		return result
 	}
 
-	result = result.Merge(report.MakeNodeMetadataWith(map[string]string{
+	result = result.Merge(report.MakeNodeWith(map[string]string{
 		NetworkRxDropped: strconv.FormatUint(c.latestStats.Network.RxDropped, 10),
 		NetworkRxBytes:   strconv.FormatUint(c.latestStats.Network.RxBytes, 10),
 		NetworkRxErrors:  strconv.FormatUint(c.latestStats.Network.RxErrors, 10),
@@ -246,7 +246,7 @@ func (c *container) GetNodeMetadata() report.NodeMetadata {
 	return result
 }
 
-// ExtractContainerIPs returns the list of container IPs given a NodeMetadata from the Container topology.
-func ExtractContainerIPs(nmd report.NodeMetadata) []string {
+// ExtractContainerIPs returns the list of container IPs given a Node from the Container topology.
+func ExtractContainerIPs(nmd report.Node) []string {
 	return strings.Fields(nmd.Metadata[ContainerIPs])
 }

--- a/probe/docker/container_linux_test.go
+++ b/probe/docker/container_linux_test.go
@@ -64,6 +64,6 @@ func TestContainer(t *testing.T) {
 
 	// Now see if we go them
 	test.Poll(t, 100*time.Millisecond, "12345", func() interface{} {
-		return c.GetNodeMetadata().Metadata[docker.MemoryUsage]
+		return c.GetNode().Metadata[docker.MemoryUsage]
 	})
 }

--- a/probe/docker/labels.go
+++ b/probe/docker/labels.go
@@ -6,20 +6,20 @@ import (
 	"github.com/weaveworks/scope/report"
 )
 
-// LabelPrefix is the key prefix used for Docker labels in NodeMetadata (e.g. a
+// LabelPrefix is the key prefix used for Docker labels in Node (e.g. a
 // Docker label "labelKey"="labelValue" will get encoded as
 // "docker_label_labelKey"="dockerValue" in the metadata)
 const LabelPrefix = "docker_label_"
 
-// AddLabels appends Docker labels to the NodeMetadata from a topology.
-func AddLabels(nmd report.NodeMetadata, labels map[string]string) {
+// AddLabels appends Docker labels to the Node from a topology.
+func AddLabels(nmd report.Node, labels map[string]string) {
 	for key, value := range labels {
 		nmd.Metadata[LabelPrefix+key] = value
 	}
 }
 
-// ExtractLabels returns the list of Docker labels given a NodeMetadata from a topology.
-func ExtractLabels(nmd report.NodeMetadata) map[string]string {
+// ExtractLabels returns the list of Docker labels given a Node from a topology.
+func ExtractLabels(nmd report.Node) map[string]string {
 	result := map[string]string{}
 	for key, value := range nmd.Metadata {
 		if strings.HasPrefix(key, LabelPrefix) {

--- a/probe/docker/labels_test.go
+++ b/probe/docker/labels_test.go
@@ -14,7 +14,7 @@ func TestLabels(t *testing.T) {
 		"foo1": "bar1",
 		"foo2": "bar2",
 	}
-	nmd := report.MakeNodeMetadata()
+	nmd := report.MakeNode()
 
 	docker.AddLabels(nmd, want)
 	have := docker.ExtractLabels(nmd)

--- a/probe/docker/registry_test.go
+++ b/probe/docker/registry_test.go
@@ -37,8 +37,8 @@ func (c *mockContainer) StartGatheringStats() error {
 
 func (c *mockContainer) StopGatheringStats() {}
 
-func (c *mockContainer) GetNodeMetadata() report.NodeMetadata {
-	return report.MakeNodeMetadataWith(map[string]string{
+func (c *mockContainer) GetNode() report.Node {
+	return report.MakeNodeWith(map[string]string{
 		docker.ContainerID:   c.c.ID,
 		docker.ContainerName: c.c.Name,
 		docker.ImageID:       c.c.Image,

--- a/probe/docker/reporter.go
+++ b/probe/docker/reporter.go
@@ -6,7 +6,7 @@ import (
 	"github.com/weaveworks/scope/report"
 )
 
-// Keys for use in NodeMetadata
+// Keys for use in Node
 const (
 	ImageID   = "docker_image_id"
 	ImageName = "docker_image_name"
@@ -39,7 +39,7 @@ func (r *Reporter) containerTopology() report.Topology {
 
 	r.registry.WalkContainers(func(c Container) {
 		nodeID := report.MakeContainerNodeID(r.scope, c.ID())
-		result.NodeMetadatas[nodeID] = c.GetNodeMetadata()
+		result.Nodes[nodeID] = c.GetNode()
 	})
 
 	return result
@@ -49,7 +49,7 @@ func (r *Reporter) containerImageTopology() report.Topology {
 	result := report.MakeTopology()
 
 	r.registry.WalkImages(func(image *docker_client.APIImages) {
-		nmd := report.MakeNodeMetadataWith(map[string]string{
+		nmd := report.MakeNodeWith(map[string]string{
 			ImageID: image.ID,
 		})
 		AddLabels(nmd, image.Labels)
@@ -59,7 +59,7 @@ func (r *Reporter) containerImageTopology() report.Topology {
 		}
 
 		nodeID := report.MakeContainerNodeID(r.scope, image.ID)
-		result.NodeMetadatas[nodeID] = nmd
+		result.Nodes[nodeID] = nmd
 	})
 
 	return result

--- a/probe/docker/reporter_test.go
+++ b/probe/docker/reporter_test.go
@@ -50,8 +50,8 @@ var (
 func TestReporter(t *testing.T) {
 	want := report.MakeReport()
 	want.Container = report.Topology{
-		NodeMetadatas: report.NodeMetadatas{
-			report.MakeContainerNodeID("", "ping"): report.MakeNodeMetadataWith(map[string]string{
+		Nodes: report.Nodes{
+			report.MakeContainerNodeID("", "ping"): report.MakeNodeWith(map[string]string{
 				docker.ContainerID:   "ping",
 				docker.ContainerName: "pong",
 				docker.ImageID:       "baz",
@@ -59,8 +59,8 @@ func TestReporter(t *testing.T) {
 		},
 	}
 	want.ContainerImage = report.Topology{
-		NodeMetadatas: report.NodeMetadatas{
-			report.MakeContainerNodeID("", "baz"): report.MakeNodeMetadataWith(map[string]string{
+		Nodes: report.Nodes{
+			report.MakeContainerNodeID("", "baz"): report.MakeNodeWith(map[string]string{
 				docker.ImageID:   "baz",
 				docker.ImageName: "bang",
 			}),

--- a/probe/docker/tagger.go
+++ b/probe/docker/tagger.go
@@ -45,7 +45,7 @@ func (t *Tagger) Tag(r report.Report) (report.Report, error) {
 }
 
 func (t *Tagger) tag(tree process.Tree, topology *report.Topology) {
-	for nodeID, nodeMetadata := range topology.NodeMetadatas {
+	for nodeID, nodeMetadata := range topology.Nodes {
 		pidStr, ok := nodeMetadata.Metadata[process.PID]
 		if !ok {
 			continue
@@ -79,10 +79,10 @@ func (t *Tagger) tag(tree process.Tree, topology *report.Topology) {
 			continue
 		}
 
-		md := report.MakeNodeMetadataWith(map[string]string{
+		md := report.MakeNodeWith(map[string]string{
 			ContainerID: c.ID(),
 		})
 
-		topology.NodeMetadatas[nodeID] = nodeMetadata.Merge(md)
+		topology.Nodes[nodeID] = nodeMetadata.Merge(md)
 	}
 }

--- a/probe/docker/tagger_test.go
+++ b/probe/docker/tagger_test.go
@@ -32,18 +32,18 @@ func TestTagger(t *testing.T) {
 	}
 
 	var (
-		pid1NodeID       = report.MakeProcessNodeID("somehost.com", "1")
-		pid2NodeID       = report.MakeProcessNodeID("somehost.com", "2")
-		wantNodeMetadata = report.MakeNodeMetadataWith(map[string]string{docker.ContainerID: "ping"})
+		pid1NodeID = report.MakeProcessNodeID("somehost.com", "1")
+		pid2NodeID = report.MakeProcessNodeID("somehost.com", "2")
+		wantNode   = report.MakeNodeWith(map[string]string{docker.ContainerID: "ping"})
 	)
 
 	input := report.MakeReport()
-	input.Process.NodeMetadatas[pid1NodeID] = report.MakeNodeMetadataWith(map[string]string{"pid": "1"})
-	input.Process.NodeMetadatas[pid2NodeID] = report.MakeNodeMetadataWith(map[string]string{"pid": "2"})
+	input.Process.Nodes[pid1NodeID] = report.MakeNodeWith(map[string]string{"pid": "1"})
+	input.Process.Nodes[pid2NodeID] = report.MakeNodeWith(map[string]string{"pid": "2"})
 
 	want := report.MakeReport()
-	want.Process.NodeMetadatas[pid1NodeID] = report.MakeNodeMetadataWith(map[string]string{"pid": "1"}).Merge(wantNodeMetadata)
-	want.Process.NodeMetadatas[pid2NodeID] = report.MakeNodeMetadataWith(map[string]string{"pid": "2"}).Merge(wantNodeMetadata)
+	want.Process.Nodes[pid1NodeID] = report.MakeNodeWith(map[string]string{"pid": "1"}).Merge(wantNode)
+	want.Process.Nodes[pid2NodeID] = report.MakeNodeWith(map[string]string{"pid": "2"}).Merge(wantNode)
 
 	tagger := docker.NewTagger(mockRegistryInstance, nil)
 	have, err := tagger.Tag(input)

--- a/probe/endpoint/nat.go
+++ b/probe/endpoint/nat.go
@@ -49,18 +49,18 @@ func toMapping(f Flow) *endpointMapping {
 	return &mapping
 }
 
-// applyNAT duplicates NodeMetadatas in the endpoint topology of a
+// applyNAT duplicates Nodes in the endpoint topology of a
 // report, based on the NAT table as returns by natTable.
 func (n *natmapper) applyNAT(rpt report.Report, scope string) {
 	n.WalkFlows(func(f Flow) {
 		mapping := toMapping(f)
 		realEndpointID := report.MakeEndpointNodeID(scope, mapping.originalIP, strconv.Itoa(mapping.originalPort))
 		copyEndpointID := report.MakeEndpointNodeID(scope, mapping.rewrittenIP, strconv.Itoa(mapping.rewrittenPort))
-		nmd, ok := rpt.Endpoint.NodeMetadatas[realEndpointID]
+		node, ok := rpt.Endpoint.Nodes[realEndpointID]
 		if !ok {
 			return
 		}
 
-		rpt.Endpoint.NodeMetadatas[copyEndpointID] = nmd.Copy()
+		rpt.Endpoint.Nodes[copyEndpointID] = node.Copy()
 	})
 }

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -135,12 +135,12 @@ func (r *Reporter) addConnection(rpt *report.Report, localAddr, remoteAddr strin
 		var (
 			localAddressNodeID  = report.MakeAddressNodeID(r.hostID, localAddr)
 			remoteAddressNodeID = report.MakeAddressNodeID(r.hostID, remoteAddr)
-			localNode           = report.MakeNodeMetadataWith(map[string]string{
+			localNode           = report.MakeNodeWith(map[string]string{
 				"name":            r.hostName,
 				Addr:              localAddr,
 				report.HostNodeID: hostNodeID,
 			})
-			remoteNode = report.MakeNodeMetadataWith(map[string]string{
+			remoteNode = report.MakeNodeWith(map[string]string{
 				Addr: remoteAddr,
 			})
 		)
@@ -166,12 +166,12 @@ func (r *Reporter) addConnection(rpt *report.Report, localAddr, remoteAddr strin
 			localEndpointNodeID  = report.MakeEndpointNodeID(r.hostID, localAddr, strconv.Itoa(int(localPort)))
 			remoteEndpointNodeID = report.MakeEndpointNodeID(r.hostID, remoteAddr, strconv.Itoa(int(remotePort)))
 
-			localNode = report.MakeNodeMetadataWith(map[string]string{
+			localNode = report.MakeNodeWith(map[string]string{
 				Addr:              localAddr,
 				Port:              strconv.Itoa(int(localPort)),
 				report.HostNodeID: hostNodeID,
 			})
-			remoteNode = report.MakeNodeMetadataWith(map[string]string{
+			remoteNode = report.MakeNodeWith(map[string]string{
 				Addr: remoteAddr,
 				Port: strconv.Itoa(int(remotePort)),
 			})

--- a/probe/endpoint/reporter_test.go
+++ b/probe/endpoint/reporter_test.go
@@ -77,7 +77,7 @@ func TestSpyNoProcesses(t *testing.T) {
 	//t.Logf("\n%s\n", buf)
 
 	// No process nodes, please
-	if want, have := 0, len(r.Endpoint.NodeMetadatas); want != have {
+	if want, have := 0, len(r.Endpoint.Nodes); want != have {
 		t.Fatalf("want %d, have %d", want, have)
 	}
 
@@ -86,15 +86,15 @@ func TestSpyNoProcesses(t *testing.T) {
 		scopedRemote = report.MakeAddressNodeID(nodeID, fixRemoteAddress.String())
 	)
 
-	if want, have := nodeName, r.Address.NodeMetadatas[scopedLocal].Metadata[docker.Name]; want != have {
+	if want, have := nodeName, r.Address.Nodes[scopedLocal].Metadata[docker.Name]; want != have {
 		t.Fatalf("want %q, have %q", want, have)
 	}
 
-	if want, have := 1, len(r.Address.NodeMetadatas[scopedRemote].Adjacency); want != have {
+	if want, have := 1, len(r.Address.Nodes[scopedRemote].Adjacency); want != have {
 		t.Fatalf("want %d, have %d", want, have)
 	}
 
-	if want, have := scopedLocal, r.Address.NodeMetadatas[scopedRemote].Adjacency[0]; want != have {
+	if want, have := scopedLocal, r.Address.Nodes[scopedRemote].Adjacency[0]; want != have {
 		t.Fatalf("want %q, have %q", want, have)
 	}
 }
@@ -116,19 +116,19 @@ func TestSpyWithProcesses(t *testing.T) {
 		scopedRemote = report.MakeEndpointNodeID(nodeID, fixRemoteAddress.String(), strconv.Itoa(int(fixRemotePort)))
 	)
 
-	if want, have := 1, len(r.Endpoint.NodeMetadatas[scopedRemote].Adjacency); want != have {
+	if want, have := 1, len(r.Endpoint.Nodes[scopedRemote].Adjacency); want != have {
 		t.Fatalf("want %d, have %d", want, have)
 	}
 
-	if want, have := scopedLocal, r.Endpoint.NodeMetadatas[scopedRemote].Adjacency[0]; want != have {
+	if want, have := scopedLocal, r.Endpoint.Nodes[scopedRemote].Adjacency[0]; want != have {
 		t.Fatalf("want %q, have %q", want, have)
 	}
 
 	for key, want := range map[string]string{
 		"pid": strconv.FormatUint(uint64(fixProcessPID), 10),
 	} {
-		if have := r.Endpoint.NodeMetadatas[scopedLocal].Metadata[key]; want != have {
-			t.Errorf("Process.NodeMetadatas[%q][%q]: want %q, have %q", scopedLocal, key, want, have)
+		if have := r.Endpoint.Nodes[scopedLocal].Metadata[key]; want != have {
+			t.Errorf("Process.Nodes[%q][%q]: want %q, have %q", scopedLocal, key, want, have)
 		}
 	}
 }

--- a/probe/host/reporter.go
+++ b/probe/host/reporter.go
@@ -8,7 +8,7 @@ import (
 	"github.com/weaveworks/scope/report"
 )
 
-// Keys for use in NodeMetadata.
+// Keys for use in Node.Metadata.
 const (
 	Timestamp     = "ts"
 	HostName      = "host_name"
@@ -68,7 +68,7 @@ func (r *Reporter) Report() (report.Report, error) {
 		return rep, err
 	}
 
-	rep.Host.NodeMetadatas[report.MakeHostNodeID(r.hostID)] = report.MakeNodeMetadataWith(map[string]string{
+	rep.Host.Nodes[report.MakeHostNodeID(r.hostID)] = report.MakeNodeWith(map[string]string{
 		Timestamp:     Now(),
 		HostName:      r.hostName,
 		LocalNetworks: strings.Join(localCIDRs, " "),

--- a/probe/host/reporter_test.go
+++ b/probe/host/reporter_test.go
@@ -45,7 +45,7 @@ func TestReporter(t *testing.T) {
 	host.Now = func() string { return now }
 
 	want := report.MakeReport()
-	want.Host.NodeMetadatas[report.MakeHostNodeID(hostID)] = report.MakeNodeMetadataWith(map[string]string{
+	want.Host.Nodes[report.MakeHostNodeID(hostID)] = report.MakeNodeWith(map[string]string{
 		host.Timestamp:     now,
 		host.HostName:      hostname,
 		host.LocalNetworks: network,

--- a/probe/host/tagger.go
+++ b/probe/host/tagger.go
@@ -17,13 +17,13 @@ func NewTagger(hostID string) Tagger {
 
 // Tag implements Tagger.
 func (t Tagger) Tag(r report.Report) (report.Report, error) {
-	other := report.MakeNodeMetadataWith(map[string]string{report.HostNodeID: t.hostNodeID})
+	other := report.MakeNodeWith(map[string]string{report.HostNodeID: t.hostNodeID})
 
 	// Explicity don't tag Endpoints and Addresses - These topologies include pseudo nodes,
 	// and as such do their own host tagging
 	for _, topology := range []report.Topology{r.Process, r.Container, r.ContainerImage, r.Host, r.Overlay} {
-		for id, md := range topology.NodeMetadatas {
-			topology.NodeMetadatas[id] = md.Merge(other)
+		for id, md := range topology.Nodes {
+			topology.Nodes[id] = md.Merge(other)
 		}
 	}
 	return r, nil

--- a/probe/host/tagger_test.go
+++ b/probe/host/tagger_test.go
@@ -13,16 +13,16 @@ func TestTagger(t *testing.T) {
 	var (
 		hostID         = "foo"
 		endpointNodeID = report.MakeEndpointNodeID(hostID, "1.2.3.4", "56789") // hostID ignored
-		nodeMetadata   = report.MakeNodeMetadataWith(map[string]string{"foo": "bar"})
+		nodeMetadata   = report.MakeNodeWith(map[string]string{"foo": "bar"})
 	)
 
 	r := report.MakeReport()
-	r.Process.NodeMetadatas[endpointNodeID] = nodeMetadata
-	want := nodeMetadata.Merge(report.MakeNodeMetadataWith(map[string]string{
+	r.Process.Nodes[endpointNodeID] = nodeMetadata
+	want := nodeMetadata.Merge(report.MakeNodeWith(map[string]string{
 		report.HostNodeID: report.MakeHostNodeID(hostID),
 	}))
 	rpt, _ := host.NewTagger(hostID).Tag(r)
-	have := rpt.Process.NodeMetadatas[endpointNodeID].Copy()
+	have := rpt.Process.Nodes[endpointNodeID].Copy()
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}

--- a/probe/overlay/weave.go
+++ b/probe/overlay/weave.go
@@ -133,7 +133,7 @@ func (w Weave) ps() ([]psEntry, error) {
 }
 
 func (w Weave) tagContainer(r report.Report, containerIDPrefix, macAddress string, ips []string) {
-	for nodeid, nmd := range r.Container.NodeMetadatas {
+	for nodeid, nmd := range r.Container.Nodes {
 		idPrefix := nmd.Metadata[docker.ContainerID][:12]
 		if idPrefix != containerIDPrefix {
 			continue
@@ -143,7 +143,7 @@ func (w Weave) tagContainer(r report.Report, containerIDPrefix, macAddress strin
 		existingIPs = existingIPs.Add(ips...)
 		nmd.Metadata[docker.ContainerIPs] = strings.Join(existingIPs, " ")
 		nmd.Metadata[WeaveMACAddress] = macAddress
-		r.Container.NodeMetadatas[nodeid] = nmd
+		r.Container.Nodes[nodeid] = nmd
 		break
 	}
 }
@@ -160,14 +160,14 @@ func (w Weave) Tag(r report.Report) (report.Report, error) {
 			continue
 		}
 		nodeID := report.MakeContainerNodeID(w.hostID, entry.ContainerID)
-		node, ok := r.Container.NodeMetadatas[nodeID]
+		node, ok := r.Container.Nodes[nodeID]
 		if !ok {
 			continue
 		}
 		hostnames := report.IDList(strings.Fields(node.Metadata[WeaveDNSHostname]))
 		hostnames = hostnames.Add(strings.TrimSuffix(entry.Hostname, "."))
 		node.Metadata[WeaveDNSHostname] = strings.Join(hostnames, " ")
-		r.Container.NodeMetadatas[nodeID] = node
+		r.Container.Nodes[nodeID] = node
 	}
 
 	psEntries, err := w.ps()
@@ -189,7 +189,7 @@ func (w Weave) Report() (report.Report, error) {
 	}
 
 	for _, peer := range status.Router.Peers {
-		r.Overlay.NodeMetadatas[report.MakeOverlayNodeID(peer.Name)] = report.MakeNodeMetadataWith(map[string]string{
+		r.Overlay.Nodes[report.MakeOverlayNodeID(peer.Name)] = report.MakeNodeWith(map[string]string{
 			WeavePeerName:     peer.Name,
 			WeavePeerNickName: peer.NickName,
 		})

--- a/probe/overlay/weave_test.go
+++ b/probe/overlay/weave_test.go
@@ -36,8 +36,8 @@ func TestWeaveTaggerOverlayTopology(t *testing.T) {
 			t.Fatal(err)
 		}
 		if want, have := (report.Topology{
-			NodeMetadatas: report.NodeMetadatas{
-				report.MakeOverlayNodeID(mockWeavePeerName): report.MakeNodeMetadataWith(map[string]string{
+			Nodes: report.Nodes{
+				report.MakeOverlayNodeID(mockWeavePeerName): report.MakeNodeWith(map[string]string{
 					overlay.WeavePeerName:     mockWeavePeerName,
 					overlay.WeavePeerNickName: mockWeavePeerNickName,
 				}),
@@ -51,8 +51,8 @@ func TestWeaveTaggerOverlayTopology(t *testing.T) {
 		nodeID := report.MakeContainerNodeID(mockHostID, mockContainerID)
 		want := report.Report{
 			Container: report.Topology{
-				NodeMetadatas: report.NodeMetadatas{
-					nodeID: report.MakeNodeMetadataWith(map[string]string{
+				Nodes: report.Nodes{
+					nodeID: report.MakeNodeWith(map[string]string{
 						docker.ContainerID:       mockContainerID,
 						overlay.WeaveDNSHostname: mockHostname,
 						overlay.WeaveMACAddress:  mockContainerMAC,
@@ -63,8 +63,8 @@ func TestWeaveTaggerOverlayTopology(t *testing.T) {
 		}
 		have, err := w.Tag(report.Report{
 			Container: report.Topology{
-				NodeMetadatas: report.NodeMetadatas{
-					nodeID: report.MakeNodeMetadataWith(map[string]string{
+				Nodes: report.Nodes{
+					nodeID: report.MakeNodeWith(map[string]string{
 						docker.ContainerID: mockContainerID,
 					}),
 				},

--- a/probe/process/reporter.go
+++ b/probe/process/reporter.go
@@ -45,7 +45,7 @@ func (r *Reporter) processTopology() (report.Topology, error) {
 	err := r.walker.Walk(func(p Process) {
 		pidstr := strconv.Itoa(p.PID)
 		nodeID := report.MakeProcessNodeID(r.scope, pidstr)
-		t.NodeMetadatas[nodeID] = report.MakeNodeMetadata()
+		t.Nodes[nodeID] = report.MakeNode()
 		for _, tuple := range []struct{ key, value string }{
 			{PID, pidstr},
 			{Comm, p.Comm},
@@ -53,11 +53,11 @@ func (r *Reporter) processTopology() (report.Topology, error) {
 			{Threads, strconv.Itoa(p.Threads)},
 		} {
 			if tuple.value != "" {
-				t.NodeMetadatas[nodeID].Metadata[tuple.key] = tuple.value
+				t.Nodes[nodeID].Metadata[tuple.key] = tuple.value
 			}
 		}
 		if p.PPID > 0 {
-			t.NodeMetadatas[nodeID].Metadata[PPID] = strconv.Itoa(p.PPID)
+			t.Nodes[nodeID].Metadata[PPID] = strconv.Itoa(p.PPID)
 		}
 	})
 

--- a/probe/process/reporter_test.go
+++ b/probe/process/reporter_test.go
@@ -34,32 +34,32 @@ func TestReporter(t *testing.T) {
 	reporter := process.NewReporter(walker, "")
 	want := report.MakeReport()
 	want.Process = report.Topology{
-		NodeMetadatas: report.NodeMetadatas{
-			report.MakeProcessNodeID("", "1"): report.MakeNodeMetadataWith(map[string]string{
+		Nodes: report.Nodes{
+			report.MakeProcessNodeID("", "1"): report.MakeNodeWith(map[string]string{
 				process.PID:     "1",
 				process.Comm:    "init",
 				process.Threads: "0",
 			}),
-			report.MakeProcessNodeID("", "2"): report.MakeNodeMetadataWith(map[string]string{
+			report.MakeProcessNodeID("", "2"): report.MakeNodeWith(map[string]string{
 				process.PID:     "2",
 				process.Comm:    "bash",
 				process.PPID:    "1",
 				process.Threads: "0",
 			}),
-			report.MakeProcessNodeID("", "3"): report.MakeNodeMetadataWith(map[string]string{
+			report.MakeProcessNodeID("", "3"): report.MakeNodeWith(map[string]string{
 				process.PID:     "3",
 				process.Comm:    "apache",
 				process.PPID:    "1",
 				process.Threads: "2",
 			}),
-			report.MakeProcessNodeID("", "4"): report.MakeNodeMetadataWith(map[string]string{
+			report.MakeProcessNodeID("", "4"): report.MakeNodeWith(map[string]string{
 				process.PID:     "4",
 				process.Comm:    "ping",
 				process.PPID:    "2",
 				process.Cmdline: "ping foo.bar.local",
 				process.Threads: "0",
 			}),
-			report.MakeProcessNodeID("", "5"): report.MakeNodeMetadataWith(map[string]string{
+			report.MakeProcessNodeID("", "5"): report.MakeNodeWith(map[string]string{
 				process.PID:     "5",
 				process.PPID:    "1",
 				process.Cmdline: "tail -f /var/log/syslog",

--- a/probe/resolver_test.go
+++ b/probe/resolver_test.go
@@ -85,7 +85,7 @@ func TestResolver(t *testing.T) {
 	go func() { r.Stop(); close(done) }()
 	select {
 	case <-done:
-	case <-time.After(100*time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 		t.Errorf("didn't Stop in time")
 	}
 }

--- a/probe/sniff/sniffer.go
+++ b/probe/sniff/sniffer.go
@@ -118,7 +118,7 @@ func interpolateCounts(r report.Report) {
 	}
 	factor := 1.0 / rate
 	for _, topology := range r.Topologies() {
-		for _, nmd := range topology.NodeMetadatas {
+		for _, nmd := range topology.Nodes {
 			for _, emd := range nmd.Edges {
 				if emd.EgressPacketCount != nil {
 					*emd.EgressPacketCount = uint64(float64(*emd.EgressPacketCount) * factor)
@@ -253,8 +253,8 @@ func (s *Sniffer) Merge(p Packet, rpt *report.Report) {
 	}
 
 	addAdjacency := func(t report.Topology, srcNodeID, dstNodeID string) report.Topology {
-		result := t.WithNode(srcNodeID, report.MakeNodeMetadata().WithAdjacent(dstNodeID))
-		result = result.WithNode(dstNodeID, report.MakeNodeMetadata())
+		result := t.WithNode(srcNodeID, report.MakeNode().WithAdjacent(dstNodeID))
+		result = result.WithNode(dstNodeID, report.MakeNode())
 		return result
 	}
 
@@ -267,7 +267,7 @@ func (s *Sniffer) Merge(p Packet, rpt *report.Report) {
 
 		rpt.Address = addAdjacency(rpt.Address, srcNodeID, dstNodeID)
 
-		emd := rpt.Address.NodeMetadatas[srcNodeID].Edges[dstNodeID]
+		emd := rpt.Address.Nodes[srcNodeID].Edges[dstNodeID]
 		if egress {
 			if emd.EgressPacketCount == nil {
 				emd.EgressPacketCount = new(uint64)
@@ -287,7 +287,7 @@ func (s *Sniffer) Merge(p Packet, rpt *report.Report) {
 			}
 			*emd.IngressByteCount += uint64(p.Network)
 		}
-		rpt.Address.NodeMetadatas[srcNodeID].Edges[dstNodeID] = emd
+		rpt.Address.Nodes[srcNodeID].Edges[dstNodeID] = emd
 	}
 
 	// If we have ports, we can add to the endpoint topology, too.
@@ -299,7 +299,7 @@ func (s *Sniffer) Merge(p Packet, rpt *report.Report) {
 
 		rpt.Endpoint = addAdjacency(rpt.Endpoint, srcNodeID, dstNodeID)
 
-		emd := rpt.Endpoint.NodeMetadatas[srcNodeID].Edges[dstNodeID]
+		emd := rpt.Endpoint.Nodes[srcNodeID].Edges[dstNodeID]
 		if egress {
 			if emd.EgressPacketCount == nil {
 				emd.EgressPacketCount = new(uint64)
@@ -319,6 +319,6 @@ func (s *Sniffer) Merge(p Packet, rpt *report.Report) {
 			}
 			*emd.IngressByteCount += uint64(p.Transport)
 		}
-		rpt.Endpoint.NodeMetadatas[srcNodeID].Edges[dstNodeID] = emd
+		rpt.Endpoint.Nodes[srcNodeID].Edges[dstNodeID] = emd
 	}
 }

--- a/probe/sniff/sniffer_internal_test.go
+++ b/probe/sniff/sniffer_internal_test.go
@@ -20,7 +20,7 @@ func TestInterpolateCounts(t *testing.T) {
 	r := report.MakeReport()
 	r.Sampling.Count = samplingCount
 	r.Sampling.Total = samplingTotal
-	r.Endpoint.NodeMetadatas[srcNodeID] = report.MakeNodeMetadata().WithEdge(dstNodeID, report.EdgeMetadata{
+	r.Endpoint.Nodes[srcNodeID] = report.MakeNode().WithEdge(dstNodeID, report.EdgeMetadata{
 		EgressPacketCount:  newu64(packetCount),
 		IngressPacketCount: newu64(packetCount),
 		EgressByteCount:    newu64(byteCount),
@@ -33,7 +33,7 @@ func TestInterpolateCounts(t *testing.T) {
 		rate   = float64(samplingCount) / float64(samplingTotal)
 		factor = 1.0 / rate
 		apply  = func(v uint64) uint64 { return uint64(factor * float64(v)) }
-		emd    = r.Endpoint.NodeMetadatas[srcNodeID].Edges[dstNodeID]
+		emd    = r.Endpoint.Nodes[srcNodeID].Edges[dstNodeID]
 	)
 	if want, have := apply(packetCount), (*emd.EgressPacketCount); want != have {
 		t.Errorf("want %d packets, have %d", want, have)

--- a/probe/sniff/sniffer_test.go
+++ b/probe/sniff/sniffer_test.go
@@ -65,12 +65,12 @@ func TestMerge(t *testing.T) {
 		dstEndpointNodeID = report.MakeEndpointNodeID(hostID, p.DstIP, p.DstPort)
 	)
 	if want, have := (report.Topology{
-		NodeMetadatas: report.NodeMetadatas{
-			srcEndpointNodeID: report.MakeNodeMetadata().WithEdge(dstEndpointNodeID, report.EdgeMetadata{
+		Nodes: report.Nodes{
+			srcEndpointNodeID: report.MakeNode().WithEdge(dstEndpointNodeID, report.EdgeMetadata{
 				EgressPacketCount: newu64(1),
 				EgressByteCount:   newu64(256),
 			}),
-			dstEndpointNodeID: report.MakeNodeMetadata(),
+			dstEndpointNodeID: report.MakeNode(),
 		},
 	}), rpt.Endpoint; !reflect.DeepEqual(want, have) {
 		t.Errorf("%s", test.Diff(want, have))
@@ -81,12 +81,12 @@ func TestMerge(t *testing.T) {
 		dstAddressNodeID = report.MakeAddressNodeID(hostID, p.DstIP)
 	)
 	if want, have := (report.Topology{
-		NodeMetadatas: report.NodeMetadatas{
-			srcAddressNodeID: report.MakeNodeMetadata().WithEdge(dstAddressNodeID, report.EdgeMetadata{
+		Nodes: report.Nodes{
+			srcAddressNodeID: report.MakeNode().WithEdge(dstAddressNodeID, report.EdgeMetadata{
 				EgressPacketCount: newu64(1),
 				EgressByteCount:   newu64(512),
 			}),
-			dstAddressNodeID: report.MakeNodeMetadata(),
+			dstAddressNodeID: report.MakeNode(),
 		},
 	}), rpt.Address; !reflect.DeepEqual(want, have) {
 		t.Errorf("%s", test.Diff(want, have))

--- a/probe/tag_report.go
+++ b/probe/tag_report.go
@@ -28,7 +28,7 @@ func Apply(r report.Report, taggers []Tagger) report.Report {
 	return r
 }
 
-// Topology is the NodeMetadata key for the origin topology.
+// Topology is the Node key for the origin topology.
 const Topology = "topology"
 
 type topologyTagger struct{}
@@ -50,9 +50,9 @@ func (topologyTagger) Tag(r report.Report) (report.Report, error) {
 		"host":            &(r.Host),
 		"overlay":         &(r.Overlay),
 	} {
-		other := report.MakeNodeMetadataWith(map[string]string{Topology: val})
-		for id, md := range topology.NodeMetadatas {
-			topology.NodeMetadatas[id] = md.Merge(other)
+		other := report.MakeNodeWith(map[string]string{Topology: val})
+		for id, md := range topology.Nodes {
+			topology.Nodes[id] = md.Merge(other)
 		}
 	}
 	return r, nil

--- a/probe/tag_report_test.go
+++ b/probe/tag_report_test.go
@@ -9,26 +9,26 @@ import (
 
 func TestApply(t *testing.T) {
 	var (
-		endpointNodeID       = "c"
-		addressNodeID        = "d"
-		endpointNodeMetadata = report.MakeNodeMetadataWith(map[string]string{"5": "6"})
-		addressNodeMetadata  = report.MakeNodeMetadataWith(map[string]string{"7": "8"})
+		endpointNodeID = "c"
+		addressNodeID  = "d"
+		endpointNode   = report.MakeNodeWith(map[string]string{"5": "6"})
+		addressNode    = report.MakeNodeWith(map[string]string{"7": "8"})
 	)
 
 	r := report.MakeReport()
-	r.Endpoint.NodeMetadatas[endpointNodeID] = endpointNodeMetadata
-	r.Address.NodeMetadatas[addressNodeID] = addressNodeMetadata
+	r.Endpoint.Nodes[endpointNodeID] = endpointNode
+	r.Address.Nodes[addressNodeID] = addressNode
 	r = Apply(r, []Tagger{newTopologyTagger()})
 
 	for _, tuple := range []struct {
-		want report.NodeMetadata
+		want report.Node
 		from report.Topology
 		via  string
 	}{
-		{endpointNodeMetadata.Merge(report.MakeNodeMetadataWith(map[string]string{"topology": "endpoint"})), r.Endpoint, endpointNodeID},
-		{addressNodeMetadata.Merge(report.MakeNodeMetadataWith(map[string]string{"topology": "address"})), r.Address, addressNodeID},
+		{endpointNode.Merge(report.MakeNodeWith(map[string]string{"topology": "endpoint"})), r.Endpoint, endpointNodeID},
+		{addressNode.Merge(report.MakeNodeWith(map[string]string{"topology": "address"})), r.Address, addressNodeID},
 	} {
-		if want, have := tuple.want, tuple.from.NodeMetadatas[tuple.via]; !reflect.DeepEqual(want, have) {
+		if want, have := tuple.want, tuple.from.Nodes[tuple.via]; !reflect.DeepEqual(want, have) {
 			t.Errorf("want %+v, have %+v", want, have)
 		}
 	}
@@ -37,9 +37,9 @@ func TestApply(t *testing.T) {
 func TestTagMissingID(t *testing.T) {
 	const nodeID = "not-found"
 	r := report.MakeReport()
-	want := report.MakeNodeMetadata()
+	want := report.MakeNode()
 	rpt, _ := newTopologyTagger().Tag(r)
-	have := rpt.Endpoint.NodeMetadatas[nodeID].Copy()
+	have := rpt.Endpoint.Nodes[nodeID].Copy()
 	if !reflect.DeepEqual(want, have) {
 		t.Error("TopologyTagger erroneously tagged a missing node ID")
 	}

--- a/render/detailed_node_test.go
+++ b/render/detailed_node_test.go
@@ -142,6 +142,16 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 		Pseudo:     false,
 		Tables: []render.Table{
 			{
+				Title:   `Container Image "image/server"`,
+				Numeric: false,
+				Rank:    4,
+				Rows: []render.Row{
+					{"Image ID", test.ServerContainerImageID, "", false},
+					{`Label "foo1"`, `bar1`, "", false},
+					{`Label "foo2"`, `bar2`, "", false},
+				},
+			},
+			{
 				Title:   `Container "server"`,
 				Numeric: false,
 				Rank:    3,

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -10,14 +10,14 @@ import (
 
 // Sterilize cleans up RenderableNodes test fixtures
 func Sterilize(r render.RenderableNodes) render.RenderableNodes {
-	// RenderableNodes contain NodeMetadatas, but generally we
+	// RenderableNodes contain Nodes, but generally we
 	// only care about the Adjacency field - the rest is internal
 	// state not sent to the client.  So in the tests we ignore
 	// this state.
 	for id, n := range r {
-		n.NodeMetadata.Metadata = report.Metadata{}
-		n.NodeMetadata.Counters = report.Counters{}
-		n.NodeMetadata.Edges = report.EdgeMetadatas{}
+		n.Node.Metadata = report.Metadata{}
+		n.Node.Counters = report.Counters{}
+		n.Node.Edges = report.EdgeMetadatas{}
 		r[id] = n
 	}
 	return r
@@ -30,10 +30,10 @@ var (
 	unknownPseudoNode2ID = render.MakePseudoNodeID("10.10.10.11", test.ServerIP, "80")
 	unknownPseudoNode1   = func(adjacency report.IDList) render.RenderableNode {
 		return render.RenderableNode{
-			ID:           unknownPseudoNode1ID,
-			LabelMajor:   "10.10.10.10",
-			Pseudo:       true,
-			NodeMetadata: report.MakeNodeMetadata().WithAdjacency(adjacency),
+			ID:         unknownPseudoNode1ID,
+			LabelMajor: "10.10.10.10",
+			Pseudo:     true,
+			Node:       report.MakeNode().WithAdjacency(adjacency),
 			EdgeMetadata: report.EdgeMetadata{
 				EgressPacketCount: newu64(70),
 				EgressByteCount:   newu64(700),
@@ -46,10 +46,10 @@ var (
 	}
 	unknownPseudoNode2 = func(adjacency report.IDList) render.RenderableNode {
 		return render.RenderableNode{
-			ID:           unknownPseudoNode2ID,
-			LabelMajor:   "10.10.10.11",
-			Pseudo:       true,
-			NodeMetadata: report.MakeNodeMetadata().WithAdjacency(adjacency),
+			ID:         unknownPseudoNode2ID,
+			LabelMajor: "10.10.10.11",
+			Pseudo:     true,
+			Node:       report.MakeNode().WithAdjacency(adjacency),
 			EdgeMetadata: report.EdgeMetadata{
 				EgressPacketCount: newu64(50),
 				EgressByteCount:   newu64(500),
@@ -61,10 +61,10 @@ var (
 	}
 	theInternetNode = func(adjacency report.IDList) render.RenderableNode {
 		return render.RenderableNode{
-			ID:           render.TheInternetID,
-			LabelMajor:   render.TheInternetMajor,
-			Pseudo:       true,
-			NodeMetadata: report.MakeNodeMetadata().WithAdjacency(adjacency),
+			ID:         render.TheInternetID,
+			LabelMajor: render.TheInternetMajor,
+			Pseudo:     true,
+			Node:       report.MakeNode().WithAdjacency(adjacency),
 			EdgeMetadata: report.EdgeMetadata{
 				EgressPacketCount: newu64(60),
 				EgressByteCount:   newu64(600),
@@ -92,7 +92,7 @@ var (
 				test.ClientProcess1NodeID,
 				test.ClientHostNodeID,
 			),
-			NodeMetadata: report.MakeNodeMetadata().WithAdjacent(ServerProcessID),
+			Node: report.MakeNode().WithAdjacent(ServerProcessID),
 			EdgeMetadata: report.EdgeMetadata{
 				EgressPacketCount: newu64(10),
 				EgressByteCount:   newu64(100),
@@ -109,7 +109,7 @@ var (
 				test.ClientProcess2NodeID,
 				test.ClientHostNodeID,
 			),
-			NodeMetadata: report.MakeNodeMetadata().WithAdjacent(ServerProcessID),
+			Node: report.MakeNode().WithAdjacent(ServerProcessID),
 			EdgeMetadata: report.EdgeMetadata{
 				EgressPacketCount: newu64(20),
 				EgressByteCount:   newu64(200),
@@ -126,7 +126,7 @@ var (
 				test.ServerProcessNodeID,
 				test.ServerHostNodeID,
 			),
-			NodeMetadata: report.MakeNodeMetadata(),
+			Node: report.MakeNode(),
 			EdgeMetadata: report.EdgeMetadata{
 				EgressPacketCount: newu64(210),
 				EgressByteCount:   newu64(2100),
@@ -143,7 +143,7 @@ var (
 				test.ServerHostNodeID,
 				test.NonContainerNodeID,
 			),
-			NodeMetadata: report.MakeNodeMetadata().WithAdjacent(render.TheInternetID),
+			Node:         report.MakeNode().WithAdjacent(render.TheInternetID),
 			EdgeMetadata: report.EdgeMetadata{},
 		},
 		unknownPseudoNode1ID: unknownPseudoNode1(report.MakeIDList(ServerProcessID)),
@@ -165,7 +165,7 @@ var (
 				test.ClientProcess2NodeID,
 				test.ClientHostNodeID,
 			),
-			NodeMetadata: report.MakeNodeMetadata().WithAdjacent("apache"),
+			Node: report.MakeNode().WithAdjacent("apache"),
 			EdgeMetadata: report.EdgeMetadata{
 				EgressPacketCount: newu64(30),
 				EgressByteCount:   newu64(300),
@@ -182,7 +182,7 @@ var (
 				test.ServerProcessNodeID,
 				test.ServerHostNodeID,
 			),
-			NodeMetadata: report.MakeNodeMetadata(),
+			Node: report.MakeNode(),
 			EdgeMetadata: report.EdgeMetadata{
 				EgressPacketCount: newu64(210),
 				EgressByteCount:   newu64(2100),
@@ -199,7 +199,7 @@ var (
 				test.ServerHostNodeID,
 				test.NonContainerNodeID,
 			),
-			NodeMetadata: report.MakeNodeMetadata().WithAdjacent(render.TheInternetID),
+			Node:         report.MakeNode().WithAdjacent(render.TheInternetID),
 			EdgeMetadata: report.EdgeMetadata{},
 		},
 		unknownPseudoNode1ID: unknownPseudoNode1(report.MakeIDList("apache")),
@@ -223,7 +223,7 @@ var (
 				test.ClientProcess2NodeID,
 				test.ClientHostNodeID,
 			),
-			NodeMetadata: report.MakeNodeMetadata().WithAdjacent(test.ServerContainerID),
+			Node: report.MakeNode().WithAdjacent(test.ServerContainerID),
 			EdgeMetadata: report.EdgeMetadata{
 				EgressPacketCount: newu64(30),
 				EgressByteCount:   newu64(300),
@@ -242,7 +242,7 @@ var (
 				test.ServerProcessNodeID,
 				test.ServerHostNodeID,
 			),
-			NodeMetadata: report.MakeNodeMetadata(),
+			Node: report.MakeNode(),
 			EdgeMetadata: report.EdgeMetadata{
 				EgressPacketCount: newu64(210),
 				EgressByteCount:   newu64(2100),
@@ -259,7 +259,7 @@ var (
 				test.ServerHostNodeID,
 				test.NonContainerNodeID,
 			),
-			NodeMetadata: report.MakeNodeMetadata().WithAdjacent(render.TheInternetID),
+			Node:         report.MakeNode().WithAdjacent(render.TheInternetID),
 			EdgeMetadata: report.EdgeMetadata{},
 		},
 		render.TheInternetID: theInternetNode(report.MakeIDList(test.ServerContainerID)),
@@ -281,7 +281,7 @@ var (
 				test.ClientProcess2NodeID,
 				test.ClientHostNodeID,
 			),
-			NodeMetadata: report.MakeNodeMetadata().WithAdjacent(test.ServerContainerImageName),
+			Node: report.MakeNode().WithAdjacent(test.ServerContainerImageName),
 			EdgeMetadata: report.EdgeMetadata{
 				EgressPacketCount: newu64(30),
 				EgressByteCount:   newu64(300),
@@ -299,7 +299,7 @@ var (
 				test.Server80NodeID,
 				test.ServerProcessNodeID,
 				test.ServerHostNodeID),
-			NodeMetadata: report.MakeNodeMetadata(),
+			Node: report.MakeNode(),
 			EdgeMetadata: report.EdgeMetadata{
 				EgressPacketCount: newu64(210),
 				EgressByteCount:   newu64(2100),
@@ -316,7 +316,7 @@ var (
 				test.NonContainerProcessNodeID,
 				test.ServerHostNodeID,
 			),
-			NodeMetadata: report.MakeNodeMetadata().WithAdjacent(render.TheInternetID),
+			Node:         report.MakeNode().WithAdjacent(render.TheInternetID),
 			EdgeMetadata: report.EdgeMetadata{},
 		},
 		render.TheInternetID: theInternetNode(report.MakeIDList(test.ServerContainerImageName)),
@@ -338,7 +338,7 @@ var (
 				test.ServerHostNodeID,
 				test.ServerAddressNodeID,
 			),
-			NodeMetadata: report.MakeNodeMetadata(),
+			Node: report.MakeNode(),
 			EdgeMetadata: report.EdgeMetadata{
 				MaxConnCountTCP: newu64(3),
 			},
@@ -353,7 +353,7 @@ var (
 				test.ClientHostNodeID,
 				test.ClientAddressNodeID,
 			),
-			NodeMetadata: report.MakeNodeMetadata().WithAdjacent(ServerHostRenderedID),
+			Node: report.MakeNode().WithAdjacent(ServerHostRenderedID),
 			EdgeMetadata: report.EdgeMetadata{
 				MaxConnCountTCP: newu64(3),
 			},
@@ -362,7 +362,7 @@ var (
 			ID:           pseudoHostID1,
 			LabelMajor:   test.UnknownClient1IP,
 			Pseudo:       true,
-			NodeMetadata: report.MakeNodeMetadata().WithAdjacent(ServerHostRenderedID),
+			Node:         report.MakeNode().WithAdjacent(ServerHostRenderedID),
 			EdgeMetadata: report.EdgeMetadata{},
 			Origins:      report.MakeIDList(test.UnknownAddress1NodeID, test.UnknownAddress2NodeID),
 		},
@@ -370,7 +370,7 @@ var (
 			ID:           pseudoHostID2,
 			LabelMajor:   test.UnknownClient3IP,
 			Pseudo:       true,
-			NodeMetadata: report.MakeNodeMetadata().WithAdjacent(ServerHostRenderedID),
+			Node:         report.MakeNode().WithAdjacent(ServerHostRenderedID),
 			EdgeMetadata: report.EdgeMetadata{},
 			Origins:      report.MakeIDList(test.UnknownAddress3NodeID),
 		},
@@ -378,7 +378,7 @@ var (
 			ID:           render.TheInternetID,
 			LabelMajor:   render.TheInternetMajor,
 			Pseudo:       true,
-			NodeMetadata: report.MakeNodeMetadata().WithAdjacent(ServerHostRenderedID),
+			Node:         report.MakeNode().WithAdjacent(ServerHostRenderedID),
 			EdgeMetadata: report.EdgeMetadata{},
 			Origins:      report.MakeIDList(test.RandomAddressNodeID),
 		},

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -215,6 +215,7 @@ var (
 			Rank:       test.ClientContainerImageID,
 			Pseudo:     false,
 			Origins: report.MakeIDList(
+				test.ClientContainerImageNodeID,
 				test.ClientContainerNodeID,
 				test.Client54001NodeID,
 				test.Client54002NodeID,
@@ -235,6 +236,7 @@ var (
 			Rank:       test.ServerContainerImageID,
 			Pseudo:     false,
 			Origins: report.MakeIDList(
+				test.ServerContainerImageNodeID,
 				test.ServerContainerNodeID,
 				test.Server80NodeID,
 				test.ServerProcessNodeID,

--- a/render/mapping.go
+++ b/render/mapping.go
@@ -121,7 +121,12 @@ func MapContainerIdentity(m RenderableNode, _ report.Networks) RenderableNodes {
 		rank  = m.Metadata[docker.ImageID]
 	)
 
-	return RenderableNodes{id: NewRenderableNodeWith(id, major, minor, rank, m)}
+	node := NewRenderableNodeWith(id, major, minor, rank, m)
+	if imageID, ok := m.Metadata[docker.ImageID]; ok {
+		scope, _, _ := report.ParseContainerNodeID(m.ID)
+		node.Origins = node.Origins.Add(report.MakeContainerNodeID(scope, imageID))
+	}
+	return RenderableNodes{id: node}
 }
 
 // MapContainerImageIdentity maps a container image topology node to container

--- a/render/mapping.go
+++ b/render/mapping.go
@@ -74,9 +74,9 @@ func MapEndpointIdentity(m RenderableNode, local report.Networks) RenderableNode
 	}
 
 	var (
-		id    = MakeEndpointID(report.ExtractHostID(m.NodeMetadata), addr, port)
+		id    = MakeEndpointID(report.ExtractHostID(m.Node), addr, port)
 		major = fmt.Sprintf("%s:%s", addr, port)
-		minor = report.ExtractHostID(m.NodeMetadata)
+		minor = report.ExtractHostID(m.Node)
 		rank  = major
 	)
 
@@ -97,9 +97,9 @@ func MapProcessIdentity(m RenderableNode, _ report.Networks) RenderableNodes {
 	}
 
 	var (
-		id    = MakeProcessID(report.ExtractHostID(m.NodeMetadata), pid)
+		id    = MakeProcessID(report.ExtractHostID(m.Node), pid)
 		major = m.Metadata["comm"]
-		minor = fmt.Sprintf("%s (%s)", report.ExtractHostID(m.NodeMetadata), pid)
+		minor = fmt.Sprintf("%s (%s)", report.ExtractHostID(m.Node), pid)
 		rank  = m.Metadata["comm"]
 	)
 
@@ -117,7 +117,7 @@ func MapContainerIdentity(m RenderableNode, _ report.Networks) RenderableNodes {
 
 	var (
 		major = m.Metadata[docker.ContainerName]
-		minor = report.ExtractHostID(m.NodeMetadata)
+		minor = report.ExtractHostID(m.Node)
 		rank  = m.Metadata[docker.ImageID]
 	)
 
@@ -174,9 +174,9 @@ func MapAddressIdentity(m RenderableNode, local report.Networks) RenderableNodes
 	}
 
 	var (
-		id    = MakeAddressID(report.ExtractHostID(m.NodeMetadata), addr)
+		id    = MakeAddressID(report.ExtractHostID(m.Node), addr)
 		major = addr
-		minor = report.ExtractHostID(m.NodeMetadata)
+		minor = report.ExtractHostID(m.Node)
 		rank  = major
 	)
 
@@ -188,7 +188,7 @@ func MapAddressIdentity(m RenderableNode, local report.Networks) RenderableNodes
 // present.
 func MapHostIdentity(m RenderableNode, _ report.Networks) RenderableNodes {
 	var (
-		id                 = MakeHostID(report.ExtractHostID(m.NodeMetadata))
+		id                 = MakeHostID(report.ExtractHostID(m.Node))
 		hostname           = m.Metadata[host.HostName]
 		parts              = strings.SplitN(hostname, ".", 2)
 		major, minor, rank = "", "", ""
@@ -233,7 +233,7 @@ func MapContainer2IP(m RenderableNode, _ report.Networks) RenderableNodes {
 	}
 	for _, addr := range strings.Fields(addrs) {
 		n := NewRenderableNodeWith(addr, "", "", "", m)
-		n.NodeMetadata.Counters[containersKey] = 1
+		n.Node.Counters[containersKey] = 1
 		result[addr] = n
 	}
 	return result
@@ -245,7 +245,7 @@ func MapContainer2IP(m RenderableNode, _ report.Networks) RenderableNodes {
 func MapIP2Container(n RenderableNode, _ report.Networks) RenderableNodes {
 	// If an IP is shared between multiple containers, we can't
 	// reliably attribute an connection based on its IP
-	if n.NodeMetadata.Counters[containersKey] > 1 {
+	if n.Node.Counters[containersKey] > 1 {
 		return RenderableNodes{}
 	}
 
@@ -257,7 +257,7 @@ func MapIP2Container(n RenderableNode, _ report.Networks) RenderableNodes {
 	// If this node is not a container, exclude it.
 	// This excludes all the nodes we've dragged in from endpoint
 	// that we failed to join to a container.
-	id, ok := n.NodeMetadata.Metadata[docker.ContainerID]
+	id, ok := n.Node.Metadata[docker.ContainerID]
 	if !ok {
 		return RenderableNodes{}
 	}
@@ -281,12 +281,12 @@ func MapEndpoint2Process(n RenderableNode, _ report.Networks) RenderableNodes {
 		return RenderableNodes{n.ID: n}
 	}
 
-	pid, ok := n.NodeMetadata.Metadata[process.PID]
+	pid, ok := n.Node.Metadata[process.PID]
 	if !ok {
 		return RenderableNodes{}
 	}
 
-	id := MakeProcessID(report.ExtractHostID(n.NodeMetadata), pid)
+	id := MakeProcessID(report.ExtractHostID(n.Node), pid)
 	return RenderableNodes{id: NewDerivedNode(id, n)}
 }
 
@@ -316,9 +316,9 @@ func MapProcess2Container(n RenderableNode, _ report.Networks) RenderableNodes {
 	// into an per-host "Uncontained" node.  If for whatever reason
 	// this node doesn't have a host id in their nodemetadata, it'll
 	// all get grouped into a single uncontained node.
-	id, ok := n.NodeMetadata.Metadata[docker.ContainerID]
+	id, ok := n.Node.Metadata[docker.ContainerID]
 	if !ok {
-		hostID := report.ExtractHostID(n.NodeMetadata)
+		hostID := report.ExtractHostID(n.Node)
 		id = MakePseudoNodeID(UncontainedID, hostID)
 		node := newDerivedPseudoNode(id, UncontainedMajor, n)
 		node.LabelMinor = hostID
@@ -339,7 +339,7 @@ func MapProcess2Name(n RenderableNode, _ report.Networks) RenderableNodes {
 		return RenderableNodes{n.ID: n}
 	}
 
-	name, ok := n.NodeMetadata.Metadata["comm"]
+	name, ok := n.Node.Metadata["comm"]
 	if !ok {
 		return RenderableNodes{}
 	}
@@ -347,7 +347,7 @@ func MapProcess2Name(n RenderableNode, _ report.Networks) RenderableNodes {
 	node := NewDerivedNode(name, n)
 	node.LabelMajor = name
 	node.Rank = name
-	node.NodeMetadata.Counters[processesKey] = 1
+	node.Node.Counters[processesKey] = 1
 	return RenderableNodes{name: node}
 }
 
@@ -359,7 +359,7 @@ func MapCountProcessName(n RenderableNode, _ report.Networks) RenderableNodes {
 		return RenderableNodes{n.ID: n}
 	}
 
-	processes := n.NodeMetadata.Counters[processesKey]
+	processes := n.Node.Counters[processesKey]
 	if processes == 1 {
 		n.LabelMinor = "1 process"
 	} else {
@@ -387,14 +387,14 @@ func MapContainer2ContainerImage(n RenderableNode, _ report.Networks) Renderable
 
 	// Otherwise, if some some reason the container doesn't have a image_id
 	// (maybe slightly out of sync reports), just drop it
-	id, ok := n.NodeMetadata.Metadata[docker.ImageID]
+	id, ok := n.Node.Metadata[docker.ImageID]
 	if !ok {
 		return RenderableNodes{}
 	}
 
 	// Add container-<id> key to NMD, which will later be counted to produce the minor label
 	result := NewDerivedNode(id, n)
-	result.NodeMetadata.Counters[containersKey] = 1
+	result.Node.Counters[containersKey] = 1
 	return RenderableNodes{id: result}
 }
 
@@ -409,7 +409,7 @@ func MapContainerImage2Name(n RenderableNode, _ report.Networks) RenderableNodes
 		return RenderableNodes{n.ID: n}
 	}
 
-	name, ok := n.NodeMetadata.Metadata[docker.ImageName]
+	name, ok := n.Node.Metadata[docker.ImageName]
 	if !ok {
 		return RenderableNodes{}
 	}
@@ -422,7 +422,7 @@ func MapContainerImage2Name(n RenderableNode, _ report.Networks) RenderableNodes
 	node := NewDerivedNode(name, n)
 	node.LabelMajor = name
 	node.Rank = name
-	node.NodeMetadata = n.NodeMetadata.Copy() // Propagate NMD for container counting.
+	node.Node = n.Node.Copy() // Propagate NMD for container counting.
 	return RenderableNodes{name: node}
 }
 
@@ -434,7 +434,7 @@ func MapCountContainers(n RenderableNode, _ report.Networks) RenderableNodes {
 		return RenderableNodes{n.ID: n}
 	}
 
-	containers := n.NodeMetadata.Counters[containersKey]
+	containers := n.Node.Counters[containersKey]
 	if containers == 1 {
 		n.LabelMinor = "1 container"
 	} else {
@@ -451,7 +451,7 @@ func MapAddress2Host(n RenderableNode, _ report.Networks) RenderableNodes {
 		return RenderableNodes{n.ID: n}
 	}
 
-	id := MakeHostID(report.ExtractHostID(n.NodeMetadata))
+	id := MakeHostID(report.ExtractHostID(n.Node))
 	return RenderableNodes{id: NewDerivedNode(id, n)}
 }
 

--- a/render/mapping_test.go
+++ b/render/mapping_test.go
@@ -11,18 +11,18 @@ import (
 	"github.com/weaveworks/scope/report"
 )
 
-func nrn(nmd report.NodeMetadata) render.RenderableNode {
-	return render.NewRenderableNode("").WithNodeMetadata(nmd)
+func nrn(nmd report.Node) render.RenderableNode {
+	return render.NewRenderableNode("").WithNode(nmd)
 }
 
 func TestMapEndpointIdentity(t *testing.T) {
 	for _, input := range []testcase{
-		{nrn(report.MakeNodeMetadata()), false},
-		{nrn(report.MakeNodeMetadataWith(map[string]string{endpoint.Addr: "1.2.3.4"})), false},
-		{nrn(report.MakeNodeMetadataWith(map[string]string{endpoint.Port: "1234"})), false},
-		{nrn(report.MakeNodeMetadataWith(map[string]string{endpoint.Addr: "1.2.3.4", endpoint.Port: "1234"})), true},
-		{nrn(report.MakeNodeMetadataWith(map[string]string{endpoint.Addr: "1.2.3.4", endpoint.Port: "40000"})), true},
-		{nrn(report.MakeNodeMetadataWith(map[string]string{report.HostNodeID: report.MakeHostNodeID("foo"), endpoint.Addr: "10.0.0.1", endpoint.Port: "20001"})), true},
+		{nrn(report.MakeNode()), false},
+		{nrn(report.MakeNodeWith(map[string]string{endpoint.Addr: "1.2.3.4"})), false},
+		{nrn(report.MakeNodeWith(map[string]string{endpoint.Port: "1234"})), false},
+		{nrn(report.MakeNodeWith(map[string]string{endpoint.Addr: "1.2.3.4", endpoint.Port: "1234"})), true},
+		{nrn(report.MakeNodeWith(map[string]string{endpoint.Addr: "1.2.3.4", endpoint.Port: "40000"})), true},
+		{nrn(report.MakeNodeWith(map[string]string{report.HostNodeID: report.MakeHostNodeID("foo"), endpoint.Addr: "10.0.0.1", endpoint.Port: "20001"})), true},
 	} {
 		testMap(t, render.MapEndpointIdentity, input)
 	}
@@ -30,8 +30,8 @@ func TestMapEndpointIdentity(t *testing.T) {
 
 func TestMapProcessIdentity(t *testing.T) {
 	for _, input := range []testcase{
-		{nrn(report.MakeNodeMetadata()), false},
-		{nrn(report.MakeNodeMetadataWith(map[string]string{process.PID: "201"})), true},
+		{nrn(report.MakeNode()), false},
+		{nrn(report.MakeNodeWith(map[string]string{process.PID: "201"})), true},
 	} {
 		testMap(t, render.MapProcessIdentity, input)
 	}
@@ -39,8 +39,8 @@ func TestMapProcessIdentity(t *testing.T) {
 
 func TestMapContainerIdentity(t *testing.T) {
 	for _, input := range []testcase{
-		{nrn(report.MakeNodeMetadata()), false},
-		{nrn(report.MakeNodeMetadataWith(map[string]string{docker.ContainerID: "a1b2c3"})), true},
+		{nrn(report.MakeNode()), false},
+		{nrn(report.MakeNodeWith(map[string]string{docker.ContainerID: "a1b2c3"})), true},
 	} {
 		testMap(t, render.MapContainerIdentity, input)
 	}
@@ -48,8 +48,8 @@ func TestMapContainerIdentity(t *testing.T) {
 
 func TestMapContainerImageIdentity(t *testing.T) {
 	for _, input := range []testcase{
-		{nrn(report.MakeNodeMetadata()), false},
-		{nrn(report.MakeNodeMetadataWith(map[string]string{docker.ImageID: "a1b2c3"})), true},
+		{nrn(report.MakeNode()), false},
+		{nrn(report.MakeNodeWith(map[string]string{docker.ImageID: "a1b2c3"})), true},
 	} {
 		testMap(t, render.MapContainerImageIdentity, input)
 	}
@@ -57,8 +57,8 @@ func TestMapContainerImageIdentity(t *testing.T) {
 
 func TestMapAddressIdentity(t *testing.T) {
 	for _, input := range []testcase{
-		{nrn(report.MakeNodeMetadata()), false},
-		{nrn(report.MakeNodeMetadataWith(map[string]string{endpoint.Addr: "192.168.1.1"})), true},
+		{nrn(report.MakeNode()), false},
+		{nrn(report.MakeNodeWith(map[string]string{endpoint.Addr: "192.168.1.1"})), true},
 	} {
 		testMap(t, render.MapAddressIdentity, input)
 	}
@@ -66,7 +66,7 @@ func TestMapAddressIdentity(t *testing.T) {
 
 func TestMapHostIdentity(t *testing.T) {
 	for _, input := range []testcase{
-		{nrn(report.MakeNodeMetadata()), true}, // TODO it's questionable if this is actually correct
+		{nrn(report.MakeNode()), true}, // TODO it's questionable if this is actually correct
 	} {
 		testMap(t, render.MapHostIdentity, input)
 	}

--- a/render/render.go
+++ b/render/render.go
@@ -135,7 +135,7 @@ func (c CustomRenderer) Render(rpt report.Report) RenderableNodes {
 	return c.RenderFunc(c.Renderer.Render(rpt))
 }
 
-// IsConnected is the key added to NodeMetadata by ColorConnected
+// IsConnected is the key added to Node.Metadata by ColorConnected
 // to indicate a node has an edge pointing to it or from it
 const IsConnected = "is_connected"
 
@@ -143,7 +143,7 @@ const IsConnected = "is_connected"
 func OnlyConnected(input RenderableNodes) RenderableNodes {
 	output := RenderableNodes{}
 	for id, node := range ColorConnected(input) {
-		if _, ok := node.NodeMetadata.Metadata[IsConnected]; ok {
+		if _, ok := node.Node.Metadata[IsConnected]; ok {
 			output[id] = node
 		}
 	}
@@ -178,7 +178,7 @@ func ColorConnected(input RenderableNodes) RenderableNodes {
 
 	for id := range connected {
 		node := input[id]
-		node.NodeMetadata.Metadata[IsConnected] = "true"
+		node.Node.Metadata[IsConnected] = "true"
 		input[id] = node
 	}
 	return input

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -98,13 +98,13 @@ func TestMapRender3(t *testing.T) {
 			return render.RenderableNodes{id: render.NewRenderableNode(id)}
 		},
 		Renderer: mockRenderer{RenderableNodes: render.RenderableNodes{
-			"foo": render.NewRenderableNode("foo").WithNodeMetadata(report.MakeNodeMetadata().WithAdjacent("baz")),
-			"baz": render.NewRenderableNode("baz").WithNodeMetadata(report.MakeNodeMetadata().WithAdjacent("foo")),
+			"foo": render.NewRenderableNode("foo").WithNode(report.MakeNode().WithAdjacent("baz")),
+			"baz": render.NewRenderableNode("baz").WithNode(report.MakeNode().WithAdjacent("foo")),
 		}},
 	}
 	want := render.RenderableNodes{
-		"_foo": render.NewRenderableNode("_foo").WithNodeMetadata(report.MakeNodeMetadata().WithAdjacent("_baz")),
-		"_baz": render.NewRenderableNode("_baz").WithNodeMetadata(report.MakeNodeMetadata().WithAdjacent("_foo")),
+		"_foo": render.NewRenderableNode("_foo").WithNode(report.MakeNode().WithAdjacent("_baz")),
+		"_baz": render.NewRenderableNode("_baz").WithNode(report.MakeNode().WithAdjacent("_foo")),
 	}
 	have := mapper.Render(report.MakeReport())
 	if !reflect.DeepEqual(want, have) {
@@ -115,15 +115,15 @@ func TestMapRender3(t *testing.T) {
 func TestMapEdge(t *testing.T) {
 	selector := render.TopologySelector(func(_ report.Report) render.RenderableNodes {
 		return render.MakeRenderableNodes(report.Topology{
-			NodeMetadatas: report.NodeMetadatas{
-				"foo": report.MakeNodeMetadata().WithMetadata(map[string]string{
+			Nodes: report.Nodes{
+				"foo": report.MakeNode().WithMetadata(map[string]string{
 					"id": "foo",
 				}).WithEdge("bar", report.EdgeMetadata{
 					EgressPacketCount: newu64(1),
 					EgressByteCount:   newu64(2),
 				}),
 
-				"bar": report.MakeNodeMetadata().WithMetadata(map[string]string{
+				"bar": report.MakeNode().WithMetadata(map[string]string{
 					"id": "bar",
 				}).WithEdge("foo", report.EdgeMetadata{
 					EgressPacketCount: newu64(3),
@@ -144,18 +144,18 @@ func TestMapEdge(t *testing.T) {
 	have := expected.Sterilize(mapper.Render(report.MakeReport()))
 	want := expected.Sterilize(render.RenderableNodes{
 		"_foo": {
-			ID:           "_foo",
-			Origins:      report.MakeIDList("foo"),
-			NodeMetadata: report.MakeNodeMetadata().WithAdjacent("_bar"),
+			ID:      "_foo",
+			Origins: report.MakeIDList("foo"),
+			Node:    report.MakeNode().WithAdjacent("_bar"),
 			EdgeMetadata: report.EdgeMetadata{
 				EgressPacketCount: newu64(4),
 				EgressByteCount:   newu64(6),
 			},
 		},
 		"_bar": {
-			ID:           "_bar",
-			Origins:      report.MakeIDList("bar"),
-			NodeMetadata: report.MakeNodeMetadata().WithAdjacent("_foo"),
+			ID:      "_bar",
+			Origins: report.MakeIDList("bar"),
+			Node:    report.MakeNode().WithAdjacent("_foo"),
 			EdgeMetadata: report.EdgeMetadata{
 				EgressPacketCount: newu64(4),
 				EgressByteCount:   newu64(6),
@@ -177,13 +177,13 @@ func TestMapEdge(t *testing.T) {
 func TestFilterRender(t *testing.T) {
 	renderer := render.FilterUnconnected(
 		mockRenderer{RenderableNodes: render.RenderableNodes{
-			"foo": {ID: "foo", NodeMetadata: report.MakeNodeMetadata().WithAdjacent("bar")},
-			"bar": {ID: "bar", NodeMetadata: report.MakeNodeMetadata().WithAdjacent("foo")},
-			"baz": {ID: "baz", NodeMetadata: report.MakeNodeMetadata()},
+			"foo": {ID: "foo", Node: report.MakeNode().WithAdjacent("bar")},
+			"bar": {ID: "bar", Node: report.MakeNode().WithAdjacent("foo")},
+			"baz": {ID: "baz", Node: report.MakeNode()},
 		}})
 	want := render.RenderableNodes{
-		"foo": {ID: "foo", NodeMetadata: report.MakeNodeMetadata().WithAdjacent("bar")},
-		"bar": {ID: "bar", NodeMetadata: report.MakeNodeMetadata().WithAdjacent("foo")},
+		"foo": {ID: "foo", Node: report.MakeNode().WithAdjacent("bar")},
+		"bar": {ID: "bar", Node: report.MakeNode().WithAdjacent("foo")},
 	}
 	have := expected.Sterilize(renderer.Render(report.MakeReport()))
 	if !reflect.DeepEqual(want, have) {

--- a/render/renderable_node.go
+++ b/render/renderable_node.go
@@ -16,7 +16,7 @@ type RenderableNode struct {
 	Origins    report.IDList `json:"origins,omitempty"`     // Core node IDs that contributed information
 
 	report.EdgeMetadata `json:"metadata"` // Numeric sums
-	report.NodeMetadata
+	report.Node
 }
 
 // NewRenderableNode makes a new RenderableNode
@@ -29,7 +29,7 @@ func NewRenderableNode(id string) RenderableNode {
 		Pseudo:       false,
 		Origins:      report.MakeIDList(),
 		EdgeMetadata: report.EdgeMetadata{},
-		NodeMetadata: report.MakeNodeMetadata(),
+		Node:         report.MakeNode(),
 	}
 }
 
@@ -43,7 +43,7 @@ func NewRenderableNodeWith(id, major, minor, rank string, rn RenderableNode) Ren
 		Pseudo:       false,
 		Origins:      rn.Origins.Copy(),
 		EdgeMetadata: rn.EdgeMetadata.Copy(),
-		NodeMetadata: rn.NodeMetadata.Copy(),
+		Node:         rn.Node.Copy(),
 	}
 }
 
@@ -57,7 +57,7 @@ func NewDerivedNode(id string, node RenderableNode) RenderableNode {
 		Pseudo:       node.Pseudo,
 		Origins:      node.Origins.Copy(),
 		EdgeMetadata: node.EdgeMetadata.Copy(),
-		NodeMetadata: node.NodeMetadata.Copy(),
+		Node:         node.Node.Copy(),
 	}
 }
 
@@ -70,14 +70,14 @@ func newDerivedPseudoNode(id, major string, node RenderableNode) RenderableNode 
 		Pseudo:       true,
 		Origins:      node.Origins.Copy(),
 		EdgeMetadata: node.EdgeMetadata.Copy(),
-		NodeMetadata: node.NodeMetadata.Copy(),
+		Node:         node.Node.Copy(),
 	}
 }
 
-// WithNodeMetadata creates a new RenderableNode based on rn, with n
-func (rn RenderableNode) WithNodeMetadata(n report.NodeMetadata) RenderableNode {
+// WithNode creates a new RenderableNode based on rn, with n
+func (rn RenderableNode) WithNode(n report.Node) RenderableNode {
 	result := rn.Copy()
-	result.NodeMetadata = result.NodeMetadata.Merge(n)
+	result.Node = result.Node.Merge(n)
 	return result
 }
 
@@ -103,7 +103,7 @@ func (rn RenderableNode) Merge(other RenderableNode) RenderableNode {
 
 	result.Origins = rn.Origins.Merge(other.Origins)
 	result.EdgeMetadata = rn.EdgeMetadata.Merge(other.EdgeMetadata)
-	result.NodeMetadata = rn.NodeMetadata.Merge(other.NodeMetadata)
+	result.Node = rn.Node.Merge(other.Node)
 
 	return result
 }
@@ -118,7 +118,7 @@ func (rn RenderableNode) Copy() RenderableNode {
 		Pseudo:       rn.Pseudo,
 		Origins:      rn.Origins.Copy(),
 		EdgeMetadata: rn.EdgeMetadata.Copy(),
-		NodeMetadata: rn.NodeMetadata.Copy(),
+		Node:         rn.Node.Copy(),
 	}
 }
 

--- a/render/renderable_node_test.go
+++ b/render/renderable_node_test.go
@@ -32,22 +32,22 @@ func TestMergeRenderableNodes(t *testing.T) {
 
 func TestMergeRenderableNode(t *testing.T) {
 	node1 := render.RenderableNode{
-		ID:           "foo",
-		LabelMajor:   "",
-		LabelMinor:   "minor",
-		Rank:         "",
-		Pseudo:       false,
-		NodeMetadata: report.MakeNodeMetadata().WithAdjacent("a1"),
-		Origins:      report.MakeIDList("o1"),
+		ID:         "foo",
+		LabelMajor: "",
+		LabelMinor: "minor",
+		Rank:       "",
+		Pseudo:     false,
+		Node:       report.MakeNode().WithAdjacent("a1"),
+		Origins:    report.MakeIDList("o1"),
 	}
 	node2 := render.RenderableNode{
-		ID:           "foo",
-		LabelMajor:   "major",
-		LabelMinor:   "",
-		Rank:         "rank",
-		Pseudo:       false,
-		NodeMetadata: report.MakeNodeMetadata().WithAdjacent("a2"),
-		Origins:      report.MakeIDList("o2"),
+		ID:         "foo",
+		LabelMajor: "major",
+		LabelMinor: "",
+		Rank:       "rank",
+		Pseudo:     false,
+		Node:       report.MakeNode().WithAdjacent("a2"),
+		Origins:    report.MakeIDList("o2"),
 	}
 	want := render.RenderableNode{
 		ID:           "foo",
@@ -55,7 +55,7 @@ func TestMergeRenderableNode(t *testing.T) {
 		LabelMinor:   "minor",
 		Rank:         "rank",
 		Pseudo:       false,
-		NodeMetadata: report.MakeNodeMetadata().WithAdjacency(report.MakeIDList("a1", "a2")),
+		Node:         report.MakeNode().WithAdjacency(report.MakeIDList("a1", "a2")),
 		Origins:      report.MakeIDList("o1", "o2"),
 		EdgeMetadata: report.EdgeMetadata{},
 	}

--- a/render/selectors.go
+++ b/render/selectors.go
@@ -32,8 +32,8 @@ func (t TopologySelector) EdgeMetadata(rpt report.Report, srcID, dstID string) r
 // MakeRenderableNodes converts a topology to a set of RenderableNodes
 func MakeRenderableNodes(t report.Topology) RenderableNodes {
 	result := RenderableNodes{}
-	for id, nmd := range t.NodeMetadatas {
-		rn := NewRenderableNode(id).WithNodeMetadata(nmd)
+	for id, nmd := range t.Nodes {
+		rn := NewRenderableNode(id).WithNode(nmd)
 		rn.Origins = report.MakeIDList(id)
 		if hostNodeID, ok := nmd.Metadata[report.HostNodeID]; ok {
 			rn.Origins = rn.Origins.Add(hostNodeID)

--- a/render/theinternet.go
+++ b/render/theinternet.go
@@ -18,7 +18,7 @@ func LocalNetworks(r report.Report) report.Networks {
 		networks = map[string]struct{}{}
 	)
 
-	for _, md := range r.Host.NodeMetadatas {
+	for _, md := range r.Host.Nodes {
 		val, ok := md.Metadata[host.LocalNetworks]
 		if !ok {
 			continue

--- a/render/theinternet_test.go
+++ b/render/theinternet_test.go
@@ -14,9 +14,9 @@ import (
 func TestReportLocalNetworks(t *testing.T) {
 	r := report.MakeReport().Merge(report.Report{
 		Host: report.Topology{
-			NodeMetadatas: report.NodeMetadatas{
-				"nonets": report.MakeNodeMetadata(),
-				"foo": report.MakeNodeMetadataWith(map[string]string{
+			Nodes: report.Nodes{
+				"nonets": report.MakeNode(),
+				"foo": report.MakeNodeWith(map[string]string{
 					host.LocalNetworks: "10.0.0.1/8 192.168.1.1/24 10.0.0.1/8 badnet/33",
 				}),
 			},

--- a/render/topologies.go
+++ b/render/topologies.go
@@ -41,11 +41,11 @@ func (r ProcessWithContainerNameRenderer) Render(rpt report.Report) RenderableNo
 	}.Render(rpt)
 
 	for id, p := range processes {
-		pid, ok := p.NodeMetadata.Metadata[process.PID]
+		pid, ok := p.Node.Metadata[process.PID]
 		if !ok {
 			continue
 		}
-		containerID, ok := p.NodeMetadata.Metadata[docker.ContainerID]
+		containerID, ok := p.Node.Metadata[docker.ContainerID]
 		if !ok {
 			continue
 		}
@@ -53,7 +53,7 @@ func (r ProcessWithContainerNameRenderer) Render(rpt report.Report) RenderableNo
 		if !ok {
 			continue
 		}
-		p.LabelMinor = fmt.Sprintf("%s (%s:%s)", report.ExtractHostID(p.NodeMetadata), container.LabelMajor, pid)
+		p.LabelMinor = fmt.Sprintf("%s (%s:%s)", report.ExtractHostID(p.Node), container.LabelMajor, pid)
 		processes[id] = p
 	}
 
@@ -86,8 +86,8 @@ var ContainerRenderer = MakeReduce(
 		// including the ProcessRenderer once.
 		Renderer: Filter{
 			f: func(n RenderableNode) bool {
-				_, inContainer := n.NodeMetadata.Metadata[docker.ContainerID]
-				_, isConnected := n.NodeMetadata.Metadata[IsConnected]
+				_, inContainer := n.Node.Metadata[docker.ContainerID]
+				_, isConnected := n.Node.Metadata[IsConnected]
 				return inContainer || isConnected
 			},
 			Renderer: CustomRenderer{

--- a/render/topology_diff_test.go
+++ b/render/topology_diff_test.go
@@ -19,11 +19,11 @@ func (r ByID) Less(i, j int) bool { return r[i].ID < r[j].ID }
 
 func TestTopoDiff(t *testing.T) {
 	nodea := render.RenderableNode{
-		ID:           "nodea",
-		LabelMajor:   "Node A",
-		LabelMinor:   "'ts an a",
-		Pseudo:       false,
-		NodeMetadata: report.MakeNodeMetadata().WithAdjacent("nodeb"),
+		ID:         "nodea",
+		LabelMajor: "Node A",
+		LabelMinor: "'ts an a",
+		Pseudo:     false,
+		Node:       report.MakeNode().WithAdjacent("nodeb"),
 	}
 	nodeap := nodea
 	nodeap.Adjacency = []string{

--- a/report/id.go
+++ b/report/id.go
@@ -87,6 +87,16 @@ func ParseEndpointNodeID(endpointNodeID string) (hostID, address, port string, o
 	return fields[0], fields[1], fields[2], true
 }
 
+// ParseContainerNodeID produces the host ID, and container id from an container
+// node ID.
+func ParseContainerNodeID(containerNodeID string) (hostID, containerID string, ok bool) {
+	fields := strings.SplitN(containerNodeID, ScopeDelim, 3)
+	if len(fields) != 2 {
+		return "", "", false
+	}
+	return fields[0], fields[1], true
+}
+
 // ParseAddressNodeID produces the host ID, address from an address node ID.
 func ParseAddressNodeID(addressNodeID string) (hostID, address string, ok bool) {
 	fields := strings.SplitN(addressNodeID, ScopeDelim, 2)

--- a/report/id.go
+++ b/report/id.go
@@ -106,8 +106,8 @@ func ParseAddressNodeID(addressNodeID string) (hostID, address string, ok bool) 
 	return fields[0], fields[1], true
 }
 
-// ExtractHostID extracts the host id from NodeMetadata
-func ExtractHostID(m NodeMetadata) string {
+// ExtractHostID extracts the host id from Node
+func ExtractHostID(m Node) string {
 	hostid, _, _ := ParseNodeID(m.Metadata[HostNodeID])
 	return hostid
 }

--- a/report/merge_test.go
+++ b/report/merge_test.go
@@ -127,21 +127,21 @@ func TestFlattenEdgeMetadata(t *testing.T) {
 	}
 }
 
-func TestMergeNodeMetadatas(t *testing.T) {
+func TestMergeNodes(t *testing.T) {
 	for name, c := range map[string]struct {
-		a, b, want report.NodeMetadatas
+		a, b, want report.Nodes
 	}{
 		"Empty a": {
-			a: report.NodeMetadatas{},
-			b: report.NodeMetadatas{
-				":192.168.1.1:12345": report.MakeNodeMetadataWith(map[string]string{
+			a: report.Nodes{},
+			b: report.Nodes{
+				":192.168.1.1:12345": report.MakeNodeWith(map[string]string{
 					PID:    "23128",
 					Name:   "curl",
 					Domain: "node-a.local",
 				}),
 			},
-			want: report.NodeMetadatas{
-				":192.168.1.1:12345": report.MakeNodeMetadataWith(map[string]string{
+			want: report.Nodes{
+				":192.168.1.1:12345": report.MakeNodeWith(map[string]string{
 					PID:    "23128",
 					Name:   "curl",
 					Domain: "node-a.local",
@@ -149,16 +149,16 @@ func TestMergeNodeMetadatas(t *testing.T) {
 			},
 		},
 		"Empty b": {
-			a: report.NodeMetadatas{
-				":192.168.1.1:12345": report.MakeNodeMetadataWith(map[string]string{
+			a: report.Nodes{
+				":192.168.1.1:12345": report.MakeNodeWith(map[string]string{
 					PID:    "23128",
 					Name:   "curl",
 					Domain: "node-a.local",
 				}),
 			},
-			b: report.NodeMetadatas{},
-			want: report.NodeMetadatas{
-				":192.168.1.1:12345": report.MakeNodeMetadataWith(map[string]string{
+			b: report.Nodes{},
+			want: report.Nodes{
+				":192.168.1.1:12345": report.MakeNodeWith(map[string]string{
 					PID:    "23128",
 					Name:   "curl",
 					Domain: "node-a.local",
@@ -166,27 +166,27 @@ func TestMergeNodeMetadatas(t *testing.T) {
 			},
 		},
 		"Simple merge": {
-			a: report.NodeMetadatas{
-				":192.168.1.1:12345": report.MakeNodeMetadataWith(map[string]string{
+			a: report.Nodes{
+				":192.168.1.1:12345": report.MakeNodeWith(map[string]string{
 					PID:    "23128",
 					Name:   "curl",
 					Domain: "node-a.local",
 				}),
 			},
-			b: report.NodeMetadatas{
-				":192.168.1.2:12345": report.MakeNodeMetadataWith(map[string]string{
+			b: report.Nodes{
+				":192.168.1.2:12345": report.MakeNodeWith(map[string]string{
 					PID:    "42",
 					Name:   "curl",
 					Domain: "node-a.local",
 				}),
 			},
-			want: report.NodeMetadatas{
-				":192.168.1.1:12345": report.MakeNodeMetadataWith(map[string]string{
+			want: report.Nodes{
+				":192.168.1.1:12345": report.MakeNodeWith(map[string]string{
 					PID:    "23128",
 					Name:   "curl",
 					Domain: "node-a.local",
 				}),
-				":192.168.1.2:12345": report.MakeNodeMetadataWith(map[string]string{
+				":192.168.1.2:12345": report.MakeNodeWith(map[string]string{
 					PID:    "42",
 					Name:   "curl",
 					Domain: "node-a.local",
@@ -194,22 +194,22 @@ func TestMergeNodeMetadatas(t *testing.T) {
 			},
 		},
 		"Merge conflict": {
-			a: report.NodeMetadatas{
-				":192.168.1.1:12345": report.MakeNodeMetadataWith(map[string]string{
+			a: report.Nodes{
+				":192.168.1.1:12345": report.MakeNodeWith(map[string]string{
 					PID:    "23128",
 					Name:   "curl",
 					Domain: "node-a.local",
 				}),
 			},
-			b: report.NodeMetadatas{
-				":192.168.1.1:12345": report.MakeNodeMetadataWith(map[string]string{ // <-- same ID
+			b: report.Nodes{
+				":192.168.1.1:12345": report.MakeNodeWith(map[string]string{ // <-- same ID
 					PID:    "0",
 					Name:   "curl",
 					Domain: "node-a.local",
 				}),
 			},
-			want: report.NodeMetadatas{
-				":192.168.1.1:12345": report.MakeNodeMetadataWith(map[string]string{
+			want: report.Nodes{
+				":192.168.1.1:12345": report.MakeNodeWith(map[string]string{
 					PID:    "23128",
 					Name:   "curl",
 					Domain: "node-a.local",

--- a/test/report_fixture.go
+++ b/test/report_fixture.go
@@ -86,11 +86,11 @@ var (
 
 	Report = report.Report{
 		Endpoint: report.Topology{
-			NodeMetadatas: report.NodeMetadatas{
-				// NodeMetadata is arbitrary. We're free to put only precisely what we
+			Nodes: report.Nodes{
+				// Node is arbitrary. We're free to put only precisely what we
 				// care to test into the fixture. Just be sure to include the bits
 				// that the mapping funcs extract :)
-				Client54001NodeID: report.MakeNodeMetadata().WithMetadata(map[string]string{
+				Client54001NodeID: report.MakeNode().WithMetadata(map[string]string{
 					endpoint.Addr:     ClientIP,
 					endpoint.Port:     ClientPort54001,
 					process.PID:       Client1PID,
@@ -100,7 +100,7 @@ var (
 					EgressByteCount:   newu64(100),
 				}),
 
-				Client54002NodeID: report.MakeNodeMetadata().WithMetadata(map[string]string{
+				Client54002NodeID: report.MakeNode().WithMetadata(map[string]string{
 					endpoint.Addr:     ClientIP,
 					endpoint.Port:     ClientPort54002,
 					process.PID:       Client2PID,
@@ -110,14 +110,14 @@ var (
 					EgressByteCount:   newu64(200),
 				}),
 
-				Server80NodeID: report.MakeNodeMetadata().WithMetadata(map[string]string{
+				Server80NodeID: report.MakeNode().WithMetadata(map[string]string{
 					endpoint.Addr:     ServerIP,
 					endpoint.Port:     ServerPort,
 					process.PID:       ServerPID,
 					report.HostNodeID: ServerHostNodeID,
 				}),
 
-				NonContainerNodeID: report.MakeNodeMetadata().WithMetadata(map[string]string{
+				NonContainerNodeID: report.MakeNode().WithMetadata(map[string]string{
 					endpoint.Addr:     ServerIP,
 					endpoint.Port:     NonContainerClientPort,
 					process.PID:       NonContainerPID,
@@ -125,7 +125,7 @@ var (
 				}).WithAdjacent(GoogleEndpointNodeID),
 
 				// Probe pseudo nodes
-				UnknownClient1NodeID: report.MakeNodeMetadata().WithMetadata(map[string]string{
+				UnknownClient1NodeID: report.MakeNode().WithMetadata(map[string]string{
 					endpoint.Addr: UnknownClient1IP,
 					endpoint.Port: UnknownClient1Port,
 				}).WithEdge(Server80NodeID, report.EdgeMetadata{
@@ -133,7 +133,7 @@ var (
 					EgressByteCount:   newu64(300),
 				}),
 
-				UnknownClient2NodeID: report.MakeNodeMetadata().WithMetadata(map[string]string{
+				UnknownClient2NodeID: report.MakeNode().WithMetadata(map[string]string{
 					endpoint.Addr: UnknownClient2IP,
 					endpoint.Port: UnknownClient2Port,
 				}).WithEdge(Server80NodeID, report.EdgeMetadata{
@@ -141,7 +141,7 @@ var (
 					EgressByteCount:   newu64(400),
 				}),
 
-				UnknownClient3NodeID: report.MakeNodeMetadata().WithMetadata(map[string]string{
+				UnknownClient3NodeID: report.MakeNode().WithMetadata(map[string]string{
 					endpoint.Addr: UnknownClient3IP,
 					endpoint.Port: UnknownClient3Port,
 				}).WithEdge(Server80NodeID, report.EdgeMetadata{
@@ -149,7 +149,7 @@ var (
 					EgressByteCount:   newu64(500),
 				}),
 
-				RandomClientNodeID: report.MakeNodeMetadata().WithMetadata(map[string]string{
+				RandomClientNodeID: report.MakeNode().WithMetadata(map[string]string{
 					endpoint.Addr: RandomClientIP,
 					endpoint.Port: RandomClientPort,
 				}).WithEdge(Server80NodeID, report.EdgeMetadata{
@@ -157,33 +157,33 @@ var (
 					EgressByteCount:   newu64(600),
 				}),
 
-				GoogleEndpointNodeID: report.MakeNodeMetadata().WithMetadata(map[string]string{
+				GoogleEndpointNodeID: report.MakeNode().WithMetadata(map[string]string{
 					endpoint.Addr: GoogleIP,
 					endpoint.Port: GooglePort,
 				}),
 			},
 		},
 		Process: report.Topology{
-			NodeMetadatas: report.NodeMetadatas{
-				ClientProcess1NodeID: report.MakeNodeMetadataWith(map[string]string{
+			Nodes: report.Nodes{
+				ClientProcess1NodeID: report.MakeNodeWith(map[string]string{
 					process.PID:        Client1PID,
 					"comm":             Client1Comm,
 					docker.ContainerID: ClientContainerID,
 					report.HostNodeID:  ClientHostNodeID,
 				}),
-				ClientProcess2NodeID: report.MakeNodeMetadataWith(map[string]string{
+				ClientProcess2NodeID: report.MakeNodeWith(map[string]string{
 					process.PID:        Client2PID,
 					"comm":             Client2Comm,
 					docker.ContainerID: ClientContainerID,
 					report.HostNodeID:  ClientHostNodeID,
 				}),
-				ServerProcessNodeID: report.MakeNodeMetadataWith(map[string]string{
+				ServerProcessNodeID: report.MakeNodeWith(map[string]string{
 					process.PID:        ServerPID,
 					"comm":             ServerComm,
 					docker.ContainerID: ServerContainerID,
 					report.HostNodeID:  ServerHostNodeID,
 				}),
-				NonContainerProcessNodeID: report.MakeNodeMetadataWith(map[string]string{
+				NonContainerProcessNodeID: report.MakeNodeWith(map[string]string{
 					process.PID:       NonContainerPID,
 					"comm":            NonContainerComm,
 					report.HostNodeID: ServerHostNodeID,
@@ -191,14 +191,14 @@ var (
 			},
 		},
 		Container: report.Topology{
-			NodeMetadatas: report.NodeMetadatas{
-				ClientContainerNodeID: report.MakeNodeMetadataWith(map[string]string{
+			Nodes: report.Nodes{
+				ClientContainerNodeID: report.MakeNodeWith(map[string]string{
 					docker.ContainerID:   ClientContainerID,
 					docker.ContainerName: "client",
 					docker.ImageID:       ClientContainerImageID,
 					report.HostNodeID:    ClientHostNodeID,
 				}),
-				ServerContainerNodeID: report.MakeNodeMetadataWith(map[string]string{
+				ServerContainerNodeID: report.MakeNodeWith(map[string]string{
 					docker.ContainerID:          ServerContainerID,
 					docker.ContainerName:        "server",
 					docker.ImageID:              ServerContainerImageID,
@@ -209,13 +209,13 @@ var (
 			},
 		},
 		ContainerImage: report.Topology{
-			NodeMetadatas: report.NodeMetadatas{
-				ClientContainerImageNodeID: report.MakeNodeMetadataWith(map[string]string{
+			Nodes: report.Nodes{
+				ClientContainerImageNodeID: report.MakeNodeWith(map[string]string{
 					docker.ImageID:    ClientContainerImageID,
 					docker.ImageName:  ClientContainerImageName,
 					report.HostNodeID: ClientHostNodeID,
 				}),
-				ServerContainerImageNodeID: report.MakeNodeMetadataWith(map[string]string{
+				ServerContainerImageNodeID: report.MakeNodeWith(map[string]string{
 					docker.ImageID:              ServerContainerImageID,
 					docker.ImageName:            ServerContainerImageName,
 					report.HostNodeID:           ServerHostNodeID,
@@ -225,46 +225,46 @@ var (
 			},
 		},
 		Address: report.Topology{
-			NodeMetadatas: report.NodeMetadatas{
-				ClientAddressNodeID: report.MakeNodeMetadata().WithMetadata(map[string]string{
+			Nodes: report.Nodes{
+				ClientAddressNodeID: report.MakeNode().WithMetadata(map[string]string{
 					endpoint.Addr:     ClientIP,
 					report.HostNodeID: ClientHostNodeID,
 				}).WithEdge(ServerAddressNodeID, report.EdgeMetadata{
 					MaxConnCountTCP: newu64(3),
 				}),
 
-				ServerAddressNodeID: report.MakeNodeMetadata().WithMetadata(map[string]string{
+				ServerAddressNodeID: report.MakeNode().WithMetadata(map[string]string{
 					endpoint.Addr:     ServerIP,
 					report.HostNodeID: ServerHostNodeID,
 				}),
 
-				UnknownAddress1NodeID: report.MakeNodeMetadata().WithMetadata(map[string]string{
+				UnknownAddress1NodeID: report.MakeNode().WithMetadata(map[string]string{
 					endpoint.Addr: UnknownClient1IP,
 				}).WithAdjacency(report.MakeIDList(ServerAddressNodeID)),
 
-				UnknownAddress2NodeID: report.MakeNodeMetadata().WithMetadata(map[string]string{
+				UnknownAddress2NodeID: report.MakeNode().WithMetadata(map[string]string{
 					endpoint.Addr: UnknownClient2IP,
 				}).WithAdjacency(report.MakeIDList(ServerAddressNodeID)),
 
-				UnknownAddress3NodeID: report.MakeNodeMetadata().WithMetadata(map[string]string{
+				UnknownAddress3NodeID: report.MakeNode().WithMetadata(map[string]string{
 					endpoint.Addr: UnknownClient3IP,
 				}).WithAdjacency(report.MakeIDList(ServerAddressNodeID)),
 
-				RandomAddressNodeID: report.MakeNodeMetadata().WithMetadata(map[string]string{
+				RandomAddressNodeID: report.MakeNode().WithMetadata(map[string]string{
 					endpoint.Addr: RandomClientIP,
 				}).WithAdjacency(report.MakeIDList(ServerAddressNodeID)),
 			},
 		},
 		Host: report.Topology{
-			NodeMetadatas: report.NodeMetadatas{
-				ClientHostNodeID: report.MakeNodeMetadataWith(map[string]string{
+			Nodes: report.Nodes{
+				ClientHostNodeID: report.MakeNodeWith(map[string]string{
 					"host_name":       ClientHostName,
 					"local_networks":  "10.10.10.0/24",
 					"os":              "Linux",
 					"load":            "0.01 0.01 0.01",
 					report.HostNodeID: ClientHostNodeID,
 				}),
-				ServerHostNodeID: report.MakeNodeMetadataWith(map[string]string{
+				ServerHostNodeID: report.MakeNodeWith(map[string]string{
 					"host_name":       ServerHostName,
 					"local_networks":  "10.10.10.0/24",
 					"os":              "Linux",

--- a/xfer/collector_test.go
+++ b/xfer/collector_test.go
@@ -17,10 +17,10 @@ func TestCollector(t *testing.T) {
 	c := xfer.NewCollector(window)
 
 	r1 := report.MakeReport()
-	r1.Endpoint.NodeMetadatas["foo"] = report.MakeNodeMetadata()
+	r1.Endpoint.Nodes["foo"] = report.MakeNode()
 
 	r2 := report.MakeReport()
-	r2.Endpoint.NodeMetadatas["bar"] = report.MakeNodeMetadata()
+	r2.Endpoint.Nodes["bar"] = report.MakeNode()
 
 	if want, have := report.MakeReport(), c.Report(); !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))


### PR DESCRIPTION
Part of #357 

```
vagrant@ubuntu-14:~/src/github.com/weaveworks/scope$ gorename -from '"github.com/weaveworks/scope/report".NodeMetadata' -to Node
Renamed 120 occurrences in 16 files in 7 packages.
vagrant@ubuntu-14:~/src/github.com/weaveworks/scope$ gorename -from '"github.com/weaveworks/scope/report".NodeMetadatas' -to Nodes
Renamed 123 occurrences in 29 files in 20 packages.
vagrant@ubuntu-14:~/src/github.com/weaveworks/scope$ gorename -from '"github.com/weaveworks/scope/report".MakeNodeMetadata' -to MakeNode
Renamed 84 occurrences in 18 files in 13 packages.
vagrant@ubuntu-14:~/src/github.com/weaveworks/scope$ gorename -from '"github.com/weaveworks/scope/report".MakeNodeMetadataWith' -to MakeNodeWith
Renamed 69 occurrences in 23 files in 15 packages.
vagrant@ubuntu-14:~/src/github.com/weaveworks/scope$ gorename -from '"github.com/weaveworks/scope/render".RenderableNode.WithNodeMetadata' -to WithNode
Renamed 7 occurrences in 4 files in 2 packages.
```

Plus some grepping through the comments.