### PR TITLE
Rename semaphore p/v to acquire/release.

### DIFF
--- a/xfer/multi_publisher.go
+++ b/xfer/multi_publisher.go
@@ -47,8 +47,8 @@ func (p *MultiPublisher) Set(target string, endpoints []string) {
 	c := make(chan tuple, len(endpoints))
 	for _, endpoint := range endpoints {
 		go func(endpoint string) {
-			p.sema.p()
-			defer p.sema.v()
+			p.sema.acquire()
+			defer p.sema.release()
 			id, publisher, err := p.factory(target, endpoint)
 			c <- tuple{publisher, target, endpoint, id, err}
 		}(endpoint)
@@ -140,5 +140,5 @@ func newSemaphore(n int) semaphore {
 	}
 	return semaphore(c)
 }
-func (s semaphore) p() { <-s }
-func (s semaphore) v() { s <- struct{}{} }
+func (s semaphore) acquire() { <-s }
+func (s semaphore) release() { s <- struct{}{} }

--- a/xfer/multi_publisher_internal_test.go
+++ b/xfer/multi_publisher_internal_test.go
@@ -12,7 +12,7 @@ func TestSemaphore(t *testing.T) {
 	// First n should be fine
 	for i := 0; i < n; i++ {
 		ok := make(chan struct{})
-		go func() { s.p(); close(ok) }()
+		go func() { s.acquire(); close(ok) }()
 		select {
 		case <-ok:
 		case <-time.After(10 * time.Millisecond):
@@ -22,7 +22,7 @@ func TestSemaphore(t *testing.T) {
 
 	// This should block
 	ok := make(chan struct{})
-	go func() { s.p(); close(ok) }()
+	go func() { s.acquire(); close(ok) }()
 	select {
 	case <-ok:
 		t.Errorf("%dth p OK, but should block", n+1)
@@ -30,7 +30,7 @@ func TestSemaphore(t *testing.T) {
 		//t.Logf("%dth p blocks, as expected", n+1)
 	}
 
-	s.v()
+	s.release()
 
 	select {
 	case <-ok:


### PR DESCRIPTION
According to [wikipedia](https://en.wikipedia.org/wiki/Semaphore_(programming)#Operation_names):

> The canonical names V and P come from the initials of Dutch words. V is generally explained as verhogen ("increase"). Several explanations have been offered for P, including proberen for "to test" or "to try,"[4] passeren for "pass," and pakken for "grab."

And:

> In ALGOL 68, the Linux kernel,[9] and in some English textbooks, the V and P operations are called, respectively, up and down. In software engineering practice, they are often called signal and wait,[10] release and acquire[10] (which the standard Java library[11] uses), or post and pend.

Fixes #610