### PR TITLE
Show pseudo nodes & connections found through procspy

### DIFF
--- a/render/mapping.go
+++ b/render/mapping.go
@@ -47,15 +47,9 @@ func MapEndpointIdentity(m RenderableNode, local report.Networks) RenderableNode
 		return RenderableNodes{}
 	}
 
-	// We need to filter out short lived connections from this view,
-	// if they don't also have a pid; see #447.  Note if they
-	// we're introduced by proc spy then they are guaranteed to
-	// have a pid on the other end of the adjacency, so we include them
-	// no matter what.
-	pid, pidOK := m.Metadata[process.PID]
-	_, conntracked := m.Metadata[endpoint.Conntracked]
+	// We only show nodes found through procspy in this view.
 	_, procspied := m.Metadata[endpoint.Procspied]
-	if !procspied && !pidOK && conntracked {
+	if !procspied {
 		return RenderableNodes{}
 	}
 
@@ -93,6 +87,7 @@ func MapEndpointIdentity(m RenderableNode, local report.Networks) RenderableNode
 		rank  = major
 	)
 
+	pid, pidOK := m.Metadata[process.PID]
 	if pidOK {
 		minor = fmt.Sprintf("%s (%s)", minor, pid)
 	}

--- a/render/mapping_test.go
+++ b/render/mapping_test.go
@@ -18,11 +18,11 @@ func nrn(nmd report.Node) render.RenderableNode {
 func TestMapEndpointIdentity(t *testing.T) {
 	for _, input := range []testcase{
 		{nrn(report.MakeNode()), false},
-		{nrn(report.MakeNodeWith(map[string]string{endpoint.Addr: "1.2.3.4"})), false},
-		{nrn(report.MakeNodeWith(map[string]string{endpoint.Port: "1234"})), false},
-		{nrn(report.MakeNodeWith(map[string]string{endpoint.Addr: "1.2.3.4", endpoint.Port: "1234"})), true},
-		{nrn(report.MakeNodeWith(map[string]string{endpoint.Addr: "1.2.3.4", endpoint.Port: "40000"})), true},
-		{nrn(report.MakeNodeWith(map[string]string{report.HostNodeID: report.MakeHostNodeID("foo"), endpoint.Addr: "10.0.0.1", endpoint.Port: "20001"})), true},
+		{nrn(report.MakeNodeWith(map[string]string{endpoint.Addr: "1.2.3.4", endpoint.Procspied: "true"})), false},
+		{nrn(report.MakeNodeWith(map[string]string{endpoint.Port: "1234", endpoint.Procspied: "true"})), false},
+		{nrn(report.MakeNodeWith(map[string]string{endpoint.Addr: "1.2.3.4", endpoint.Port: "1234", endpoint.Procspied: "true"})), true},
+		{nrn(report.MakeNodeWith(map[string]string{endpoint.Addr: "1.2.3.4", endpoint.Port: "40000", endpoint.Procspied: "true"})), true},
+		{nrn(report.MakeNodeWith(map[string]string{report.HostNodeID: report.MakeHostNodeID("foo"), endpoint.Addr: "10.0.0.1", endpoint.Port: "20001", endpoint.Procspied: "true"})), true},
 	} {
 		testMap(t, render.MapEndpointIdentity, input)
 	}

--- a/report/topology.go
+++ b/report/topology.go
@@ -99,7 +99,7 @@ func MakeNodeWith(m map[string]string) Node {
 	return MakeNode().WithMetadata(m)
 }
 
-// WithMetadata returns a fresh copy of n, with Metadata set to m
+// WithMetadata returns a fresh copy of n, with Metadata m merged in.
 func (n Node) WithMetadata(m map[string]string) Node {
 	result := n.Copy()
 	result.Metadata = result.Metadata.Merge(m)

--- a/report/topology.go
+++ b/report/topology.go
@@ -102,7 +102,7 @@ func MakeNodeWith(m map[string]string) Node {
 // WithMetadata returns a fresh copy of n, with Metadata set to m
 func (n Node) WithMetadata(m map[string]string) Node {
 	result := n.Copy()
-	result.Metadata = m
+	result.Metadata = result.Metadata.Merge(m)
 	return result
 }
 

--- a/test/report_fixture.go
+++ b/test/report_fixture.go
@@ -48,6 +48,8 @@ var (
 	ServerComm       = "apache"
 	NonContainerComm = "bash"
 
+	True = "true"
+
 	ClientHostNodeID = report.MakeHostNodeID(ClientHostID)
 	ServerHostNodeID = report.MakeHostNodeID(ServerHostID)
 
@@ -92,75 +94,84 @@ var (
 				// care to test into the fixture. Just be sure to include the bits
 				// that the mapping funcs extract :)
 				Client54001NodeID: report.MakeNode().WithMetadata(map[string]string{
-					endpoint.Addr:     ClientIP,
-					endpoint.Port:     ClientPort54001,
-					process.PID:       Client1PID,
-					report.HostNodeID: ClientHostNodeID,
+					endpoint.Addr:      ClientIP,
+					endpoint.Port:      ClientPort54001,
+					process.PID:        Client1PID,
+					report.HostNodeID:  ClientHostNodeID,
+					endpoint.Procspied: True,
 				}).WithEdge(Server80NodeID, report.EdgeMetadata{
 					EgressPacketCount: newu64(10),
 					EgressByteCount:   newu64(100),
 				}),
 
 				Client54002NodeID: report.MakeNode().WithMetadata(map[string]string{
-					endpoint.Addr:     ClientIP,
-					endpoint.Port:     ClientPort54002,
-					process.PID:       Client2PID,
-					report.HostNodeID: ClientHostNodeID,
+					endpoint.Addr:      ClientIP,
+					endpoint.Port:      ClientPort54002,
+					process.PID:        Client2PID,
+					report.HostNodeID:  ClientHostNodeID,
+					endpoint.Procspied: True,
 				}).WithEdge(Server80NodeID, report.EdgeMetadata{
 					EgressPacketCount: newu64(20),
 					EgressByteCount:   newu64(200),
 				}),
 
 				Server80NodeID: report.MakeNode().WithMetadata(map[string]string{
-					endpoint.Addr:     ServerIP,
-					endpoint.Port:     ServerPort,
-					process.PID:       ServerPID,
-					report.HostNodeID: ServerHostNodeID,
+					endpoint.Addr:      ServerIP,
+					endpoint.Port:      ServerPort,
+					process.PID:        ServerPID,
+					report.HostNodeID:  ServerHostNodeID,
+					endpoint.Procspied: True,
 				}),
 
 				NonContainerNodeID: report.MakeNode().WithMetadata(map[string]string{
-					endpoint.Addr:     ServerIP,
-					endpoint.Port:     NonContainerClientPort,
-					process.PID:       NonContainerPID,
-					report.HostNodeID: ServerHostNodeID,
+					endpoint.Addr:      ServerIP,
+					endpoint.Port:      NonContainerClientPort,
+					process.PID:        NonContainerPID,
+					report.HostNodeID:  ServerHostNodeID,
+					endpoint.Procspied: True,
 				}).WithAdjacent(GoogleEndpointNodeID),
 
 				// Probe pseudo nodes
 				UnknownClient1NodeID: report.MakeNode().WithMetadata(map[string]string{
-					endpoint.Addr: UnknownClient1IP,
-					endpoint.Port: UnknownClient1Port,
+					endpoint.Addr:      UnknownClient1IP,
+					endpoint.Port:      UnknownClient1Port,
+					endpoint.Procspied: True,
 				}).WithEdge(Server80NodeID, report.EdgeMetadata{
 					EgressPacketCount: newu64(30),
 					EgressByteCount:   newu64(300),
 				}),
 
 				UnknownClient2NodeID: report.MakeNode().WithMetadata(map[string]string{
-					endpoint.Addr: UnknownClient2IP,
-					endpoint.Port: UnknownClient2Port,
+					endpoint.Addr:      UnknownClient2IP,
+					endpoint.Port:      UnknownClient2Port,
+					endpoint.Procspied: True,
 				}).WithEdge(Server80NodeID, report.EdgeMetadata{
 					EgressPacketCount: newu64(40),
 					EgressByteCount:   newu64(400),
 				}),
 
 				UnknownClient3NodeID: report.MakeNode().WithMetadata(map[string]string{
-					endpoint.Addr: UnknownClient3IP,
-					endpoint.Port: UnknownClient3Port,
+					endpoint.Addr:      UnknownClient3IP,
+					endpoint.Port:      UnknownClient3Port,
+					endpoint.Procspied: True,
 				}).WithEdge(Server80NodeID, report.EdgeMetadata{
 					EgressPacketCount: newu64(50),
 					EgressByteCount:   newu64(500),
 				}),
 
 				RandomClientNodeID: report.MakeNode().WithMetadata(map[string]string{
-					endpoint.Addr: RandomClientIP,
-					endpoint.Port: RandomClientPort,
+					endpoint.Addr:      RandomClientIP,
+					endpoint.Port:      RandomClientPort,
+					endpoint.Procspied: True,
 				}).WithEdge(Server80NodeID, report.EdgeMetadata{
 					EgressPacketCount: newu64(60),
 					EgressByteCount:   newu64(600),
 				}),
 
 				GoogleEndpointNodeID: report.MakeNode().WithMetadata(map[string]string{
-					endpoint.Addr: GoogleIP,
-					endpoint.Port: GooglePort,
+					endpoint.Addr:      GoogleIP,
+					endpoint.Port:      GooglePort,
+					endpoint.Procspied: True,
 				}),
 			},
 		},


### PR DESCRIPTION
Previously I'd filtered out nodes (and connections) found through conntrack, as we didn't want all the cruft to appear in the process view.  But this had also filtered out a subset of those nodes which were also found by procspy, and merged with a conntracked node.

This change stops us filtering those nodes, restoring the pseudo node behaviour to that of 0.6.

Fixes #489 