### PR TITLE
Use argv[0] for process name, differentiate scope app and probe.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Weaveworks Inc <help@weave.works>
 LABEL works.weave.role=system
 WORKDIR /home/weave
 RUN echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >>/etc/apk/repositories && \
-	apk add --update runit conntrack-tools iproute2 util-linux curl && \
+	apk add --update bash runit conntrack-tools iproute2 util-linux curl && \
 	rm -rf /var/cache/apk/*
 ADD ./docker.tgz /
 ADD ./weave /usr/bin/

--- a/docker/run-app
+++ b/docker/run-app
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 
-exec /home/weave/scope app $(cat /etc/weave/scope-app.args)
+exec -a scope-app /home/weave/scope app $(cat /etc/weave/scope-app.args)

--- a/docker/run-probe
+++ b/docker/run-probe
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 
-exec /home/weave/scope probe $(cat /etc/weave/scope-probe.args) $(cat /etc/weave/apps)
+exec -a scope-probe /home/weave/scope probe $(cat /etc/weave/scope-probe.args) $(cat /etc/weave/apps)

--- a/probe/endpoint/procspy/proc.go
+++ b/probe/endpoint/procspy/proc.go
@@ -71,7 +71,7 @@ func walkProcPid(buf *bytes.Buffer, walker process.Walker) (map[uint64]*Proc, er
 			if proc == nil {
 				proc = &Proc{
 					PID:  uint(p.PID),
-					Name: p.Comm,
+					Name: p.Name,
 				}
 			}
 			res[statT.Ino] = proc

--- a/probe/endpoint/procspy/proc_internal_test.go
+++ b/probe/endpoint/procspy/proc_internal_test.go
@@ -24,8 +24,8 @@ var mockFS = fs.Dir("",
 				},
 			),
 			fs.File{
-				FName:     "comm",
-				FContents: "foo\n",
+				FName:     "cmdline",
+				FContents: "foo",
 			},
 			fs.Dir("ns",
 				fs.File{

--- a/probe/process/reporter.go
+++ b/probe/process/reporter.go
@@ -10,7 +10,7 @@ import (
 // We use these keys in node metadata
 const (
 	PID         = "pid"
-	Comm        = "comm"
+	Name        = "name"
 	PPID        = "ppid"
 	Cmdline     = "cmdline"
 	Threads     = "threads"
@@ -65,7 +65,7 @@ func (r *Reporter) processTopology() (report.Topology, error) {
 		node := report.MakeNode()
 		for _, tuple := range []struct{ key, value string }{
 			{PID, pidstr},
-			{Comm, p.Comm},
+			{Name, p.Name},
 			{Cmdline, p.Cmdline},
 			{Threads, strconv.Itoa(p.Threads)},
 		} {

--- a/probe/process/reporter_test.go
+++ b/probe/process/reporter_test.go
@@ -25,10 +25,10 @@ func (m *mockWalker) Walk(f func(process.Process, process.Process)) error {
 func TestReporter(t *testing.T) {
 	walker := &mockWalker{
 		processes: []process.Process{
-			{PID: 1, PPID: 0, Comm: "init"},
-			{PID: 2, PPID: 1, Comm: "bash"},
-			{PID: 3, PPID: 1, Comm: "apache", Threads: 2},
-			{PID: 4, PPID: 2, Comm: "ping", Cmdline: "ping foo.bar.local"},
+			{PID: 1, PPID: 0, Name: "init"},
+			{PID: 2, PPID: 1, Name: "bash"},
+			{PID: 3, PPID: 1, Name: "apache", Threads: 2},
+			{PID: 4, PPID: 2, Name: "ping", Cmdline: "ping foo.bar.local"},
 			{PID: 5, PPID: 1, Cmdline: "tail -f /var/log/syslog"},
 		},
 	}
@@ -42,27 +42,27 @@ func TestReporter(t *testing.T) {
 	want.Process = report.MakeTopology().AddNode(
 		report.MakeProcessNodeID("", "1"), report.MakeNodeWith(map[string]string{
 			process.PID:     "1",
-			process.Comm:    "init",
+			process.Name:    "init",
 			process.Threads: "0",
 		}).WithMetric(process.MemoryUsage, report.MakeMetric().Add(now, 0.)),
 	).AddNode(
 		report.MakeProcessNodeID("", "2"), report.MakeNodeWith(map[string]string{
 			process.PID:     "2",
-			process.Comm:    "bash",
+			process.Name:    "bash",
 			process.PPID:    "1",
 			process.Threads: "0",
 		}).WithMetric(process.MemoryUsage, report.MakeMetric().Add(now, 0.)),
 	).AddNode(
 		report.MakeProcessNodeID("", "3"), report.MakeNodeWith(map[string]string{
 			process.PID:     "3",
-			process.Comm:    "apache",
+			process.Name:    "apache",
 			process.PPID:    "1",
 			process.Threads: "2",
 		}).WithMetric(process.MemoryUsage, report.MakeMetric().Add(now, 0.)),
 	).AddNode(
 		report.MakeProcessNodeID("", "4"), report.MakeNodeWith(map[string]string{
 			process.PID:     "4",
-			process.Comm:    "ping",
+			process.Name:    "ping",
 			process.PPID:    "2",
 			process.Cmdline: "ping foo.bar.local",
 			process.Threads: "0",

--- a/probe/process/tree_test.go
+++ b/probe/process/tree_test.go
@@ -10,10 +10,10 @@ import (
 func TestTree(t *testing.T) {
 	walker := &mockWalker{
 		processes: []process.Process{
-			{PID: 1, PPID: 0, Comm: "init"},
-			{PID: 2, PPID: 1, Comm: "bash"},
-			{PID: 3, PPID: 1, Comm: "apache", Threads: 2},
-			{PID: 4, PPID: 2, Comm: "ping", Cmdline: "ping foo.bar.local"},
+			{PID: 1, PPID: 0, Name: "init"},
+			{PID: 2, PPID: 1, Name: "bash"},
+			{PID: 3, PPID: 1, Name: "apache", Threads: 2},
+			{PID: 4, PPID: 2, Name: "ping", Cmdline: "ping foo.bar.local"},
 		},
 	}
 

--- a/probe/process/walker.go
+++ b/probe/process/walker.go
@@ -5,7 +5,7 @@ import "sync"
 // Process represents a single process.
 type Process struct {
 	PID, PPID int
-	Comm      string
+	Name      string
 	Cmdline   string
 	Threads   int
 	Jiffies   uint64

--- a/probe/process/walker_darwin.go
+++ b/probe/process/walker_darwin.go
@@ -68,7 +68,7 @@ func parseLSOF(output string) (map[string]Process, error) {
 			process.PID = pid
 
 		case 'c':
-			process.Comm = value
+			process.Name = value
 
 		case 'n':
 			// 'n' is the last field, with '-F cn'
@@ -83,7 +83,7 @@ func parseLSOF(output string) (map[string]Process, error) {
 			}
 			processes[addresses[0]] = Process{
 				PID:  process.PID,
-				Comm: process.Comm,
+				Name: process.Name,
 			}
 
 		default:

--- a/probe/process/walker_linux.go
+++ b/probe/process/walker_linux.go
@@ -83,21 +83,22 @@ func (w *walker) Walk(f func(Process, Process)) error {
 			continue
 		}
 
-		cmdline := ""
+		cmdline, name := "", "(unknown)"
 		if cmdlineBuf, err := cachedReadFile(path.Join(w.procRoot, filename, "cmdline")); err == nil {
+			// like proc, treat name as the first element of command line
+			i := bytes.IndexByte(cmdlineBuf, '\000')
+			if i == -1 {
+				i = len(cmdlineBuf)
+			}
+			name = string(cmdlineBuf[:i])
 			cmdlineBuf = bytes.Replace(cmdlineBuf, []byte{'\000'}, []byte{' '}, -1)
 			cmdline = string(cmdlineBuf)
-		}
-
-		comm := "(unknown)"
-		if commBuf, err := cachedReadFile(path.Join(w.procRoot, filename, "comm")); err == nil {
-			comm = strings.TrimSpace(string(commBuf))
 		}
 
 		f(Process{
 			PID:      pid,
 			PPID:     ppid,
-			Comm:     comm,
+			Name:     name,
 			Cmdline:  cmdline,
 			Threads:  threads,
 			Jiffies:  jiffies,

--- a/probe/process/walker_linux_test.go
+++ b/probe/process/walker_linux_test.go
@@ -14,10 +14,6 @@ var mockFS = fs.Dir("",
 	fs.Dir("proc",
 		fs.Dir("3",
 			fs.File{
-				FName:     "comm",
-				FContents: "curl\n",
-			},
-			fs.File{
 				FName:     "cmdline",
 				FContents: "curl\000google.com",
 			},
@@ -28,12 +24,8 @@ var mockFS = fs.Dir("",
 		),
 		fs.Dir("2",
 			fs.File{
-				FName:     "comm",
-				FContents: "bash\n",
-			},
-			fs.File{
 				FName:     "cmdline",
-				FContents: "",
+				FContents: "bash",
 			},
 			fs.File{
 				FName:     "stat",
@@ -42,12 +34,8 @@ var mockFS = fs.Dir("",
 		),
 		fs.Dir("4",
 			fs.File{
-				FName:     "comm",
-				FContents: "apache\n",
-			},
-			fs.File{
 				FName:     "cmdline",
-				FContents: "",
+				FContents: "apache",
 			},
 			fs.File{
 				FName:     "stat",
@@ -57,12 +45,8 @@ var mockFS = fs.Dir("",
 		fs.Dir("notapid"),
 		fs.Dir("1",
 			fs.File{
-				FName:     "comm",
-				FContents: "init\n",
-			},
-			fs.File{
 				FName:     "cmdline",
-				FContents: "",
+				FContents: "init",
 			},
 			fs.File{
 				FName:     "stat",
@@ -77,10 +61,10 @@ func TestWalker(t *testing.T) {
 	defer fs_hook.Restore()
 
 	want := map[int]process.Process{
-		3: {PID: 3, PPID: 2, Comm: "curl", Cmdline: "curl google.com", Threads: 1},
-		2: {PID: 2, PPID: 1, Comm: "bash", Cmdline: "", Threads: 1},
-		4: {PID: 4, PPID: 3, Comm: "apache", Cmdline: "", Threads: 1},
-		1: {PID: 1, PPID: 0, Comm: "init", Cmdline: "", Threads: 1},
+		3: {PID: 3, PPID: 2, Name: "curl", Cmdline: "curl google.com", Threads: 1},
+		2: {PID: 2, PPID: 1, Name: "bash", Cmdline: "bash", Threads: 1},
+		4: {PID: 4, PPID: 3, Name: "apache", Cmdline: "apache", Threads: 1},
+		1: {PID: 1, PPID: 0, Name: "init", Cmdline: "init", Threads: 1},
 	}
 
 	have := map[int]process.Process{}

--- a/probe/process/walker_test.go
+++ b/probe/process/walker_test.go
@@ -20,10 +20,10 @@ func TestBasicWalk(t *testing.T) {
 
 func TestCache(t *testing.T) {
 	processes := []process.Process{
-		{PID: 1, PPID: 0, Comm: "init"},
-		{PID: 2, PPID: 1, Comm: "bash"},
-		{PID: 3, PPID: 1, Comm: "apache", Threads: 2},
-		{PID: 4, PPID: 2, Comm: "ping", Cmdline: "ping foo.bar.local"},
+		{PID: 1, PPID: 0, Name: "init", Cmdline: "init"},
+		{PID: 2, PPID: 1, Name: "bash", Cmdline: "bash"},
+		{PID: 3, PPID: 1, Name: "apache", Threads: 2, Cmdline: "apache"},
+		{PID: 4, PPID: 2, Name: "ping", Cmdline: "ping foo.bar.local"},
 	}
 	walker := &mockWalker{
 		processes: processes,

--- a/render/detailed_node.go
+++ b/render/detailed_node.go
@@ -341,7 +341,7 @@ func processOriginTable(nmd report.Node, addHostTag bool, addContainerTag bool) 
 
 	var (
 		title           = "Process"
-		name, commFound = nmd.Metadata[process.Comm]
+		name, commFound = nmd.Metadata[process.Name]
 		pid, pidFound   = nmd.Metadata[process.PID]
 	)
 	if commFound {

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -68,9 +68,9 @@ var (
 	RenderedProcesses = (render.RenderableNodes{
 		ClientProcess1ID: {
 			ID:         ClientProcess1ID,
-			LabelMajor: fixture.Client1Comm,
+			LabelMajor: fixture.Client1Name,
 			LabelMinor: fmt.Sprintf("%s (%s)", fixture.ClientHostID, fixture.Client1PID),
-			Rank:       fixture.Client1Comm,
+			Rank:       fixture.Client1Name,
 			Pseudo:     false,
 			Origins: report.MakeIDList(
 				fixture.Client54001NodeID,
@@ -85,9 +85,9 @@ var (
 		},
 		ClientProcess2ID: {
 			ID:         ClientProcess2ID,
-			LabelMajor: fixture.Client2Comm,
+			LabelMajor: fixture.Client2Name,
 			LabelMinor: fmt.Sprintf("%s (%s)", fixture.ClientHostID, fixture.Client2PID),
-			Rank:       fixture.Client2Comm,
+			Rank:       fixture.Client2Name,
 			Pseudo:     false,
 			Origins: report.MakeIDList(
 				fixture.Client54002NodeID,
@@ -104,7 +104,7 @@ var (
 			ID:         ServerProcessID,
 			LabelMajor: "apache",
 			LabelMinor: fmt.Sprintf("%s (%s)", fixture.ServerHostID, fixture.ServerPID),
-			Rank:       fixture.ServerComm,
+			Rank:       fixture.ServerName,
 			Pseudo:     false,
 			Origins: report.MakeIDList(
 				fixture.Server80NodeID,
@@ -119,9 +119,9 @@ var (
 		},
 		nonContainerProcessID: {
 			ID:         nonContainerProcessID,
-			LabelMajor: fixture.NonContainerComm,
+			LabelMajor: fixture.NonContainerName,
 			LabelMinor: fmt.Sprintf("%s (%s)", fixture.ServerHostID, fixture.NonContainerPID),
-			Rank:       fixture.NonContainerComm,
+			Rank:       fixture.NonContainerName,
 			Pseudo:     false,
 			Origins: report.MakeIDList(
 				fixture.NonContainerProcessNodeID,
@@ -173,11 +173,11 @@ var (
 				IngressByteCount:   newu64(2100),
 			},
 		},
-		fixture.NonContainerComm: {
-			ID:         fixture.NonContainerComm,
-			LabelMajor: fixture.NonContainerComm,
+		fixture.NonContainerName: {
+			ID:         fixture.NonContainerName,
+			LabelMajor: fixture.NonContainerName,
 			LabelMinor: "1 process",
-			Rank:       fixture.NonContainerComm,
+			Rank:       fixture.NonContainerName,
 			Pseudo:     false,
 			Origins: report.MakeIDList(
 				fixture.NonContainerProcessNodeID,

--- a/render/mapping.go
+++ b/render/mapping.go
@@ -110,9 +110,9 @@ func MapProcessIdentity(m RenderableNode, _ report.Networks) RenderableNodes {
 
 	var (
 		id    = MakeProcessID(report.ExtractHostID(m.Node), pid)
-		major = m.Metadata["comm"]
+		major = m.Metadata[process.Name]
 		minor = fmt.Sprintf("%s (%s)", report.ExtractHostID(m.Node), pid)
-		rank  = m.Metadata["comm"]
+		rank  = m.Metadata[process.Name]
 	)
 
 	return RenderableNodes{id: NewRenderableNodeWith(id, major, minor, rank, m)}
@@ -440,7 +440,7 @@ func MapProcess2Name(n RenderableNode, _ report.Networks) RenderableNodes {
 		return RenderableNodes{n.ID: n}
 	}
 
-	name, ok := n.Node.Metadata["comm"]
+	name, ok := n.Node.Metadata[process.Name]
 	if !ok {
 		return RenderableNodes{}
 	}

--- a/test/fixture/report_fixture.go
+++ b/test/fixture/report_fixture.go
@@ -47,10 +47,10 @@ var (
 	ServerPID       = "215"
 	NonContainerPID = "1234"
 
-	Client1Comm      = "curl"
-	Client2Comm      = "curl"
-	ServerComm       = "apache"
-	NonContainerComm = "bash"
+	Client1Name      = "curl"
+	Client2Name      = "curl"
+	ServerName       = "apache"
+	NonContainerName = "bash"
 
 	True = "true"
 
@@ -197,25 +197,25 @@ var (
 			Nodes: report.Nodes{
 				ClientProcess1NodeID: report.MakeNodeWith(map[string]string{
 					process.PID:        Client1PID,
-					"comm":             Client1Comm,
+					process.Name:       Client1Name,
 					docker.ContainerID: ClientContainerID,
 					report.HostNodeID:  ClientHostNodeID,
 				}),
 				ClientProcess2NodeID: report.MakeNodeWith(map[string]string{
 					process.PID:        Client2PID,
-					"comm":             Client2Comm,
+					process.Name:       Client2Name,
 					docker.ContainerID: ClientContainerID,
 					report.HostNodeID:  ClientHostNodeID,
 				}),
 				ServerProcessNodeID: report.MakeNodeWith(map[string]string{
 					process.PID:        ServerPID,
-					"comm":             ServerComm,
+					process.Name:       ServerName,
 					docker.ContainerID: ServerContainerID,
 					report.HostNodeID:  ServerHostNodeID,
 				}),
 				NonContainerProcessNodeID: report.MakeNodeWith(map[string]string{
 					process.PID:       NonContainerPID,
-					"comm":            NonContainerComm,
+					process.Name:      NonContainerName,
 					report.HostNodeID: ServerHostNodeID,
 				}),
 			},


### PR DESCRIPTION
As of #732 scope became a single binary, and it became hard to differentiate the app from the probe.  This PR reintroduces the naming difference, and also bring the process names in scope more inline with `ps`.