### PR TITLE
Basic Kubernetes Integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ $(RUNSVINIT): vendor/runsvinit/*.go
 
 $(APP_EXE): app/*.go render/*.go report/*.go xfer/*.go
 
-$(PROBE_EXE): probe/*.go probe/docker/*.go probe/endpoint/*.go probe/host/*.go probe/process/*.go probe/overlay/*.go report/*.go xfer/*.go
+$(PROBE_EXE): probe/*.go probe/docker/*.go probe/kubernetes/*.go probe/endpoint/*.go probe/host/*.go probe/process/*.go probe/overlay/*.go report/*.go xfer/*.go
 
 $(APP_EXE) $(PROBE_EXE):
 	go get -d -tags netgo ./$(@D)

--- a/app/api_topologies_test.go
+++ b/app/api_topologies_test.go
@@ -1,9 +1,17 @@
 package main
 
 import (
+	"bytes"
+	"encoding/gob"
 	"encoding/json"
 	"net/http/httptest"
 	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+
+	"github.com/weaveworks/scope/probe/kubernetes"
+	"github.com/weaveworks/scope/report"
+	"github.com/weaveworks/scope/test"
 )
 
 func TestAPITopology(t *testing.T) {
@@ -36,5 +44,58 @@ func TestAPITopology(t *testing.T) {
 		if have := topology.Stats.NonpseudoNodeCount; have <= 0 {
 			t.Errorf("NonpseudoNodeCount isn't positive for %s: %d", topology.Name, have)
 		}
+	}
+}
+
+func TestAPITopologyAddsKubernetes(t *testing.T) {
+	ts := httptest.NewServer(Router(StaticReport{}))
+	defer ts.Close()
+
+	body := getRawJSON(t, ts, "/api/topology")
+
+	var topologies []APITopologyDesc
+	if err := json.Unmarshal(body, &topologies); err != nil {
+		t.Fatalf("JSON parse error: %s", err)
+	}
+	equals(t, 3, len(topologies))
+
+	// Enable the kubernetes topologies
+	rpt := report.MakeReport()
+	rpt.Pod = report.MakeTopology()
+	rpt.Pod.Nodes[test.ClientPodNodeID] = kubernetes.NewPod(&api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "pong-a",
+			Namespace: "ping",
+			Labels:    map[string]string{"ponger": "true"},
+		},
+		Status: api.PodStatus{
+			HostIP: "1.2.3.4",
+			ContainerStatuses: []api.ContainerStatus{
+				{ContainerID: "container1"},
+				{ContainerID: "container2"},
+			},
+		},
+	}).GetNode()
+	buf := &bytes.Buffer{}
+	if err := gob.NewEncoder(buf).Encode(rpt); err != nil {
+		t.Fatalf("GOB encoding error: %s", err)
+	}
+	checkRequest(t, ts, "POST", "/api/report", buf.Bytes())
+
+	body = getRawJSON(t, ts, "/api/topology")
+	if err := json.Unmarshal(body, &topologies); err != nil {
+		t.Fatalf("JSON parse error: %s", err)
+	}
+	equals(t, 4, len(topologies))
+
+	found := false
+	for _, topology := range topologies {
+		if topology.Name == "Pods" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Could not find pods topology")
 	}
 }

--- a/app/scope_test.go
+++ b/app/scope_test.go
@@ -50,19 +50,19 @@ func checkRequest(t *testing.T, ts *httptest.Server, method, path string, body [
 	}
 	req, err := http.NewRequest(method, fullPath, bodyReader)
 	if err != nil {
-		t.Fatalf("Error getting %s: %s", path, err)
+		t.Fatalf("Error getting %s: %s %s", method, path, err)
 	}
 
 	client := &http.Client{}
 	res, err := client.Do(req)
 	if err != nil {
-		t.Fatalf("Error getting %s: %s", path, err)
+		t.Fatalf("Error getting %s %s: %s", method, path, err)
 	}
 
 	body, err = ioutil.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
-		t.Fatalf("%s body read error: %s", path, err)
+		t.Fatalf("%s %s body read error: %s", method, path, err)
 	}
 	return res, body
 }

--- a/experimental/kubernetes/install-scope.bash
+++ b/experimental/kubernetes/install-scope.bash
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+export SSH_AUTH_SOCK=
+
+remote() {
+  host=$1
+  shift
+  echo "[$host] Running: $@" >&2
+  gcloud compute ssh $host --command "$@"
+}
+
+for h in $(gcloud compute instances list | grep -v NAME | awk '{print $1}') ; do
+  cat ~/work/weave/repos/scope/scope.tar | remote $h "sudo docker load"
+  cat ~/work/weave/repos/scope/scope | remote $h "sudo tee /usr/local/bin/scope >/dev/null; sudo chmod a+x /usr/local/bin/scope"
+  if $(echo $h | grep -q "master") ; then
+    remote $h "sudo scope stop ; sudo DOCKER_BRIDGE=cbr0 scope launch --probe.docker.bridge cbr0 --probe.kubernetes true"
+  else
+    remote $h "sudo scope stop ; sudo DOCKER_BRIDGE=cbr0 scope launch --no-app --probe.docker.bridge cbr0 kubernetes-master"
+  fi
+done

--- a/probe/kubernetes/client.go
+++ b/probe/kubernetes/client.go
@@ -1,0 +1,91 @@
+package kubernetes
+
+import (
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+// These constants are keys used in node metadata
+const (
+	Namespace = "kubernetes_namespace"
+)
+
+// Client keeps track of running kubernetes pods and services
+type Client interface {
+	Stop()
+	WalkPods(f func(Pod) error) error
+	WalkServices(f func(Service) error) error
+}
+
+type client struct {
+	quit             chan struct{}
+	client           cache.Getter
+	podReflector     *cache.Reflector
+	serviceReflector *cache.Reflector
+	podStore         *cache.StoreToPodLister
+	serviceStore     *cache.StoreToServiceLister
+}
+
+// NewClient returns a usable Client. Don't forget to Stop it.
+func NewClient(addr string, resyncPeriod time.Duration) (Client, error) {
+	c, err := unversioned.New(&unversioned.Config{Host: addr})
+	if err != nil {
+		return nil, err
+	}
+
+	podListWatch := cache.NewListWatchFromClient(c, "pods", api.NamespaceAll, fields.Everything())
+	podStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	podReflector := cache.NewReflector(podListWatch, &api.Pod{}, podStore, resyncPeriod)
+
+	serviceListWatch := cache.NewListWatchFromClient(c, "services", api.NamespaceAll, fields.Everything())
+	serviceStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	serviceReflector := cache.NewReflector(serviceListWatch, &api.Service{}, serviceStore, resyncPeriod)
+
+	quit := make(chan struct{})
+	podReflector.RunUntil(quit)
+	serviceReflector.RunUntil(quit)
+
+	return &client{
+		quit:             quit,
+		client:           c,
+		podReflector:     podReflector,
+		podStore:         &cache.StoreToPodLister{Store: podStore},
+		serviceReflector: serviceReflector,
+		serviceStore:     &cache.StoreToServiceLister{Store: serviceStore},
+	}, nil
+}
+
+func (c *client) WalkPods(f func(Pod) error) error {
+	pods, err := c.podStore.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	for _, pod := range pods {
+		if err := f(NewPod(pod)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *client) WalkServices(f func(Service) error) error {
+	list, err := c.serviceStore.List()
+	if err != nil {
+		return err
+	}
+	for i := range list.Items {
+		if err := f(NewService(&(list.Items[i]))); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *client) Stop() {
+	close(c.quit)
+}

--- a/probe/kubernetes/pod.go
+++ b/probe/kubernetes/pod.go
@@ -1,0 +1,88 @@
+package kubernetes
+
+import (
+	"strings"
+	"time"
+
+	"github.com/weaveworks/scope/report"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+// These constants are keys used in node metadata
+const (
+	PodID           = "kubernetes_pod_id"
+	PodName         = "kubernetes_pod_name"
+	PodCreated      = "kubernetes_pod_created"
+	PodContainerIDs = "kubernetes_pod_container_ids"
+	ServiceIDs      = "kubernetes_service_ids"
+)
+
+// Pod represents a Kubernetes pod
+type Pod interface {
+	ID() string
+	Name() string
+	Namespace() string
+	ContainerIDs() []string
+	Created() string
+	AddServiceID(id string)
+	Labels() labels.Labels
+	GetNode() report.Node
+}
+
+type pod struct {
+	*api.Pod
+	serviceIDs []string
+	Node       *api.Node
+}
+
+// NewPod creates a new Pod
+func NewPod(p *api.Pod) Pod {
+	return &pod{Pod: p}
+}
+
+func (p *pod) ID() string {
+	return p.ObjectMeta.Namespace + "/" + p.ObjectMeta.Name
+}
+
+func (p *pod) Name() string {
+	return p.ObjectMeta.Name
+}
+
+func (p *pod) Namespace() string {
+	return p.ObjectMeta.Namespace
+}
+
+func (p *pod) Created() string {
+	return p.ObjectMeta.CreationTimestamp.Format(time.RFC822)
+}
+
+func (p *pod) ContainerIDs() []string {
+	ids := []string{}
+	for _, container := range p.Status.ContainerStatuses {
+		ids = append(ids, strings.TrimPrefix(container.ContainerID, "docker://"))
+	}
+	return ids
+}
+
+func (p *pod) Labels() labels.Labels {
+	return labels.Set(p.ObjectMeta.Labels)
+}
+
+func (p *pod) AddServiceID(id string) {
+	p.serviceIDs = append(p.serviceIDs, id)
+}
+
+func (p *pod) GetNode() report.Node {
+	n := report.MakeNodeWith(map[string]string{
+		PodID:           p.ID(),
+		PodName:         p.Name(),
+		Namespace:       p.Namespace(),
+		PodCreated:      p.Created(),
+		PodContainerIDs: strings.Join(p.ContainerIDs(), " "),
+	})
+	if len(p.serviceIDs) > 0 {
+		n.Metadata[ServiceIDs] = strings.Join(p.serviceIDs, " ")
+	}
+	return n
+}

--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -1,0 +1,62 @@
+package kubernetes
+
+import (
+	"github.com/weaveworks/scope/report"
+)
+
+// Reporter generate Reports containing Container and ContainerImage topologies
+type Reporter struct {
+	client Client
+}
+
+// NewReporter makes a new Reporter
+func NewReporter(client Client) *Reporter {
+	return &Reporter{
+		client: client,
+	}
+}
+
+// Report generates a Report containing Container and ContainerImage topologies
+func (r *Reporter) Report() (report.Report, error) {
+	result := report.MakeReport()
+	serviceTopology, services, err := r.serviceTopology()
+	if err != nil {
+		return result, err
+	}
+	podTopology, err := r.podTopology(services)
+	if err != nil {
+		return result, err
+	}
+	result.Service = result.Service.Merge(serviceTopology)
+	result.Pod = result.Pod.Merge(podTopology)
+	return result, nil
+}
+
+func (r *Reporter) serviceTopology() (report.Topology, []Service, error) {
+	var (
+		result   = report.MakeTopology()
+		services = []Service{}
+	)
+	err := r.client.WalkServices(func(s Service) error {
+		nodeID := report.MakeServiceNodeID(s.Namespace(), s.Name())
+		result = result.AddNode(nodeID, s.GetNode())
+		services = append(services, s)
+		return nil
+	})
+	return result, services, err
+}
+
+func (r *Reporter) podTopology(services []Service) (report.Topology, error) {
+	result := report.MakeTopology()
+	err := r.client.WalkPods(func(p Pod) error {
+		for _, service := range services {
+			if service.Selector().Matches(p.Labels()) {
+				p.AddServiceID(service.ID())
+			}
+		}
+		nodeID := report.MakePodNodeID(p.Namespace(), p.Name())
+		result = result.AddNode(nodeID, p.GetNode())
+		return nil
+	})
+	return result, err
+}

--- a/probe/kubernetes/reporter_test.go
+++ b/probe/kubernetes/reporter_test.go
@@ -1,0 +1,150 @@
+package kubernetes_test
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+
+	"github.com/weaveworks/scope/probe/kubernetes"
+	"github.com/weaveworks/scope/report"
+	"github.com/weaveworks/scope/test"
+)
+
+var (
+	podTypeMeta = unversioned.TypeMeta{
+		Kind:       "Pod",
+		APIVersion: "v1",
+	}
+	apiPod1 = api.Pod{
+		TypeMeta: podTypeMeta,
+		ObjectMeta: api.ObjectMeta{
+			Name:              "pong-a",
+			Namespace:         "ping",
+			CreationTimestamp: unversioned.Now(),
+			Labels:            map[string]string{"ponger": "true"},
+		},
+		Status: api.PodStatus{
+			HostIP: "1.2.3.4",
+			ContainerStatuses: []api.ContainerStatus{
+				{ContainerID: "container1"},
+				{ContainerID: "container2"},
+			},
+		},
+	}
+	apiPod2 = api.Pod{
+		TypeMeta: podTypeMeta,
+		ObjectMeta: api.ObjectMeta{
+			Name:              "pong-b",
+			Namespace:         "ping",
+			CreationTimestamp: unversioned.Now(),
+			Labels:            map[string]string{"ponger": "true"},
+		},
+		Status: api.PodStatus{
+			HostIP: "1.2.3.4",
+			ContainerStatuses: []api.ContainerStatus{
+				{ContainerID: "container3"},
+				{ContainerID: "container4"},
+			},
+		},
+	}
+	apiService1 = api.Service{
+		TypeMeta: unversioned.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: api.ObjectMeta{
+			Name:              "pongservice",
+			Namespace:         "ping",
+			CreationTimestamp: unversioned.Now(),
+		},
+		Spec: api.ServiceSpec{
+			Type:      api.ServiceTypeLoadBalancer,
+			ClusterIP: "10.0.1.1",
+			Ports: []api.ServicePort{
+				{Protocol: "TCP", Port: 6379},
+			},
+			Selector: map[string]string{"ponger": "true"},
+		},
+		Status: api.ServiceStatus{
+			LoadBalancer: api.LoadBalancerStatus{
+				Ingress: []api.LoadBalancerIngress{
+					{IP: "10.0.1.2"},
+				},
+			},
+		},
+	}
+	pod1               = kubernetes.NewPod(&apiPod1)
+	pod2               = kubernetes.NewPod(&apiPod2)
+	service1           = kubernetes.NewService(&apiService1)
+	mockClientInstance = &mockClient{
+		pods:     []kubernetes.Pod{pod1, pod2},
+		services: []kubernetes.Service{service1},
+	}
+)
+
+type mockClient struct {
+	pods     []kubernetes.Pod
+	services []kubernetes.Service
+}
+
+func (c *mockClient) Stop() {}
+func (c *mockClient) WalkPods(f func(kubernetes.Pod) error) error {
+	for _, pod := range c.pods {
+		if err := f(pod); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func (c *mockClient) WalkServices(f func(kubernetes.Service) error) error {
+	for _, service := range c.services {
+		if err := f(service); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestReporter(t *testing.T) {
+	want := report.MakeReport()
+	pod1ID := report.MakePodNodeID("ping", "pong-a")
+	pod2ID := report.MakePodNodeID("ping", "pong-b")
+	want.Pod = report.Topology{
+		Nodes: report.Nodes{
+			pod1ID: report.MakeNodeWith(map[string]string{
+				kubernetes.PodID:           "ping/pong-a",
+				kubernetes.PodName:         "pong-a",
+				kubernetes.Namespace:       "ping",
+				kubernetes.PodCreated:      pod1.Created(),
+				kubernetes.PodContainerIDs: "container1 container2",
+				kubernetes.ServiceIDs:      "ping/pongservice",
+			}),
+			pod2ID: report.MakeNodeWith(map[string]string{
+				kubernetes.PodID:           "ping/pong-b",
+				kubernetes.PodName:         "pong-b",
+				kubernetes.Namespace:       "ping",
+				kubernetes.PodCreated:      pod1.Created(),
+				kubernetes.PodContainerIDs: "container3 container4",
+				kubernetes.ServiceIDs:      "ping/pongservice",
+			}),
+		},
+	}
+	want.Service = report.Topology{
+		Nodes: report.Nodes{
+			report.MakeServiceNodeID("ping", "pongservice"): report.MakeNodeWith(map[string]string{
+				kubernetes.ServiceID:      "ping/pongservice",
+				kubernetes.ServiceName:    "pongservice",
+				kubernetes.Namespace:      "ping",
+				kubernetes.ServiceCreated: pod1.Created(),
+			}),
+		},
+	}
+
+	reporter := kubernetes.NewReporter(mockClientInstance)
+	have, _ := reporter.Report()
+	if !reflect.DeepEqual(want, have) {
+		t.Errorf("%s", test.Diff(want, have))
+	}
+}

--- a/probe/kubernetes/service.go
+++ b/probe/kubernetes/service.go
@@ -1,0 +1,59 @@
+package kubernetes
+
+import (
+	"time"
+
+	"github.com/weaveworks/scope/report"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+// These constants are keys used in node metadata
+const (
+	ServiceID      = "kubernetes_service_id"
+	ServiceName    = "kubernetes_service_name"
+	ServiceCreated = "kubernetes_service_created"
+)
+
+// Service represents a Kubernetes service
+type Service interface {
+	ID() string
+	Name() string
+	Namespace() string
+	GetNode() report.Node
+	Selector() labels.Selector
+}
+
+type service struct {
+	*api.Service
+}
+
+// NewService creates a new Service
+func NewService(s *api.Service) Service {
+	return &service{Service: s}
+}
+
+func (s *service) ID() string {
+	return s.ObjectMeta.Namespace + "/" + s.ObjectMeta.Name
+}
+
+func (s *service) Name() string {
+	return s.ObjectMeta.Name
+}
+
+func (s *service) Namespace() string {
+	return s.ObjectMeta.Namespace
+}
+
+func (s *service) Selector() labels.Selector {
+	return labels.SelectorFromSet(labels.Set(s.Spec.Selector))
+}
+
+func (s *service) GetNode() report.Node {
+	return report.MakeNodeWith(map[string]string{
+		ServiceID:      s.ID(),
+		ServiceName:    s.Name(),
+		ServiceCreated: s.ObjectMeta.CreationTimestamp.Format(time.RFC822),
+		Namespace:      s.Namespace(),
+	})
+}

--- a/render/detailed_node_test.go
+++ b/render/detailed_node_test.go
@@ -61,6 +61,7 @@ func TestOriginTable(t *testing.T) {
 				{fmt.Sprintf(`Label %q`, render.AmazonECSContainerNameLabel), `server`, "", false},
 				{`Label "foo1"`, `bar1`, "", false},
 				{`Label "foo2"`, `bar2`, "", false},
+				{`Label "io.kubernetes.pod.name"`, "ping/pong-b", "", false},
 			},
 		},
 	} {
@@ -162,6 +163,7 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 					{fmt.Sprintf(`Label %q`, render.AmazonECSContainerNameLabel), `server`, "", false},
 					{`Label "foo1"`, `bar1`, "", false},
 					{`Label "foo2"`, `bar2`, "", false},
+					{`Label "io.kubernetes.pod.name"`, "ping/pong-b", "", false},
 				},
 			},
 			{

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -368,6 +368,141 @@ var (
 			Origins:      report.MakeIDList(test.RandomAddressNodeID),
 		},
 	}).Prune()
+
+	RenderedPods = (render.RenderableNodes{
+		"ping/pong-a": {
+			ID:         "ping/pong-a",
+			LabelMajor: "pong-a",
+			LabelMinor: "1 container",
+			Rank:       "ping/pong-a",
+			Pseudo:     false,
+			Origins: report.MakeIDList(
+				test.Client54001NodeID,
+				test.Client54002NodeID,
+				test.ClientProcess1NodeID,
+				test.ClientProcess2NodeID,
+				test.ClientHostNodeID,
+				test.ClientContainerNodeID,
+				test.ClientContainerImageNodeID,
+				test.ClientPodNodeID,
+			),
+			Node: report.MakeNode().WithAdjacent("ping/pong-b"),
+			EdgeMetadata: report.EdgeMetadata{
+				EgressPacketCount: newu64(30),
+				EgressByteCount:   newu64(300),
+			},
+		},
+		"ping/pong-b": {
+			ID:         "ping/pong-b",
+			LabelMajor: "pong-b",
+			LabelMinor: "1 container",
+			Rank:       "ping/pong-b",
+			Pseudo:     false,
+			Origins: report.MakeIDList(
+				test.Server80NodeID,
+				test.ServerPodNodeID,
+				test.ServerProcessNodeID,
+				test.ServerContainerNodeID,
+				test.ServerHostNodeID,
+				test.ServerContainerImageNodeID,
+			),
+			Node: report.MakeNode(),
+			EdgeMetadata: report.EdgeMetadata{
+				IngressPacketCount: newu64(210),
+				IngressByteCount:   newu64(2100),
+			},
+		},
+		uncontainedServerID: {
+			ID:         uncontainedServerID,
+			LabelMajor: render.UncontainedMajor,
+			LabelMinor: test.ServerHostName,
+			Rank:       "",
+			Pseudo:     true,
+			Origins: report.MakeIDList(
+				test.ServerHostNodeID,
+				test.NonContainerProcessNodeID,
+				test.NonContainerNodeID,
+			),
+			Node:         report.MakeNode().WithAdjacent(render.TheInternetID),
+			EdgeMetadata: report.EdgeMetadata{},
+		},
+		render.TheInternetID: {
+			ID:         render.TheInternetID,
+			LabelMajor: render.TheInternetMajor,
+			Pseudo:     true,
+			Node:       report.MakeNode().WithAdjacent("ping/pong-b"),
+			EdgeMetadata: report.EdgeMetadata{
+				EgressPacketCount: newu64(60),
+				EgressByteCount:   newu64(600),
+			},
+			Origins: report.MakeIDList(
+				test.RandomClientNodeID,
+				test.GoogleEndpointNodeID,
+			),
+		},
+	}).Prune()
+
+	RenderedPodServices = (render.RenderableNodes{
+		"ping/pongservice": {
+			ID:         test.ServiceID,
+			LabelMajor: "pongservice",
+			LabelMinor: "2 pods",
+			Rank:       test.ServiceID,
+			Pseudo:     false,
+			Origins: report.MakeIDList(
+				test.Client54001NodeID,
+				test.Client54002NodeID,
+				test.ClientProcess1NodeID,
+				test.ClientProcess2NodeID,
+				test.ClientHostNodeID,
+				test.ClientContainerNodeID,
+				test.ClientContainerImageNodeID,
+				test.ClientPodNodeID,
+				test.Server80NodeID,
+				test.ServerPodNodeID,
+				test.ServiceNodeID,
+				test.ServerProcessNodeID,
+				test.ServerContainerNodeID,
+				test.ServerHostNodeID,
+				test.ServerContainerImageNodeID,
+			),
+			Node: report.MakeNode().WithAdjacent(test.ServiceID), // ?? Shouldn't be adjacent to itself?
+			EdgeMetadata: report.EdgeMetadata{
+				EgressPacketCount:  newu64(30),
+				EgressByteCount:    newu64(300),
+				IngressPacketCount: newu64(210),
+				IngressByteCount:   newu64(2100),
+			},
+		},
+		uncontainedServerID: {
+			ID:         uncontainedServerID,
+			LabelMajor: render.UncontainedMajor,
+			LabelMinor: test.ServerHostName,
+			Rank:       "",
+			Pseudo:     true,
+			Origins: report.MakeIDList(
+				test.ServerHostNodeID,
+				test.NonContainerProcessNodeID,
+				test.NonContainerNodeID,
+			),
+			Node:         report.MakeNode().WithAdjacent(render.TheInternetID),
+			EdgeMetadata: report.EdgeMetadata{},
+		},
+		render.TheInternetID: {
+			ID:         render.TheInternetID,
+			LabelMajor: render.TheInternetMajor,
+			Pseudo:     true,
+			Node:       report.MakeNode().WithAdjacent(test.ServiceID),
+			EdgeMetadata: report.EdgeMetadata{
+				EgressPacketCount: newu64(60),
+				EgressByteCount:   newu64(600),
+			},
+			Origins: report.MakeIDList(
+				test.RandomClientNodeID,
+				test.GoogleEndpointNodeID,
+			),
+		},
+	}).Prune()
 )
 
 func newu64(value uint64) *uint64 { return &value }

--- a/render/mapping.go
+++ b/render/mapping.go
@@ -9,6 +9,7 @@ import (
 	"github.com/weaveworks/scope/probe/docker"
 	"github.com/weaveworks/scope/probe/endpoint"
 	"github.com/weaveworks/scope/probe/host"
+	"github.com/weaveworks/scope/probe/kubernetes"
 	"github.com/weaveworks/scope/probe/process"
 	"github.com/weaveworks/scope/report"
 )
@@ -22,7 +23,9 @@ const (
 	TheInternetMajor = "The Internet"
 
 	containersKey = "containers"
+	podsKey       = "pods"
 	processesKey  = "processes"
+	servicesKey   = "services"
 
 	AmazonECSContainerNameLabel = "com.amazonaws.ecs.container-name"
 )
@@ -165,6 +168,40 @@ func MapContainerImageIdentity(m RenderableNode, _ report.Networks) RenderableNo
 	var (
 		major = m.Metadata[docker.ImageName]
 		rank  = m.Metadata[docker.ImageID]
+	)
+
+	return RenderableNodes{id: NewRenderableNodeWith(id, major, "", rank, m)}
+}
+
+// MapPodIdentity maps a pod topology node to pod renderable node. As it is
+// only ever run on pod topology nodes, we expect that certain keys
+// are present.
+func MapPodIdentity(m RenderableNode, _ report.Networks) RenderableNodes {
+	id, ok := m.Metadata[kubernetes.PodID]
+	if !ok {
+		return RenderableNodes{}
+	}
+
+	var (
+		major = m.Metadata[kubernetes.PodName]
+		rank  = m.Metadata[kubernetes.PodID]
+	)
+
+	return RenderableNodes{id: NewRenderableNodeWith(id, major, "", rank, m)}
+}
+
+// MapServiceIdentity maps a service topology node to service renderable node. As it is
+// only ever run on service topology nodes, we expect that certain keys
+// are present.
+func MapServiceIdentity(m RenderableNode, _ report.Networks) RenderableNodes {
+	id, ok := m.Metadata[kubernetes.ServiceID]
+	if !ok {
+		return RenderableNodes{}
+	}
+
+	var (
+		major = m.Metadata[kubernetes.ServiceName]
+		rank  = m.Metadata[kubernetes.ServiceID]
 	)
 
 	return RenderableNodes{id: NewRenderableNodeWith(id, major, "", rank, m)}
@@ -430,6 +467,38 @@ func MapContainer2ContainerImage(n RenderableNode, _ report.Networks) Renderable
 	return RenderableNodes{id: result}
 }
 
+// MapPod2Service maps pod RenderableNodes to service RenderableNodes.
+//
+// If this function is given a node without a kubernetes_pod_id
+// (including other pseudo nodes), it will produce an "Uncontained"
+// pseudo node.
+//
+// Otherwise, this function will produce a node with the correct ID
+// format for a container, but without any Major or Minor labels.
+// It does not have enough info to do that, and the resulting graph
+// must be merged with a pod graph to get that info.
+func MapPod2Service(n RenderableNode, _ report.Networks) RenderableNodes {
+	// Propogate all pseudo nodes
+	if n.Pseudo {
+		return RenderableNodes{n.ID: n}
+	}
+
+	// Otherwise, if some some reason the pod doesn't have a service_ids (maybe
+	// slightly out of sync reports, or its not in a service), just drop it
+	ids, ok := n.Node.Metadata[kubernetes.ServiceIDs]
+	if !ok {
+		return RenderableNodes{}
+	}
+
+	result := RenderableNodes{}
+	for _, id := range strings.Fields(ids) {
+		n := NewDerivedNode(id, n)
+		n.Node.Counters[podsKey] = 1
+		result[id] = n
+	}
+	return result
+}
+
 func imageNameWithoutVersion(name string) string {
 	parts := strings.SplitN(name, ":", 2)
 	if len(parts) == 2 {
@@ -463,6 +532,45 @@ func MapContainerImage2Name(n RenderableNode, _ report.Networks) RenderableNodes
 	return RenderableNodes{name: node}
 }
 
+// MapContainer2Pod maps container RenderableNodes to pod
+// RenderableNodes.
+//
+// If this function is given a node without a kubernetes_pod_id
+// (including other pseudo nodes), it will produce an "Unmanaged"
+// pseudo node.
+//
+// Otherwise, this function will produce a node with the correct ID
+// format for a container, but without any Major or Minor labels.
+// It does not have enough info to do that, and the resulting graph
+// must be merged with a container graph to get that info.
+func MapContainer2Pod(n RenderableNode, _ report.Networks) RenderableNodes {
+	// Propogate all pseudo nodes
+	if n.Pseudo {
+		return RenderableNodes{n.ID: n}
+	}
+
+	// Otherwise, if some some reason the container doesn't have a pod_id (maybe
+	// slightly out of sync reports, or its not in a pod), just drop it
+	id, ok := n.Node.Metadata["docker_label_io.kubernetes.pod.name"]
+	if !ok {
+		return RenderableNodes{}
+	}
+
+	// Add container-<id> key to NMD, which will later be counted to produce the
+	// minor label
+	result := NewRenderableNodeWith(id, "", "", id, n)
+	result.Node.Counters[containersKey] = 1
+	// Due to a bug in kubernetes, addon pods on the master node are not returned
+	// from the API. This is a workaround until
+	// https://github.com/kubernetes/kubernetes/issues/14738 is fixed.
+	if s := strings.SplitN(id, "/", 2); len(s) == 2 {
+		result.LabelMajor = s[1]
+		result.Node.Metadata[kubernetes.Namespace] = s[0]
+		result.Node.Metadata[kubernetes.PodName] = s[1]
+	}
+	return RenderableNodes{id: result}
+}
+
 // MapCountContainers maps 1:1 container image nodes, counting
 // the number of containers grouped together and putting
 // that info in the minor label.
@@ -476,6 +584,22 @@ func MapCountContainers(n RenderableNode, _ report.Networks) RenderableNodes {
 		n.LabelMinor = "1 container"
 	} else {
 		n.LabelMinor = fmt.Sprintf("%d containers", containers)
+	}
+	return RenderableNodes{n.ID: n}
+}
+
+// MapCountPods maps 1:1 service nodes, counting the number of pods grouped
+// together and putting that info in the minor label.
+func MapCountPods(n RenderableNode, _ report.Networks) RenderableNodes {
+	if n.Pseudo {
+		return RenderableNodes{n.ID: n}
+	}
+
+	pods := n.Node.Counters[podsKey]
+	if pods == 1 {
+		n.LabelMinor = "1 pod"
+	} else {
+		n.LabelMinor = fmt.Sprintf("%d pods", pods)
 	}
 	return RenderableNodes{n.ID: n}
 }

--- a/render/mapping_test.go
+++ b/render/mapping_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/weaveworks/scope/probe/docker"
 	"github.com/weaveworks/scope/probe/endpoint"
+	"github.com/weaveworks/scope/probe/kubernetes"
 	"github.com/weaveworks/scope/probe/process"
 	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/scope/report"
@@ -69,6 +70,24 @@ func TestMapHostIdentity(t *testing.T) {
 		{nrn(report.MakeNode()), true}, // TODO it's questionable if this is actually correct
 	} {
 		testMap(t, render.MapHostIdentity, input)
+	}
+}
+
+func TestMapPodIdentity(t *testing.T) {
+	for _, input := range []testcase{
+		{nrn(report.MakeNode()), false},
+		{nrn(report.MakeNodeWith(map[string]string{kubernetes.PodID: "ping/pong", kubernetes.PodName: "pong"})), true},
+	} {
+		testMap(t, render.MapPodIdentity, input)
+	}
+}
+
+func TestMapServiceIdentity(t *testing.T) {
+	for _, input := range []testcase{
+		{nrn(report.MakeNode()), false},
+		{nrn(report.MakeNodeWith(map[string]string{kubernetes.ServiceID: "ping/pong", kubernetes.ServiceName: "pong"})), true},
+	} {
+		testMap(t, render.MapServiceIdentity, input)
 	}
 }
 

--- a/render/render.go
+++ b/render/render.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/weaveworks/scope/probe/docker"
+	"github.com/weaveworks/scope/probe/kubernetes"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -289,6 +290,12 @@ func FilterSystem(r Renderer) Renderer {
 				return false
 			}
 			if node.Metadata[docker.LabelPrefix+"works.weave.role"] == "system" {
+				return false
+			}
+			if node.Metadata[kubernetes.Namespace] == "kube-system" {
+				return false
+			}
+			if strings.HasPrefix(node.Metadata[docker.LabelPrefix+"io.kubernetes.pod.name"], "kube-system/") {
 				return false
 			}
 			return true

--- a/render/selectors.go
+++ b/render/selectors.go
@@ -91,4 +91,14 @@ var (
 	SelectHost = TopologySelector(func(r report.Report) RenderableNodes {
 		return MakeRenderableNodes(r.Host)
 	})
+
+	// SelectPod selects the pod topology.
+	SelectPod = TopologySelector(func(r report.Report) RenderableNodes {
+		return MakeRenderableNodes(r.Pod)
+	})
+
+	// SelectService selects the service topology.
+	SelectService = TopologySelector(func(r report.Report) RenderableNodes {
+		return MakeRenderableNodes(r.Service)
+	})
 )

--- a/render/topologies.go
+++ b/render/topologies.go
@@ -190,3 +190,35 @@ var HostRenderer = MakeReduce(
 		Renderer: SelectHost,
 	},
 )
+
+// PodRenderer is a Renderer which produces a renderable kubernetes
+// graph by merging the container graph and the pods topology.
+var PodRenderer = Map{
+	MapFunc: MapCountContainers,
+	Renderer: MakeReduce(
+		Map{
+			MapFunc:  MapPodIdentity,
+			Renderer: SelectPod,
+		},
+		Map{
+			MapFunc:  MapContainer2Pod,
+			Renderer: ContainerRenderer,
+		},
+	),
+}
+
+// PodsServiceRenderer is a Renderer which produces a renderable kubernetes services
+// graph by merging the pods graph and the services topology.
+var PodServiceRenderer = Map{
+	MapFunc: MapCountPods,
+	Renderer: MakeReduce(
+		Map{
+			MapFunc:  MapPod2Service,
+			Renderer: PodRenderer,
+		},
+		Map{
+			MapFunc:  MapServiceIdentity,
+			Renderer: SelectService,
+		},
+	),
+}

--- a/render/topologies_test.go
+++ b/render/topologies_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/weaveworks/scope/probe/docker"
+	"github.com/weaveworks/scope/probe/kubernetes"
 	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/scope/render/expected"
 	"github.com/weaveworks/scope/test"
@@ -58,6 +59,39 @@ func TestContainerImageRenderer(t *testing.T) {
 func TestHostRenderer(t *testing.T) {
 	have := render.HostRenderer.Render(test.Report).Prune()
 	want := expected.RenderedHosts
+	if !reflect.DeepEqual(want, have) {
+		t.Error(test.Diff(want, have))
+	}
+}
+
+func TestPodRenderer(t *testing.T) {
+	have := render.PodRenderer.Render(test.Report).Prune()
+	want := expected.RenderedPods
+	if !reflect.DeepEqual(want, have) {
+		t.Error(test.Diff(want, have))
+	}
+}
+
+func TestPodFilterRenderer(t *testing.T) {
+	// tag on containers or pod namespace in the topology and ensure
+	// it is filtered out correctly.
+	input := test.Report.Copy()
+	input.Pod.Nodes[test.ClientPodNodeID].Metadata[kubernetes.PodID] = "kube-system/foo"
+	input.Pod.Nodes[test.ClientPodNodeID].Metadata[kubernetes.Namespace] = "kube-system"
+	input.Pod.Nodes[test.ClientPodNodeID].Metadata[kubernetes.PodName] = "foo"
+	input.Container.Nodes[test.ClientContainerNodeID].Metadata[docker.LabelPrefix+"io.kubernetes.pod.name"] = "kube-system/foo"
+	have := render.FilterSystem(render.PodRenderer).Render(input).Prune()
+	want := expected.RenderedPods.Copy()
+	delete(want, test.ClientPodID)
+	delete(want, test.ClientContainerID)
+	if !reflect.DeepEqual(want, have) {
+		t.Error(test.Diff(want, have))
+	}
+}
+
+func TestPodServiceRenderer(t *testing.T) {
+	have := render.PodServiceRenderer.Render(test.Report).Prune()
+	want := expected.RenderedPodServices
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}

--- a/report/id.go
+++ b/report/id.go
@@ -94,6 +94,16 @@ func MakeContainerNodeID(hostID, containerID string) string {
 	return hostID + ScopeDelim + containerID
 }
 
+// MakePodNodeID produces a pod node ID from its composite parts.
+func MakePodNodeID(hostID, podID string) string {
+	return hostID + ScopeDelim + podID
+}
+
+// MakeServiceNodeID produces a service node ID from its composite parts.
+func MakeServiceNodeID(namespaceID, serviceID string) string {
+	return namespaceID + ScopeDelim + serviceID
+}
+
 // MakeOverlayNodeID produces an overlay topology node ID from a router peer's
 // name, which is assumed to be globally unique.
 func MakeOverlayNodeID(peerName string) string {

--- a/report/report.go
+++ b/report/report.go
@@ -28,6 +28,16 @@ type Report struct {
 	// Edges are not present.
 	Container Topology
 
+	// Pod nodes represent all Kubernetes pods running on hosts running probes.
+	// Metadata includes things like pod id, name etc. Edges are not
+	// present.
+	Pod Topology
+
+	// Service nodes represent all Kubernetes services running on hosts running probes.
+	// Metadata includes things like service id, name etc. Edges are not
+	// present.
+	Service Topology
+
 	// ContainerImages nodes represent all Docker containers images on
 	// hosts running probes. Metadata includes things like image id, name etc.
 	// Edges are not present.
@@ -64,6 +74,8 @@ func MakeReport() Report {
 		Container:      MakeTopology(),
 		ContainerImage: MakeTopology(),
 		Host:           MakeTopology(),
+		Pod:            MakeTopology(),
+		Service:        MakeTopology(),
 		Overlay:        MakeTopology(),
 		Sampling:       Sampling{},
 		Window:         0,
@@ -79,6 +91,8 @@ func (r Report) Copy() Report {
 		Container:      r.Container.Copy(),
 		ContainerImage: r.ContainerImage.Copy(),
 		Host:           r.Host.Copy(),
+		Pod:            r.Pod.Copy(),
+		Service:        r.Service.Copy(),
 		Overlay:        r.Overlay.Copy(),
 		Sampling:       r.Sampling,
 		Window:         r.Window,
@@ -95,6 +109,8 @@ func (r Report) Merge(other Report) Report {
 	cp.Container = r.Container.Merge(other.Container)
 	cp.ContainerImage = r.ContainerImage.Merge(other.ContainerImage)
 	cp.Host = r.Host.Merge(other.Host)
+	cp.Pod = r.Pod.Merge(other.Pod)
+	cp.Service = r.Service.Merge(other.Service)
 	cp.Overlay = r.Overlay.Merge(other.Overlay)
 	cp.Sampling = r.Sampling.Merge(other.Sampling)
 	cp.Window += other.Window
@@ -109,6 +125,8 @@ func (r Report) Topologies() []Topology {
 		r.Process,
 		r.Container,
 		r.ContainerImage,
+		r.Pod,
+		r.Service,
 		r.Host,
 		r.Overlay,
 	}


### PR DESCRIPTION
@tomwilkie, @peterbourgon any feedback would be great.

I'm not super-happy with the result, as there are still some shortcomings:

* We can't yet correlate connections going through the kube-proxy into pseudo service nodes, which means that all connections go through the "Uncontained" pseudo-node. This is because I haven't been able to figure out how to do it.
* We can't ever get full resolution on connections going through a service, as it might include a userspace hop (depending on configuration).
* There is a bug in k8s where [some pods are not listed in the API](https://github.com/kubernetes/kubernetes/issues/14738). I've raised an issue, and added a workaround.
* Need to pass a `--probe.kuberetes true` flag on the master node to enable it (for now).
* There may be some issues rendering incoming internet connections from external load-balancers, depending on how they do that routing, but none beyond what scope would already have.
* Kubernetes uses a lot of ephemeral (high) ports, which breaks the assumption about a higher port number being the client, and causes the graph to be laid out strangely.

In the example, there are:
* 3 php (frontend) pods, accepting incoming http requests, and making requests to redis
* 1 redis-master pod, handling writes
* 2 redis-slave pods (one per minion), handling reads. The redis-slave pods maintain an open socket to redis-master for replication.

Screenshots of it:
Pods view. I'm not sure if we should show the "2 containers" under each node, or if we should skip that.
<img width="1552" alt="screen shot 2015-09-29 at 16 45 40" src="https://cloud.githubusercontent.com/assets/250199/10215753/1db07cea-681c-11e5-8875-910ba2558b6a.png">

Pods-by-Service view, where pods are grouped when they belong to a common service
<img width="1552" alt="screen shot 2015-09-29 at 16 45 53" src="https://cloud.githubusercontent.com/assets/250199/10215755/25dfb4d0-681c-11e5-89ee-7a532cee9245.png">

As you can see, all the connections routing through "Uncontained" makes the output mostly useless. However, we *can* filter out the loads of kube-system pods, which clutter up the view considerably.
