### PR TITLE
When flattening edge metadata and propagating to the server end of the edge, reverse the direction of the metadata.

### DIFF
--- a/render/detailed_node_test.go
+++ b/render/detailed_node_test.go
@@ -184,8 +184,8 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 				Numeric: false,
 				Rank:    0,
 				Rows: []render.Row{
-					{"Egress packet rate", "105", "packets/sec", false},
-					{"Egress byte rate", "1.0", "KBps", false},
+					{"Ingress packet rate", "105", "packets/sec", false},
+					{"Ingress byte rate", "1.0", "KBps", false},
 					{"Client", "Server", "", true},
 					{
 						fmt.Sprintf("%s:%s", test.UnknownClient1IP, test.UnknownClient1Port),

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -113,8 +113,8 @@ var (
 			),
 			Node: report.MakeNode(),
 			EdgeMetadata: report.EdgeMetadata{
-				EgressPacketCount: newu64(210),
-				EgressByteCount:   newu64(2100),
+				IngressPacketCount: newu64(210),
+				IngressByteCount:   newu64(2100),
 			},
 		},
 		nonContainerProcessID: {
@@ -169,8 +169,8 @@ var (
 			),
 			Node: report.MakeNode(),
 			EdgeMetadata: report.EdgeMetadata{
-				EgressPacketCount: newu64(210),
-				EgressByteCount:   newu64(2100),
+				IngressPacketCount: newu64(210),
+				IngressByteCount:   newu64(2100),
 			},
 		},
 		test.NonContainerComm: {
@@ -229,8 +229,8 @@ var (
 			),
 			Node: report.MakeNode(),
 			EdgeMetadata: report.EdgeMetadata{
-				EgressPacketCount: newu64(210),
-				EgressByteCount:   newu64(2100),
+				IngressPacketCount: newu64(210),
+				IngressByteCount:   newu64(2100),
 			},
 		},
 		uncontainedServerID: {
@@ -286,8 +286,8 @@ var (
 				test.ServerHostNodeID),
 			Node: report.MakeNode(),
 			EdgeMetadata: report.EdgeMetadata{
-				EgressPacketCount: newu64(210),
-				EgressByteCount:   newu64(2100),
+				IngressPacketCount: newu64(210),
+				IngressByteCount:   newu64(2100),
 			},
 		},
 		uncontainedServerID: {

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -147,8 +147,10 @@ func TestMapEdge(t *testing.T) {
 			Origins: report.MakeIDList("foo"),
 			Node:    report.MakeNode().WithAdjacent("_bar"),
 			EdgeMetadata: report.EdgeMetadata{
-				EgressPacketCount: newu64(4),
-				EgressByteCount:   newu64(6),
+				EgressPacketCount:  newu64(1),
+				EgressByteCount:    newu64(2),
+				IngressPacketCount: newu64(3),
+				IngressByteCount:   newu64(4),
 			},
 		},
 		"_bar": {
@@ -156,8 +158,10 @@ func TestMapEdge(t *testing.T) {
 			Origins: report.MakeIDList("bar"),
 			Node:    report.MakeNode().WithAdjacent("_foo"),
 			EdgeMetadata: report.EdgeMetadata{
-				EgressPacketCount: newu64(4),
-				EgressByteCount:   newu64(6),
+				EgressPacketCount:  newu64(3),
+				EgressByteCount:    newu64(4),
+				IngressPacketCount: newu64(1),
+				IngressByteCount:   newu64(2),
 			},
 		},
 	}).Prune()

--- a/render/selectors.go
+++ b/render/selectors.go
@@ -47,7 +47,7 @@ func MakeRenderableNodes(t report.Topology) RenderableNodes {
 			srcNode.EdgeMetadata = srcNode.EdgeMetadata.Flatten(emd)
 
 			dstNode := result[dstID]
-			dstNode.EdgeMetadata = dstNode.EdgeMetadata.Flatten(emd)
+			dstNode.EdgeMetadata = dstNode.EdgeMetadata.Flatten(emd.Reversed())
 			result[dstID] = dstNode
 		}
 

--- a/report/topology.go
+++ b/report/topology.go
@@ -249,6 +249,17 @@ func (e EdgeMetadata) Copy() EdgeMetadata {
 	}
 }
 
+// Reversed returns a value copy of the EdgeMetadata, with the direction reversed.
+func (e EdgeMetadata) Reversed() EdgeMetadata {
+	return EdgeMetadata{
+		EgressPacketCount:  cpu64ptr(e.IngressPacketCount),
+		IngressPacketCount: cpu64ptr(e.EgressPacketCount),
+		EgressByteCount:    cpu64ptr(e.IngressByteCount),
+		IngressByteCount:   cpu64ptr(e.EgressByteCount),
+		MaxConnCountTCP:    cpu64ptr(e.MaxConnCountTCP),
+	}
+}
+
 func cpu64ptr(u *uint64) *uint64 {
 	if u == nil {
 		return nil


### PR DESCRIPTION
Fixes #373