### PR TITLE
Don't tag processes with stopped container ids, maintain container-by-pid index correctly.

### DIFF
--- a/probe/docker/container_test.go
+++ b/probe/docker/container_test.go
@@ -105,8 +105,8 @@ func TestContainer(t *testing.T) {
 	if c.Image() != "baz" {
 		t.Errorf("%s != baz", c.Image())
 	}
-	if c.PID() != 1 {
-		t.Errorf("%d != 1", c.PID())
+	if c.PID() != 2 {
+		t.Errorf("%d != 2", c.PID())
 	}
 	if have := docker.ExtractContainerIPs(c.GetNode("", []net.IP{})); !reflect.DeepEqual(have, []string{"1.2.3.4"}) {
 		t.Errorf("%v != %v", have, []string{"1.2.3.4"})

--- a/probe/docker/registry.go
+++ b/probe/docker/registry.go
@@ -252,9 +252,15 @@ func (r *registry) updateContainerState(containerID string) {
 	if !ok {
 		c = NewContainerStub(dockerContainer)
 		r.containers[containerID] = c
-		r.containersByPID[dockerContainer.State.Pid] = c
 	} else {
+		// potentially remove existing pid mapping.
+		delete(r.containersByPID, c.PID())
 		c.UpdateState(dockerContainer)
+	}
+
+	// Update PID index
+	if c.PID() > 1 {
+		r.containersByPID[c.PID()] = c
 	}
 
 	// Trigger anyone watching for updates

--- a/probe/docker/registry_test.go
+++ b/probe/docker/registry_test.go
@@ -38,6 +38,10 @@ func (c *mockContainer) Hostname() string {
 	return ""
 }
 
+func (c *mockContainer) State() string {
+	return docker.StateRunning
+}
+
 func (c *mockContainer) StartGatheringStats() error {
 	return nil
 }
@@ -133,7 +137,7 @@ var (
 		ID:    "ping",
 		Name:  "pong",
 		Image: "baz",
-		State: client.State{Pid: 1, Running: true},
+		State: client.State{Pid: 2, Running: true},
 		NetworkSettings: &client.NetworkSettings{
 			IPAddress: "1.2.3.4",
 			Ports: map[client.Port][]client.PortBinding{
@@ -249,7 +253,7 @@ func TestLookupByPID(t *testing.T) {
 		test.Poll(t, 100*time.Millisecond, want, func() interface{} {
 			var have docker.Container
 			registry.LockedPIDLookup(func(lookup func(int) docker.Container) {
-				have = lookup(1)
+				have = lookup(2)
 			})
 			return have
 		})

--- a/probe/docker/reporter_test.go
+++ b/probe/docker/reporter_test.go
@@ -41,7 +41,7 @@ func (r *mockRegistry) WatchContainerUpdates(_ docker.ContainerUpdateWatcher) {}
 var (
 	mockRegistryInstance = &mockRegistry{
 		containersByPID: map[int]docker.Container{
-			1: &mockContainer{container1},
+			2: &mockContainer{container1},
 		},
 		images: map[string]*client.APIImages{
 			"baz": &apiImage1,

--- a/probe/docker/tagger.go
+++ b/probe/docker/tagger.go
@@ -78,7 +78,7 @@ func (t *Tagger) tag(tree process.Tree, topology *report.Topology) {
 			}
 		})
 
-		if c == nil {
+		if c == nil || c.State() == StateStopped || c.PID() == 1 {
 			continue
 		}
 

--- a/probe/docker/tagger_test.go
+++ b/probe/docker/tagger_test.go
@@ -28,22 +28,22 @@ func TestTagger(t *testing.T) {
 	defer func() { docker.NewProcessTreeStub = oldProcessTree }()
 
 	docker.NewProcessTreeStub = func(_ process.Walker) (process.Tree, error) {
-		return &mockProcessTree{map[int]int{2: 1}}, nil
+		return &mockProcessTree{map[int]int{3: 2}}, nil
 	}
 
 	var (
-		pid1NodeID = report.MakeProcessNodeID("somehost.com", "1")
-		pid2NodeID = report.MakeProcessNodeID("somehost.com", "2")
+		pid1NodeID = report.MakeProcessNodeID("somehost.com", "2")
+		pid2NodeID = report.MakeProcessNodeID("somehost.com", "3")
 		wantNode   = report.MakeNodeWith(map[string]string{docker.ContainerID: "ping"})
 	)
 
 	input := report.MakeReport()
-	input.Process.AddNode(pid1NodeID, report.MakeNodeWith(map[string]string{"pid": "1"}))
-	input.Process.AddNode(pid2NodeID, report.MakeNodeWith(map[string]string{"pid": "2"}))
+	input.Process.AddNode(pid1NodeID, report.MakeNodeWith(map[string]string{process.PID: "2"}))
+	input.Process.AddNode(pid2NodeID, report.MakeNodeWith(map[string]string{process.PID: "3"}))
 
 	want := report.MakeReport()
-	want.Process.AddNode(pid1NodeID, report.MakeNodeWith(map[string]string{"pid": "1"}).Merge(wantNode))
-	want.Process.AddNode(pid2NodeID, report.MakeNodeWith(map[string]string{"pid": "2"}).Merge(wantNode))
+	want.Process.AddNode(pid1NodeID, report.MakeNodeWith(map[string]string{process.PID: "2"}).Merge(wantNode))
+	want.Process.AddNode(pid2NodeID, report.MakeNodeWith(map[string]string{process.PID: "3"}).Merge(wantNode))
 
 	tagger := docker.NewTagger(mockRegistryInstance, nil)
 	have, err := tagger.Tag(input)


### PR DESCRIPTION
Fixes #661 

It seems stopped containers have a pid of 1, which meant all processes on the system got tagged with a stopped container ID, unless they were in another container.

Also, we keep a container-by-pid index, to help with tagging of processes; this wasn't being maintained correctly with container starting, stopping, etc.