### PR TITLE
Don't apply filters to node endpoints & update details panel logic

### DIFF
--- a/app/router.go
+++ b/app/router.go
@@ -63,7 +63,7 @@ func registerTopologyRoutes(c collector, router *mux.Router) {
 	get.HandleFunc("/api/topology/{topology}/ws",
 		topologyRegistry.captureRenderer(c, handleWs)) // NB not gzip!
 	get.MatcherFunc(URLMatcher("/api/topology/{topology}/{id}")).HandlerFunc(
-		gzipHandler(topologyRegistry.captureRenderer(c, handleNode)))
+		gzipHandler(topologyRegistry.captureRendererWithoutFilters(c, handleNode)))
 	get.MatcherFunc(URLMatcher("/api/topology/{topology}/{local}/{remote}")).HandlerFunc(
 		gzipHandler(topologyRegistry.captureRenderer(c, handleEdge)))
 	get.HandleFunc("/api/report", gzipHandler(makeRawReportHandler(c)))

--- a/client/app/scripts/components/node-details.js
+++ b/client/app/scripts/components/node-details.js
@@ -77,14 +77,19 @@ const NodeDetails = React.createClass({
     const details = this.props.details;
     const nodeExists = this.props.nodes && this.props.nodes.has(this.props.nodeId);
 
+    if (details) {
+      return this.renderDetails();
+    }
+
     if (!nodeExists) {
       return this.renderNotAvailable();
     }
 
-    if (!details) {
-      return this.renderLoading();
-    }
+    return this.renderLoading();
+  },
 
+  renderDetails: function() {
+    const details = this.props.details;
     const nodeColor = this.getNodeColorDark(details.rank, details.label_major);
     const styles = {
       controls: {


### PR DESCRIPTION
Such that node which disappear from the topology (eg when they are stopped) don't disappear from the details panel.

Fixes #693