### PR TITLE
Mitigate dancing nodes

### DIFF
--- a/client/app/scripts/charts/__tests__/node-layout-test.js
+++ b/client/app/scripts/charts/__tests__/node-layout-test.js
@@ -1,0 +1,50 @@
+jest.dontMock('../nodes-layout');
+jest.dontMock('../../constants/naming'); // edge naming: 'source-target'
+
+describe('NodesLayout', () => {
+  const NodesLayout = require('../nodes-layout');
+
+  function scale(val) {
+    return val * 3;
+  }
+  const topologyId = 'tid';
+  const width = 80;
+  const height = 80;
+  const margins = {
+    left: 0,
+    top: 0
+  };
+
+  const nodeSets = {
+    initial4: {
+      nodes: {
+        n1: {id: 'n1'},
+        n2: {id: 'n2'},
+        n3: {id: 'n3'},
+        n4: {id: 'n4'}
+      },
+      edges: {
+        'n1-n3': {id: 'n1-n3', source: {id: 'n1'}, target: {id: 'n3'}},
+        'n1-n4': {id: 'n1-n4', source: {id: 'n1'}, target: {id: 'n4'}},
+        'n2-n4': {id: 'n2-n4', source: {id: 'n2'}, target: {id: 'n4'}}
+      }
+    }
+  };
+
+  it('lays out initial nodeset', () => {
+    const nodes = nodeSets.initial4.nodes;
+    const edges = nodeSets.initial4.edges;
+    NodesLayout.doLayout(nodes, edges, width, height, scale, margins, topologyId);
+    expect(nodes.n1.x).toBeLessThan(nodes.n2.x);
+    expect(nodes.n1.y).toEqual(nodes.n2.y);
+
+    expect(nodes.n1.x).toEqual(nodes.n3.x);
+    expect(nodes.n1.y).toBeLessThan(nodes.n3.y);
+
+    expect(nodes.n3.x).toBeLessThan(nodes.n4.x);
+    expect(nodes.n3.y).toEqual(nodes.n4.y);
+
+    console.log(nodes, nodeSets.initial4.nodes);
+  });
+
+});

--- a/client/app/scripts/charts/__tests__/node-layout-test.js
+++ b/client/app/scripts/charts/__tests__/node-layout-test.js
@@ -1,7 +1,7 @@
 jest.dontMock('../nodes-layout');
 jest.dontMock('../../constants/naming'); // edge naming: 'source-target'
 
