### PR TITLE
Dont treat missing node as UI error

### DIFF
--- a/client/app/scripts/utils/web-api-utils.js
+++ b/client/app/scripts/utils/web-api-utils.js
@@ -112,8 +112,11 @@ function getNodeDetails(topologyUrl, nodeId, options) {
         AppActions.receiveNodeDetails(res.node);
       },
       error: function(err) {
-        debug('Error in node details request: ' + err);
-        AppActions.receiveError(topologyUrl);
+        debug('Error in node details request: ' + err.responseText);
+        // dont treat missing node as error
+        if (err.status !== 404) {
+          AppActions.receiveError(topologyUrl);
+        }
       }
     });
   }


### PR DESCRIPTION
A missing node no longer flashes the `Trying to reconnect` status.

Fixes #607 