### PR TITLE
Make probes use TLS against scope.weave.works by default

### DIFF
--- a/common/sanitize/sanitize.go
+++ b/common/sanitize/sanitize.go
@@ -29,7 +29,11 @@ func URL(defaultScheme string, defaultPort int, defaultPath string) func(string)
 		if _, port, err := net.SplitHostPort(u.Host); err != nil && defaultPort > 0 {
 			u.Host += fmt.Sprintf(":%d", defaultPort)
 		} else if port == "443" {
-			u.Scheme = "https"
+			if u.Scheme == "ws" {
+				u.Scheme = "wss"
+			} else {
+				u.Scheme = "https"
+			}
 		}
 		if defaultPath != "" && u.Path != defaultPath {
 			u.Path = defaultPath

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -108,7 +108,7 @@ while true; do
                 shift
             fi
             PROBE_ARGS="$PROBE_ARGS -token=$ARG_VALUE"
-            echo "scope.weave.works:80" >/etc/weave/apps
+            echo "scope.weave.works:443" >/etc/weave/apps
             touch /etc/service/app/down
             ;;
         --no-app)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -67,6 +67,7 @@ weave_expose() {
 mkdir -p /etc/weave
 APP_ARGS=""
 PROBE_ARGS=""
+TOKEN_PROVIDED=false
 
 if [ "$1" = version ]; then
     /home/weave/scope version
@@ -108,7 +109,7 @@ while true; do
                 shift
             fi
             PROBE_ARGS="$PROBE_ARGS -token=$ARG_VALUE"
-            echo "scope.weave.works:443" >/etc/weave/apps
+            TOKEN_PROVIDED=true
             touch /etc/service/app/down
             ;;
         --no-app)
@@ -157,7 +158,15 @@ echo "$PROBE_ARGS" >/etc/weave/scope-probe.args
 # using Weave DNS. We stick these in /etc/weave/apps
 # for the run-probe script to pick up.
 MANUAL_APPS=$@
+
+# Implicitly target the Scope Service if a service token was provided with
+# no explicit manual app.
+if [ "$MANUAL_APPS" = "" -a "$TOKEN_PROVIDED" = "true" ]; then
+    MANUAL_APPS="scope.weave.works:443"
+fi
+
 echo "$MANUAL_APPS" >>/etc/weave/apps
+
 
 exec /home/weave/runsvinit
 

--- a/xfer/app_client.go
+++ b/xfer/app_client.go
@@ -189,7 +189,6 @@ func (c *appClient) controlConnection() (bool, error) {
 	dialer := websocket.Dialer{}
 	headers := http.Header{}
 	c.ProbeConfig.authorizeHeaders(headers)
-	// TODO(twilkie) need to update sanitize to work with wss
 	url := sanitize.URL("ws://", 0, "/api/control/ws")(c.target)
 	conn, _, err := dialer.Dial(url, headers)
 	if err != nil {
@@ -273,7 +272,6 @@ func (c *appClient) pipeConnection(id string, pipe Pipe) (bool, error) {
 	dialer := websocket.Dialer{}
 	headers := http.Header{}
 	c.ProbeConfig.authorizeHeaders(headers)
-	// TODO(twilkie) need to update sanitize to work with wss
 	url := sanitize.URL("ws://", 0, fmt.Sprintf("/api/pipe/%s/probe", id))(c.target)
 	conn, resp, err := dialer.Dial(url, headers)
 	if resp != nil && resp.StatusCode == http.StatusNotFound {


### PR DESCRIPTION
Also:

* Fix `wss://` for websockets
* Only target scope.weave.works implicitly if no app is provided

I have tested this against the scope.weave.works (i.e. `scope launch --probe-token=foo`), and all connections are successful. 

Fixes #777 

@tomwilkie PTAL and make whatever corrections you think are necessary since I will be away for 3 weeks.