### PR TITLE
Make scope work with weave master.

### DIFF
--- a/integration/320_container_edge_cross_host_2_test.sh
+++ b/integration/320_container_edge_cross_host_2_test.sh
@@ -12,7 +12,7 @@ scope_on $HOST2 launch
 
 weave_on $HOST1 run -d --name nginx nginx
 weave_on $HOST2 run -d --name client alpine /bin/sh -c "while true; do \
-	wget http://nginx.weave.local:80/ >/dev/null || true; \
+	wget http://nginx.weave.local:80/ -O - >/dev/null || true; \
 	sleep 1; \
 done"
 


### PR DESCRIPTION
Fixes #560

- Don't use the embedded weave script to drive dns or expose; run the appropriate weaveexec image instead
- Deal with weave being in the host net namespace
- Embedded weave script still needed to get container ips.