### PR TITLE
Make report propagation more reliable

### DIFF
--- a/probe/main.go
+++ b/probe/main.go
@@ -86,8 +86,15 @@ func main() {
 		log.Printf("warning: process reporting enabled, but that requires root to find everything")
 	}
 
-	publisherFactory := func(target string) (xfer.Publisher, error) { return xfer.NewHTTPPublisher(target, *token, probeID) }
+	publisherFactory := func(target string) (xfer.Publisher, error) {
+		publisher, err := xfer.NewHTTPPublisher(target, *token, probeID)
+		if err != nil {
+			return nil, err
+		}
+		return xfer.NewBackgroundPublisher(publisher), nil
+	}
 	publishers := xfer.NewMultiPublisher(publisherFactory)
+	defer publishers.Stop()
 	resolver := newStaticResolver(targets, publishers.Add)
 	defer resolver.Stop()
 

--- a/xfer/publisher_test.go
+++ b/xfer/publisher_test.go
@@ -102,3 +102,4 @@ func TestMultiPublisher(t *testing.T) {
 type mockPublisher struct{ count int }
 
 func (p *mockPublisher) Publish(report.Report) error { p.count++; return nil }
+func (p *mockPublisher) Stop()                       {}


### PR DESCRIPTION
Fixes #458, fixes #467 

- Make scope push the reports asynchronously
- Backoff when report push fails