### PR TITLE
Compile flags compatible with 1.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ $(PROBE_EXE): probe/*.go probe/docker/*.go probe/endpoint/*.go probe/host/*.go p
 
 $(APP_EXE) $(PROBE_EXE):
 	go get -d -tags netgo ./$(@D)
-	go build -ldflags "-extldflags \"-static\" -X main.version=$(SCOPE_VERSION)" -tags netgo -o $@ ./$(@D)
+	go build -ldflags "-extldflags \"-static\" -X main.version $(SCOPE_VERSION)" -tags netgo -o $@ ./$(@D)
 	@strings $@ | grep cgo_stub\\\.go >/dev/null || { \
 	        rm $@; \
 	        echo "\nYour go standard library was built without the 'netgo' build tag."; \


### PR DESCRIPTION
In #440 we changed the build flags that inject the version number to work with go1.5; but the new format doesn't work with go1.4.

The old format still works in 1.5, just spits a warning.  Lets stick with the old format until everyone has moved to go1.5.