### PR TITLE
Mitigate one-line-of-nodes layouts

### DIFF
--- a/client/app/scripts/charts/__tests__/node-layout-test.js
+++ b/client/app/scripts/charts/__tests__/node-layout-test.js
@@ -1,4 +1,5 @@
 jest.dontMock('../nodes-layout');
+jest.dontMock('../topology-utils');
 jest.dontMock('../../constants/naming'); // edge naming: 'source-target'
 
 import { fromJS, Map } from 'immutable';
@@ -65,6 +66,26 @@ describe('NodesLayout', () => {
       nodes: fromJS({
         n1: {id: 'n1'},
         n4: {id: 'n4'}
+      }),
+      edges: fromJS({
+        'n1-n4': {id: 'n1-n4', source: 'n1', target: 'n4'}
+      })
+    },
+    single3: {
+      nodes: fromJS({
+        n1: {id: 'n1'},
+        n2: {id: 'n2'},
+        n3: {id: 'n3'}
+      }),
+      edges: fromJS({})
+    },
+    singlePortrait: {
+      nodes: fromJS({
+        n1: {id: 'n1'},
+        n2: {id: 'n2'},
+        n3: {id: 'n3'},
+        n4: {id: 'n4'},
+        n5: {id: 'n5'}
       }),
       edges: fromJS({
         'n1-n4': {id: 'n1-n4', source: 'n1', target: 'n4'}
@@ -231,5 +252,38 @@ describe('NodesLayout', () => {
     resultCoords = getNodeCoordinates(result.nodes);
     expect(resultCoords.slice(0, 2)).toEqual(coords.slice(0, 2));
     expect(resultCoords.slice(2, 6)).toEqual(coords.slice(4, 8));
+  });
+
+  it('renders single nodes in a square', () => {
+    const result = NodesLayout.doLayout(
+      nodeSets.single3.nodes,
+      nodeSets.single3.edges);
+
+    nodes = result.nodes.toJS();
+
+    expect(nodes.n1.x).toEqual(nodes.n3.x);
+    expect(nodes.n1.y).toEqual(nodes.n2.y);
+    expect(nodes.n1.x).toBeLessThan(nodes.n2.x);
+    expect(nodes.n1.y).toBeLessThan(nodes.n3.y);
+  });
+
+  it('renders single nodes next to portrait graph', () => {
+    const result = NodesLayout.doLayout(
+      nodeSets.singlePortrait.nodes,
+      nodeSets.singlePortrait.edges);
+
+    nodes = result.nodes.toJS();
+
+    // first square row on same level as top-most other node
+    expect(nodes.n1.y).toEqual(nodes.n2.y);
+    expect(nodes.n1.y).toEqual(nodes.n3.y);
+    expect(nodes.n4.y).toEqual(nodes.n5.y);
+
+    // all singles right to other nodes
+    expect(nodes.n1.x).toEqual(nodes.n4.x);
+    expect(nodes.n1.x).toBeLessThan(nodes.n2.x);
+    expect(nodes.n1.x).toBeLessThan(nodes.n3.x);
+    expect(nodes.n1.x).toBeLessThan(nodes.n5.x);
+    expect(nodes.n2.x).toEqual(nodes.n5.x);
   });
 });

--- a/client/app/scripts/charts/__tests__/topology-utils-test.js
+++ b/client/app/scripts/charts/__tests__/topology-utils-test.js
@@ -1,0 +1,109 @@
+jest.dontMock('../topology-utils');
+jest.dontMock('../../constants/naming'); // edge naming: 'source-target'
+
+import { fromJS } from 'immutable';
+
+describe('TopologyUtils', () => {
+  let TopologyUtils;
+  let nodes;
+
+  const nodeSets = {
+    initial4: {
+      nodes: fromJS({
+        n1: {id: 'n1'},
+        n2: {id: 'n2'},
+        n3: {id: 'n3'},
+        n4: {id: 'n4'}
+      }),
+      edges: fromJS({
+        'n1-n3': {id: 'n1-n3', source: 'n1', target: 'n3'},
+        'n1-n4': {id: 'n1-n4', source: 'n1', target: 'n4'},
+        'n2-n4': {id: 'n2-n4', source: 'n2', target: 'n4'}
+      })
+    },
+    removeEdge24: {
+      nodes: fromJS({
+        n1: {id: 'n1'},
+        n2: {id: 'n2'},
+        n3: {id: 'n3'},
+        n4: {id: 'n4'}
+      }),
+      edges: fromJS({
+        'n1-n3': {id: 'n1-n3', source: 'n1', target: 'n3'},
+        'n1-n4': {id: 'n1-n4', source: 'n1', target: 'n4'}
+      })
+    },
+    removeNode2: {
+      nodes: fromJS({
+        n1: {id: 'n1'},
+        n3: {id: 'n3'},
+        n4: {id: 'n4'}
+      }),
+      edges: fromJS({
+        'n1-n3': {id: 'n1-n3', source: 'n1', target: 'n3'},
+        'n1-n4': {id: 'n1-n4', source: 'n1', target: 'n4'}
+      })
+    },
+    removeNode23: {
+      nodes: fromJS({
+        n1: {id: 'n1'},
+        n4: {id: 'n4'}
+      }),
+      edges: fromJS({
+        'n1-n4': {id: 'n1-n4', source: 'n1', target: 'n4'}
+      })
+    },
+    single3: {
+      nodes: fromJS({
+        n1: {id: 'n1'},
+        n2: {id: 'n2'},
+        n3: {id: 'n3'}
+      }),
+      edges: fromJS({})
+    },
+    singlePortrait: {
+      nodes: fromJS({
+        n1: {id: 'n1'},
+        n2: {id: 'n2'},
+        n3: {id: 'n3'},
+        n4: {id: 'n4'},
+        n5: {id: 'n5'}
+      }),
+      edges: fromJS({
+        'n1-n4': {id: 'n1-n4', source: 'n1', target: 'n4'}
+      })
+    }
+  };
+
+  beforeEach(() => {
+    TopologyUtils = require('../topology-utils');
+  });
+
+  it('sets node degrees', () => {
+    nodes = TopologyUtils.updateNodeDegrees(
+      nodeSets.initial4.nodes,
+      nodeSets.initial4.edges).toJS();
+
+    expect(nodes.n1.degree).toEqual(2);
+    expect(nodes.n2.degree).toEqual(1);
+    expect(nodes.n3.degree).toEqual(1);
+    expect(nodes.n4.degree).toEqual(2);
+
+    nodes = TopologyUtils.updateNodeDegrees(
+      nodeSets.removeEdge24.nodes,
+      nodeSets.removeEdge24.edges).toJS();
+
+    expect(nodes.n1.degree).toEqual(2);
+    expect(nodes.n2.degree).toEqual(0);
+    expect(nodes.n3.degree).toEqual(1);
+    expect(nodes.n4.degree).toEqual(1);
+
+    nodes = TopologyUtils.updateNodeDegrees(
+      nodeSets.single3.nodes,
+      nodeSets.single3.edges).toJS();
+
+    expect(nodes.n1.degree).toEqual(0);
+    expect(nodes.n2.degree).toEqual(0);
+    expect(nodes.n3.degree).toEqual(0);
+  });
+});

--- a/client/app/scripts/charts/nodes-chart.js
+++ b/client/app/scripts/charts/nodes-chart.js
@@ -12,7 +12,6 @@ const Naming = require('../constants/naming');
 const NodesLayout = require('./nodes-layout');
 const Node = require('./node');
 const NodesError = require('./nodes-error');
-const TopologyUtils = require('./topology-utils');
 
 const MARGINS = {
   top: 130,
@@ -236,7 +235,6 @@ const NodesChart = React.createClass({
         pseudo: node.get('pseudo'),
         subLabel: node.get('label_minor'),
         rank: node.get('rank'),
-        degree: TopologyUtils.getDegreeForNodeId(topology, id),
         x: 0,
         y: 0
       });

--- a/client/app/scripts/charts/nodes-chart.js
+++ b/client/app/scripts/charts/nodes-chart.js
@@ -12,6 +12,7 @@ const Naming = require('../constants/naming');
 const NodesLayout = require('./nodes-layout');
 const Node = require('./node');
 const NodesError = require('./nodes-error');
+const TopologyUtils = require('./topology-utils');
 
 const MARGINS = {
   top: 130,
@@ -235,6 +236,7 @@ const NodesChart = React.createClass({
         pseudo: node.get('pseudo'),
         subLabel: node.get('label_minor'),
         rank: node.get('rank'),
+        degree: TopologyUtils.getDegreeForNodeId(topology, id),
         x: 0,
         y: 0
       });

--- a/client/app/scripts/charts/topology-utils.js
+++ b/client/app/scripts/charts/topology-utils.js
@@ -1,0 +1,15 @@
+
+export function getDegreeForNodeId(topology, nodeId) {
+  let degree = 0;
+  topology.forEach(node => {
+    if (node.get('id') === nodeId) {
+      if (node.get('adjacency')) {
+        degree += node.get('adjacency').size;
+      }
+    } else if (node.get('adjacency') && node.get('adjacency').includes(nodeId)) {
+      // FIXME this can still count edges double if both directions exist
+      degree++;
+    }
+  });
+  return degree;
+}

--- a/client/app/scripts/charts/topology-utils.js
+++ b/client/app/scripts/charts/topology-utils.js
@@ -1,15 +1,10 @@
 
-export function getDegreeForNodeId(topology, nodeId) {
-  let degree = 0;
-  topology.forEach(node => {
-    if (node.get('id') === nodeId) {
-      if (node.get('adjacency')) {
-        degree += node.get('adjacency').size;
-      }
-    } else if (node.get('adjacency') && node.get('adjacency').includes(nodeId)) {
-      // FIXME this can still count edges double if both directions exist
-      degree++;
-    }
+export function updateNodeDegrees(nodes, edges) {
+  return nodes.map(node => {
+    const nodeId = node.get('id');
+    const degree = edges.count(edge => {
+      return edge.get('source') === nodeId || edge.get('target') === nodeId;
+    });
+    return node.set('degree', degree);
   });
-  return degree;
 }


### PR DESCRIPTION
Previously it looked like this:

![screen shot 2015-11-17 at 15 14 10](https://cloud.githubusercontent.com/assets/859729/11213775/1aee7c2c-8d3e-11e5-8f8c-ab0fdc99c71d.png)

To mitigate:
* exclude 0-degree nodes from layout run
* layout 0-degree nodes separately 

With this PR it looks like this for the same report:

![screen shot 2015-11-17 at 15 13 58](https://cloud.githubusercontent.com/assets/859729/11213784/2a11c3da-8d3e-11e5-95f8-58a4e60733be.png)