-import { fromJS, is } from 'immutable';
+import { fromJS, List } from 'immutable';
 
 describe('NodesLayout', () => {
   const NodesLayout = require('../nodes-layout');
@@ -16,7 +16,7 @@ describe('NodesLayout', () => {
     left: 0,
     top: 0
   };
-  let history;
+  let history = List();
   let nodes;
 
   const nodeSets = {
@@ -44,8 +44,23 @@ describe('NodesLayout', () => {
         'n1-n3': {id: 'n1-n3', source: 'n1', target: 'n3'},
         'n1-n4': {id: 'n1-n4', source: 'n1', target: 'n4'}
       })
-    }
+    },
+    removeNode2: {
+      nodes: fromJS({
+        n1: {id: 'n1'},
+        n3: {id: 'n3'},
+        n4: {id: 'n4'}
+      }),
+      edges: fromJS({
+        'n1-n3': {id: 'n1-n3', source: 'n1', target: 'n3'},
+        'n1-n4': {id: 'n1-n4', source: 'n1', target: 'n4'}
+      })
+    },
   };
+
+  beforeEach(() => {
+    history = history.clear();
+  })
 
   it('lays out initial nodeset in a rectangle', () => {
     const result = NodesLayout.doLayout(
@@ -66,10 +81,10 @@ describe('NodesLayout', () => {
     let result = NodesLayout.doLayout(
       nodeSets.initial4.nodes,
       nodeSets.initial4.edges);
-    history = [{
+    history = history.unshift({
       nodes: result.nodes,
       edges: result.edges
-    }];
+    });
     result = NodesLayout.doLayout(
       nodeSets.removeEdge24.nodes,
       nodeSets.removeEdge24.edges,
@@ -91,20 +106,20 @@ describe('NodesLayout', () => {
       nodeSets.initial4.nodes,
       nodeSets.initial4.edges);
 
-    history = [{
+    history = history.unshift({
       nodes: result.nodes,
       edges: result.edges
-    }];
+    });
     result = NodesLayout.doLayout(
       nodeSets.removeEdge24.nodes,
       nodeSets.removeEdge24.edges,
       {history}
     );
 
-    history = [{
+    history = history.unshift({
       nodes: result.nodes,
       edges: result.edges
-    }];
+    });
     result = NodesLayout.doLayout(
       nodeSets.initial4.nodes,
       nodeSets.initial4.edges,
@@ -122,6 +137,27 @@ describe('NodesLayout', () => {
     expect(nodes.n3.y).toEqual(nodes.n4.y);
   });
 
+  it('keeps nodes in rectangle after node dissappears', () => {
+    let result = NodesLayout.doLayout(
+      nodeSets.initial4.nodes,
+      nodeSets.initial4.edges);
 
+    history = history.unshift({
+      nodes: result.nodes,
+      edges: result.edges
+    });
+    result = NodesLayout.doLayout(
+      nodeSets.removeNode2.nodes,
+      nodeSets.removeNode2.edges,
+      {history}
+    );
+
+    nodes = result.nodes.toJS();
+
+    expect(nodes.n1.x).toEqual(nodes.n3.x);
+    expect(nodes.n1.y).toBeLessThan(nodes.n3.y);
+    expect(nodes.n3.x).toBeLessThan(nodes.n4.x);
+    expect(nodes.n3.y).toEqual(nodes.n4.y);
+  });
 
 });

--- a/client/app/scripts/charts/__tests__/node-layout-test.js
+++ b/client/app/scripts/charts/__tests__/node-layout-test.js
@@ -6,18 +6,21 @@ import { fromJS, Map } from 'immutable';
 describe('NodesLayout', () => {
   const NodesLayout = require('../nodes-layout');
 
-  function scale(val) {
-    return val * 3;
+  function getNodeCoordinates(nodes) {
+    const coords = [];
+    nodes
+      .sortBy(node => node.get('id'))
+      .forEach(node => {
+        coords.push(node.get('x'));
+        coords.push(node.get('y'));
+      });
+    return coords;
   }
-  const topologyId = 'tid';
-  const width = 80;
-  const height = 80;
-  const margins = {
-    left: 0,
-    top: 0
-  };
+
   let options;
   let nodes;
+  let coords;
+  let resultCoords;
 
   const nodeSets = {
     initial4: {
@@ -122,6 +125,7 @@ describe('NodesLayout', () => {
     options.cachedLayout = result;
     options.nodeCache = options.nodeCache.merge(result.nodes);
     options.edgeCache = options.edgeCache.merge(result.edge);
+    coords = getNodeCoordinates(result.nodes);
 
     result = NodesLayout.doLayout(
       nodeSets.removeEdge24.nodes,
@@ -131,12 +135,8 @@ describe('NodesLayout', () => {
     nodes = result.nodes.toJS();
     // console.log('remove 1 edge', nodes, result);
 
-    expect(nodes.n1.x).toBeLessThan(nodes.n2.x);
-    expect(nodes.n1.y).toEqual(nodes.n2.y);
-    expect(nodes.n1.x).toEqual(nodes.n3.x);
-    expect(nodes.n1.y).toBeLessThan(nodes.n3.y);
-    expect(nodes.n3.x).toBeLessThan(nodes.n4.x);
-    expect(nodes.n3.y).toEqual(nodes.n4.y);
+    resultCoords = getNodeCoordinates(result.nodes);
+    expect(resultCoords).toEqual(coords);
   });
 
   it('keeps nodes in rectangle after removed edge reappears', () => {
@@ -144,6 +144,7 @@ describe('NodesLayout', () => {
       nodeSets.initial4.nodes,
       nodeSets.initial4.edges);
 
+    coords = getNodeCoordinates(result.nodes);
     options.cachedLayout = result;
     options.nodeCache = options.nodeCache.merge(result.nodes);
     options.edgeCache = options.edgeCache.merge(result.edge);
@@ -165,12 +166,8 @@ describe('NodesLayout', () => {
     nodes = result.nodes.toJS();
     // console.log('re-add 1 edge', nodes, result);
 
-    expect(nodes.n1.x).toBeLessThan(nodes.n2.x);
-    expect(nodes.n1.y).toEqual(nodes.n2.y);
-    expect(nodes.n1.x).toEqual(nodes.n3.x);
-    expect(nodes.n1.y).toBeLessThan(nodes.n3.y);
-    expect(nodes.n3.x).toBeLessThan(nodes.n4.x);
-    expect(nodes.n3.y).toEqual(nodes.n4.y);
+    resultCoords = getNodeCoordinates(result.nodes);
+    expect(resultCoords).toEqual(coords);
   });
 
   it('keeps nodes in rectangle after node dissappears', () => {
@@ -189,10 +186,9 @@ describe('NodesLayout', () => {
 
     nodes = result.nodes.toJS();
 
-    expect(nodes.n1.x).toEqual(nodes.n3.x);
-    expect(nodes.n1.y).toBeLessThan(nodes.n3.y);
-    expect(nodes.n3.x).toBeLessThan(nodes.n4.x);
-    expect(nodes.n3.y).toEqual(nodes.n4.y);
+    resultCoords = getNodeCoordinates(result.nodes);
+    expect(resultCoords.slice(0,2)).toEqual(coords.slice(0,2));
+    expect(resultCoords.slice(2,6)).toEqual(coords.slice(4,8));
   });
 
   it('keeps nodes in rectangle after removed node reappears', () => {
@@ -202,6 +198,7 @@ describe('NodesLayout', () => {
 
     nodes = result.nodes.toJS();
 
+    coords = getNodeCoordinates(result.nodes);
     options.cachedLayout = result;
     options.nodeCache = options.nodeCache.merge(result.nodes);
     options.edgeCache = options.edgeCache.merge(result.edge);
@@ -229,10 +226,9 @@ describe('NodesLayout', () => {
     nodes = result.nodes.toJS();
     // console.log('re-add 1 node', nodes);
 
-    expect(nodes.n1.x).toEqual(nodes.n3.x);
-    expect(nodes.n1.y).toBeLessThan(nodes.n3.y);
-    expect(nodes.n3.x).toBeLessThan(nodes.n4.x);
-    expect(nodes.n3.y).toEqual(nodes.n4.y);
+    resultCoords = getNodeCoordinates(result.nodes);
+    expect(resultCoords.slice(0,2)).toEqual(coords.slice(0,2));
+    expect(resultCoords.slice(2,6)).toEqual(coords.slice(4,8));
   });
 
 });

--- a/client/app/scripts/charts/__tests__/node-layout-test.js
+++ b/client/app/scripts/charts/__tests__/node-layout-test.js
@@ -34,7 +34,7 @@ describe('NodesLayout', () => {
   it('lays out initial nodeset', () => {
     const nodes = nodeSets.initial4.nodes;
     const edges = nodeSets.initial4.edges;
-    NodesLayout.doLayout(nodes, edges, width, height, scale, margins, topologyId);
+    NodesLayout.doLayout(nodes, edges);
     expect(nodes.n1.x).toBeLessThan(nodes.n2.x);
     expect(nodes.n1.y).toEqual(nodes.n2.y);
 

--- a/client/app/scripts/charts/__tests__/node-layout-test.js
+++ b/client/app/scripts/charts/__tests__/node-layout-test.js
@@ -1,6 +1,8 @@
 jest.dontMock('../nodes-layout');
 jest.dontMock('../../constants/naming'); // edge naming: 'source-target'
 
+import { fromJS } from 'immutable';
+
 describe('NodesLayout', () => {
   const NodesLayout = require('../nodes-layout');
 
@@ -14,6 +16,8 @@ describe('NodesLayout', () => {
     left: 0,
     top: 0
   };
+  let history;
+  let nodes;
 
   const nodeSets = {
     initial4: {
@@ -24,27 +28,57 @@ describe('NodesLayout', () => {
         n4: {id: 'n4'}
       },
       edges: {
-        'n1-n3': {id: 'n1-n3', source: {id: 'n1'}, target: {id: 'n3'}},
-        'n1-n4': {id: 'n1-n4', source: {id: 'n1'}, target: {id: 'n4'}},
-        'n2-n4': {id: 'n2-n4', source: {id: 'n2'}, target: {id: 'n4'}}
+        'n1-n3': {id: 'n1-n3', source: 'n1', target: 'n3'},
+        'n1-n4': {id: 'n1-n4', source: 'n1', target: 'n4'},
+        'n2-n4': {id: 'n2-n4', source: 'n2', target: 'n4'}
+      }
+    },
+    removeEdge24: {
+      nodes: {
+        n1: {id: 'n1'},
+        n2: {id: 'n2'},
+        n3: {id: 'n3'},
+        n4: {id: 'n4'}
+      },
+      edges: {
+        'n1-n3': {id: 'n1-n3', source: 'n1', target: 'n3'},
+        'n1-n4': {id: 'n1-n4', source: 'n1', target: 'n4'}
       }
     }
   };
 
-  it('lays out initial nodeset', () => {
-    const nodes = nodeSets.initial4.nodes;
-    const edges = nodeSets.initial4.edges;
-    NodesLayout.doLayout(nodes, edges);
+  it('lays out initial nodeset in a rectangle', () => {
+    const result = NodesLayout.doLayout(
+      fromJS(nodeSets.initial4.nodes),
+      fromJS(nodeSets.initial4.edges));
+    // console.log('initial', result.get('nodes'));
+    nodes = result.nodes.toJS();
+
     expect(nodes.n1.x).toBeLessThan(nodes.n2.x);
     expect(nodes.n1.y).toEqual(nodes.n2.y);
-
     expect(nodes.n1.x).toEqual(nodes.n3.x);
     expect(nodes.n1.y).toBeLessThan(nodes.n3.y);
-
     expect(nodes.n3.x).toBeLessThan(nodes.n4.x);
     expect(nodes.n3.y).toEqual(nodes.n4.y);
-
-    console.log(nodes, nodeSets.initial4.nodes);
   });
+
+  // it('keeps nodes in rectangle after removing one edge', () => {
+  //   history = [{
+  //     nodes: nodeSets.initial4.nodes,
+  //     edges: nodeSets.initial4.edges
+  //   }];
+  //   nodes = nodeSets.removeEdge24.nodes;
+  //   edges = nodeSets.removeEdge24.edges;
+  //   NodesLayout.doLayout(nodes, edges, {history});
+  //   console.log('remove 1 edge', nodes);
+  //
+  //   expect(nodes.n1.x).toBeLessThan(nodes.n2.x);
+  //   expect(nodes.n1.y).toEqual(nodes.n2.y);
+  //   expect(nodes.n1.x).toEqual(nodes.n3.x);
+  //   expect(nodes.n1.y).toBeLessThan(nodes.n3.y);
+  //   expect(nodes.n3.x).toBeLessThan(nodes.n4.x);
+  //   expect(nodes.n3.y).toEqual(nodes.n4.y);
+  //
+  // });
 
 });

--- a/client/app/scripts/charts/__tests__/node-layout-test.js
+++ b/client/app/scripts/charts/__tests__/node-layout-test.js
@@ -1,7 +1,7 @@
 jest.dontMock('../nodes-layout');
 jest.dontMock('../../constants/naming'); // edge naming: 'source-target'
 
-import { fromJS } from 'immutable';
+import { fromJS, is } from 'immutable';
 
 describe('NodesLayout', () => {
   const NodesLayout = require('../nodes-layout');
@@ -21,36 +21,36 @@ describe('NodesLayout', () => {
 
   const nodeSets = {
     initial4: {
-      nodes: {
+      nodes: fromJS({
         n1: {id: 'n1'},
         n2: {id: 'n2'},
         n3: {id: 'n3'},
         n4: {id: 'n4'}
-      },
-      edges: {
+      }),
+      edges: fromJS({
         'n1-n3': {id: 'n1-n3', source: 'n1', target: 'n3'},
         'n1-n4': {id: 'n1-n4', source: 'n1', target: 'n4'},
         'n2-n4': {id: 'n2-n4', source: 'n2', target: 'n4'}
-      }
+      })
     },
     removeEdge24: {
-      nodes: {
+      nodes: fromJS({
         n1: {id: 'n1'},
         n2: {id: 'n2'},
         n3: {id: 'n3'},
         n4: {id: 'n4'}
-      },
-      edges: {
+      }),
+      edges: fromJS({
         'n1-n3': {id: 'n1-n3', source: 'n1', target: 'n3'},
         'n1-n4': {id: 'n1-n4', source: 'n1', target: 'n4'}
-      }
+      })
     }
   };
 
   it('lays out initial nodeset in a rectangle', () => {
     const result = NodesLayout.doLayout(
-      fromJS(nodeSets.initial4.nodes),
-      fromJS(nodeSets.initial4.edges));
+      nodeSets.initial4.nodes,
+      nodeSets.initial4.edges);
     // console.log('initial', result.get('nodes'));
     nodes = result.nodes.toJS();
 
@@ -62,23 +62,66 @@ describe('NodesLayout', () => {
     expect(nodes.n3.y).toEqual(nodes.n4.y);
   });
 
-  // it('keeps nodes in rectangle after removing one edge', () => {
-  //   history = [{
-  //     nodes: nodeSets.initial4.nodes,
-  //     edges: nodeSets.initial4.edges
-  //   }];
-  //   nodes = nodeSets.removeEdge24.nodes;
-  //   edges = nodeSets.removeEdge24.edges;
-  //   NodesLayout.doLayout(nodes, edges, {history});
-  //   console.log('remove 1 edge', nodes);
-  //
-  //   expect(nodes.n1.x).toBeLessThan(nodes.n2.x);
-  //   expect(nodes.n1.y).toEqual(nodes.n2.y);
-  //   expect(nodes.n1.x).toEqual(nodes.n3.x);
-  //   expect(nodes.n1.y).toBeLessThan(nodes.n3.y);
-  //   expect(nodes.n3.x).toBeLessThan(nodes.n4.x);
-  //   expect(nodes.n3.y).toEqual(nodes.n4.y);
-  //
-  // });
+  it('keeps nodes in rectangle after removing one edge', () => {
+    let result = NodesLayout.doLayout(
+      nodeSets.initial4.nodes,
+      nodeSets.initial4.edges);
+    history = [{
+      nodes: result.nodes,
+      edges: result.edges
+    }];
+    result = NodesLayout.doLayout(
+      nodeSets.removeEdge24.nodes,
+      nodeSets.removeEdge24.edges,
+      {history}
+    );
+    nodes = result.nodes.toJS();
+    // console.log('remove 1 edge', nodes, result);
+
+    expect(nodes.n1.x).toBeLessThan(nodes.n2.x);
+    expect(nodes.n1.y).toEqual(nodes.n2.y);
+    expect(nodes.n1.x).toEqual(nodes.n3.x);
+    expect(nodes.n1.y).toBeLessThan(nodes.n3.y);
+    expect(nodes.n3.x).toBeLessThan(nodes.n4.x);
+    expect(nodes.n3.y).toEqual(nodes.n4.y);
+  });
+
+  it('keeps nodes in rectangle after removed edge reappears', () => {
+    let result = NodesLayout.doLayout(
+      nodeSets.initial4.nodes,
+      nodeSets.initial4.edges);
+
+    history = [{
+      nodes: result.nodes,
+      edges: result.edges
+    }];
+    result = NodesLayout.doLayout(
+      nodeSets.removeEdge24.nodes,
+      nodeSets.removeEdge24.edges,
+      {history}
+    );
+
+    history = [{
+      nodes: result.nodes,
+      edges: result.edges
+    }];
+    result = NodesLayout.doLayout(
+      nodeSets.initial4.nodes,
+      nodeSets.initial4.edges,
+      {history}
+    );
+
+    nodes = result.nodes.toJS();
+    // console.log('re-add 1 edge', nodes, result);
+
+    expect(nodes.n1.x).toBeLessThan(nodes.n2.x);
+    expect(nodes.n1.y).toEqual(nodes.n2.y);
+    expect(nodes.n1.x).toEqual(nodes.n3.x);
+    expect(nodes.n1.y).toBeLessThan(nodes.n3.y);
+    expect(nodes.n3.x).toBeLessThan(nodes.n4.x);
+    expect(nodes.n3.y).toEqual(nodes.n4.y);
+  });
+
+
 
 });

--- a/client/app/scripts/charts/__tests__/node-layout-test.js
+++ b/client/app/scripts/charts/__tests__/node-layout-test.js
@@ -74,6 +74,31 @@ describe('NodesLayout', () => {
     };
   });
 
+  it('detects unseen nodes', () => {
+    const set1 = fromJS({
+      n1: {id: 'n1'}
+    });
+    const set12 = fromJS({
+      n1: {id: 'n1'},
+      n2: {id: 'n2'}
+    });
+    const set13 = fromJS({
+      n1: {id: 'n1'},
+      n3: {id: 'n3'}
+    });
+    let hasUnseen;
+    hasUnseen = NodesLayout.hasUnseenNodes(set12, set1);
+    expect(hasUnseen).toBeTruthy();
+    hasUnseen = NodesLayout.hasUnseenNodes(set13, set1);
+    expect(hasUnseen).toBeTruthy();
+    hasUnseen = NodesLayout.hasUnseenNodes(set1, set12);
+    expect(hasUnseen).toBeFalsy();
+    hasUnseen = NodesLayout.hasUnseenNodes(set1, set13);
+    expect(hasUnseen).toBeFalsy();
+    hasUnseen = NodesLayout.hasUnseenNodes(set12, set13);
+    expect(hasUnseen).toBeTruthy();
+  });
+
   it('lays out initial nodeset in a rectangle', () => {
     const result = NodesLayout.doLayout(
       nodeSets.initial4.nodes,

--- a/client/app/scripts/charts/nodes-chart.js
+++ b/client/app/scripts/charts/nodes-chart.js
@@ -31,6 +31,7 @@ const NodesChart = React.createClass({
     return {
       nodes: makeMap(),
       edges: makeMap(),
+      history: [],
       nodeScale: d3.scale.linear(),
       shiftTranslate: [0, 0],
       panTranslate: [0, 0],
@@ -453,7 +454,8 @@ const NodesChart = React.createClass({
       height: props.height,
       scale: nodeScale,
       margins: MARGINS,
-      topologyId: this.props.topologyId
+      topologyId: this.props.topologyId,
+      history: state.history
     };
 
     const timedLayouter = timely(NodesLayout.doLayout);
@@ -492,6 +494,7 @@ const NodesChart = React.createClass({
     }
 
     return {
+      history: [graph],
       nodes: stateNodes,
       edges: stateEdges,
       nodeScale: nodeScale,

--- a/client/app/scripts/charts/nodes-chart.js
+++ b/client/app/scripts/charts/nodes-chart.js
@@ -428,17 +428,16 @@ const NodesChart = React.createClass({
     const nodeSize = expanse / 3; // single node should fill a third of the screen
     const normalizedNodeSize = nodeSize / Math.sqrt(n); // assuming rectangular layout
     const nodeScale = this.state.nodeScale.range([0, normalizedNodeSize]);
+    const options = {
+      width: props.width,
+      height: props.height,
+      scale: nodeScale,
+      margins: MARGINS,
+      topologyId: this.props.topologyId
+    };
 
     const timedLayouter = timely(NodesLayout.doLayout);
-    const graph = timedLayouter(
-      nodes,
-      edges,
-      props.width,
-      props.height,
-      nodeScale,
-      MARGINS,
-      this.props.topologyId
-    );
+    const graph = timedLayouter(nodes, edges, options);
 
     debug('graph layout took ' + timedLayouter.time + 'ms');
 

--- a/client/app/scripts/charts/nodes-chart.js
+++ b/client/app/scripts/charts/nodes-chart.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const d3 = require('d3');
 const debug = require('debug')('scope:nodes-chart');
 const React = require('react');
+const makeList = require('immutable').List;
 const makeMap = require('immutable').Map;
 const timely = require('timely');
 const Spring = require('react-motion').Spring;
@@ -21,6 +22,8 @@ const MARGINS = {
   bottom: 0
 };
 
+const MAX_HISTORY = 3;
+
 // make sure circular layouts a bit denser with 3-6 nodes
 const radiusDensity = d3.scale.threshold()
   .domain([3, 6]).range([2.5, 3.5, 3]);
@@ -31,7 +34,7 @@ const NodesChart = React.createClass({
     return {
       nodes: makeMap(),
       edges: makeMap(),
-      history: [],
+      history: makeList(),
       nodeScale: d3.scale.linear(),
       shiftTranslate: [0, 0],
       panTranslate: [0, 0],
@@ -493,8 +496,11 @@ const NodesChart = React.createClass({
       this.zoom.scale(zoomFactor);
     }
 
+    // throw away old layouts and save this layout result, first item is recent
+    const history = state.history.setSize(MAX_HISTORY - 1).unshift(graph);
+
     return {
-      history: [graph],
+      history: history,
       nodes: stateNodes,
       edges: stateEdges,
       nodeScale: nodeScale,

--- a/client/app/scripts/charts/nodes-chart.js
+++ b/client/app/scripts/charts/nodes-chart.js
@@ -2,7 +2,6 @@ const _ = require('lodash');
 const d3 = require('d3');
 const debug = require('debug')('scope:nodes-chart');
 const React = require('react');
-const makeList = require('immutable').List;
 const makeMap = require('immutable').Map;
 const timely = require('timely');
 const Spring = require('react-motion').Spring;
@@ -32,7 +31,6 @@ const NodesChart = React.createClass({
     return {
       nodes: makeMap(),
       edges: makeMap(),
-      history: makeList(),
       nodeScale: d3.scale.linear(),
       shiftTranslate: [0, 0],
       panTranslate: [0, 0],
@@ -177,9 +175,10 @@ const NodesChart = React.createClass({
   },
 
   renderMaxNodesError: function(show) {
+    const errorHint = 'We\u0027re working on it, but for now, try a different view?';
     return (
       <NodesError faIconClass="fa-ban" hidden={!show}>
-        <div className="centered">Too many nodes to show in the browser.<br />We're working on it, but for now, try a different view?</div>
+        <div className="centered">Too many nodes to show in the browser.<br />{errorHint}</div>
       </NodesError>
     );
   },
@@ -455,8 +454,7 @@ const NodesChart = React.createClass({
       height: props.height,
       scale: nodeScale,
       margins: MARGINS,
-      topologyId: this.props.topologyId,
-      history: state.history
+      topologyId: this.props.topologyId
     };
 
     const timedLayouter = timely(NodesLayout.doLayout);

--- a/client/app/scripts/charts/nodes-chart.js
+++ b/client/app/scripts/charts/nodes-chart.js
@@ -22,8 +22,6 @@ const MARGINS = {
   bottom: 0
 };
 
-const MAX_HISTORY = 3;
-
 // make sure circular layouts a bit denser with 3-6 nodes
 const radiusDensity = d3.scale.threshold()
   .domain([3, 6]).range([2.5, 3.5, 3]);
@@ -496,11 +494,7 @@ const NodesChart = React.createClass({
       this.zoom.scale(zoomFactor);
     }
 
-    // throw away old layouts and save this layout result, first item is recent
-    const history = state.history.setSize(MAX_HISTORY - 1).unshift(graph);
-
     return {
-      history: history,
       nodes: stateNodes,
       edges: stateEdges,
       nodeScale: nodeScale,

--- a/client/app/scripts/charts/nodes-layout.js
+++ b/client/app/scripts/charts/nodes-layout.js
@@ -246,9 +246,11 @@ export function doLayout(nodes, edges, opts) {
   }
 
   // cache results
-  cache.cachedLayout = layout;
-  cache.nodeCache = cache.nodeCache.merge(layout.nodes);
-  cache.edgeCache = cache.edgeCache.merge(layout.edges);
+  if (layout) {
+    cache.cachedLayout = layout;
+    cache.nodeCache = cache.nodeCache.merge(layout.nodes);
+    cache.edgeCache = cache.edgeCache.merge(layout.edges);
+  }
 
   return layout;
 }

--- a/client/app/scripts/charts/nodes-layout.js
+++ b/client/app/scripts/charts/nodes-layout.js
@@ -6,7 +6,14 @@ const _ = require('lodash');
 const MAX_NODES = 100;
 const topologyGraphs = {};
 
-const doLayout = function(nodes, edges, width, height, scale, margins, topologyId) {
+export function doLayout(nodes, edges, opts) {
+  const options = opts || {};
+  const margins = options.margins || {top: 0, left: 0};
+  const width = options.width || 800;
+  const height = options.height || width / 2;
+  const scale = options.scale || (val => val * 2);
+  const topologyId = options.topologyId || 'noId';
+
   let offsetX = 0 + margins.left;
   let offsetY = 0 + margins.top;
   let graph;
@@ -101,8 +108,4 @@ const doLayout = function(nodes, edges, width, height, scale, margins, topologyI
   // return object with the width and height of layout
 
   return layout;
-};
-
-module.exports = {
-  doLayout: doLayout
-};
+}

--- a/client/app/scripts/charts/nodes-layout.js
+++ b/client/app/scripts/charts/nodes-layout.js
@@ -156,6 +156,24 @@ export function hasUnseenNodes(nodes, cache) {
 }
 
 /**
+ * Determine if edge has same endpoints in new nodes as well as in the nodeCache
+ * @param  {Map}  edge      Edge with source and target
+ * @param  {Map}  nodes     new node set
+ * @param  {Map}  nodeCache set of previous nodes
+ * @return {Boolean}           True if old and new endpoints have same coordinates
+ */
+function hasSameEndpoints(edge, nodes, nodeCache) {
+  const oldSource = nodeCache.get(edge.get('source'));
+  const oldTarget = nodeCache.get(edge.get('target'));
+  const newSource = nodes.get(edge.get('source'));
+  const newTarget = nodes.get(edge.get('target'));
+  return (oldSource.get('x') === newSource.get('x')
+    && oldSource.get('y') === newSource.get('y')
+    && oldTarget.get('x') === newTarget.get('x')
+    && oldTarget.get('y') === newTarget.get('y'));
+}
+
+/**
  * Clones a previous layout
  * @param  {Object} layout Layout object
  * @param  {Map} nodes  new nodes
@@ -180,7 +198,7 @@ function copyLayoutProperties(layout, nodeCache, edgeCache) {
     return node.merge(nodeCache.get(node.get('id')));
   });
   layout.edges = layout.edges.map(edge => {
-    if (edgeCache.has(edge.get('id'))) {
+    if (edgeCache.has(edge.get('id')) && hasSameEndpoints(edge, layout.nodes, nodeCache)) {
       return edge.merge(edgeCache.get(edge.get('id')));
     }
     return setSimpleEdgePoints(edge, nodeCache);

--- a/client/app/scripts/charts/nodes-layout.js
+++ b/client/app/scripts/charts/nodes-layout.js
@@ -144,9 +144,13 @@ function setSimpleEdgePoints(edge, nodeCache) {
  * @param  {Map} cache     old Map of nodes
  * @return {Boolean}       True if nodes had node ids that are not in cache
  */
-function hasUnseenNodes(nodes, cache) {
-  return (nodes.size > cache.size
-    || !ImmSet.fromKeys(nodes).isSubset(ImmSet.fromKeys(nodes)));
+export function hasUnseenNodes(nodes, cache) {
+  const hasUnseen = nodes.size > cache.size
+    || !ImmSet.fromKeys(nodes).isSubset(ImmSet.fromKeys(cache));
+  if (hasUnseen) {
+    debug('unseen nodes:', ...ImmSet.fromKeys(nodes).subtract(ImmSet.fromKeys(cache)).toJS());
+  }
+  return hasUnseen;
 }
 
 /**

--- a/client/app/scripts/charts/nodes-layout.js
+++ b/client/app/scripts/charts/nodes-layout.js
@@ -159,18 +159,18 @@ export function hasUnseenNodes(nodes, cache) {
  * Determine if edge has same endpoints in new nodes as well as in the nodeCache
  * @param  {Map}  edge      Edge with source and target
  * @param  {Map}  nodes     new node set
- * @param  {Map}  nodeCache set of previous nodes
  * @return {Boolean}           True if old and new endpoints have same coordinates
  */
-function hasSameEndpoints(edge, nodes, nodeCache) {
-  const oldSource = nodeCache.get(edge.get('source'));
-  const oldTarget = nodeCache.get(edge.get('target'));
-  const newSource = nodes.get(edge.get('source'));
-  const newTarget = nodes.get(edge.get('target'));
-  return (oldSource.get('x') === newSource.get('x')
-    && oldSource.get('y') === newSource.get('y')
-    && oldTarget.get('x') === newTarget.get('x')
-    && oldTarget.get('y') === newTarget.get('y'));
+function hasSameEndpoints(cachedEdge, nodes) {
+  const oldPoints = cachedEdge.get('points');
+  const oldSourcePoint = oldPoints[0];
+  const oldTargetPoint = oldPoints[oldPoints.length - 1];
+  const newSource = nodes.get(cachedEdge.get('source'));
+  const newTarget = nodes.get(cachedEdge.get('target'));
+  return (oldSourcePoint.x === newSource.get('x')
+    && oldSourcePoint.y === newSource.get('y')
+    && oldTargetPoint.x === newTarget.get('x')
+    && oldTargetPoint.y === newTarget.get('y'));
 }
 
 /**
@@ -198,7 +198,7 @@ function copyLayoutProperties(layout, nodeCache, edgeCache) {
     return node.merge(nodeCache.get(node.get('id')));
   });
   layout.edges = layout.edges.map(edge => {
-    if (edgeCache.has(edge.get('id')) && hasSameEndpoints(edge, layout.nodes, nodeCache)) {
+    if (edgeCache.has(edge.get('id')) && hasSameEndpoints(edgeCache.get(edge.get('id')), layout.nodes)) {
       return edge.merge(edgeCache.get(edge.get('id')));
     }
     return setSimpleEdgePoints(edge, nodeCache);

--- a/client/app/scripts/charts/nodes-layout.js
+++ b/client/app/scripts/charts/nodes-layout.js
@@ -6,6 +6,8 @@ const Naming = require('../constants/naming');
 
 const MAX_NODES = 100;
 const topologyCaches = {};
+let layoutRuns = 0;
+let layoutRunsTrivial = 0;
 
 /**
  * Layout engine runner
@@ -214,8 +216,9 @@ export function doLayout(nodes, edges, opts) {
   const edgeCache = options.edgeCache || cache.edgeCache;
   let layout;
 
+  ++layoutRuns;
   if (cachedLayout && nodeCache && edgeCache && !hasUnseenNodes(nodes, nodeCache)) {
-    debug('skip layout, trivial adjustment');
+    debug('skip layout, trivial adjustment', ++layoutRunsTrivial, layoutRuns);
     layout = cloneLayout(cachedLayout, nodes, edges);
     // copy old properties, works also if nodes get re-added
     layout = copyLayoutProperties(layout, nodeCache, edgeCache);

--- a/client/package.json
+++ b/client/package.json
@@ -78,6 +78,7 @@
       "react",
       "immutable",
       "d3",
+      "dagre",
       "keymirror",
       "object-assign",
       "lodash",


### PR DESCRIPTION
This is to mitigate the dancing node problem in #419 

Heuristics to implement towards iterative layout engine (minimize re-layouts):

* dont layout on edge removal
* dont layout on edge adding
* dont layout on node removal
* relayout on node adding
* track degradation of layouts via scoring (edge crossings, wrong edge direction) and only re-layout when exceeding a threshold

Be smart about node adding:
* track recent layouts for reuse of previous node locations of same node (instead of layout on node adding) 
* add node to 1st neighbour and stretch rest on same level
