### PR TITLE
Include host scope for container joins based on IP.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ dependencies:
     - git clone https://github.com/weaveworks/tools.git $TOOLS
     - sudo apt-get update
     - sudo apt-get --only-upgrade install tar libpcap0.8-dev
-    - sudo apt-get install jq
+    - sudo apt-get install jq pv
     - curl https://sdk.cloud.google.com | bash
     - test -z "$SECRET_PASSWORD" || bin/setup-circleci-secrets "$SECRET_PASSWORD"
     - go get $WEAVE_REPO/...

--- a/integration/setup.sh
+++ b/integration/setup.sh
@@ -6,7 +6,8 @@ set -e
 
 echo Copying scope images and scripts to hosts
 for HOST in $HOSTS; do
-	docker_on $HOST load -i ../scope.tar
+	SIZE=$(stat --printf="%s" ../scope.tar)
+	cat ../scope.tar | pv -N "scope.tar" -s $SIZE | $SSH -C $HOST sudo docker load
 	upload_executable $HOST ../scope
 	upload_executable $HOST ../scope /usr/local/scope/bin/scope
 done

--- a/probe/docker/container.go
+++ b/probe/docker/container.go
@@ -224,12 +224,11 @@ func (c *container) GetNode(hostID string, localAddrs []net.IP) report.Node {
 	c.RLock()
 	defer c.RUnlock()
 
-	ips := append(c.container.NetworkSettings.SecondaryIPAddresses,
-		c.container.NetworkSettings.IPAddress)
+	ips := append(c.container.NetworkSettings.SecondaryIPAddresses, c.container.NetworkSettings.IPAddress)
 	// Treat all Docker IPs as local scoped.
 	ipsWithScopes := []string{}
 	for _, ip := range ips {
-		ipsWithScopes = append(ipsWithScopes, fmt.Sprintf("%s:%s", hostID, ip))
+		ipsWithScopes = append(ipsWithScopes, report.MakeScopedAddressNodeID(hostID, ip))
 	}
 
 	result := report.MakeNodeWith(map[string]string{

--- a/probe/docker/container_linux_test.go
+++ b/probe/docker/container_linux_test.go
@@ -70,7 +70,7 @@ func TestContainer(t *testing.T) {
 		"docker_container_created":         "01 Jan 01 00:00 UTC",
 		"docker_container_id":              "ping",
 		"docker_container_ips":             "1.2.3.4",
-		"docker_container_ips_with_scopes": "scope:1.2.3.4",
+		"docker_container_ips_with_scopes": "scope;1.2.3.4",
 		"docker_container_name":            "pong",
 		"docker_container_ports":           "1.2.3.4:80->80/tcp, 81/tcp",
 		"docker_image_id":                  "baz",

--- a/probe/docker/container_linux_test.go
+++ b/probe/docker/container_linux_test.go
@@ -66,19 +66,20 @@ func TestContainer(t *testing.T) {
 
 	// Now see if we go them
 	want := report.MakeNode().WithMetadata(map[string]string{
-		"docker_container_command": " ",
-		"docker_container_created": "01 Jan 01 00:00 UTC",
-		"docker_container_id":      "ping",
-		"docker_container_ips":     "1.2.3.4",
-		"docker_container_name":    "pong",
-		"docker_container_ports":   "1.2.3.4:80->80/tcp, 81/tcp",
-		"docker_image_id":          "baz",
-		"docker_label_foo1":        "bar1",
-		"docker_label_foo2":        "bar2",
-		"memory_usage":             "12345",
+		"docker_container_command":         " ",
+		"docker_container_created":         "01 Jan 01 00:00 UTC",
+		"docker_container_id":              "ping",
+		"docker_container_ips":             "1.2.3.4",
+		"docker_container_ips_with_scopes": "scope:1.2.3.4",
+		"docker_container_name":            "pong",
+		"docker_container_ports":           "1.2.3.4:80->80/tcp, 81/tcp",
+		"docker_image_id":                  "baz",
+		"docker_label_foo1":                "bar1",
+		"docker_label_foo2":                "bar2",
+		"memory_usage":                     "12345",
 	})
 	test.Poll(t, 100*time.Millisecond, want, func() interface{} {
-		node := c.GetNode([]net.IP{})
+		node := c.GetNode("scope", []net.IP{})
 		for k, v := range node.Metadata {
 			if v == "0" || v == "" {
 				delete(node.Metadata, k)
@@ -93,7 +94,7 @@ func TestContainer(t *testing.T) {
 	if c.PID() != 1 {
 		t.Errorf("%s != 1", c.PID())
 	}
-	if !reflect.DeepEqual(docker.ExtractContainerIPs(c.GetNode([]net.IP{})), []string{"1.2.3.4"}) {
-		t.Errorf("%v != %v", docker.ExtractContainerIPs(c.GetNode([]net.IP{})), []string{"1.2.3.4"})
+	if have := docker.ExtractContainerIPs(c.GetNode("", []net.IP{})); !reflect.DeepEqual(have, []string{"1.2.3.4"}) {
+		t.Errorf("%v != %v", have, []string{"1.2.3.4"})
 	}
 }

--- a/probe/docker/registry_test.go
+++ b/probe/docker/registry_test.go
@@ -41,7 +41,7 @@ func (c *mockContainer) StartGatheringStats() error {
 
 func (c *mockContainer) StopGatheringStats() {}
 
-func (c *mockContainer) GetNode(_ []net.IP) report.Node {
+func (c *mockContainer) GetNode(_ string, _ []net.IP) report.Node {
 	return report.MakeNodeWith(map[string]string{
 		docker.ContainerID:   c.c.ID,
 		docker.ContainerName: c.c.Name,

--- a/probe/docker/reporter.go
+++ b/probe/docker/reporter.go
@@ -46,7 +46,7 @@ func (r *Reporter) containerTopology(localAddrs []net.IP) report.Topology {
 
 	r.registry.WalkContainers(func(c Container) {
 		nodeID := report.MakeContainerNodeID(r.hostID, c.ID())
-		result.AddNode(nodeID, c.GetNode(localAddrs))
+		result.AddNode(nodeID, c.GetNode(r.hostID, localAddrs))
 	})
 
 	return result

--- a/probe/overlay/weave.go
+++ b/probe/overlay/weave.go
@@ -178,6 +178,13 @@ func (w *Weave) Tag(r report.Report) (report.Report, error) {
 		existingIPs := report.MakeIDList(docker.ExtractContainerIPs(node)...)
 		existingIPs = existingIPs.Add(e.ips...)
 		node.Metadata[docker.ContainerIPs] = strings.Join(existingIPs, " ")
+
+		existingIPsWithScopes := report.MakeIDList(docker.ExtractContainerIPsWithScopes(node)...)
+		for _, ip := range e.ips {
+			existingIPsWithScopes = existingIPsWithScopes.Add(fmt.Sprintf(":%s", ip))
+		}
+		node.Metadata[docker.ContainerIPsWithScopes] = strings.Join(existingIPsWithScopes, " ")
+
 		node.Metadata[WeaveMACAddress] = e.macAddress
 	}
 	return r, nil

--- a/probe/overlay/weave.go
+++ b/probe/overlay/weave.go
@@ -181,7 +181,7 @@ func (w *Weave) Tag(r report.Report) (report.Report, error) {
 
 		existingIPsWithScopes := report.MakeIDList(docker.ExtractContainerIPsWithScopes(node)...)
 		for _, ip := range e.ips {
-			existingIPsWithScopes = existingIPsWithScopes.Add(fmt.Sprintf(":%s", ip))
+			existingIPsWithScopes = existingIPsWithScopes.Add(report.MakeAddressNodeID("", ip))
 		}
 		node.Metadata[docker.ContainerIPsWithScopes] = strings.Join(existingIPsWithScopes, " ")
 

--- a/probe/overlay/weave_test.go
+++ b/probe/overlay/weave_test.go
@@ -85,7 +85,7 @@ const (
 	mockContainerID          = "83183a667c01"
 	mockContainerMAC         = "d6:f2:5a:12:36:a8"
 	mockContainerIP          = "10.0.0.123"
-	mockContainerIPWithScope = ":10.0.0.123"
+	mockContainerIPWithScope = ";10.0.0.123"
 	mockHostname             = "hostname.weave.local"
 )
 

--- a/probe/overlay/weave_test.go
+++ b/probe/overlay/weave_test.go
@@ -51,10 +51,11 @@ func TestWeaveTaggerOverlayTopology(t *testing.T) {
 			Container: report.Topology{
 				Nodes: report.Nodes{
 					nodeID: report.MakeNodeWith(map[string]string{
-						docker.ContainerID:       mockContainerID,
-						overlay.WeaveDNSHostname: mockHostname,
-						overlay.WeaveMACAddress:  mockContainerMAC,
-						docker.ContainerIPs:      mockContainerIP,
+						docker.ContainerID:            mockContainerID,
+						overlay.WeaveDNSHostname:      mockHostname,
+						overlay.WeaveMACAddress:       mockContainerMAC,
+						docker.ContainerIPs:           mockContainerIP,
+						docker.ContainerIPsWithScopes: mockContainerIPWithScope,
 					}),
 				},
 			},
@@ -78,13 +79,14 @@ func TestWeaveTaggerOverlayTopology(t *testing.T) {
 }
 
 const (
-	mockHostID            = "host1"
-	mockWeavePeerName     = "winnebago"
-	mockWeavePeerNickName = "winny"
-	mockContainerID       = "83183a667c01"
-	mockContainerMAC      = "d6:f2:5a:12:36:a8"
-	mockContainerIP       = "10.0.0.123"
-	mockHostname          = "hostname.weave.local"
+	mockHostID               = "host1"
+	mockWeavePeerName        = "winnebago"
+	mockWeavePeerNickName    = "winny"
+	mockContainerID          = "83183a667c01"
+	mockContainerMAC         = "d6:f2:5a:12:36:a8"
+	mockContainerIP          = "10.0.0.123"
+	mockContainerIPWithScope = ":10.0.0.123"
+	mockHostname             = "hostname.weave.local"
 )
 
 var (

--- a/report/id.go
+++ b/report/id.go
@@ -76,6 +76,18 @@ func MakeAddressNodeID(hostID, address string) string {
 	return scope + ScopeDelim + address
 }
 
+// MakeScopedEndpointNodeID is like MakeEndpointNodeID, but it always
+// prefixes the ID witha scope.
+func MakeScopedEndpointNodeID(hostID, address, port string) string {
+	return hostID + ScopeDelim + address + ScopeDelim + port
+}
+
+// MakeScopedAddressNodeID is like MakeAddressNodeID, but it always
+// prefixes the ID witha scope.
+func MakeScopedAddressNodeID(hostID, address string) string {
+	return hostID + ScopeDelim + address
+}
+
 // MakeProcessNodeID produces a process node ID from its composite parts.
 func MakeProcessNodeID(hostID, pid string) string {
 	return hostID + ScopeDelim + pid


### PR DESCRIPTION
Part of #520 - can explain false edges between containers on different hosts, but the bug has been seen between containers on the same host, and this shouldn't affect that.