### PR TITLE
Add 'latest' CRDT, make UI update quicker.

### DIFF
--- a/common/mtime/mtime.go
+++ b/common/mtime/mtime.go
@@ -1,0 +1,16 @@
+package mtime
+
+import "time"
+
+// Now returns the current time.
+var Now = func() time.Time { return time.Now() }
+
+// NowForce sets the time returned by Now to t.
+func NowForce(t time.Time) {
+	Now = func() time.Time { return t }
+}
+
+// NowReset makes Now returns the current time again.
+func NowReset() {
+	Now = func() time.Time { return time.Now() }
+}

--- a/probe/docker/container.go
+++ b/probe/docker/container.go
@@ -17,6 +17,7 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 
+	"github.com/weaveworks/scope/common/mtime"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -268,7 +269,7 @@ func (c *container) GetNode(hostID string, localAddrs []net.IP) report.Node {
 		ContainerPorts:         c.ports(localAddrs),
 		ContainerIPs:           report.MakeStringSet(ips...),
 		ContainerIPsWithScopes: report.MakeStringSet(ipsWithScopes...),
-	}).WithLatest(ContainerState, state)
+	}).WithLatest(ContainerState, mtime.Now(), state)
 
 	if c.container.State.Paused {
 		result = result.WithControls(UnpauseContainer)

--- a/probe/docker/container.go
+++ b/probe/docker/container.go
@@ -264,12 +264,11 @@ func (c *container) GetNode(hostID string, localAddrs []net.IP) report.Node {
 		ContainerCommand:  c.container.Path + " " + strings.Join(c.container.Args, " "),
 		ImageID:           c.container.Image,
 		ContainerHostname: c.Hostname(),
-		ContainerState:    state,
 	}).WithSets(report.Sets{
 		ContainerPorts:         c.ports(localAddrs),
 		ContainerIPs:           report.MakeStringSet(ips...),
 		ContainerIPsWithScopes: report.MakeStringSet(ipsWithScopes...),
-	})
+	}).WithLatest(ContainerState, state)
 
 	if c.container.State.Paused {
 		result = result.WithControls(UnpauseContainer)
@@ -285,7 +284,7 @@ func (c *container) GetNode(hostID string, localAddrs []net.IP) report.Node {
 		return result
 	}
 
-	result = result.Merge(report.MakeNodeWith(map[string]string{
+	result = result.WithMetadata(map[string]string{
 		NetworkRxDropped: strconv.FormatUint(c.latestStats.Network.RxDropped, 10),
 		NetworkRxBytes:   strconv.FormatUint(c.latestStats.Network.RxBytes, 10),
 		NetworkRxErrors:  strconv.FormatUint(c.latestStats.Network.RxErrors, 10),
@@ -305,7 +304,8 @@ func (c *container) GetNode(hostID string, localAddrs []net.IP) report.Node {
 		CPUTotalUsage:        strconv.FormatUint(c.latestStats.CPUStats.CPUUsage.TotalUsage, 10),
 		CPUUsageInKernelmode: strconv.FormatUint(c.latestStats.CPUStats.CPUUsage.UsageInKernelmode, 10),
 		CPUSystemCPUUsage:    strconv.FormatUint(c.latestStats.CPUStats.SystemCPUUsage, 10),
-	}))
+	})
+
 	return result
 }
 

--- a/probe/docker/container_test.go
+++ b/probe/docker/container_test.go
@@ -14,6 +14,7 @@ import (
 
 	client "github.com/fsouza/go-dockerclient"
 
+	"github.com/weaveworks/scope/common/mtime"
 	"github.com/weaveworks/scope/probe/docker"
 	"github.com/weaveworks/scope/report"
 	"github.com/weaveworks/scope/test"
@@ -64,6 +65,10 @@ func TestContainer(t *testing.T) {
 		t.Error(err)
 	}
 
+	now := time.Now()
+	mtime.NowForce(now)
+	defer mtime.NowReset()
+
 	// Now see if we go them
 	want := report.MakeNode().WithMetadata(map[string]string{
 		"docker_container_command": " ",
@@ -80,7 +85,7 @@ func TestContainer(t *testing.T) {
 		"docker_container_ips_with_scopes": report.MakeStringSet("scope;1.2.3.4"),
 	}).WithControls(
 		docker.RestartContainer, docker.StopContainer, docker.PauseContainer,
-	).WithLatest("docker_container_state", "running")
+	).WithLatest("docker_container_state", now, "running")
 
 	test.Poll(t, 100*time.Millisecond, want, func() interface{} {
 		node := c.GetNode("scope", []net.IP{})

--- a/probe/docker/container_test.go
+++ b/probe/docker/container_test.go
@@ -74,12 +74,14 @@ func TestContainer(t *testing.T) {
 		"docker_label_foo1":        "bar1",
 		"docker_label_foo2":        "bar2",
 		"memory_usage":             "12345",
-		"docker_container_state":   "running",
 	}).WithSets(report.Sets{
 		"docker_container_ports":           report.MakeStringSet("1.2.3.4:80->80/tcp", "81/tcp"),
 		"docker_container_ips":             report.MakeStringSet("1.2.3.4"),
 		"docker_container_ips_with_scopes": report.MakeStringSet("scope;1.2.3.4"),
-	}).WithControls(docker.RestartContainer, docker.StopContainer, docker.PauseContainer)
+	}).WithControls(
+		docker.RestartContainer, docker.StopContainer, docker.PauseContainer,
+	).WithLatest("docker_container_state", "running")
+
 	test.Poll(t, 100*time.Millisecond, want, func() interface{} {
 		node := c.GetNode("scope", []net.IP{})
 		for k, v := range node.Metadata {

--- a/probe/host/tagger.go
+++ b/probe/host/tagger.go
@@ -23,16 +23,16 @@ func NewTagger(hostID, probeID string) Tagger {
 
 // Tag implements Tagger.
 func (t Tagger) Tag(r report.Report) (report.Report, error) {
-	other := report.MakeNodeWith(map[string]string{
+	metadata := map[string]string{
 		report.HostNodeID: t.hostNodeID,
 		report.ProbeID:    t.probeID,
-	})
+	}
 
 	// Explicity don't tag Endpoints and Addresses - These topologies include pseudo nodes,
 	// and as such do their own host tagging
 	for _, topology := range []report.Topology{r.Process, r.Container, r.ContainerImage, r.Host, r.Overlay} {
-		for id := range topology.Nodes {
-			topology.AddNode(id, other)
+		for id, node := range topology.Nodes {
+			topology.AddNode(id, node.WithMetadata(metadata))
 		}
 	}
 	return r, nil

--- a/probe/tag_report.go
+++ b/probe/tag_report.go
@@ -57,9 +57,9 @@ func (topologyTagger) Tag(r report.Report) (report.Report, error) {
 		"host":            &(r.Host),
 		"overlay":         &(r.Overlay),
 	} {
-		other := report.MakeNodeWith(map[string]string{Topology: val})
-		for id := range topology.Nodes {
-			topology.AddNode(id, other)
+		metadata := map[string]string{Topology: val}
+		for id, node := range topology.Nodes {
+			topology.AddNode(id, node.WithMetadata(metadata))
 		}
 	}
 	return r, nil

--- a/probe/tag_report_test.go
+++ b/probe/tag_report_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/weaveworks/scope/report"
-	"github.com/weaveworks/scope/test"
 )
 
 func TestApply(t *testing.T) {
@@ -38,11 +37,9 @@ func TestApply(t *testing.T) {
 func TestTagMissingID(t *testing.T) {
 	const nodeID = "not-found"
 	r := report.MakeReport()
-	want := report.MakeNode()
 	rpt, _ := newTopologyTagger().Tag(r)
-	have := rpt.Endpoint.Nodes[nodeID].Copy()
-	if !reflect.DeepEqual(want, have) {
-		t.Error(test.Diff(want, have))
+	_, ok := rpt.Endpoint.Nodes[nodeID]
+	if ok {
 		t.Error("TopologyTagger erroneously tagged a missing node ID")
 	}
 }

--- a/render/detailed_node.go
+++ b/render/detailed_node.go
@@ -207,7 +207,7 @@ func controlsFor(topology report.Topology, nodeID string) []ControlInstance {
 		return result
 	}
 
-	for _, id := range node.Controls {
+	for _, id := range node.Controls.Controls {
 		if control, ok := topology.Controls[id]; ok {
 			result = append(result, ControlInstance{
 				ProbeID: node.Metadata[report.ProbeID],
@@ -347,6 +347,13 @@ func containerOriginTable(nmd report.Node, addHostTag bool) (Table, bool) {
 	rows := []Row{}
 	for _, tuple := range []struct{ key, human string }{
 		{docker.ContainerState, "State"},
+	} {
+		if val, ok := nmd.Latest.Lookup(tuple.key); ok && val != "" {
+			rows = append(rows, Row{Key: tuple.human, ValueMajor: val, ValueMinor: ""})
+		}
+	}
+
+	for _, tuple := range []struct{ key, human string }{
 		{docker.ContainerID, "ID"},
 		{docker.ImageID, "Image ID"},
 		{docker.ContainerPorts, "Ports"},

--- a/render/detailed_node_test.go
+++ b/render/detailed_node_test.go
@@ -58,6 +58,7 @@ func TestOriginTable(t *testing.T) {
 			Rank:    3,
 			Rows: []render.Row{
 				{"Host", fixture.ServerHostID, "", false},
+				{"State", "running", "", false},
 				{"ID", fixture.ServerContainerID, "", false},
 				{"Image ID", fixture.ServerContainerImageID, "", false},
 				{fmt.Sprintf(`Label %q`, render.AmazonECSContainerNameLabel), `server`, "", false},
@@ -161,6 +162,7 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 				Numeric: false,
 				Rank:    3,
 				Rows: []render.Row{
+					{"State", "running", "", false},
 					{"ID", fixture.ServerContainerID, "", false},
 					{"Image ID", fixture.ServerContainerImageID, "", false},
 					{fmt.Sprintf(`Label %q`, render.AmazonECSContainerNameLabel), `server`, "", false},

--- a/render/filters.go
+++ b/render/filters.go
@@ -138,8 +138,8 @@ func FilterStopped(r Renderer) Renderer {
 	return Filter{
 		Renderer: r,
 		FilterFunc: func(node RenderableNode) bool {
-			containerState := node.Metadata[docker.ContainerState]
-			return containerState != docker.StateStopped
+			containerState, ok := node.Latest.Lookup(docker.ContainerState)
+			return !ok || containerState != docker.StateStopped
 		},
 	}
 }

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -190,7 +190,7 @@ func TestFilterRender(t *testing.T) {
 	want := render.RenderableNodes{
 		"foo": {ID: "foo", Origins: report.IDList{}, Node: report.MakeNode().WithAdjacent("bar")},
 		"bar": {ID: "bar", Origins: report.IDList{}, Node: report.MakeNode().WithAdjacent("foo")},
-	}
+	}.Prune()
 	have := renderer.Render(report.MakeReport()).Prune()
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -212,7 +212,7 @@ func TestFilterRender2(t *testing.T) {
 	want := render.RenderableNodes{
 		"foo": {ID: "foo", Origins: report.IDList{}, Node: report.MakeNode()},
 		"baz": {ID: "baz", Origins: report.IDList{}, Node: report.MakeNode()},
-	}
+	}.Prune()
 	have := renderer.Render(report.MakeReport()).Prune()
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -253,7 +253,7 @@ func TestFilterUnconnectedPesudoNodes(t *testing.T) {
 		}
 		want := render.RenderableNodes{
 			"foo": {ID: "foo", Origins: report.IDList{}, Node: report.MakeNode()},
-		}
+		}.Prune()
 		have := renderer.Render(report.MakeReport()).Prune()
 		if !reflect.DeepEqual(want, have) {
 			t.Error(test.Diff(want, have))
@@ -272,7 +272,7 @@ func TestFilterUnconnectedPesudoNodes(t *testing.T) {
 		}
 		want := render.RenderableNodes{
 			"foo": {ID: "foo", Origins: report.IDList{}, Node: report.MakeNode()},
-		}
+		}.Prune()
 		have := renderer.Render(report.MakeReport()).Prune()
 		if !reflect.DeepEqual(want, have) {
 			t.Error(test.Diff(want, have))

--- a/render/renderable_node.go
+++ b/render/renderable_node.go
@@ -134,10 +134,12 @@ func (rn RenderableNode) Copy() RenderableNode {
 // Specifically, that means cutting out parts of the Node.
 func (rn RenderableNode) Prune() RenderableNode {
 	cp := rn.Copy()
-	cp.Node.Metadata = report.Metadata{}   // snip
-	cp.Node.Counters = report.Counters{}   // snip
-	cp.Node.Edges = report.EdgeMetadatas{} // snip
-	cp.Node.Sets = report.Sets{}           // snip
+	cp.Node.Metadata = report.Metadata{}     // snip
+	cp.Node.Counters = report.Counters{}     // snip
+	cp.Node.Edges = report.EdgeMetadatas{}   // snip
+	cp.Node.Sets = report.Sets{}             // snip
+	cp.Node.Controls = report.NodeControls{} // snip
+	cp.Node.Latest = report.LatestMap{}      // snip
 	return cp
 }
 

--- a/render/renderable_node.go
+++ b/render/renderable_node.go
@@ -134,12 +134,7 @@ func (rn RenderableNode) Copy() RenderableNode {
 // Specifically, that means cutting out parts of the Node.
 func (rn RenderableNode) Prune() RenderableNode {
 	cp := rn.Copy()
-	cp.Node.Metadata = report.Metadata{}     // snip
-	cp.Node.Counters = report.Counters{}     // snip
-	cp.Node.Edges = report.EdgeMetadatas{}   // snip
-	cp.Node.Sets = report.Sets{}             // snip
-	cp.Node.Controls = report.NodeControls{} // snip
-	cp.Node.Latest = report.LatestMap{}      // snip
+	cp.Node = report.MakeNode().WithAdjacent(cp.Node.Adjacency...)
 	return cp
 }
 

--- a/render/renderable_node_test.go
+++ b/render/renderable_node_test.go
@@ -23,7 +23,7 @@ func TestMergeRenderableNodes(t *testing.T) {
 		"bar": render.NewRenderableNode("bar"),
 		"baz": render.NewRenderableNode("baz"),
 	}).Prune()
-	have := nodes1.Merge(nodes2)
+	have := nodes1.Merge(nodes2).Prune()
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}
@@ -57,8 +57,8 @@ func TestMergeRenderableNode(t *testing.T) {
 		Node:         report.MakeNode().WithAdjacent("a1").WithAdjacent("a2"),
 		Origins:      report.MakeIDList("o1", "o2"),
 		EdgeMetadata: report.EdgeMetadata{},
-	}
-	have := node1.Merge(node2)
+	}.Prune()
+	have := node1.Merge(node2).Prune()
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}

--- a/report/controls.go
+++ b/report/controls.go
@@ -1,5 +1,9 @@
 package report
 
+import (
+	"time"
+)
+
 // Controls describe the control tags within the Nodes
 type Controls map[string]Control
 
@@ -31,4 +35,41 @@ func (cs Controls) Copy() Controls {
 // AddControl returns a fresh Controls, c added to cs.
 func (cs Controls) AddControl(c Control) {
 	cs[c.ID] = c
+}
+
+// NodeControls represent the individual controls that are valid
+// for a given node at a given point in time.  Its is immutable.
+type NodeControls struct {
+	Timestamp int64  `json:"timestamp"`
+	Controls  IDList `json:"controls"`
+}
+
+// MakeNodeControls makes a new NodeControls
+func MakeNodeControls() NodeControls {
+	return NodeControls{
+		Timestamp: time.Now().Unix(),
+		Controls:  MakeIDList(),
+	}
+}
+
+// Copy is a noop, as NodeControls is immutable
+func (nc NodeControls) Copy() NodeControls {
+	return nc
+}
+
+// Merge returns the newest of the two NodeControls; it does not take the union
+// of the valid Controls.
+func (nc NodeControls) Merge(other NodeControls) NodeControls {
+	if other.Timestamp > nc.Timestamp {
+		return other
+	}
+	return nc
+}
+
+// Add the new control IDs to this NodeControls, producing a fresh NodeControls.
+func (nc NodeControls) Add(ids ...string) NodeControls {
+	return NodeControls{
+		Timestamp: time.Now().Unix(),
+		Controls:  nc.Controls.Add(ids...),
+	}
 }

--- a/report/latest_map.go
+++ b/report/latest_map.go
@@ -1,0 +1,128 @@
+package report
+
+import (
+	"bytes"
+	"encoding/gob"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/mndrix/ps"
+)
+
+// LatestMap is a persitent map which support latest-win merges. We have to
+// embed ps.Map as its an interface.  LatestMaps are immutable.
+type LatestMap struct {
+	ps.Map
+}
+
+// LatestEntry represents a timestamped value inside the LatestMap.
+type LatestEntry struct {
+	Timestamp int64  `json:"timestamp"`
+	Value     string `json:"value"`
+}
+
+func (e LatestEntry) String() string {
+	return fmt.Sprintf("\"%s\" (%d)", e.Value, e.Timestamp)
+}
+
+// MakeLatestMap makes an empty LatestMap
+func MakeLatestMap() LatestMap {
+	return LatestMap{ps.NewMap()}
+}
+
+// Copy is a noop, as LatestMaps are immutable.
+func (m LatestMap) Copy() LatestMap {
+	return m
+}
+
+// Merge produces a fresh LatestMap, container the kers from both inputs. When
+// both inputs container the same key, the latter value is used.
+func (m LatestMap) Merge(newer LatestMap) LatestMap {
+	// expect people to do old.Merge(new), optimise for that.
+	// ie if you do {k: v}.Merge({k: v'}), we end up just returning
+	// newer, unmodified.
+	output := newer.Map
+
+	m.Map.ForEach(func(key string, olderVal interface{}) {
+		if newerVal, ok := newer.Map.Lookup(key); ok {
+			if olderVal.(LatestEntry).Timestamp > newerVal.(LatestEntry).Timestamp {
+				output = output.Set(key, olderVal)
+			}
+		} else {
+			output = output.Set(key, olderVal)
+		}
+	})
+
+	return LatestMap{output}
+}
+
+// Lookup the value for the given key.
+func (m LatestMap) Lookup(key string) (string, bool) {
+	value, ok := m.Map.Lookup(key)
+	if !ok {
+		return "", false
+	}
+	return value.(LatestEntry).Value, true
+}
+
+// Set the value for the given key.
+func (m LatestMap) Set(key string, value string) LatestMap {
+	now := time.Now()
+	return LatestMap{m.Map.Set(key, LatestEntry{now.Unix(), value})}
+}
+
+func (m LatestMap) toIntermediate() map[string]LatestEntry {
+	intermediate := map[string]LatestEntry{}
+	m.ForEach(func(key string, val interface{}) {
+		intermediate[key] = val.(LatestEntry)
+	})
+	return intermediate
+}
+
+func fromIntermediate(in map[string]LatestEntry) LatestMap {
+	out := ps.NewMap()
+	for k, v := range in {
+		out = out.Set(k, v)
+	}
+	return LatestMap{out}
+}
+
+// MarshalJSON implements json.Marshaller
+func (m LatestMap) MarshalJSON() ([]byte, error) {
+	buf := bytes.Buffer{}
+	var err error
+	if m.Map != nil {
+		err = json.NewEncoder(&buf).Encode(m.toIntermediate())
+	} else {
+		err = json.NewEncoder(&buf).Encode(nil)
+	}
+	return buf.Bytes(), err
+}
+
+// UnmarshalJSON implements json.Unmarshaler
+func (m *LatestMap) UnmarshalJSON(input []byte) error {
+	in := map[string]LatestEntry{}
+	if err := json.NewDecoder(bytes.NewBuffer(input)).Decode(&in); err != nil {
+		return err
+	}
+	*m = fromIntermediate(in)
+	return nil
+}
+
+// GobEncode implements gob.Marshaller
+func (m LatestMap) GobEncode() ([]byte, error) {
+	buf := bytes.Buffer{}
+	err := gob.NewEncoder(&buf).Encode(m.toIntermediate())
+	return buf.Bytes(), err
+}
+
+// GobDecode implements gob.Unmarshaller
+func (m *LatestMap) GobDecode(input []byte) error {
+	in := map[string]LatestEntry{}
+	if err := gob.NewDecoder(bytes.NewBuffer(input)).Decode(&in); err != nil {
+		return err
+	}
+	*m = fromIntermediate(in)
+	return nil
+}

--- a/report/latest_map.go
+++ b/report/latest_map.go
@@ -18,8 +18,8 @@ type LatestMap struct {
 
 // LatestEntry represents a timestamped value inside the LatestMap.
 type LatestEntry struct {
-	Timestamp int64  `json:"timestamp"`
-	Value     string `json:"value"`
+	Timestamp time.Time `json:"timestamp"`
+	Value     string    `json:"value"`
 }
 
 func (e LatestEntry) String() string {
@@ -46,7 +46,7 @@ func (m LatestMap) Merge(newer LatestMap) LatestMap {
 
 	m.Map.ForEach(func(key string, olderVal interface{}) {
 		if newerVal, ok := newer.Map.Lookup(key); ok {
-			if olderVal.(LatestEntry).Timestamp > newerVal.(LatestEntry).Timestamp {
+			if newerVal.(LatestEntry).Timestamp.Before(olderVal.(LatestEntry).Timestamp) {
 				output = output.Set(key, olderVal)
 			}
 		} else {
@@ -67,9 +67,8 @@ func (m LatestMap) Lookup(key string) (string, bool) {
 }
 
 // Set the value for the given key.
-func (m LatestMap) Set(key string, value string) LatestMap {
-	now := time.Now()
-	return LatestMap{m.Map.Set(key, LatestEntry{now.Unix(), value})}
+func (m LatestMap) Set(key string, timestamp time.Time, value string) LatestMap {
+	return LatestMap{m.Map.Set(key, LatestEntry{timestamp, value})}
 }
 
 func (m LatestMap) toIntermediate() map[string]LatestEntry {

--- a/report/topology.go
+++ b/report/topology.go
@@ -88,7 +88,8 @@ type Node struct {
 	Sets      Sets          `json:"sets,omitempty"`
 	Adjacency IDList        `json:"adjacency"`
 	Edges     EdgeMetadatas `json:"edges,omitempty"`
-	Controls  IDList        `json:"controls,omitempty"`
+	Controls  NodeControls  `json:"controls,omitempty"`
+	Latest    LatestMap     `json:"latest,omitempty"`
 }
 
 // MakeNode creates a new Node with no initial metadata.
@@ -99,7 +100,8 @@ func MakeNode() Node {
 		Sets:      Sets{},
 		Adjacency: MakeIDList(),
 		Edges:     EdgeMetadatas{},
-		Controls:  MakeIDList(),
+		Controls:  MakeNodeControls(),
+		Latest:    MakeLatestMap(),
 	}
 }
 
@@ -160,6 +162,13 @@ func (n Node) WithControls(cs ...string) Node {
 	return result
 }
 
+// WithLatest produces a new Node with k mapped to v in the Latest metadata.
+func (n Node) WithLatest(k, v string) Node {
+	result := n.Copy()
+	result.Latest = result.Latest.Set(k, v)
+	return result
+}
+
 // Copy returns a value copy of the Node.
 func (n Node) Copy() Node {
 	cp := MakeNode()
@@ -169,6 +178,7 @@ func (n Node) Copy() Node {
 	cp.Adjacency = n.Adjacency.Copy()
 	cp.Edges = n.Edges.Copy()
 	cp.Controls = n.Controls.Copy()
+	cp.Latest = n.Latest.Copy()
 	return cp
 }
 
@@ -182,6 +192,7 @@ func (n Node) Merge(other Node) Node {
 	cp.Adjacency = cp.Adjacency.Merge(other.Adjacency)
 	cp.Edges = cp.Edges.Merge(other.Edges)
 	cp.Controls = cp.Controls.Merge(other.Controls)
+	cp.Latest = cp.Latest.Merge(other.Latest)
 	return cp
 }
 

--- a/report/topology.go
+++ b/report/topology.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 )
 
 // Topology describes a specific view of a network. It consists of nodes and
@@ -140,9 +141,9 @@ func (n Node) WithSets(sets Sets) Node {
 }
 
 // WithAdjacent returns a fresh copy of n, with 'a' added to Adjacency
-func (n Node) WithAdjacent(a string) Node {
+func (n Node) WithAdjacent(a ...string) Node {
 	result := n.Copy()
-	result.Adjacency = result.Adjacency.Add(a)
+	result.Adjacency = result.Adjacency.Add(a...)
 	return result
 }
 
@@ -163,9 +164,9 @@ func (n Node) WithControls(cs ...string) Node {
 }
 
 // WithLatest produces a new Node with k mapped to v in the Latest metadata.
-func (n Node) WithLatest(k, v string) Node {
+func (n Node) WithLatest(k string, ts time.Time, v string) Node {
 	result := n.Copy()
-	result.Latest = result.Latest.Set(k, v)
+	result.Latest = result.Latest.Set(k, ts, v)
 	return result
 }
 

--- a/test/fixture/report_fixture.go
+++ b/test/fixture/report_fixture.go
@@ -219,7 +219,7 @@ var (
 					docker.ImageID:                                ClientContainerImageID,
 					report.HostNodeID:                             ClientHostNodeID,
 					docker.LabelPrefix + "io.kubernetes.pod.name": ClientPodID,
-				}),
+				}).WithLatest(docker.ContainerState, docker.StateRunning),
 				ServerContainerNodeID: report.MakeNodeWith(map[string]string{
 					docker.ContainerID:                                      ServerContainerID,
 					docker.ContainerName:                                    "task-name-5-server-aceb93e2f2b797caba01",
@@ -229,7 +229,7 @@ var (
 					docker.LabelPrefix + "foo1":                             "bar1",
 					docker.LabelPrefix + "foo2":                             "bar2",
 					docker.LabelPrefix + "io.kubernetes.pod.name":           ServerPodID,
-				}),
+				}).WithLatest(docker.ContainerState, docker.StateRunning),
 			},
 		},
 		ContainerImage: report.Topology{

--- a/test/fixture/report_fixture.go
+++ b/test/fixture/report_fixture.go
@@ -15,6 +15,8 @@ import (
 // This is an example Report:
 //   2 hosts with probes installed - client & server.
 var (
+	Now = time.Now()
+
 	ClientHostID  = "client.hostname.com"
 	ServerHostID  = "server.hostname.com"
 	UnknownHostID = ""
@@ -219,7 +221,7 @@ var (
 					docker.ImageID:                                ClientContainerImageID,
 					report.HostNodeID:                             ClientHostNodeID,
 					docker.LabelPrefix + "io.kubernetes.pod.name": ClientPodID,
-				}).WithLatest(docker.ContainerState, docker.StateRunning),
+				}).WithLatest(docker.ContainerState, Now, docker.StateRunning),
 				ServerContainerNodeID: report.MakeNodeWith(map[string]string{
 					docker.ContainerID:                                      ServerContainerID,
 					docker.ContainerName:                                    "task-name-5-server-aceb93e2f2b797caba01",
@@ -229,7 +231,7 @@ var (
 					docker.LabelPrefix + "foo1":                             "bar1",
 					docker.LabelPrefix + "foo2":                             "bar2",
 					docker.LabelPrefix + "io.kubernetes.pod.name":           ServerPodID,
-				}).WithLatest(docker.ContainerState, docker.StateRunning),
+				}).WithLatest(docker.ContainerState, Now, docker.StateRunning),
 			},
 		},
 		ContainerImage: report.Topology{

--- a/vendor/github.com/mndrix/ps/LICENSE
+++ b/vendor/github.com/mndrix/ps/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2013 Michael Hendricks
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/mndrix/ps/README.md
+++ b/vendor/github.com/mndrix/ps/README.md
@@ -1,0 +1,8 @@
+ps
+==
+
+Persistent data structures for Go.  See the [full package documentation](http://godoc.org/github.com/mndrix/ps)
+
+Install with
+
+    go get github.com/mndrix/ps

--- a/vendor/github.com/mndrix/ps/list.go
+++ b/vendor/github.com/mndrix/ps/list.go
@@ -1,0 +1,93 @@
+package ps
+
+// List is a persistent list of possibly heterogenous values.
+type List interface {
+	// IsNil returns true if the list is empty
+	IsNil() bool
+
+	// Cons returns a new list with val as the head
+	Cons(val interface{}) List
+
+	// Head returns the first element of the list;
+	// panics if the list is empty
+	Head() interface{}
+
+	// Tail returns a list with all elements except the head;
+	// panics if the list is empty
+	Tail() List
+
+	// Size returns the list's length.  This takes O(1) time.
+	Size() int
+
+	// ForEach executes a callback for each value in the list.
+	ForEach(f func(interface{}))
+
+	// Reverse returns a list whose elements are in the opposite order as
+	// the original list.
+	Reverse() List
+}
+
+// Immutable (i.e. persistent) list
+type list struct {
+	depth int // the number of nodes after, and including, this one
+	value interface{}
+	tail  *list
+}
+
+// An empty list shared by all lists
+var nilList = &list{}
+
+// NewList returns a new, empty list.  The result is a singly linked
+// list implementation.  All lists share an empty tail, so allocating
+// empty lists is efficient in time and memory.
+func NewList() List {
+	return nilList
+}
+
+func (self *list) IsNil() bool {
+	return self == nilList
+}
+
+func (self *list) Size() int {
+	return self.depth
+}
+
+func (tail *list) Cons(val interface{}) List {
+	var xs list
+	xs.depth = tail.depth + 1
+	xs.value = val
+	xs.tail = tail
+	return &xs
+}
+
+func (self *list) Head() interface{} {
+	if self.IsNil() {
+		panic("Called Head() on an empty list")
+	}
+
+	return self.value
+}
+
+func (self *list) Tail() List {
+	if self.IsNil() {
+		panic("Called Tail() on an empty list")
+	}
+
+	return self.tail
+}
+
+// ForEach executes a callback for each value in the list
+func (self *list) ForEach(f func(interface{})) {
+	if self.IsNil() {
+		return
+	}
+	f(self.Head())
+	self.Tail().ForEach(f)
+}
+
+// Reverse returns a list with elements in opposite order as this list
+func (self *list) Reverse() List {
+	reversed := NewList()
+	self.ForEach(func(v interface{}) { reversed = reversed.Cons(v) })
+	return reversed
+}

--- a/vendor/github.com/mndrix/ps/list_test.go
+++ b/vendor/github.com/mndrix/ps/list_test.go
@@ -1,0 +1,46 @@
+package ps
+
+import "testing"
+
+func TestListImmutable(t *testing.T) {
+	// build some lists
+	one := NewList().Cons("first")
+	two := one.Cons("second")
+	zwei := one.Cons("zweite")
+
+	// check each list's length
+	if size := one.Size(); size != 1 {
+		t.Errorf("one doesn't have 1 item, it has %d", size)
+	}
+	if size := two.Size(); size != 2 {
+		t.Errorf("two doesn't have 2 items, it has %d", size)
+	}
+	if size := zwei.Size(); size != 2 {
+		t.Errorf("zwei doesn't have 2 item, it has %d", size)
+	}
+
+	// check each list's contents
+	if one.Head() != "first" {
+		t.Errorf("one has the wrong head")
+	}
+	if two.Head() != "second" {
+		t.Errorf("two has the wrong head")
+	}
+	if two.Tail().Head() != "first" {
+		t.Errorf("two has the wrong ending")
+	}
+	if zwei.Head() != "zweite" {
+		t.Errorf("zwei has the wrong head")
+	}
+	if zwei.Tail().Head() != "first" {
+		t.Errorf("zwei has the wrong ending")
+	}
+}
+
+// benchmark making a really long list
+func BenchmarkListCons(b *testing.B) {
+	l := NewList()
+	for i := 0; i < b.N; i++ {
+		l = l.Cons(i)
+	}
+}

--- a/vendor/github.com/mndrix/ps/map.go
+++ b/vendor/github.com/mndrix/ps/map.go
@@ -1,0 +1,314 @@
+// Fully persistent data structures. A persistent data structure is a data
+// structure that always preserves the previous version of itself when
+// it is modified. Such data structures are effectively immutable,
+// as their operations do not update the structure in-place, but instead
+// always yield a new structure.
+//
+// Persistent
+// data structures typically share structure among themselves.  This allows
+// operations to avoid copying the entire data structure.
+package ps
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// A Map associates unique keys (type string) with values (type Any).
+type Map interface {
+	// IsNil returns true if the Map is empty
+	IsNil() bool
+
+	// Set returns a new map in which key and value are associated.
+	// If the key didn't exist before, it's created; otherwise, the
+	// associated value is changed.
+	// This operation is O(log N) in the number of keys.
+	Set(key string, value interface{}) Map
+
+	// Delete returns a new map with the association for key, if any, removed.
+	// This operation is O(log N) in the number of keys.
+	Delete(key string) Map
+
+	// Lookup returns the value associated with a key, if any.  If the key
+	// exists, the second return value is true; otherwise, false.
+	// This operation is O(log N) in the number of keys.
+	Lookup(key string) (interface{}, bool)
+
+	// Size returns the number of key value pairs in the map.
+	// This takes O(1) time.
+	Size() int
+
+	// ForEach executes a callback on each key value pair in the map.
+	ForEach(f func(key string, val interface{}))
+
+	// Keys returns a slice with all keys in this map.
+	// This operation is O(N) in the number of keys.
+	Keys() []string
+
+	String() string
+}
+
+// Immutable (i.e. persistent) associative array
+const childCount = 8
+const shiftSize = 3
+
+type tree struct {
+	count    int
+	hash     uint64 // hash of the key (used for tree balancing)
+	key      string
+	value    interface{}
+	children [childCount]*tree
+}
+
+var nilMap = &tree{}
+
+// Recursively set nilMap's subtrees to point at itself.
+// This eliminates all nil pointers in the map structure.
+// All map nodes are created by cloning this structure so
+// they avoid the problem too.
+func init() {
+	for i := range nilMap.children {
+		nilMap.children[i] = nilMap
+	}
+}
+
+// NewMap allocates a new, persistent map from strings to values of
+// any type.
+// This is currently implemented as a path-copying binary tree.
+func NewMap() Map {
+	return nilMap
+}
+
+func (self *tree) IsNil() bool {
+	return self == nilMap
+}
+
+// clone returns an exact duplicate of a tree node
+func (self *tree) clone() *tree {
+	var m tree
+	m = *self
+	return &m
+}
+
+// constants for FNV-1a hash algorithm
+const (
+	offset64 uint64 = 14695981039346656037
+	prime64  uint64 = 1099511628211
+)
+
+// hashKey returns a hash code for a given string
+func hashKey(key string) uint64 {
+	hash := offset64
+	for _, codepoint := range key {
+		hash ^= uint64(codepoint)
+		hash *= prime64
+	}
+	return hash
+}
+
+// Set returns a new map similar to this one but with key and value
+// associated.  If the key didn't exist, it's created; otherwise, the
+// associated value is changed.
+func (self *tree) Set(key string, value interface{}) Map {
+	hash := hashKey(key)
+	return setLowLevel(self, hash, hash, key, value)
+}
+
+func setLowLevel(self *tree, partialHash, hash uint64, key string, value interface{}) *tree {
+	if self.IsNil() { // an empty tree is easy
+		m := self.clone()
+		m.count = 1
+		m.hash = hash
+		m.key = key
+		m.value = value
+		return m
+	}
+
+	if hash != self.hash {
+		m := self.clone()
+		i := partialHash % childCount
+		m.children[i] = setLowLevel(self.children[i], partialHash>>shiftSize, hash, key, value)
+		recalculateCount(m)
+		return m
+	}
+
+	// did we find a hash collision?
+	if key != self.key {
+		oops := fmt.Sprintf("Hash collision between: '%s' and '%s'.  Please report to https://github.com/mndrix/ps/issues/new", self.key, key)
+		panic(oops)
+	}
+
+	// replacing a key's previous value
+	m := self.clone()
+	m.value = value
+	return m
+}
+
+// modifies a map by recalculating its key count based on the counts
+// of its subtrees
+func recalculateCount(m *tree) {
+	count := 0
+	for _, t := range m.children {
+		count += t.Size()
+	}
+	m.count = count + 1 // add one to count ourself
+}
+
+func (m *tree) Delete(key string) Map {
+	hash := hashKey(key)
+	newMap, _ := deleteLowLevel(m, hash, hash)
+	return newMap
+}
+
+func deleteLowLevel(self *tree, partialHash, hash uint64) (*tree, bool) {
+	// empty trees are easy
+	if self.IsNil() {
+		return self, false
+	}
+
+	if hash != self.hash {
+		i := partialHash % childCount
+		child, found := deleteLowLevel(self.children[i], partialHash>>shiftSize, hash)
+		if !found {
+			return self, false
+		}
+		newMap := self.clone()
+		newMap.children[i] = child
+		recalculateCount(newMap)
+		return newMap, true // ? this wasn't in the original code
+	}
+
+	// we must delete our own node
+	if self.isLeaf() { // we have no children
+		return nilMap, true
+	}
+	/*
+	   if self.subtreeCount() == 1 { // only one subtree
+	       for _, t := range self.children {
+	           if t != nilMap {
+	               return t, true
+	           }
+	       }
+	       panic("Tree with 1 subtree actually had no subtrees")
+	   }
+	*/
+
+	// find a node to replace us
+	i := -1
+	size := -1
+	for j, t := range self.children {
+		if t.Size() > size {
+			i = j
+			size = t.Size()
+		}
+	}
+
+	// make chosen leaf smaller
+	replacement, child := self.children[i].deleteLeftmost()
+	newMap := replacement.clone()
+	for j := range self.children {
+		if j == i {
+			newMap.children[j] = child
+		} else {
+			newMap.children[j] = self.children[j]
+		}
+	}
+	recalculateCount(newMap)
+	return newMap, true
+}
+
+// delete the leftmost node in a tree returning the node that
+// was deleted and the tree left over after its deletion
+func (m *tree) deleteLeftmost() (*tree, *tree) {
+	if m.isLeaf() {
+		return m, nilMap
+	}
+
+	for i, t := range m.children {
+		if t != nilMap {
+			deleted, child := t.deleteLeftmost()
+			newMap := m.clone()
+			newMap.children[i] = child
+			recalculateCount(newMap)
+			return deleted, newMap
+		}
+	}
+	panic("Tree isn't a leaf but also had no children. How does that happen?")
+}
+
+// isLeaf returns true if this is a leaf node
+func (m *tree) isLeaf() bool {
+	return m.Size() == 1
+}
+
+// returns the number of child subtrees we have
+func (m *tree) subtreeCount() int {
+	count := 0
+	for _, t := range m.children {
+		if t != nilMap {
+			count++
+		}
+	}
+	return count
+}
+
+func (m *tree) Lookup(key string) (interface{}, bool) {
+	hash := hashKey(key)
+	return lookupLowLevel(m, hash, hash)
+}
+
+func lookupLowLevel(self *tree, partialHash, hash uint64) (interface{}, bool) {
+	if self.IsNil() { // an empty tree is easy
+		return nil, false
+	}
+
+	if hash != self.hash {
+		i := partialHash % childCount
+		return lookupLowLevel(self.children[i], partialHash>>shiftSize, hash)
+	}
+
+	// we found it
+	return self.value, true
+}
+
+func (m *tree) Size() int {
+	return m.count
+}
+
+func (m *tree) ForEach(f func(key string, val interface{})) {
+	if m.IsNil() {
+		return
+	}
+
+	// ourself
+	f(m.key, m.value)
+
+	// children
+	for _, t := range m.children {
+		if t != nilMap {
+			t.ForEach(f)
+		}
+	}
+}
+
+func (m *tree) Keys() []string {
+	keys := make([]string, m.Size())
+	i := 0
+	m.ForEach(func(k string, v interface{}) {
+		keys[i] = k
+		i++
+	})
+	return keys
+}
+
+// make it easier to display maps for debugging
+func (m *tree) String() string {
+	keys := m.Keys()
+	buf := bytes.NewBufferString("{")
+	for _, key := range keys {
+		val, _ := m.Lookup(key)
+		fmt.Fprintf(buf, "%s: %s, ", key, val)
+	}
+	fmt.Fprintf(buf, "}\n")
+	return buf.String()
+}

--- a/vendor/github.com/mndrix/ps/map_test.go
+++ b/vendor/github.com/mndrix/ps/map_test.go
@@ -1,0 +1,157 @@
+package ps
+
+import . "strconv"
+
+import "testing"
+import "sort"
+
+func TestMapNil(t *testing.T) {
+	m := NewMap()
+	keys := m.Keys()
+	if len(keys) != 0 {
+		t.Errorf("Empty map has keys")
+	}
+}
+
+func TestMapImmutable(t *testing.T) {
+	// build a couple small maps
+	world := NewMap().Set("hello", "world")
+	kids := world.Set("hello", "kids")
+
+	// both maps should still retain their data
+	if v, _ := world.Lookup("hello"); v != "world" {
+		t.Errorf("Set() modified the receiving map")
+	}
+	if size := world.Size(); size != 1 {
+		t.Errorf("world size is not 1 : %d", size)
+	}
+	if v, _ := kids.Lookup("hello"); v != "kids" {
+		t.Errorf("Set() did not modify the resulting map")
+	}
+	if size := kids.Size(); size != 1 {
+		t.Errorf("kids size is not 1 : %d", size)
+	}
+
+	// both maps have the right keys
+	if keys := world.Keys(); len(keys) != 1 || keys[0] != "hello" {
+		t.Errorf("world has the wrong keys: %#v", keys)
+	}
+	if keys := kids.Keys(); len(keys) != 1 || keys[0] != "hello" {
+		t.Errorf("kids has the wrong keys: %#v", keys)
+	}
+
+	// test deletion
+	empty := kids.Delete("hello")
+	if size := empty.Size(); size != 0 {
+		t.Errorf("empty size is not 1 : %d", size)
+	}
+	if keys := empty.Keys(); len(keys) != 0 {
+		t.Errorf("empty has the wrong keys: %#v", keys)
+	}
+}
+
+func TestMapMultipleKeys(t *testing.T) {
+	// map with multiple keys each with pointer values
+	one := 1
+	two := 2
+	three := 3
+	m := NewMap().Set("one", &one).Set("two", &two).Set("three", &three)
+
+	// do we have the right number of keys?
+	keys := m.Keys()
+	if len(keys) != 3 {
+		t.Logf("wrong size keys: %d", len(keys))
+		t.FailNow()
+	}
+
+	// do we have the right keys?
+	sort.Strings(keys)
+	if keys[0] != "one" {
+		t.Errorf("unexpected key: %s", keys[0])
+	}
+	if keys[1] != "three" {
+		t.Errorf("unexpected key: %s", keys[1])
+	}
+	if keys[2] != "two" {
+		t.Errorf("unexpected key: %s", keys[2])
+	}
+
+	// do we have the right values?
+	vp, ok := m.Lookup("one")
+	if !ok {
+		t.Logf("missing value for one")
+		t.FailNow()
+	}
+	if v := vp.(*int); *v != 1 {
+		t.Errorf("wrong value: %d\n", *v)
+	}
+	vp, ok = m.Lookup("two")
+	if !ok {
+		t.Logf("missing value for two")
+		t.FailNow()
+	}
+	if v := vp.(*int); *v != 2 {
+		t.Errorf("wrong value: %d\n", *v)
+	}
+	vp, ok = m.Lookup("three")
+	if !ok {
+		t.Logf("missing value for three")
+		t.FailNow()
+	}
+	if v := vp.(*int); *v != 3 {
+		t.Errorf("wrong value: %d\n", *v)
+	}
+}
+
+func TestMapManyKeys(t *testing.T) {
+	// build a map with many keys and values
+	count := 100
+	m := NewMap()
+	for i := 0; i < count; i++ {
+		m = m.Set(Itoa(i), i)
+	}
+
+	if m.Size() != 100 {
+		t.Errorf("Wrong number of keys: %d", m.Size())
+	}
+
+	m = m.Delete("42").Delete("7").Delete("19").Delete("99")
+	if m.Size() != 96 {
+		t.Errorf("Wrong number of keys: %d", m.Size())
+	}
+
+	for i := 43; i < 99; i++ {
+		v, ok := m.Lookup(Itoa(i))
+		if !ok || v != i {
+			t.Errorf("Wrong value for key %d", i)
+		}
+	}
+}
+
+func TestMapHashKey(t *testing.T) {
+	hash := hashKey("this is a key")
+	if hash != 10424450902216330915 {
+		t.Errorf("This isn't FNV-1a hashing: %d", hash)
+	}
+}
+
+func BenchmarkMapSet(b *testing.B) {
+	m := NewMap()
+	for i := 0; i < b.N; i++ {
+		m = m.Set("foo", i)
+	}
+}
+
+func BenchmarkMapDelete(b *testing.B) {
+	m := NewMap().Set("key", "value")
+	for i := 0; i < b.N; i++ {
+		m.Delete("key")
+	}
+}
+
+func BenchmarkHashKey(b *testing.B) {
+	key := "this is a key"
+	for i := 0; i < b.N; i++ {
+		_ = hashKey(key)
+	}
+}

--- a/vendor/github.com/mndrix/ps/profile.sh
+++ b/vendor/github.com/mndrix/ps/profile.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+go test -c
+./ps.test -test.run=none -test.bench=$2 -test.$1profile=$1.profile

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -525,6 +525,12 @@
 			"branch": "master"
 		},
 		{
+			"importpath": "github.com/google/gopacket",
+			"repository": "https://github.com/google/gopacket",
+			"revision": "1b0b78901cdd351ecfc68bf1a2adafcd2ff30220",
+			"branch": "master"
+		},
+		{
 			"importpath": "github.com/gorilla/context",
 			"repository": "https://github.com/gorilla/context",
 			"revision": "1c83b3eabd45b6d76072b66b746c20815fb2872d",
@@ -572,6 +578,12 @@
 			"revision": "d0c3fe89de86839aecf2e0579c40ba3bb336a453",
 			"branch": "master",
 			"path": "/pbutil"
+		},
+		{
+			"importpath": "github.com/mndrix/ps",
+			"repository": "https://github.com/mndrix/ps",
+			"revision": "35fef6f28be7e47a87d8a71ef5b80cbf2c4c167a",
+			"branch": "master"
 		},
 		{
 			"importpath": "github.com/nu7hatch/gouuid",
@@ -855,12 +867,6 @@
 			"importpath": "speter.net/go/exp/math/dec/inf",
 			"repository": "https://code.google.com/p/go-decimal-inf.exp",
 			"revision": "42ca6cd68aa922bc3f32f1e056e61b65945d9ad7",
-			"branch": "master"
-		},
-		{
-			"importpath": "github.com/google/gopacket",
-			"repository": "https://github.com/google/gopacket",
-			"revision": "1b0b78901cdd351ecfc68bf1a2adafcd2ff30220",
 			"branch": "master"
 		}
 	]


### PR DESCRIPTION
The idea is to have an alternative to the metadata map on each node, where the merge results are deterministic (pick the latest value).  This should allow us to propagate state changes faster in the UI, as we don't have to wait for the 15s window to pass.

Also using this as an opportunity to try some of the persistent datatypes, to help address #502.