### PR TITLE
Build inside the build container, using go1.5, by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,15 +29,12 @@ docker/weave:
 	curl -L git.io/weave -o docker/weave
 	chmod u+x docker/weave
 
-$(SCOPE_EXPORT): backend $(DOCKER_DISTRIB) docker/weave $(RUNSVINIT) docker/Dockerfile docker/run-app docker/run-probe docker/entrypoint.sh docker/ca-certificates.crt
+$(SCOPE_EXPORT): backend $(DOCKER_DISTRIB) docker/weave $(RUNSVINIT) docker/Dockerfile docker/run-app docker/run-probe docker/entrypoint.sh
 	@if [ -z '$(DOCKER_SQUASH)' ] ; then echo "Please install docker-squash by running 'make deps' (and make sure GOPATH/bin is in your PATH)." && exit 1 ; fi
 	cp $(APP_EXE) $(PROBE_EXE) docker/
 	cp $(DOCKER_DISTRIB) docker/docker.tgz
 	$(SUDO) docker build -t $(SCOPE_IMAGE) docker/
 	$(SUDO) docker save $(SCOPE_IMAGE):latest | sudo $(DOCKER_SQUASH) -t $(SCOPE_IMAGE) | tee $@ | $(SUDO) docker load
-
-docker/ca-certificates.crt: /etc/ssl/certs/ca-certificates.crt
-	cp $? $@
 
 $(RUNSVINIT): vendor/runsvinit/*.go
 	go build -o $@ github.com/weaveworks/scope/vendor/runsvinit

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 
 # If you can use Docker without being root, you can `make SUDO= <target>`
 SUDO=sudo
-DOCKER_SQUASH=$(shell which docker-squash 2>/dev/null)
 DOCKERHUB_USER=weaveworks
 APP_EXE=app/scope-app
 PROBE_EXE=probe/scope-probe
@@ -30,11 +29,10 @@ docker/weave:
 	chmod u+x docker/weave
 
 $(SCOPE_EXPORT): backend $(DOCKER_DISTRIB) docker/weave $(RUNSVINIT) docker/Dockerfile docker/run-app docker/run-probe docker/entrypoint.sh
-	@if [ -z '$(DOCKER_SQUASH)' ] ; then echo "Please install docker-squash by running 'make deps' (and make sure GOPATH/bin is in your PATH)." && exit 1 ; fi
 	cp $(APP_EXE) $(PROBE_EXE) docker/
 	cp $(DOCKER_DISTRIB) docker/docker.tgz
 	$(SUDO) docker build -t $(SCOPE_IMAGE) docker/
-	$(SUDO) docker save $(SCOPE_IMAGE):latest | sudo $(DOCKER_SQUASH) -t $(SCOPE_IMAGE) | tee $@ | $(SUDO) docker load
+	$(SUDO) docker save $(SCOPE_IMAGE):latest > $@
 
 $(RUNSVINIT): vendor/runsvinit/*.go
 	go build -o $@ github.com/weaveworks/scope/vendor/runsvinit
@@ -98,7 +96,6 @@ clean:
 
 deps:
 	go get -u -f -tags netgo \
-		github.com/jwilder/docker-squash \
 		github.com/golang/lint/golint \
 		github.com/fzipp/gocyclo \
 		github.com/mattn/goveralls \

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ docker/weave:
 	curl -L git.io/weave -o docker/weave
 	chmod u+x docker/weave
 
-$(SCOPE_EXPORT): $(APP_EXE) $(PROBE_EXE) $(DOCKER_DISTRIB) docker/weave $(RUNSVINIT) docker/Dockerfile docker/run-app docker/run-probe docker/entrypoint.sh docker/ca-certificates.crt
+$(SCOPE_EXPORT): backend $(DOCKER_DISTRIB) docker/weave $(RUNSVINIT) docker/Dockerfile docker/run-app docker/run-probe docker/entrypoint.sh docker/ca-certificates.crt
 	@if [ -z '$(DOCKER_SQUASH)' ] ; then echo "Please install docker-squash by running 'make deps' (and make sure GOPATH/bin is in your PATH)." && exit 1 ; fi
 	cp $(APP_EXE) $(PROBE_EXE) docker/
 	cp $(DOCKER_DISTRIB) docker/docker.tgz
@@ -91,13 +91,13 @@ $(SCOPE_BACKEND_BUILD_UPTODATE): backend/*
 	touch $@
 
 backend: $(SCOPE_BACKEND_BUILD_UPTODATE)
-	docker run -ti $(RM) -v $(shell pwd):/go/src/github.com/weaveworks/scope $(SCOPE_BACKEND_BUILD_IMAGE) /build.bash
+	docker run -ti $(RM) -v $(GOPATH)/src:/go/src -e GOARCH -e GOOS $(SCOPE_BACKEND_BUILD_IMAGE) /build.bash
 
 frontend: $(SCOPE_UI_BUILD_UPTODATE)
 
 clean:
 	go clean ./...
-	rm -rf $(SCOPE_EXPORT) $(SCOPE_UI_BUILD_EXPORT) $(APP_EXE) $(PROBE_EXE) client/build/app.js docker/weave
+	rm -rf $(SCOPE_EXPORT) $(SCOPE_UI_BUILD_UPTODATE) $(SCOPE_BACKEND_BUILD_UPTODATE) $(APP_EXE) $(PROBE_EXE) client/build/app.js docker/weave
 
 deps:
 	go get -u -f -tags netgo \

--- a/README.md
+++ b/README.md
@@ -142,15 +142,13 @@ sudo scope launch --service-token=<token>
 The build is in five stages. `make deps` installs some tools we use later in
 the build. `make frontend` builds a UI build image with all NPM dependencies.
 `make static` compiles the UI into `static.go` which is part of the repository
-for convenience. `make backend` builds the backend Go app which then includes
-the static files. The final `make` pushes the app into a Docker image called
-**weaveworks/scope**.
+for convenience. The final `make` builds the app and probe, in a container,
+and pushes the lot into a Docker image called **weaveworks/scope**.
 
 ```
 make deps
 make frontend
 make static
-make backend
 make
 ```
 

--- a/backend/build.bash
+++ b/backend/build.bash
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-set -x
+set -eux
 
 # Mount the scope repo:
 #  -v $(pwd):/go/src/github.com/weaveworks/scope
 
-cd /go/src/github.com/weaveworks/scope
-make deps
+cd $GOPATH/src/github.com/weaveworks/scope
 make app/scope-app
 make probe/scope-probe
 

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ machine:
   services:
     - docker
   environment:
-    GOPATH: /home/ubuntu:$GOPATH
+    GOPATH: /home/ubuntu
     TOOLS: /home/ubuntu/src/github.com/weaveworks/tools
     SRCDIR: /home/ubuntu/src/github.com/weaveworks/scope
     PATH: $PATH:$HOME/.local/bin
@@ -36,13 +36,17 @@ dependencies:
     - mkdir -p $(dirname $SRCDIR)
     - cp -r $(pwd)/ $SRCDIR
     - cd $SRCDIR/client; $TOOLS/rebuild-image weaveworks/scope-ui-build . Dockerfile package.json webpack.production.config.js .eslintrc
+    - cd $SRCDIR/backend; $TOOLS/rebuild-image weaveworks/scope-backend-build . Dockerfile build.sh
+    - touch $SRCDIR/.scope_backend_build.uptodate
 
 test:
   override:
     - cd $SRCDIR; $TOOLS/lint .
     - cd $SRCDIR; make RM= client-test
     - cd $SRCDIR; make RM= static
-    - cd $SRCDIR; rm -f app/scope-app probe/scope-probe; make
+    - cd $SRCDIR; rm -f app/scope-app probe/scope-probe; GOARCH=arm make RM= backend
+    - cd $SRCDIR; rm -f app/scope-app probe/scope-probe; GOOS=darwin make RM= backend
+    - cd $SRCDIR; rm -f app/scope-app probe/scope-probe; make RM=
     - cd $SRCDIR; $TOOLS/test -slow
     - cd $SRCDIR/experimental; make
     - test -z "$SECRET_PASSWORD" || (cd $SRCDIR/integration; ./gce.sh setup)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,5 @@ ADD ./weave /usr/bin/
 COPY ./scope-app ./scope-probe ./runsvinit ./entrypoint.sh /home/weave/
 COPY ./run-app /etc/service/app/run
 COPY ./run-probe /etc/service/probe/run
-COPY ./ca-certificates.crt /etc/ssl/certs/
 EXPOSE 4040
 ENTRYPOINT ["/home/weave/entrypoint.sh"]

--- a/integration/310_container_to_container_edge_test.sh
+++ b/integration/310_container_to_container_edge_test.sh
@@ -4,11 +4,11 @@
 
 start_suite "Test short lived connections between containers"
 
-weave_on $HOST1 launch
+WEAVE_NO_FASTDP=true weave_on $HOST1 launch
 scope_on $HOST1 launch
 weave_on $HOST1 run -d --name nginx nginx
 weave_on $HOST1 run -d --name client alpine /bin/sh -c "while true; do \
-	wget http://nginx.weave.local:80/ >/dev/null || true; \
+	wget http://nginx.weave.local:80/ -O - >/dev/null || true; \
 	sleep 1; \
 done"
 

--- a/integration/320_container_edge_cross_host_2_test.sh
+++ b/integration/320_container_edge_cross_host_2_test.sh
@@ -4,8 +4,8 @@
 
 start_suite "Test short lived connections between containers on different hosts"
 
-weave_on $HOST1 launch $HOST1 $HOST2
-weave_on $HOST2 launch $HOST1 $HOST2
+WEAVE_NO_FASTDP=true weave_on $HOST1 launch $HOST1 $HOST2
+WEAVE_NO_FASTDP=true weave_on $HOST2 launch $HOST1 $HOST2
 
 scope_on $HOST1 launch
 scope_on $HOST2 launch


### PR DESCRIPTION
Fixes #550, fixes #530

And build for GOOS=darwin and GOARCH=arm

With this change, `make` should build the scope container on a correctly configured Mac, using Docker Machine.