### PR TITLE
[docs] Refer to different Scope setups as standalone and service modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ serving the UI, and pushing these topologies to the UI.
 +-----------------------+
 ```
 
-## Multi host setup
+## Standalone Mode
 
 When running Scope in a cluster, each probe sends reports to each app.
 The App merges the reports from each probe into a more complete report.
@@ -99,7 +99,7 @@ acceptable, both with and without ports:
 Hostnames will be regularly resolved as A records, and each answer used as a
 target.
 
-## Using Scope Service
+## Service Mode
 
 Scope can also be used to feed reports to the Scope Service. The Scope Service
 allows you centrally manage and share access to your Scope UI. In this

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ acceptable, both with and without ports:
 Hostnames will be regularly resolved as A records, and each answer used as a
 target.
 
-## Using Weave Scope in Service Mode
+## Using Weave Scope in Cloud Service Mode
 
 Scope can also be used to feed reports to the Scope Service. The Scope Service
 allows you centrally manage and share access to your Scope UI. In this

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ serving the UI, and pushing these topologies to the UI.
 +-----------------------+
 ```
 
-## Standalone Mode
+## Using Weave Scope in Standalone Mode
 
 When running Scope in a cluster, each probe sends reports to each app.
 The App merges the reports from each probe into a more complete report.
@@ -99,7 +99,7 @@ acceptable, both with and without ports:
 Hostnames will be regularly resolved as A records, and each answer used as a
 target.
 
-## Service Mode
+## Using Weave Scope in Service Mode
 
 Scope can also be used to feed reports to the Scope Service. The Scope Service
 allows you centrally manage and share access to your Scope UI. In this


### PR DESCRIPTION
@pidster @kpoplin @abuehrle @mjlodge PTAL

This stems from the internal terminology discussion. It will make the Scope documentation consistent with https://github.com/weaveworks/integrations/pull/27 (which is awaiting for terminology consistency to be merged).

Both @abuehrle and I agree that *standalone mode* is more intuitive than *multi-host setup*. We also agree on this being ultimately a product/marketing decision.

CC: @peterbourgon @tomwilkie @paulbellamy 