### PR TITLE
Can't share buffers like that!

### DIFF
--- a/xfer/buffer.go
+++ b/xfer/buffer.go
@@ -2,38 +2,71 @@ package xfer
 
 import (
 	"bytes"
+	"io"
 	"sync"
 	"sync/atomic"
 )
 
 // A Buffer is a reference counted bytes.Buffer, which belongs
 // to a sync.Pool
-type Buffer struct {
+type Buffer interface {
+	io.Reader
+	io.Writer
+
+	// Get returns a new buffer sharing the contents of this
+	// buffer, but with its own cursor.  Get also increases
+	// the reference count.  It is safe for concurrent calls.
+	Get() Buffer
+
+	// Put decreases the reference count, and when it hits zero, puts the
+	// buffer back in the pool.
+	Put()
+}
+
+type baseBuffer struct {
 	bytes.Buffer
 	pool *sync.Pool
 	refs int32
 }
 
+type dependentBuffer struct {
+	*bytes.Buffer
+	buf *baseBuffer
+}
+
 // NewBuffer creates a new buffer
-func NewBuffer(pool *sync.Pool) *Buffer {
-	return &Buffer{
+func NewBuffer(pool *sync.Pool) Buffer {
+	return &baseBuffer{
 		pool: pool,
 		refs: 0,
 	}
 }
 
-// Get increases the reference count.  It is safe for concurrent calls.
-func (b *Buffer) Get() {
+// Get implements Buffer
+func (b *baseBuffer) Get() Buffer {
 	atomic.AddInt32(&b.refs, 1)
+	return &dependentBuffer{
+		Buffer: bytes.NewBuffer(b.Bytes()),
+		buf:    b,
+	}
 }
 
-// Put decreases the reference count, and when it hits zero, puts the
-// buffer back in the pool.
-func (b *Buffer) Put() {
+// Put implements Buffer
+func (b *baseBuffer) Put() {
 	if atomic.AddInt32(&b.refs, -1) == 0 {
 		b.Reset()
 		b.pool.Put(b)
 	}
+}
+
+// Get implements Buffer
+func (b *dependentBuffer) Get() Buffer {
+	return b.buf.Get()
+}
+
+// Put implements Buffer
+func (b *dependentBuffer) Put() {
+	b.buf.Put()
 }
 
 // NewBufferPool creates a new buffer pool.

--- a/xfer/publisher_test.go
+++ b/xfer/publisher_test.go
@@ -81,10 +81,11 @@ func TestMultiPublisher(t *testing.T) {
 		p              = &mockPublisher{}
 		factory        = func(string) (xfer.Publisher, error) { return p, nil }
 		multiPublisher = xfer.NewMultiPublisher(factory)
+		buffers        = xfer.NewBufferPool()
 	)
 
 	multiPublisher.Add("first")
-	if err := multiPublisher.Publish(xfer.NewBuffer(nil)); err != nil {
+	if err := multiPublisher.Publish(buffers.Get().(xfer.Buffer)); err != nil {
 		t.Error(err)
 	}
 	if want, have := 1, p.count; want != have {
@@ -92,7 +93,7 @@ func TestMultiPublisher(t *testing.T) {
 	}
 
 	multiPublisher.Add("second") // but factory returns same mockPublisher
-	if err := multiPublisher.Publish(xfer.NewBuffer(nil)); err != nil {
+	if err := multiPublisher.Publish(buffers.Get().(xfer.Buffer)); err != nil {
 		t.Error(err)
 	}
 	if want, have := 3, p.count; want != have {
@@ -102,5 +103,5 @@ func TestMultiPublisher(t *testing.T) {
 
 type mockPublisher struct{ count int }
 
-func (p *mockPublisher) Publish(*xfer.Buffer) error { p.count++; return nil }
-func (p *mockPublisher) Stop()                      {}
+func (p *mockPublisher) Publish(xfer.Buffer) error { p.count++; return nil }
+func (p *mockPublisher) Stop()                     {}

--- a/xfer/report_publisher.go
+++ b/xfer/report_publisher.go
@@ -25,11 +25,12 @@ func NewReportPublisher(publisher Publisher) *ReportPublisher {
 
 // Publish serialises and compresses a report, then passes it to a publisher
 func (p *ReportPublisher) Publish(r report.Report) error {
-	buf := p.buffers.Get().(*Buffer)
+	buf := p.buffers.Get().(Buffer)
+	buf.Get()
+	defer buf.Put()
+
 	gzwriter := gzip.NewWriter(buf)
 	if err := gob.NewEncoder(gzwriter).Encode(r); err != nil {
-		buf.Reset()
-		p.buffers.Put(buf)
 		return err
 	}
 	gzwriter.Close() // otherwise the content won't get flushed to the output stream


### PR DESCRIPTION
As part of #470 I introduces reference counted, shared buffers such that we only serialise and compress a report once.  I got it a bit wrong: byte.Buffers contain a cursor, and therefore can only be used 'once'.

This change adapts that code such that a 'new' byte buffer is created for each report publisher, but they share the underlying []bytes, and use the reference counting to track the usage of that.

This manifested itself as a panic in the app as it couldn't decompress reports (as they were empty) - the panic was fixed in #481 without identifying the underly cause.

This change also adds error reporting on the app for why requests fail.

Fixes #471