### PR TITLE
Sort DNS answers before returning a name with Get()

### DIFF
--- a/probe/endpoint/resolver.go
+++ b/probe/endpoint/resolver.go
@@ -3,6 +3,7 @@ package endpoint
 import (
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 	"time"
 
@@ -70,6 +71,7 @@ func (r *ReverseResolver) loop() {
 		<-r.Throttle // rate limit our DNS resolutions
 		names, err := r.Resolver(request)
 		if err == nil && len(names) > 0 {
+			sort.Strings(names)
 			name := strings.TrimRight(names[0], ".")
 			r.cache.Set(request, name)
 		} else {

--- a/probe/endpoint/resolver_test.go
+++ b/probe/endpoint/resolver_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestReverseResolver(t *testing.T) {
-	tests := map[string]string{
-		"1.2.3.4": "test.domain.name",
-		"4.3.2.1": "im.a.little.tea.pot",
+	tests := map[string][]string{
+		"1.2.3.4": {"test.domain.name"},
+		"4.3.2.1": {"im.a.little.tea.pot"},
 	}
 
 	revRes := NewReverseResolver()
@@ -20,8 +20,8 @@ func TestReverseResolver(t *testing.T) {
 
 	// Use a mocked resolver function.
 	revRes.Resolver = func(addr string) (names []string, err error) {
-		if name, ok := tests[addr]; ok {
-			return []string{name}, nil
+		if names, ok := tests[addr]; ok {
+			return names, nil
 		}
 		return []string{}, errors.New("invalid IP")
 	}
@@ -29,8 +29,8 @@ func TestReverseResolver(t *testing.T) {
 	// Up the rate limit so the test runs faster.
 	revRes.Throttle = time.Tick(time.Millisecond)
 
-	for ip, hostname := range tests {
-		test.Poll(t, 100*time.Millisecond, hostname, func() interface{} {
+	for ip, names := range tests {
+		test.Poll(t, 100*time.Millisecond, names[0], func() interface{} {
 			result, _ := revRes.Get(ip)
 			return result
 		})


### PR DESCRIPTION
Reated to #504 (it mitigates it) by sorting the DNS answers and getting the first one on `Get()`