### PR TITLE
Report coverage correctly

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -60,9 +60,6 @@ test:
   post:
     - test -z "$SECRET_PASSWORD" || (cd $SRCDIR/integration; ./gce.sh destroy):
         parallel: true
-
-teardown:
-  pre:
     - test "$CIRCLE_NODE_INDEX" != "0" || (cd $SRCDIR; ./tools/cover/gather_coverage.sh ./coverage $SRCDIR/coverage):
         parallel: true
     - test "$CIRCLE_NODE_INDEX" != "0" || (goveralls -repotoken $COVERALLS_REPO_TOKEN -coverprofile=$SRCDIR/profile.cov -service=circleci || true):

--- a/integration/310_container_to_container_edge_test.sh
+++ b/integration/310_container_to_container_edge_test.sh
@@ -4,7 +4,7 @@
 
 start_suite "Test short lived connections between containers"
 
-WEAVE_NO_FASTDP=true weave_on $HOST1 launch
+WEAVE_NO_FASTDP=true WEAVE_DOCKER_ARGS=$ADD_HOST_ARGS weave_on $HOST1 launch
 scope_on $HOST1 launch
 weave_on $HOST1 run -d --name nginx nginx
 weave_on $HOST1 run -d --name client alpine /bin/sh -c "while true; do \

--- a/integration/320_container_edge_cross_host_2_test.sh
+++ b/integration/320_container_edge_cross_host_2_test.sh
@@ -4,8 +4,8 @@
 
 start_suite "Test short lived connections between containers on different hosts"
 
-WEAVE_NO_FASTDP=true weave_on $HOST1 launch $HOST1 $HOST2
-WEAVE_NO_FASTDP=true weave_on $HOST2 launch $HOST1 $HOST2
+WEAVE_NO_FASTDP=true WEAVE_DOCKER_ARGS=$ADD_HOST_ARGS weave_on $HOST1 launch $HOST1 $HOST2
+WEAVE_NO_FASTDP=true WEAVE_DOCKER_ARGS=$ADD_HOST_ARGS weave_on $HOST2 launch $HOST1 $HOST2
 
 scope_on $HOST1 launch
 scope_on $HOST2 launch

--- a/tools/runner/runner.go
+++ b/tools/runner/runner.go
@@ -138,16 +138,11 @@ func updateScheduler(test string, duration float64) {
 
 func getSchedule(tests []string) ([]string, error) {
 	var (
-		prefix      = os.Getenv("SCHEDULER_PREFIX")
-		buildNum    = os.Getenv("CIRCLE_BUILD_NUM")
+		testRun     = "integration-" + os.Getenv("CIRCLE_BUILD_NUM")
 		shardCount  = os.Getenv("CIRCLE_NODE_TOTAL")
 		shardID     = os.Getenv("CIRCLE_NODE_INDEX")
 		requestBody = &bytes.Buffer{}
-		testRun     = "integration-" + buildNum
 	)
-	if prefix != "" {
-		testRun = prefix + "-" + buildNum
-	}
 	if err := json.NewEncoder(requestBody).Encode(schedule{tests}); err != nil {
 		return []string{}, err
 	}

--- a/tools/test
+++ b/tools/test
@@ -63,7 +63,7 @@ for dir in $TESTDIRS; do
 
     GO_TEST_ARGS_RUN="$GO_TEST_ARGS"
     if [ -n "$SLOW" ]; then
-        COVERPKGS=$( (go list $dir; go list -f '{{join .Deps "\n"}}' $dir | grep -v "vendor" | grep "^$PACKAGE_BASE/") | paste -s -d,)
+        COVERPKGS=$( (go list $dir; go list -f '{{join .Deps "\n"}}' $dir | grep -v "vendor" | grep "^$PACKAGE_BASE/") | paste -s -d, -)
         output=$(mktemp $coverdir/unit.XXXXXXXXXX)
         GO_TEST_ARGS_RUN="$GO_TEST_ARGS -coverprofile=$output -coverpkg=$COVERPKGS"
     fi


### PR DESCRIPTION
Coverage reports need to contain output from both shards, but due to a change in circle the other shard was getting stopped before we attempted to collect the reports.