### PR TITLE
Also proxy Websockets through the dev server while in dev mode.

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -1,8 +1,5 @@
 {
   "extends": "airbnb",
-  "globals": {
-    __WS_URL__: false
-  },
   "env": {
     "browser": true,
     "jest": true,

--- a/client/app/scripts/components/terminal.js
+++ b/client/app/scripts/components/terminal.js
@@ -10,7 +10,7 @@ import { getPipeStatus, basePath } from '../utils/web-api-utils';
 import Term from '../vendor/term.js';
 
 const wsProto = location.protocol === 'https:' ? 'wss' : 'ws';
-const wsUrl = __WS_URL__ || wsProto + '://' + location.host + basePath(location.pathname);
+const wsUrl = wsProto + '://' + location.host + basePath(location.pathname);
 const log = debug('scope:terminal');
 
 const DEFAULT_COLS = 80;

--- a/client/app/scripts/utils/web-api-utils.js
+++ b/client/app/scripts/utils/web-api-utils.js
@@ -7,7 +7,7 @@ import { clearControlError, closeWebsocket, openWebsocket, receiveError,
   receiveTopologies } from '../actions/app-actions';
 
 const wsProto = location.protocol === 'https:' ? 'wss' : 'ws';
-const wsUrl = __WS_URL__ || wsProto + '://' + location.host + location.pathname.replace(/\/$/, '');
+const wsUrl = wsProto + '://' + location.host + location.pathname.replace(/\/$/, '');
 const log = debug('scope:web-api-utils');
 
 const apiTimerInterval = 10000;

--- a/client/package.json
+++ b/client/package.json
@@ -53,8 +53,7 @@
   },
   "optionalDependencies": {
     "express": "~4.13.3",
-    "express-http-proxy": "~0.6.0",
-    "proxy-middleware": "~0.15.0",
+    "http-proxy": "^1.12.0",
     "react-hot-loader": "~1.3.0",
     "webpack-dev-server": "~1.12.1"
   },
@@ -75,9 +74,6 @@
     "testPathDirs": [
       "<rootDir>/app/scripts"
     ],
-    "globals": {
-      "__WS_URL__": false
-    },
     "moduleFileExtensions": [
       "js",
       "json"

--- a/client/webpack.local.config.js
+++ b/client/webpack.local.config.js
@@ -15,9 +15,6 @@ var path = require('path');
 
  // Inject websocket url to dev backend
 var BACKEND_HOST = process.env.BACKEND_HOST || 'localhost:4040';
-var GLOBALS = {
-  __WS_URL__: JSON.stringify('ws://' + BACKEND_HOST)
-};
 
 module.exports = {
 
@@ -48,7 +45,6 @@ module.exports = {
 
   // Necessary plugins for hot load
   plugins: [
-    new webpack.DefinePlugin(GLOBALS),
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin()
   ],

--- a/client/webpack.production.config.js
+++ b/client/webpack.production.config.js
@@ -3,7 +3,6 @@ var autoprefixer = require('autoprefixer');
 var path = require('path');
 
 var GLOBALS = {
-  __WS_URL__: 'false',
   'process.env': {NODE_ENV: '"production"'}
 };
 


### PR DESCRIPTION
WS were not using the proxy and instead were making a direct connection to the provided BACKEND_HOST.

Now they also are proxied.
- Simplifies FE code/build as we don't have a special case for websockets.
- Can more easily test WS error handling by simulating loss of connection to the BE by shutting down proxy.