### PR TITLE
In containers view, show short lived connections to/from the internet.

### DIFF
--- a/integration/300_internet_edge_test.sh
+++ b/integration/300_internet_edge_test.sh
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+. ./config.sh
+
+start_suite "Test short lived connections from the Internet"
+
+weave_on $HOST1 launch
+scope_on $HOST1 launch
+docker_on $HOST1 run -d -p 80:80 --name nginx nginx
+
+do_connections() {
+	while true; do
+		curl -s http://$HOST1:80/ >/dev/null
+		sleep 1
+	done
+}
+do_connections&
+
+sleep 5 # give the probe a few seconds to build a report and send it to the app
+
+has_container $HOST1 nginx 1
+has_connection $HOST1 "The Internet" nginx
+
+kill %do_connections
+
+scope_end_suite

--- a/probe/docker/container_linux_test.go
+++ b/probe/docker/container_linux_test.go
@@ -78,7 +78,7 @@ func TestContainer(t *testing.T) {
 		"memory_usage":             "12345",
 	})
 	test.Poll(t, 100*time.Millisecond, want, func() interface{} {
-		node := c.GetNode()
+		node := c.GetNode([]net.IP{})
 		for k, v := range node.Metadata {
 			if v == "0" {
 				delete(node.Metadata, k)
@@ -93,7 +93,7 @@ func TestContainer(t *testing.T) {
 	if c.PID() != 1 {
 		t.Errorf("%s != 1", c.PID())
 	}
-	if !reflect.DeepEqual(docker.ExtractContainerIPs(c.GetNode()), []string{"1.2.3.4"}) {
-		t.Errorf("%v != %v", docker.ExtractContainerIPs(c.GetNode()), []string{"1.2.3.4"})
+	if !reflect.DeepEqual(docker.ExtractContainerIPs(c.GetNode([]net.IP{})), []string{"1.2.3.4"}) {
+		t.Errorf("%v != %v", docker.ExtractContainerIPs(c.GetNode([]net.IP{})), []string{"1.2.3.4"})
 	}
 }

--- a/probe/docker/registry_test.go
+++ b/probe/docker/registry_test.go
@@ -1,6 +1,7 @@
 package docker_test
 
 import (
+	"net"
 	"runtime"
 	"sort"
 	"sync"
@@ -36,7 +37,7 @@ func (c *mockContainer) StartGatheringStats() error {
 
 func (c *mockContainer) StopGatheringStats() {}
 
-func (c *mockContainer) GetNode() report.Node {
+func (c *mockContainer) GetNode(_ []net.IP) report.Node {
 	return report.MakeNodeWith(map[string]string{
 		docker.ContainerID:   c.c.ID,
 		docker.ContainerName: c.c.Name,

--- a/render/short_lived_connections_test.go
+++ b/render/short_lived_connections_test.go
@@ -1,0 +1,94 @@
+package render_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/weaveworks/scope/probe/docker"
+	"github.com/weaveworks/scope/probe/endpoint"
+	"github.com/weaveworks/scope/render"
+	"github.com/weaveworks/scope/report"
+	"github.com/weaveworks/scope/test"
+)
+
+var (
+	serverHostID     = "host1"
+	serverHostNodeID = report.MakeHostNodeID(serverHostID)
+
+	randomIP             = "3.4.5.6"
+	randomPort           = "56789"
+	randomEndpointNodeID = report.MakeEndpointNodeID(serverHostID, randomIP, randomPort)
+
+	serverIP             = "192.168.1.1"
+	serverPort           = "80"
+	serverEndpointNodeID = report.MakeEndpointNodeID(serverHostID, serverIP, serverPort)
+
+	containerID     = "a1b2c3d4e5"
+	containerIP     = "192.168.0.1"
+	containerName   = "foo"
+	containerNodeID = report.MakeContainerNodeID(serverHostID, containerID)
+
+	rpt = report.Report{
+		Endpoint: report.Topology{
+			Nodes: report.Nodes{
+				randomEndpointNodeID: report.MakeNode().WithMetadata(map[string]string{
+					endpoint.Addr:        randomIP,
+					endpoint.Port:        randomPort,
+					endpoint.Conntracked: "true",
+				}).WithAdjacent(serverEndpointNodeID),
+
+				serverEndpointNodeID: report.MakeNode().WithMetadata(map[string]string{
+					endpoint.Addr:        serverIP,
+					endpoint.Port:        serverPort,
+					endpoint.Conntracked: "true",
+				}),
+			},
+		},
+		Container: report.Topology{
+			Nodes: report.Nodes{
+				containerNodeID: report.MakeNode().WithMetadata(map[string]string{
+					docker.ContainerID:    containerID,
+					docker.ContainerName:  containerName,
+					docker.ContainerIPs:   containerIP,
+					docker.ContainerPorts: fmt.Sprintf("%s:%s->%s/tcp", serverIP, serverPort, serverPort),
+					report.HostNodeID:     serverHostNodeID,
+				}),
+			},
+		},
+		Host: report.Topology{
+			Nodes: report.Nodes{
+				serverHostNodeID: report.MakeNodeWith(map[string]string{
+					"local_networks":  "192.168.0.0/16",
+					report.HostNodeID: serverHostNodeID,
+				}),
+			},
+		},
+	}
+
+	want = (render.RenderableNodes{
+		render.TheInternetID: {
+			ID:         render.TheInternetID,
+			LabelMajor: render.TheInternetMajor,
+			Pseudo:     true,
+			Node:       report.MakeNode().WithAdjacent(containerID),
+			Origins:    report.MakeIDList(randomEndpointNodeID),
+		},
+		containerID: {
+			ID:         containerID,
+			LabelMajor: containerName,
+			LabelMinor: serverHostID,
+			Rank:       "",
+			Pseudo:     false,
+			Origins:    report.MakeIDList(containerNodeID, serverEndpointNodeID, serverHostNodeID),
+			Node:       report.MakeNode(),
+		},
+	}).Prune()
+)
+
+func TestShortLivedInternetNodeConnections(t *testing.T) {
+	have := (render.ContainerWithImageNameRenderer.Render(rpt)).Prune()
+	if !reflect.DeepEqual(want, have) {
+		t.Error(test.Diff(want, have))
+	}
+}


### PR DESCRIPTION
Problem: short-lived, incoming connections from the internet to a container don't show up in the UI.  This is because the local end of the connection is to the hosts IP (not a container), and we drop nodes without a container on them.

Outgoing short lived connections to the internet do work.

We should take into account the container port mappings when translating this node to a container ID.  This can be done unambiguously.