### PR TITLE
Speed up incremental build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,11 +36,10 @@ tags
 # Project specific
 .*.uptodate
 scope.tar
-scope_ui_build.tar
+.pkg
 prog/scope
 docker/scope
-docker/docker*
-docker*.tgz
+docker/docker.tgz
 docker/weave
 docker/runsvinit
 experimental/bridge/bridge

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ scope_ui_build.tar
 prog/scope
 docker/scope
 docker/docker*
+docker*.tgz
 docker/weave
 docker/runsvinit
 experimental/bridge/bridge

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SCOPE_BACKEND_BUILD_IMAGE=$(DOCKERHUB_USER)/scope-backend-build
 SCOPE_BACKEND_BUILD_UPTODATE=.scope_backend_build.uptodate
 SCOPE_VERSION=$(shell git rev-parse --short HEAD)
 DOCKER_VERSION=1.6.2
-DOCKER_DISTRIB=docker-$(DOCKER_VERSION).tgz
+DOCKER_DISTRIB=.pkg/docker-$(DOCKER_VERSION).tgz
 DOCKER_DISTRIB_URL=https://get.docker.com/builds/Linux/x86_64/docker-$(DOCKER_VERSION).tgz
 RUNSVINIT=vendor/runsvinit/runsvinit
 RM=--rm
@@ -42,14 +42,15 @@ $(SCOPE_EXE): $(shell find ./ -path ./vendor -prune -o -type f -name *.go) prog/
 
 ifeq ($(BUILD_IN_CONTAINER),true)
 $(SCOPE_EXE) $(RUNSVINIT): $(SCOPE_BACKEND_BUILD_UPTODATE)
-	@mkdir -p $(shell pwd)/pkg
+	@mkdir -p $(shell pwd)/.pkg
 	$(SUDO) docker run $(RM) $(RUN_FLAGS) -v $(shell pwd):/go/src/github.com/weaveworks/scope -e GOARCH -e GOOS \
-		-v $(shell pwd)/pkg:/go/pkg \
+		-v $(shell pwd)/.pkg:/go/pkg \
 		$(SCOPE_BACKEND_BUILD_IMAGE) SCOPE_VERSION=$(SCOPE_VERSION) GO_BUILD_INSTALL_DEPS=$(GO_BUILD_INSTALL_DEPS) $@
 
 shell:
+	@mkdir -p $(shell pwd)/.pkg
 	$(SUDO) docker run $(RM) $(RUN_FLAGS) -v $(shell pwd):/go/src/github.com/weaveworks/scope -e GOARCH -e GOOS \
-		-v $(shell pwd)/pkg:/go/pkg \
+		-v $(shell pwd)/.pkg:/go/pkg \
 		$(SCOPE_BACKEND_BUILD_IMAGE) SCOPE_VERSION=$(SCOPE_VERSION) GO_BUILD_INSTALL_DEPS=$(GO_BUILD_INSTALL_DEPS) $@
 else
 $(SCOPE_EXE):
@@ -113,7 +114,7 @@ clean:
 	go clean ./...
 	$(SUDO) docker rmi $(SCOPE_UI_BUILD_IMAGE) $(SCOPE_BACKEND_BUILD_IMAGE) >/dev/null 2>&1 || true
 	rm -rf $(SCOPE_EXPORT) $(SCOPE_UI_BUILD_UPTODATE) $(SCOPE_BACKEND_BUILD_UPTODATE) \
-		$(SCOPE_EXE) $(RUNSVINIT) prog/static.go client/build/app.js docker/weave pkg/
+		$(SCOPE_EXE) $(RUNSVINIT) prog/static.go client/build/app.js docker/weave .pkg
 
 ifeq ($(BUILD_IN_CONTAINER),true)
 tests: $(SCOPE_BACKEND_BUILD_UPTODATE)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all deps static clean client-lint client-test client-sync backend frontend
+.PHONY: all deps static clean client-lint client-test client-sync backend frontend shell
 
 # If you can use Docker without being root, you can `make SUDO= <target>`
 SUDO=sudo -E
