### PR TITLE
Fix JS error on missing edge target

### DIFF
--- a/client/app/scripts/stores/__tests__/app-store-test.js
+++ b/client/app/scripts/stores/__tests__/app-store-test.js
@@ -11,7 +11,7 @@ describe('AppStore', function() {
     n1: {
       id: 'n1',
       rank: undefined,
-      adjacency: undefined,
+      adjacency: ['n1', 'n2'],
       pseudo: undefined,
       label_major: undefined,
       label_minor: undefined
@@ -64,10 +64,22 @@ describe('AppStore', function() {
     type: ActionTypes.RECEIVE_NODES_DELTA,
     delta: {
       add: [{
-        id: 'n1'
+        id: 'n1',
+        adjacency: ['n1', 'n2']
       }, {
         id: 'n2'
       }]
+    }
+  };
+
+  const ReceiveNodesDeltaUpdateAction = {
+    type: ActionTypes.RECEIVE_NODES_DELTA,
+    delta: {
+      update: [{
+        id: 'n1',
+        adjacency: ['n1']
+      }],
+      remove: ['n2']
     }
   };
 
@@ -119,6 +131,15 @@ describe('AppStore', function() {
     expect(AppStore.getTopologies().length).toBe(1);
     expect(AppStore.getCurrentTopology().name).toBe('topo 1 grouped');
     expect(AppStore.getCurrentTopologyUrl()).toBe('/topo1-grouped');
+  });
+
+  // nodes delta
+
+  it('replaces adjacency on update', function() {
+    registeredCallback(ReceiveNodesDeltaAction);
+    expect(AppStore.getNodes().toJS().n1.adjacency).toEqual(['n1', 'n2']);
+    registeredCallback(ReceiveNodesDeltaUpdateAction);
+    expect(AppStore.getNodes().toJS().n1.adjacency).toEqual(['n1']);
   });
 
   // browsing

--- a/client/app/scripts/stores/app-store.js
+++ b/client/app/scripts/stores/app-store.js
@@ -247,7 +247,7 @@ AppStore.registeredCallback = function(payload) {
 
       // update existing nodes
       _.each(payload.delta.update, function(node) {
-        nodes = nodes.set(node.id, nodes.get(node.id).mergeDeep(makeNode(node)));
+        nodes = nodes.set(node.id, nodes.get(node.id).merge(makeNode(node)));
       });
 
       // add new nodes

--- a/client/package.json
+++ b/client/package.json
@@ -40,6 +40,7 @@
     "file-loader": "^0.8.4",
     "istanbul-instrumenter-loader": "^0.1.3",
     "jasmine-core": "^2.3.4",
+    "json-loader": "^0.5.2",
     "karma": "^0.13.3",
     "karma-cli": "0.0.4",
     "karma-coverage": "^0.4.2",

--- a/client/webpack.local.config.js
+++ b/client/webpack.local.config.js
@@ -49,6 +49,10 @@ module.exports = {
     ],
     loaders: [
       {
+        test: /\.json$/,
+        loader: 'json-loader'
+      },
+      {
         test: /\.less$/,
         loader: 'style-loader!css-loader!postcss-loader!less-loader'
       },


### PR DESCRIPTION
* replace mergeDeep with merge on node updates to set adjacency to
  updated value
* added json-loader to make json import of websocket frames easier
* console message for this was `Cannot read property 'id' of undefined`