### PR TITLE
Report number of filtered nodes in topology stats.

### DIFF
--- a/client/app/scripts/actions/app-actions.js
+++ b/client/app/scripts/actions/app-actions.js
@@ -5,15 +5,25 @@ let RouterUtils;
 let WebapiUtils;
 
 module.exports = {
-  changeTopologyOption: function(option, value) {
+  changeTopologyOption: function(option, value, topologyId) {
     AppDispatcher.dispatch({
       type: ActionTypes.CHANGE_TOPOLOGY_OPTION,
+      topologyId: topologyId,
       option: option,
       value: value
     });
     RouterUtils.updateRoute();
+    // update all request workers with new options
+    WebapiUtils.getTopologies(
+      AppStore.getActiveTopologyOptions()
+    );
     WebapiUtils.getNodesDelta(
       AppStore.getCurrentTopologyUrl(),
+      AppStore.getActiveTopologyOptions()
+    );
+    WebapiUtils.getNodeDetails(
+      AppStore.getCurrentTopologyUrl(),
+      AppStore.getSelectedNodeId(),
       AppStore.getActiveTopologyOptions()
     );
   },
@@ -146,6 +156,9 @@ module.exports = {
       state: state,
       type: ActionTypes.ROUTE_TOPOLOGY
     });
+    WebapiUtils.getTopologies(
+      AppStore.getActiveTopologyOptions()
+    );
     WebapiUtils.getNodesDelta(
       AppStore.getCurrentTopologyUrl(),
       AppStore.getActiveTopologyOptions()

--- a/client/app/scripts/charts/nodes-chart.js
+++ b/client/app/scripts/charts/nodes-chart.js
@@ -394,7 +394,10 @@ const NodesChart = React.createClass({
     const n = props.nodes.size;
 
     if (n === 0) {
-      return {};
+      return {
+        nodes: {},
+        edges: {}
+      };
     }
 
     const nodes = this.initNodes(props.nodes, state.nodes);

--- a/client/app/scripts/components/app.js
+++ b/client/app/scripts/components/app.js
@@ -48,7 +48,10 @@ const App = React.createClass({
     window.addEventListener('keyup', this.onKeyPress);
 
     RouterUtils.getRouter().start({hashbang: true});
-    WebapiUtils.getTopologies();
+    if (!AppStore.isRouteSet()) {
+      // dont request topologies when already done via router
+      WebapiUtils.getTopologies(AppStore.getActiveTopologyOptions());
+    }
     WebapiUtils.getApiDetails();
   },
 
@@ -93,6 +96,7 @@ const App = React.createClass({
 
         <Sidebar>
           <TopologyOptions options={this.state.currentTopologyOptions}
+            topologyId={this.state.currentTopologyId}
             activeOptions={this.state.activeTopologyOptions} />
           <Status errorUrl={this.state.errorUrl} topology={this.state.currentTopology}
             topologiesLoaded={this.state.topologiesLoaded}

--- a/client/app/scripts/components/status.js
+++ b/client/app/scripts/components/status.js
@@ -21,7 +21,10 @@ const Status = React.createClass({
       showWarningIcon = true;
     } else if (this.props.topology) {
       const stats = this.props.topology.stats;
-      text = `${stats.node_count} nodes, ${stats.edge_count} connections`;
+      text = `${stats.node_count} nodes`;
+      if (stats.filtered_nodes) {
+        text = `${text} (${stats.filtered_nodes} filtered)`;
+      }
       classNames += ' status-stats';
       showWarningIcon = false;
     }

--- a/client/app/scripts/components/topologies.js
+++ b/client/app/scripts/components/topologies.js
@@ -2,7 +2,6 @@ const React = require('react');
 const _ = require('lodash');
 
 const AppActions = require('../actions/app-actions');
-const AppStore = require('../stores/app-store');
 
 const Topologies = React.createClass({
 
@@ -13,7 +12,7 @@ const Topologies = React.createClass({
 
   renderSubTopology: function(subTopology) {
     const isActive = subTopology.name === this.props.currentTopology.name;
-    const topologyId = AppStore.getTopologyIdForUrl(subTopology.url);
+    const topologyId = subTopology.id;
     const title = this.renderTitle(subTopology);
     const className = isActive ? 'topologies-sub-item topologies-sub-item-active' : 'topologies-sub-item';
 
@@ -35,7 +34,7 @@ const Topologies = React.createClass({
   renderTopology: function(topology) {
     const isActive = topology.name === this.props.currentTopology.name;
     const className = isActive ? 'topologies-item-main topologies-item-main-active' : 'topologies-item-main';
-    const topologyId = AppStore.getTopologyIdForUrl(topology.url);
+    const topologyId = topology.id;
     const title = this.renderTitle(topology);
 
     return (

--- a/client/app/scripts/components/topology-option-action.js
+++ b/client/app/scripts/components/topology-option-action.js
@@ -6,7 +6,7 @@ const TopologyOptionAction = React.createClass({
 
   onClick: function(ev) {
     ev.preventDefault();
-    AppActions.changeTopologyOption(this.props.option, this.props.value);
+    AppActions.changeTopologyOption(this.props.option, this.props.value, this.props.topologyId);
   },
 
   render: function() {

--- a/client/app/scripts/components/topology-options.js
+++ b/client/app/scripts/components/topology-options.js
@@ -5,9 +5,9 @@ const TopologyOptionAction = require('./topology-option-action');
 
 const TopologyOptions = React.createClass({
 
-  renderAction: function(action, option) {
+  renderAction: function(action, option, topologyId) {
     return (
-      <TopologyOptionAction option={option} value={action} />
+      <TopologyOptionAction option={option} value={action} topologyId={topologyId} />
     );
   },
 
@@ -15,11 +15,12 @@ const TopologyOptions = React.createClass({
     let activeText;
     const actions = [];
     const activeOptions = this.props.activeOptions;
+    const topologyId = this.props.topologyId;
     items.forEach(function(item) {
-      if (activeOptions[item.option] && activeOptions[item.option] === item.value) {
+      if (activeOptions && activeOptions.has(item.option) && activeOptions.get(item.option) === item.value) {
         activeText = item.display;
       } else {
-        actions.push(this.renderAction(item.value, item.option));
+        actions.push(this.renderAction(item.value, item.option, topologyId));
       }
     }, this);
 

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -20,6 +20,9 @@ func (m mockRenderer) Render(rpt report.Report) render.RenderableNodes {
 func (m mockRenderer) EdgeMetadata(rpt report.Report, localID, remoteID string) report.EdgeMetadata {
 	return m.edgeMetadata
 }
+func (m mockRenderer) Stats(rpt report.Report) render.Stats {
+	return render.Stats{}
+}
 
 func TestReduceRender(t *testing.T) {
 	renderer := render.Reduce([]render.Renderer{

--- a/render/selectors.go
+++ b/render/selectors.go
@@ -29,6 +29,11 @@ func (t TopologySelector) EdgeMetadata(rpt report.Report, srcID, dstID string) r
 	return metadata
 }
 
+// Stats implements Renderer
+func (t TopologySelector) Stats(r report.Report) Stats {
+	return Stats{}
+}
+
 // MakeRenderableNodes converts a topology to a set of RenderableNodes
 func MakeRenderableNodes(t report.Topology) RenderableNodes {
 	result := RenderableNodes{}

--- a/render/topologies.go
+++ b/render/topologies.go
@@ -27,14 +27,14 @@ var ProcessRenderer = MakeReduce(
 	},
 )
 
-// ProcessWithContainerNameRenderer is a Renderer which produces a process
+// processWithContainerNameRenderer is a Renderer which produces a process
 // graph enriched with container names where appropriate
-type ProcessWithContainerNameRenderer struct{}
+type processWithContainerNameRenderer struct {
+	Renderer
+}
 
-// Render produces a process graph where the minor labels contain the
-// container name, if found.
-func (r ProcessWithContainerNameRenderer) Render(rpt report.Report) RenderableNodes {
-	processes := ProcessRenderer.Render(rpt)
+func (r processWithContainerNameRenderer) Render(rpt report.Report) RenderableNodes {
+	processes := r.Renderer.Render(rpt)
 	containers := Map{
 		MapFunc:  MapContainerIdentity,
 		Renderer: SelectContainer,
@@ -60,10 +60,9 @@ func (r ProcessWithContainerNameRenderer) Render(rpt report.Report) RenderableNo
 	return processes
 }
 
-// EdgeMetadata produces an EdgeMetadata for a given edge.
-func (r ProcessWithContainerNameRenderer) EdgeMetadata(rpt report.Report, localID, remoteID string) report.EdgeMetadata {
-	return ProcessRenderer.EdgeMetadata(rpt, localID, remoteID)
-}
+// ProcessWithContainerNameRenderer is a Renderer which produces a process
+// graph enriched with container names where appropriate
+var ProcessWithContainerNameRenderer = processWithContainerNameRenderer{ProcessRenderer}
 
 // ProcessRenderer is a Renderer which produces a renderable process
 // name graph by munging the progess graph.
@@ -120,14 +119,14 @@ var ContainerRenderer = MakeReduce(
 	},
 )
 
-// ContainerWithImageNameRenderer is a Renderer which produces a container
-// graph where the ranks are the image names, not their IDs
-type ContainerWithImageNameRenderer struct{}
+type containerWithImageNameRenderer struct {
+	Renderer
+}
 
 // Render produces a process graph where the minor labels contain the
 // container name, if found.
-func (r ContainerWithImageNameRenderer) Render(rpt report.Report) RenderableNodes {
-	containers := ContainerRenderer.Render(rpt)
+func (r containerWithImageNameRenderer) Render(rpt report.Report) RenderableNodes {
+	containers := r.Renderer.Render(rpt)
 	images := Map{
 		MapFunc:  MapContainerImageIdentity,
 		Renderer: SelectContainerImage,
@@ -149,10 +148,9 @@ func (r ContainerWithImageNameRenderer) Render(rpt report.Report) RenderableNode
 	return containers
 }
 
-// EdgeMetadata produces an EdgeMetadata for a given edge.
-func (r ContainerWithImageNameRenderer) EdgeMetadata(rpt report.Report, localID, remoteID string) report.EdgeMetadata {
-	return ContainerRenderer.EdgeMetadata(rpt, localID, remoteID)
-}
+// ContainerWithImageNameRenderer is a Renderer which produces a container
+// graph where the ranks are the image names, not their IDs
+var ContainerWithImageNameRenderer = containerWithImageNameRenderer{ContainerRenderer}
 
 // ContainerImageRenderer is a Renderer which produces a renderable container
 // image graph by merging the container graph and the container image topology.

--- a/render/topologies_test.go
+++ b/render/topologies_test.go
@@ -27,7 +27,7 @@ func TestProcessNameRenderer(t *testing.T) {
 }
 
 func TestContainerRenderer(t *testing.T) {
-	have := (render.ContainerWithImageNameRenderer{}.Render(test.Report)).Prune()
+	have := (render.ContainerWithImageNameRenderer.Render(test.Report)).Prune()
 	want := expected.RenderedContainers
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -39,7 +39,7 @@ func TestContainerFilterRenderer(t *testing.T) {
 	// it is filtered out correctly.
 	input := test.Report.Copy()
 	input.Container.Nodes[test.ClientContainerNodeID].Metadata[docker.LabelPrefix+"works.weave.role"] = "system"
-	have := render.FilterSystem(render.ContainerWithImageNameRenderer{}).Render(input).Prune()
+	have := render.FilterSystem(render.ContainerWithImageNameRenderer).Render(input).Prune()
 	want := expected.RenderedContainers.Copy()
 	delete(want, test.ClientContainerID)
 	if !reflect.DeepEqual(want, have) {


### PR DESCRIPTION
@davkal this adds a filtered_nodes field to the /api/topology endpoint.  You'll need to ensure you pass the same query parameters (ie system=show) to this endpoint to get accurate stats.  Could you do the UI pieces?

Fixes #509 