@@ -12,12 +12,13 @@ SCOPE_BACKEND_BUILD_IMAGE=$(DOCKERHUB_USER)/scope-backend-build
 SCOPE_BACKEND_BUILD_UPTODATE=.scope_backend_build.uptodate
 SCOPE_VERSION=$(shell git rev-parse --short HEAD)
 DOCKER_VERSION=1.6.2
-DOCKER_DISTRIB=docker/docker-$(DOCKER_VERSION).tgz
+DOCKER_DISTRIB=docker-$(DOCKER_VERSION).tgz
 DOCKER_DISTRIB_URL=https://get.docker.com/builds/Linux/x86_64/docker-$(DOCKER_VERSION).tgz
 RUNSVINIT=vendor/runsvinit/runsvinit
 RM=--rm
 RUN_FLAGS=-ti
 BUILD_IN_CONTAINER=true
+GO_BUILD_FLAGS=-i -ldflags "-extldflags \"-static\" -X main.version=$(SCOPE_VERSION)" -tags netgo
 
 all: $(SCOPE_EXPORT)
 
@@ -36,15 +37,22 @@ $(SCOPE_EXPORT): $(SCOPE_EXE) $(DOCKER_DISTRIB) docker/weave $(RUNSVINIT) docker
 
 $(RUNSVINIT): vendor/runsvinit/*.go
 
-$(SCOPE_EXE): $(shell find ./ -type f -name *.go) prog/static.go
+$(SCOPE_EXE): $(shell find ./ -path ./vendor -prune -o -type f -name *.go) prog/static.go
 
 ifeq ($(BUILD_IN_CONTAINER),true)
 $(SCOPE_EXE) $(RUNSVINIT): $(SCOPE_BACKEND_BUILD_UPTODATE)
+	@mkdir -p $(shell pwd)/pkg
 	$(SUDO) docker run $(RM) $(RUN_FLAGS) -v $(shell pwd):/go/src/github.com/weaveworks/scope -e GOARCH -e GOOS \
+		-v $(shell pwd)/pkg:/go/pkg \
+		$(SCOPE_BACKEND_BUILD_IMAGE) SCOPE_VERSION=$(SCOPE_VERSION) $@
+
+shell:
+	$(SUDO) docker run $(RM) $(RUN_FLAGS) -v $(shell pwd):/go/src/github.com/weaveworks/scope -e GOARCH -e GOOS \
+		-v $(shell pwd)/pkg:/go/pkg \
 		$(SCOPE_BACKEND_BUILD_IMAGE) SCOPE_VERSION=$(SCOPE_VERSION) $@
 else
 $(SCOPE_EXE):
-	go build -ldflags "-extldflags \"-static\" -X main.version=$(SCOPE_VERSION)" -tags netgo -o $@ ./$(@D)
+	time go build $(GO_BUILD_FLAGS) -o $@ ./$(@D)
 	@strings $@ | grep cgo_stub\\\.go >/dev/null || { \
 	        rm $@; \
 	        echo "\nYour go standard library was built without the 'netgo' build tag."; \
@@ -55,7 +63,10 @@ $(SCOPE_EXE):
 	    }
 
 $(RUNSVINIT):
-	go build -ldflags "-extldflags \"-static\"" -o $@ ./$(@D)
+	time go build $(GO_BUILD_FLAGS) -o $@ ./$(@D)
+
+shell:
+	/bin/bash
 endif
 
 static: prog/static.go
@@ -101,7 +112,7 @@ clean:
 	go clean ./...
 	$(SUDO) docker rmi $(SCOPE_UI_BUILD_IMAGE) $(SCOPE_BACKEND_BUILD_IMAGE) >/dev/null 2>&1 || true
 	rm -rf $(SCOPE_EXPORT) $(SCOPE_UI_BUILD_UPTODATE) $(SCOPE_BACKEND_BUILD_UPTODATE) \
-		$(SCOPE_EXE) $(RUNSVINIT) prog/static.go client/build/app.js docker/weave
+		$(SCOPE_EXE) $(RUNSVINIT) prog/static.go client/build/app.js docker/weave pkg/
 
 ifeq ($(BUILD_IN_CONTAINER),true)
 tests: $(SCOPE_BACKEND_BUILD_UPTODATE)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ RUNSVINIT=vendor/runsvinit/runsvinit
 RM=--rm
 RUN_FLAGS=-ti
 BUILD_IN_CONTAINER=true
-GO_BUILD_FLAGS=-i -ldflags "-extldflags \"-static\" -X main.version=$(SCOPE_VERSION)" -tags netgo
+GO_BUILD_INSTALL_DEPS=-i
+GO_BUILD_FLAGS=$(GO_BUILD_INSTALL_DEPS) -ldflags "-extldflags \"-static\" -X main.version=$(SCOPE_VERSION)" -tags netgo
 
 all: $(SCOPE_EXPORT)
 
@@ -44,12 +45,12 @@ $(SCOPE_EXE) $(RUNSVINIT): $(SCOPE_BACKEND_BUILD_UPTODATE)
 	@mkdir -p $(shell pwd)/pkg
 	$(SUDO) docker run $(RM) $(RUN_FLAGS) -v $(shell pwd):/go/src/github.com/weaveworks/scope -e GOARCH -e GOOS \
 		-v $(shell pwd)/pkg:/go/pkg \
-		$(SCOPE_BACKEND_BUILD_IMAGE) SCOPE_VERSION=$(SCOPE_VERSION) $@
+		$(SCOPE_BACKEND_BUILD_IMAGE) SCOPE_VERSION=$(SCOPE_VERSION) GO_BUILD_INSTALL_DEPS=$(GO_BUILD_INSTALL_DEPS) $@
 
 shell:
 	$(SUDO) docker run $(RM) $(RUN_FLAGS) -v $(shell pwd):/go/src/github.com/weaveworks/scope -e GOARCH -e GOOS \
 		-v $(shell pwd)/pkg:/go/pkg \
-		$(SCOPE_BACKEND_BUILD_IMAGE) SCOPE_VERSION=$(SCOPE_VERSION) $@
+		$(SCOPE_BACKEND_BUILD_IMAGE) SCOPE_VERSION=$(SCOPE_VERSION) GO_BUILD_INSTALL_DEPS=$(GO_BUILD_INSTALL_DEPS) $@
 else
 $(SCOPE_EXE):
 	time go build $(GO_BUILD_FLAGS) -o $@ ./$(@D)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.5.1
+FROM golang:1.5.2
 ENV GO15VENDOREXPERIMENT 1
-RUN apt-get update && apt-get install -y libpcap-dev python-pip
-RUN pip install requests
+RUN apt-get update && apt-get install -y libpcap-dev python-requests time
+RUN go clean -i net && go install -tags netgo std
 COPY build.sh /
 ENTRYPOINT ["/build.sh"]

--- a/circle.yml
+++ b/circle.yml
@@ -41,7 +41,7 @@ test:
         parallel: true
     - cd $SRCDIR; make RM= static:
         parallel: true
-    - cd $SRCDIR; rm -f prog/scope; if [ "$CIRCLE_NODE_INDEX" = "0" ]; then GOARCH=arm make RM= prog/scope; else GOOS=darwin make RM= prog/scope; fi:
+    - cd $SRCDIR; rm -f prog/scope; if [ "$CIRCLE_NODE_INDEX" = "0" ]; then GOARCH=arm make GO_BUILD_INSTALL_DEPS= RM= prog/scope; else GOOS=darwin make GO_BUILD_INSTALL_DEPS= RM= prog/scope; fi:
         parallel: true
     - cd $SRCDIR; rm -f prog/scope; make RM=:
         parallel: true


### PR DESCRIPTION
- Pass `-i` to `go build` to speed up builds (forces `go build` to install dependancies, thanks @bboreham)
- Share `scope/pkg` into build container as `/go/pkg` (cached intermediate packages are installed here)
- Ignore files in `./vendor` for Makefile dependancies
- Don't send two copies of the docker tarball to the docker daemon when building container
- Add `make shell` target to get a shell in the build container
- Don't install `python-pip` in the build container, just `python-requests`
- Update to go 1.5.2