### PR TITLE
Reduce probe cpu usage

### DIFF
--- a/experimental/demoprobe/main.go
+++ b/experimental/demoprobe/main.go
@@ -84,14 +84,14 @@ func demoReport(nodeCount int) report.Report {
 		)
 
 		// Endpoint topology
-		r.Endpoint = r.Endpoint.WithNode(srcPortID, report.MakeNode().WithMetadata(map[string]string{
+		r.Endpoint = r.Endpoint.AddNode(srcPortID, report.MakeNode().WithMetadata(map[string]string{
 			process.PID: "4000",
 			"name":      c.srcProc,
 			"domain":    "node-" + src,
 		}).WithEdge(dstPortID, report.EdgeMetadata{
 			MaxConnCountTCP: newu64(uint64(rand.Intn(100) + 10)),
 		}))
-		r.Endpoint = r.Endpoint.WithNode(dstPortID, report.MakeNode().WithMetadata(map[string]string{
+		r.Endpoint = r.Endpoint.AddNode(dstPortID, report.MakeNode().WithMetadata(map[string]string{
 			process.PID: "4000",
 			"name":      c.dstProc,
 			"domain":    "node-" + dst,
@@ -100,15 +100,15 @@ func demoReport(nodeCount int) report.Report {
 		}))
 
 		// Address topology
-		r.Address = r.Address.WithNode(srcAddressID, report.MakeNode().WithMetadata(map[string]string{
+		r.Address = r.Address.AddNode(srcAddressID, report.MakeNode().WithMetadata(map[string]string{
 			docker.Name: src,
 		}).WithAdjacent(dstAddressID))
-		r.Address = r.Address.WithNode(srcAddressID, report.MakeNode().WithMetadata(map[string]string{
+		r.Address = r.Address.AddNode(srcAddressID, report.MakeNode().WithMetadata(map[string]string{
 			docker.Name: dst,
 		}).WithAdjacent(srcAddressID))
 
 		// Host data
-		r.Host = r.Host.WithNode("hostX", report.MakeNodeWith(map[string]string{
+		r.Host = r.Host.AddNode("hostX", report.MakeNodeWith(map[string]string{
 			"ts":             time.Now().UTC().Format(time.RFC3339Nano),
 			"host_name":      "host-x",
 			"local_networks": localNet.String(),

--- a/experimental/demoprobe/main.go
+++ b/experimental/demoprobe/main.go
@@ -27,10 +27,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	rp := xfer.NewReportPublisher(publisher)
 
 	rand.Seed(time.Now().UnixNano())
 	for range time.Tick(*publishInterval) {
-		if err := publisher.Publish(demoReport(*hostCount)); err != nil {
+		if err := rp.Publish(demoReport(*hostCount)); err != nil {
 			log.Print(err)
 		}
 	}

--- a/experimental/fixprobe/main.go
+++ b/experimental/fixprobe/main.go
@@ -39,7 +39,8 @@ func main() {
 		log.Fatal(err)
 	}
 
+	rp := xfer.NewReportPublisher(publisher)
 	for range time.Tick(*publishInterval) {
-		publisher.Publish(fixedReport)
+		rp.Publish(fixedReport)
 	}
 }

--- a/experimental/genreport/generate.go
+++ b/experimental/genreport/generate.go
@@ -64,14 +64,14 @@ func DemoReport(nodeCount int) report.Report {
 		)
 
 		// Endpoint topology
-		r.Endpoint = r.Endpoint.WithNode(srcPortID, report.MakeNode().WithMetadata(map[string]string{
+		r.Endpoint = r.Endpoint.AddNode(srcPortID, report.MakeNode().WithMetadata(map[string]string{
 			"pid":    "4000",
 			"name":   c.srcProc,
 			"domain": "node-" + src,
 		}).WithEdge(dstPortID, report.EdgeMetadata{
 			MaxConnCountTCP: newu64(uint64(rand.Intn(100) + 10)),
 		}))
-		r.Endpoint = r.Endpoint.WithNode(dstPortID, report.MakeNode().WithMetadata(map[string]string{
+		r.Endpoint = r.Endpoint.AddNode(dstPortID, report.MakeNode().WithMetadata(map[string]string{
 			"pid":    "4000",
 			"name":   c.dstProc,
 			"domain": "node-" + dst,
@@ -80,15 +80,15 @@ func DemoReport(nodeCount int) report.Report {
 		}))
 
 		// Address topology
-		r.Address = r.Address.WithNode(srcAddressID, report.MakeNode().WithMetadata(map[string]string{
+		r.Address = r.Address.AddNode(srcAddressID, report.MakeNode().WithMetadata(map[string]string{
 			"name": src,
 		}).WithAdjacent(dstAddressID))
-		r.Address = r.Address.WithNode(dstAddressID, report.MakeNode().WithMetadata(map[string]string{
+		r.Address = r.Address.AddNode(dstAddressID, report.MakeNode().WithMetadata(map[string]string{
 			"name": dst,
 		}).WithAdjacent(srcAddressID))
 
 		// Host data
-		r.Host = r.Host.WithNode("hostX", report.MakeNodeWith(map[string]string{
+		r.Host = r.Host.AddNode("hostX", report.MakeNodeWith(map[string]string{
 			"ts":             time.Now().UTC().Format(time.RFC3339Nano),
 			"host_name":      "host-x",
 			"local_networks": localNet.String(),

--- a/probe/endpoint/conntrack.go
+++ b/probe/endpoint/conntrack.go
@@ -105,7 +105,7 @@ var ConntrackModulePresent = func() bool {
 
 // NB this is not re-entrant!
 func (c *Conntracker) run(args ...string) {
-	args = append([]string{"-E", "-o", "xml"}, args...)
+	args = append([]string{"-E", "-o", "xml", "-p", "tcp"}, args...)
 	cmd := exec.Command("conntrack", args...)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -178,8 +178,8 @@ func (r *Reporter) addConnection(rpt *report.Report, localAddr, remoteAddr strin
 			})
 		}
 
-		rpt.Address = rpt.Address.WithNode(localAddressNodeID, localNode)
-		rpt.Address = rpt.Address.WithNode(remoteAddressNodeID, remoteNode)
+		rpt.Address = rpt.Address.AddNode(localAddressNodeID, localNode)
+		rpt.Address = rpt.Address.AddNode(remoteAddressNodeID, remoteNode)
 	}
 
 	// Update endpoint topology
@@ -225,8 +225,8 @@ func (r *Reporter) addConnection(rpt *report.Report, localAddr, remoteAddr strin
 		if extraRemoteNode != nil {
 			remoteNode = remoteNode.Merge(*extraRemoteNode)
 		}
-		rpt.Endpoint = rpt.Endpoint.WithNode(localEndpointNodeID, localNode)
-		rpt.Endpoint = rpt.Endpoint.WithNode(remoteEndpointNodeID, remoteNode)
+		rpt.Endpoint = rpt.Endpoint.AddNode(localEndpointNodeID, localNode)
+		rpt.Endpoint = rpt.Endpoint.AddNode(remoteEndpointNodeID, remoteNode)
 	}
 }
 

--- a/probe/main.go
+++ b/probe/main.go
@@ -175,6 +175,7 @@ func main() {
 			pubTick = time.Tick(*publishInterval)
 			spyTick = time.Tick(*spyInterval)
 			r       = report.MakeReport()
+			p       = xfer.NewReportPublisher(publishers)
 		)
 
 		for {
@@ -182,7 +183,7 @@ func main() {
 			case <-pubTick:
 				publishTicks.WithLabelValues().Add(1)
 				r.Window = *publishInterval
-				if err := publishers.Publish(r); err != nil {
+				if err := p.Publish(r); err != nil {
 					log.Printf("publish: %v", err)
 				}
 				r = report.MakeReport()

--- a/probe/main.go
+++ b/probe/main.go
@@ -186,6 +186,7 @@ func main() {
 				r = report.MakeReport()
 
 			case <-spyTick:
+				start := time.Now()
 				if err := processCache.Update(); err != nil {
 					log.Printf("error reading processes: %v", err)
 				}
@@ -197,6 +198,10 @@ func main() {
 					r = r.Merge(newReport)
 				}
 				r = Apply(r, taggers)
+
+				if took := time.Since(start); took > *spyInterval {
+					log.Printf("report generation took too long (%s)", took)
+				}
 
 			case <-quit:
 				return

--- a/probe/overlay/weave_test.go
+++ b/probe/overlay/weave_test.go
@@ -30,6 +30,8 @@ func TestWeaveTaggerOverlayTopology(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	w.Tick()
+
 	{
 		have, err := w.Report()
 		if err != nil {

--- a/probe/process/walker.go
+++ b/probe/process/walker.go
@@ -39,8 +39,8 @@ func (c *CachingWalker) Walk(f func(Process)) error {
 	return nil
 }
 
-// Update updates cached copy of process list
-func (c *CachingWalker) Update() error {
+// Tick updates cached copy of process list
+func (c *CachingWalker) Tick() error {
 	newCache := []Process{}
 	err := c.source.Walk(func(p Process) {
 		newCache = append(newCache, p)

--- a/probe/process/walker_test.go
+++ b/probe/process/walker_test.go
@@ -29,7 +29,7 @@ func TestCache(t *testing.T) {
 		processes: processes,
 	}
 	cachingWalker := process.NewCachingWalker(walker)
-	err := cachingWalker.Update()
+	err := cachingWalker.Tick()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +45,7 @@ func TestCache(t *testing.T) {
 		t.Errorf("%v (%v)", test.Diff(processes, have), err)
 	}
 
-	err = cachingWalker.Update()
+	err = cachingWalker.Tick()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/probe/sniff/sniffer.go
+++ b/probe/sniff/sniffer.go
@@ -253,8 +253,8 @@ func (s *Sniffer) Merge(p Packet, rpt *report.Report) {
 	}
 
 	addAdjacency := func(t report.Topology, srcNodeID, dstNodeID string) report.Topology {
-		result := t.WithNode(srcNodeID, report.MakeNode().WithAdjacent(dstNodeID))
-		result = result.WithNode(dstNodeID, report.MakeNode())
+		result := t.AddNode(srcNodeID, report.MakeNode().WithAdjacent(dstNodeID))
+		result = result.AddNode(dstNodeID, report.MakeNode())
 		return result
 	}
 

--- a/probe/tag_report.go
+++ b/probe/tag_report.go
@@ -16,6 +16,13 @@ type Reporter interface {
 	Report() (report.Report, error)
 }
 
+// Ticker is something which will be invoked every spyDuration.
+// It's useful for things that should be updated on that interval.
+// For example, cached shared state between Taggers and Reporters.
+type Ticker interface {
+	Tick() error
+}
+
 // Apply tags the report with all the taggers.
 func Apply(r report.Report, taggers []Tagger) report.Report {
 	var err error

--- a/report/topology.go
+++ b/report/topology.go
@@ -20,16 +20,17 @@ func MakeTopology() Topology {
 	}
 }
 
-// WithNode produces a topology from t, with nmd added under key nodeID; if a
-// node already exists for this key, nmd is merged with that node. Note that a
-// fresh topology is returned.
-func (t Topology) WithNode(nodeID string, nmd Node) Topology {
+// AddNode adds node to the topology under key nodeID; if a
+// node already exists for this key, nmd is merged with that node.
+// The same topology is returned to enable chaining.
+// This method is different from all the other similar methods
+// in that it mutates the Topology, to solve issues of GC pressure.
+func (t Topology) AddNode(nodeID string, nmd Node) Topology {
 	if existing, ok := t.Nodes[nodeID]; ok {
 		nmd = nmd.Merge(existing)
 	}
-	result := t.Copy()
-	result.Nodes[nodeID] = nmd
-	return result
+	t.Nodes[nodeID] = nmd
+	return t
 }
 
 // Copy returns a value copy of the Topology.

--- a/xfer/buffer.go
+++ b/xfer/buffer.go
@@ -1,0 +1,46 @@
+package xfer
+
+import (
+	"bytes"
+	"sync"
+	"sync/atomic"
+)
+
+// A Buffer is a reference counted bytes.Buffer, which belongs
+// to a sync.Pool
+type Buffer struct {
+	bytes.Buffer
+	pool *sync.Pool
+	refs int32
+}
+
+// NewBuffer creates a new buffer
+func NewBuffer(pool *sync.Pool) *Buffer {
+	return &Buffer{
+		pool: pool,
+		refs: 0,
+	}
+}
+
+// Get increases the reference count.  It is safe for concurrent calls.
+func (b *Buffer) Get() {
+	atomic.AddInt32(&b.refs, 1)
+}
+
+// Put decreases the reference count, and when it hits zero, puts the
+// buffer back in the pool.
+func (b *Buffer) Put() {
+	if atomic.AddInt32(&b.refs, -1) == 0 {
+		b.Reset()
+		b.pool.Put(b)
+	}
+}
+
+// NewBufferPool creates a new buffer pool.
+func NewBufferPool() *sync.Pool {
+	result := &sync.Pool{}
+	result.New = func() interface{} {
+		return NewBuffer(result)
+	}
+	return result
+}

--- a/xfer/publisher.go
+++ b/xfer/publisher.go
@@ -15,7 +15,8 @@ const (
 	maxBackoff     = 60 * time.Second
 )
 
-// Publisher is something which can send a report to a remote collector.
+// Publisher is something which can send a buffered set of data somewhere,
+// probably to a collector.
 type Publisher interface {
 	Publish(*Buffer) error
 	Stop()

--- a/xfer/publisher.go
+++ b/xfer/publisher.go
@@ -1,9 +1,6 @@
 package xfer
 
 import (
-	"bytes"
-	"compress/gzip"
-	"encoding/gob"
 	"fmt"
 	"log"
 	"net/http"
@@ -11,8 +8,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/weaveworks/scope/report"
 )
 
 const (
@@ -22,7 +17,7 @@ const (
 
 // Publisher is something which can send a report to a remote collector.
 type Publisher interface {
-	Publish(report.Report) error
+	Publish(*Buffer) error
 	Stop()
 }
 
@@ -63,16 +58,10 @@ func (p HTTPPublisher) String() string {
 }
 
 // Publish publishes the report to the URL.
-func (p HTTPPublisher) Publish(rpt report.Report) error {
-	gzbuf := bytes.Buffer{}
-	gzwriter := gzip.NewWriter(&gzbuf)
+func (p HTTPPublisher) Publish(buf *Buffer) error {
+	defer buf.Put()
 
-	if err := gob.NewEncoder(gzwriter).Encode(rpt); err != nil {
-		return err
-	}
-	gzwriter.Close() // otherwise the content won't get flushed to the output stream
-
-	req, err := http.NewRequest("POST", p.url, &gzbuf)
+	req, err := http.NewRequest("POST", p.url, buf)
 	if err != nil {
 		return err
 	}
@@ -108,7 +97,7 @@ func AuthorizationHeader(token string) string {
 // concurrent publishes are dropped.
 type BackgroundPublisher struct {
 	publisher Publisher
-	reports   chan report.Report
+	reports   chan *Buffer
 	quit      chan struct{}
 }
 
@@ -116,7 +105,7 @@ type BackgroundPublisher struct {
 func NewBackgroundPublisher(p Publisher) *BackgroundPublisher {
 	result := &BackgroundPublisher{
 		publisher: p,
-		reports:   make(chan report.Report),
+		reports:   make(chan *Buffer),
 		quit:      make(chan struct{}),
 	}
 	go result.loop()
@@ -146,9 +135,9 @@ func (b *BackgroundPublisher) loop() {
 }
 
 // Publish implements Publisher
-func (b *BackgroundPublisher) Publish(r report.Report) error {
+func (b *BackgroundPublisher) Publish(buf *Buffer) error {
 	select {
-	case b.reports <- r:
+	case b.reports <- buf:
 	default:
 	}
 	return nil
@@ -198,13 +187,18 @@ func (p *MultiPublisher) Add(target string) {
 }
 
 // Publish implements Publisher by emitting the report to all publishers.
-func (p *MultiPublisher) Publish(rpt report.Report) error {
+func (p *MultiPublisher) Publish(buf *Buffer) error {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
+	// First take a reference for each publisher
+	for range p.m {
+		buf.Get()
+	}
+
 	var errs []string
 	for _, publisher := range p.m {
-		if err := publisher.Publish(rpt); err != nil {
+		if err := publisher.Publish(buf); err != nil {
 			errs = append(errs, err.Error())
 		}
 	}

--- a/xfer/publisher_test.go
+++ b/xfer/publisher_test.go
@@ -64,7 +64,8 @@ func TestHTTPPublisher(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := p.Publish(rpt); err != nil {
+	rp := xfer.NewReportPublisher(p)
+	if err := rp.Publish(rpt); err != nil {
 		t.Error(err)
 	}
 
@@ -83,7 +84,7 @@ func TestMultiPublisher(t *testing.T) {
 	)
 
 	multiPublisher.Add("first")
-	if err := multiPublisher.Publish(report.MakeReport()); err != nil {
+	if err := multiPublisher.Publish(xfer.NewBuffer(nil)); err != nil {
 		t.Error(err)
 	}
 	if want, have := 1, p.count; want != have {
@@ -91,7 +92,7 @@ func TestMultiPublisher(t *testing.T) {
 	}
 
 	multiPublisher.Add("second") // but factory returns same mockPublisher
-	if err := multiPublisher.Publish(report.MakeReport()); err != nil {
+	if err := multiPublisher.Publish(xfer.NewBuffer(nil)); err != nil {
 		t.Error(err)
 	}
 	if want, have := 3, p.count; want != have {
@@ -101,5 +102,5 @@ func TestMultiPublisher(t *testing.T) {
 
 type mockPublisher struct{ count int }
 
-func (p *mockPublisher) Publish(report.Report) error { p.count++; return nil }
-func (p *mockPublisher) Stop()                       {}
+func (p *mockPublisher) Publish(*xfer.Buffer) error { p.count++; return nil }
+func (p *mockPublisher) Stop()                      {}

--- a/xfer/report_publisher.go
+++ b/xfer/report_publisher.go
@@ -1,0 +1,79 @@
+package xfer
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/gob"
+	"sync"
+	"sync/atomic"
+
+	"github.com/weaveworks/scope/report"
+)
+
+// A Buffer is a reference counted bytes.Buffer, which belongs
+// to a sync.Pool
+type Buffer struct {
+	bytes.Buffer
+	pool *sync.Pool
+	refs int32
+}
+
+// NewBuffer creates a new buffer
+func NewBuffer(pool *sync.Pool) *Buffer {
+	return &Buffer{
+		pool: pool,
+		refs: 0,
+	}
+}
+
+// Get increases the reference count.  It is safe for concurrent calls.
+func (b *Buffer) Get() {
+	atomic.AddInt32(&b.refs, 1)
+}
+
+// Put decreases the reference count, and when it hits zero, puts the
+// buffer back in the pool.
+func (b *Buffer) Put() {
+	if atomic.AddInt32(&b.refs, -1) == 0 {
+		b.Reset()
+		b.pool.Put(b)
+	}
+}
+
+// NewBufferPool creates a new buffer pool.
+func NewBufferPool() *sync.Pool {
+	result := &sync.Pool{}
+	result.New = func() interface{} {
+		return NewBuffer(result)
+	}
+	return result
+}
+
+// A ReportPublisher uses a buffer pool to serialise reports, which it
+// then passes to a publisher
+type ReportPublisher struct {
+	buffers   *sync.Pool
+	publisher Publisher
+}
+
+// NewReportPublisher creates a new report publisher
+func NewReportPublisher(publisher Publisher) *ReportPublisher {
+	return &ReportPublisher{
+		buffers:   NewBufferPool(),
+		publisher: publisher,
+	}
+}
+
+// Publish serialises and compresses a report, then passes it to a publisher
+func (p *ReportPublisher) Publish(r report.Report) error {
+	buf := p.buffers.Get().(*Buffer)
+	gzwriter := gzip.NewWriter(buf)
+	if err := gob.NewEncoder(gzwriter).Encode(r); err != nil {
+		buf.Reset()
+		p.buffers.Put(buf)
+		return err
+	}
+	gzwriter.Close() // otherwise the content won't get flushed to the output stream
+
+	return p.publisher.Publish(buf)
+}

--- a/xfer/report_publisher.go
+++ b/xfer/report_publisher.go
@@ -1,53 +1,12 @@
 package xfer
 
 import (
-	"bytes"
 	"compress/gzip"
 	"encoding/gob"
 	"sync"
-	"sync/atomic"
 
 	"github.com/weaveworks/scope/report"
 )
-
-// A Buffer is a reference counted bytes.Buffer, which belongs
-// to a sync.Pool
-type Buffer struct {
-	bytes.Buffer
-	pool *sync.Pool
-	refs int32
-}
-
-// NewBuffer creates a new buffer
-func NewBuffer(pool *sync.Pool) *Buffer {
-	return &Buffer{
-		pool: pool,
-		refs: 0,
-	}
-}
-
-// Get increases the reference count.  It is safe for concurrent calls.
-func (b *Buffer) Get() {
-	atomic.AddInt32(&b.refs, 1)
-}
-
-// Put decreases the reference count, and when it hits zero, puts the
-// buffer back in the pool.
-func (b *Buffer) Put() {
-	if atomic.AddInt32(&b.refs, -1) == 0 {
-		b.Reset()
-		b.pool.Put(b)
-	}
-}
-
-// NewBufferPool creates a new buffer pool.
-func NewBufferPool() *sync.Pool {
-	result := &sync.Pool{}
-	result.New = func() interface{} {
-		return NewBuffer(result)
-	}
-	return result
-}
 
 // A ReportPublisher uses a buffer pool to serialise reports, which it
 // then passes to a publisher


### PR DESCRIPTION
2 issues - report generation is taking too long, and cpu usage is too high.

Reducing CPU usage (~40% to <20%), see #284
- WithNode -> AddNode, don't copy all the nodes every time we add a single one.
- Cache generated endpoint IDs to relieve some more GC pressure.
- Only gob serialise and gz compress reports once per publish cycle, not once per app. 
- In weave tagger, stop iterating through all containers to find a container by prefix.  Build an index instead.

Report generation:
- Log a warning when it takes too long
- Generate them in parallel
- Only fetch weave status json once per cycle (fixes #397)