### PR TITLE
Use label "com.amazonaws.ecs.container-name" to render container names

### DIFF
--- a/render/detailed_node.go
+++ b/render/detailed_node.go
@@ -334,7 +334,7 @@ func containerOriginTable(nmd report.Node, addHostTag bool) (Table, bool) {
 
 	var (
 		title           = "Container"
-		name, nameFound = nmd.Metadata[docker.ContainerName]
+		name, nameFound = GetRenderableContainerName(nmd)
 	)
 	if nameFound {
 		title += ` "` + name + `"`

--- a/render/detailed_node_test.go
+++ b/render/detailed_node_test.go
@@ -58,6 +58,7 @@ func TestOriginTable(t *testing.T) {
 				{"Host", test.ServerHostID, "", false},
 				{"ID", test.ServerContainerID, "", false},
 				{"Image ID", test.ServerContainerImageID, "", false},
+				{fmt.Sprintf(`Label %q`, render.AmazonECSContainerNameLabel), `server`, "", false},
 				{`Label "foo1"`, `bar1`, "", false},
 				{`Label "foo2"`, `bar2`, "", false},
 			},
@@ -158,6 +159,7 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 				Rows: []render.Row{
 					{"ID", test.ServerContainerID, "", false},
 					{"Image ID", test.ServerContainerImageID, "", false},
+					{fmt.Sprintf(`Label %q`, render.AmazonECSContainerNameLabel), `server`, "", false},
 					{`Label "foo1"`, `bar1`, "", false},
 					{`Label "foo2"`, `bar2`, "", false},
 				},

--- a/test/report_fixture.go
+++ b/test/report_fixture.go
@@ -6,6 +6,7 @@ import (
 	"github.com/weaveworks/scope/probe/docker"
 	"github.com/weaveworks/scope/probe/endpoint"
 	"github.com/weaveworks/scope/probe/process"
+	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -199,12 +200,13 @@ var (
 					report.HostNodeID:    ClientHostNodeID,
 				}),
 				ServerContainerNodeID: report.MakeNodeWith(map[string]string{
-					docker.ContainerID:          ServerContainerID,
-					docker.ContainerName:        "server",
-					docker.ImageID:              ServerContainerImageID,
-					report.HostNodeID:           ServerHostNodeID,
-					docker.LabelPrefix + "foo1": "bar1",
-					docker.LabelPrefix + "foo2": "bar2",
+					docker.ContainerID:                                      ServerContainerID,
+					docker.ContainerName:                                    "task-name-5-server-aceb93e2f2b797caba01",
+					docker.ImageID:                                          ServerContainerImageID,
+					report.HostNodeID:                                       ServerHostNodeID,
+					docker.LabelPrefix + render.AmazonECSContainerNameLabel: "server",
+					docker.LabelPrefix + "foo1":                             "bar1",
+					docker.LabelPrefix + "foo2":                             "bar2",
 				}),
 			},
 		},


### PR DESCRIPTION
Addresses https://github.com/weaveworks/scope/issues/432 in the case of Amazon's ECS.