### PR TITLE
Fix regression in missing edges

### DIFF
--- a/probe/endpoint/conntrack_test.go
+++ b/probe/endpoint/conntrack_test.go
@@ -76,7 +76,7 @@ func TestConntracker(t *testing.T) {
 		return testExec.NewMockCmd(reader)
 	}
 
-	conntracker, err := NewConntracker()
+	conntracker, err := NewConntracker(false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/probe/endpoint/nat.go
+++ b/probe/endpoint/nat.go
@@ -21,7 +21,7 @@ type natmapper struct {
 }
 
 func newNATMapper() (*natmapper, error) {
-	ct, err := NewConntracker("--any-nat")
+	ct, err := NewConntracker(true, "--any-nat")
 	if err != nil {
 		return nil, err
 	}

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -93,6 +93,7 @@ func (r *Reporter) Report() (report.Report, error) {
 		SpyDuration.WithLabelValues().Observe(float64(time.Since(begin)))
 	}(time.Now())
 
+	hostNodeID := report.MakeHostNodeID(r.hostID)
 	rpt := report.MakeReport()
 	conns, err := procspy.Connections(r.includeProcesses)
 	if err != nil {
@@ -109,7 +110,8 @@ func (r *Reporter) Report() (report.Report, error) {
 		extraNodeInfo := report.MakeNode()
 		if conn.Proc.PID > 0 {
 			extraNodeInfo = extraNodeInfo.WithMetadata(report.Metadata{
-				process.PID: strconv.FormatUint(uint64(conn.Proc.PID), 10),
+				process.PID:       strconv.FormatUint(uint64(conn.Proc.PID), 10),
+				report.HostNodeID: hostNodeID,
 			})
 		}
 		r.addConnection(&rpt, localAddr, remoteAddr, localPort, remotePort, &extraNodeInfo, nil)
@@ -138,10 +140,7 @@ func (r *Reporter) Report() (report.Report, error) {
 }
 
 func (r *Reporter) addConnection(rpt *report.Report, localAddr, remoteAddr string, localPort, remotePort uint16, extraLocalNode, extraRemoteNode *report.Node) {
-	var (
-		localIsClient = int(localPort) > int(remotePort)
-		hostNodeID    = report.MakeHostNodeID(r.hostID)
-	)
+	localIsClient := int(localPort) > int(remotePort)
 
 	// Update address topology
 	{
@@ -149,9 +148,8 @@ func (r *Reporter) addConnection(rpt *report.Report, localAddr, remoteAddr strin
 			localAddressNodeID  = report.MakeAddressNodeID(r.hostID, localAddr)
 			remoteAddressNodeID = report.MakeAddressNodeID(r.hostID, remoteAddr)
 			localNode           = report.MakeNodeWith(map[string]string{
-				"name":            r.hostName,
-				Addr:              localAddr,
-				report.HostNodeID: hostNodeID,
+				"name": r.hostName,
+				Addr:   localAddr,
 			})
 			remoteNode = report.MakeNodeWith(map[string]string{
 				Addr: remoteAddr,
@@ -189,9 +187,8 @@ func (r *Reporter) addConnection(rpt *report.Report, localAddr, remoteAddr strin
 			remoteEndpointNodeID = report.MakeEndpointNodeID(r.hostID, remoteAddr, strconv.Itoa(int(remotePort)))
 
 			localNode = report.MakeNodeWith(map[string]string{
-				Addr:              localAddr,
-				Port:              strconv.Itoa(int(localPort)),
-				report.HostNodeID: hostNodeID,
+				Addr: localAddr,
+				Port: strconv.Itoa(int(localPort)),
 			})
 			remoteNode = report.MakeNodeWith(map[string]string{
 				Addr: remoteAddr,

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -176,6 +176,12 @@ func (r *Reporter) addConnection(rpt *report.Report, localAddr, remoteAddr strin
 			})
 		}
 
+		if extraLocalNode != nil {
+			localNode = localNode.Merge(*extraLocalNode)
+		}
+		if extraRemoteNode != nil {
+			remoteNode = remoteNode.Merge(*extraRemoteNode)
+		}
 		rpt.Address = rpt.Address.AddNode(localAddressNodeID, localNode)
 		rpt.Address = rpt.Address.AddNode(remoteAddressNodeID, remoteNode)
 	}

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -55,7 +55,7 @@ func NewReporter(hostID, hostName string, includeProcesses bool, useConntrack bo
 		err                    error
 	)
 	if conntrackModulePresent && useConntrack {
-		conntracker, err = NewConntracker()
+		conntracker, err = NewConntracker(true)
 		if err != nil {
 			log.Printf("Failed to start conntracker: %v", err)
 		}

--- a/probe/process/reporter.go
+++ b/probe/process/reporter.go
@@ -45,7 +45,7 @@ func (r *Reporter) processTopology() (report.Topology, error) {
 	err := r.walker.Walk(func(p Process) {
 		pidstr := strconv.Itoa(p.PID)
 		nodeID := report.MakeProcessNodeID(r.scope, pidstr)
-		t.Nodes[nodeID] = report.MakeNode()
+		node := report.MakeNode()
 		for _, tuple := range []struct{ key, value string }{
 			{PID, pidstr},
 			{Comm, p.Comm},
@@ -53,12 +53,13 @@ func (r *Reporter) processTopology() (report.Topology, error) {
 			{Threads, strconv.Itoa(p.Threads)},
 		} {
 			if tuple.value != "" {
-				t.Nodes[nodeID].Metadata[tuple.key] = tuple.value
+				node.Metadata[tuple.key] = tuple.value
 			}
 		}
 		if p.PPID > 0 {
-			t.Nodes[nodeID].Metadata[PPID] = strconv.Itoa(p.PPID)
+			node.Metadata[PPID] = strconv.Itoa(p.PPID)
 		}
+		t.AddNode(nodeID, node)
 	})
 
 	return t, err

--- a/render/mapping.go
+++ b/render/mapping.go
@@ -180,9 +180,17 @@ func MapAddressIdentity(m RenderableNode, local report.Networks) RenderableNodes
 		return RenderableNodes{}
 	}
 
+	// Conntracked connections don't have a host id unless
+	// they were merged with a procspied connection.  Filter
+	// out those that weren't.
+	_, hasHostID := m.Metadata[report.HostNodeID]
+	_, conntracked := m.Metadata[endpoint.Conntracked]
+	if !hasHostID && conntracked {
+		return RenderableNodes{}
+	}
+
 	// Nodes without a hostid are treated as psuedo nodes
-	_, ok = m.Metadata[report.HostNodeID]
-	if !ok {
+	if !hasHostID {
 		// If the addr is not in a network local to this report, we emit an
 		// internet node
 		if !local.Contains(net.ParseIP(addr)) {

--- a/report/topology.go
+++ b/report/topology.go
@@ -66,9 +66,10 @@ func (n Nodes) Copy() Nodes {
 func (n Nodes) Merge(other Nodes) Nodes {
 	cp := n.Copy()
 	for k, v := range other {
-		if _, ok := cp[k]; !ok { // don't overwrite
-			cp[k] = v.Copy()
+		if n, ok := cp[k]; ok { // don't overwrite
+			v = v.Merge(n)
 		}
+		cp[k] = v
 	}
 	return cp
 }


### PR DESCRIPTION
Fix for #446

- When applying NAT mappings, merge with existing nodes
- Catch NAT mappings which already exist when scope is started
