### PR TITLE
[WIP] Probe plugins

### DIFF
--- a/common/exec/exec.go
+++ b/common/exec/exec.go
@@ -7,6 +7,7 @@ import (
 
 // Cmd is a hook for mocking
 type Cmd interface {
+	StdinPipe() (io.WriteCloser, error)
 	StdoutPipe() (io.ReadCloser, error)
 	StderrPipe() (io.ReadCloser, error)
 	Start() error
@@ -15,7 +16,9 @@ type Cmd interface {
 }
 
 // Command is a hook for mocking
-var Command = func(name string, args ...string) Cmd {
+var Command = realCommand
+
+func realCommand(name string, args ...string) Cmd {
 	return &realCmd{exec.Command(name, args...)}
 }
 
@@ -25,4 +28,14 @@ type realCmd struct {
 
 func (c *realCmd) Kill() error {
 	return c.Cmd.Process.Kill()
+}
+
+// Mock out Command with the supplied function
+func Mock(f func(string, ...string) Cmd) {
+	Command = f
+}
+
+// Restore the original Command
+func Restore() {
+	Command = realCommand
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Weaveworks Inc <help@weave.works>
 LABEL works.weave.role=system
 WORKDIR /home/weave
 RUN echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >>/etc/apk/repositories && \
-	apk add --update bash runit conntrack-tools iproute2 util-linux curl && \
+	apk add --update bash runit conntrack-tools iproute2 util-linux curl python && \
 	rm -rf /var/cache/apk/*
 ADD ./docker.tgz /
 ADD ./weave /usr/bin/

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -66,7 +66,7 @@ weave_expose() {
 
 mkdir -p /etc/weave
 APP_ARGS=""
-PROBE_ARGS=""
+PROBE_ARGS="-plugin.path=/etc/scope/plugins"
 TOKEN_PROVIDED=false
 
 if [ "$1" = version ]; then

--- a/plugins/demo.py
+++ b/plugins/demo.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python
+#
+# Example Scope probe plugin that annotates processes
+# on the local system with details from their environment.
+#
+import sys
+from BaseHTTPServer import BaseHTTPRequestHandler
+from httplib import HTTPResponse
+
+def parse_request():
+  req = BaseHTTPRequestHandler()
+  req.rfile = sys.stdin
+  req.raw_requestline = req.rfile.readline()
+  req.parse_request()
+  return req
+
+def send_response(data):
+  data_json = json.dumps(data)
+  sys.stdout.write("HTTP/1.0 200 OK\n")
+  sys.stdout.write("Content-Length: %d\n" % len(data_json))
+  sys.stdout.write("\n")
+  sys.stdout.write(data_json)
+
+def main():
+  req = parse_request()
+  if req.command == "POST" and req.path == "/tag":
+    report = json.load(req.rfile)
+    report = tag()
+  elif req.command == "GET" and req.path == "/report":
+    report = report()
+
+if __name__ == "__main__":
+  main()

--- a/probe/endpoint/conntrack_internal_test.go
+++ b/probe/endpoint/conntrack_internal_test.go
@@ -86,9 +86,9 @@ func TestConntracker(t *testing.T) {
 	exec.Command = func(name string, args ...string) exec.Cmd {
 		if first {
 			first = false
-			return testexec.NewMockCmd(existingConnectionsReader)
+			return testexec.NewMockCmd(existingConnectionsReader, nil)
 		}
-		return testexec.NewMockCmd(reader)
+		return testexec.NewMockCmd(reader, nil)
 	}
 
 	flowWalker := newConntrackFlowWalker(true)

--- a/probe/plugins/plugins.go
+++ b/probe/plugins/plugins.go
@@ -1,0 +1,197 @@
+package plugins
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"path"
+	"sync"
+	"time"
+
+	"github.com/weaveworks/scope/common/exec"
+	"github.com/weaveworks/scope/common/fs"
+	"github.com/weaveworks/scope/report"
+)
+
+const pluginPollDuration = 1 * time.Minute
+
+// PluginRegistry keeps a list of plugins and periodically refreshes it.
+type PluginRegistry struct {
+	sync.Mutex
+	pluginPath string
+	plugins    []plugin
+	quit       chan struct{}
+}
+
+// NewPluginRegistry makes a new plugin registry.
+func NewPluginRegistry(pluginPath string) *PluginRegistry {
+	result := &PluginRegistry{
+		pluginPath: pluginPath,
+		quit:       make(chan struct{}),
+	}
+	go result.loop()
+	return result
+}
+
+// Stop the plugin registry.
+func (r *PluginRegistry) Stop() {
+	close(r.quit)
+}
+
+func (r *PluginRegistry) loop() {
+	ticker := time.Tick(pluginPollDuration)
+	for {
+		r.scanPlugins()
+		select {
+		case <-ticker:
+		case <-r.quit:
+			return
+		}
+	}
+}
+
+func (r *PluginRegistry) scanPlugins() {
+	files, err := fs.ReadDir(r.pluginPath)
+	if err != nil {
+		log.Println("Error listing plugin dir:", err)
+		return
+	}
+
+	plugins := []plugin{}
+	for _, file := range files {
+		// check it a regular, executable file
+		mode := file.Mode()
+		if mode&os.ModeType != 0 {
+			log.Println("Not regular file, skipping:", file.Name())
+		}
+		if mode.Perm()&0111 == 0 {
+			log.Println("Not executable, skipping:", file.Name())
+			continue
+		}
+		plugins = append(plugins, plugin{
+			path: path.Join(r.pluginPath, file.Name()),
+		})
+	}
+
+	r.Lock()
+	defer r.Unlock()
+	r.plugins = plugins
+}
+
+// Name implements Tagger
+func (*PluginRegistry) Name() string {
+	return "Plugins"
+}
+
+func (r *PluginRegistry) withAll(f func(plugin) report.Report) report.Report {
+	r.Lock()
+	defer r.Unlock()
+	reports := make(chan report.Report, len(r.plugins))
+	wg := sync.WaitGroup{}
+	wg.Add(len(r.plugins))
+	for _, p := range r.plugins {
+		go func(p plugin) {
+			reports <- f(p)
+			wg.Done()
+		}(p)
+	}
+	wg.Wait()
+	close(reports)
+	result := report.MakeReport()
+	for out := range reports {
+		result = result.Merge(out)
+	}
+	return result
+}
+
+// Tag implements Tagger
+func (r *PluginRegistry) Tag(rep report.Report) (report.Report, error) {
+	result := r.withAll(func(p plugin) report.Report {
+		out, err := p.tag(rep)
+		if err != nil {
+			log.Printf("Plugin %s error tagging report: %v", p.path, err)
+			return rep
+		}
+		return out
+	})
+	return result, nil
+}
+
+// Report implements Reporter
+func (r *PluginRegistry) Report() (report.Report, error) {
+	result := r.withAll(func(p plugin) report.Report {
+		out, err := p.report()
+		if err != nil {
+			log.Printf("Plugin %s error tagging report: %v", p.path, err)
+			return report.MakeReport()
+		}
+		return out
+	})
+	return result, nil
+}
+
+type plugin struct {
+	path string
+}
+
+func (p plugin) doRequest(req *http.Request) (*http.Response, error) {
+	cmd := exec.Command(p.path)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	defer cmd.Wait()
+
+	// Write a HTTP request to the exec'd process' stdin.
+	req.Write(stdin)
+	stdin.Close()
+
+	// Read a HTTRP response from the exec'd process' stdout.
+	return http.ReadResponse(bufio.NewReader(stdout), req)
+}
+
+func (p plugin) tag(r report.Report) (report.Report, error) {
+	buf := bytes.Buffer{}
+	if err := json.NewEncoder(&buf).Encode(r); err != nil {
+		return report.MakeReport(), err
+	}
+	req, err := http.NewRequest("POST", "/tag", &buf)
+	if err != nil {
+		return report.MakeReport(), err
+	}
+	resp, err := p.doRequest(req)
+	if err != nil {
+		return report.MakeReport(), err
+	}
+	result := report.MakeReport()
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return report.MakeReport(), err
+	}
+	return result, nil
+}
+
+func (p plugin) report() (report.Report, error) {
+	req, err := http.NewRequest("GET", "/report", nil)
+	if err != nil {
+		return report.MakeReport(), err
+	}
+	resp, err := p.doRequest(req)
+	if err != nil {
+		return report.MakeReport(), err
+	}
+	result := report.MakeReport()
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return report.MakeReport(), err
+	}
+	return result, nil
+}

--- a/probe/plugins/plugins_internal_test.go
+++ b/probe/plugins/plugins_internal_test.go
@@ -1,0 +1,108 @@
+package plugins
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"path"
+	"reflect"
+	"testing"
+	"time"
+
+	exec_hook "github.com/weaveworks/scope/common/exec"
+	fs_hook "github.com/weaveworks/scope/common/fs"
+	"github.com/weaveworks/scope/test"
+	"github.com/weaveworks/scope/test/exec"
+	"github.com/weaveworks/scope/test/fixture"
+	"github.com/weaveworks/scope/test/fs"
+)
+
+const pluginDir = "/etc/weave/scope/plugins"
+
+var mockFS = fs.Dir("",
+	fs.Dir("etc",
+		fs.Dir("weave",
+			fs.Dir("scope",
+				fs.Dir("plugins",
+					fs.File{
+						FName: "notaplugin",
+					},
+					fs.File{
+						FName: "plugin1",
+						FMode: 0700,
+					},
+					fs.File{
+						FName: "plugin2",
+						FMode: 0777,
+					},
+				),
+			),
+		),
+	),
+)
+
+func TestPluginDiscovery(t *testing.T) {
+	fs_hook.Mock(mockFS)
+	defer fs_hook.Restore()
+
+	registry := NewPluginRegistry(pluginDir)
+	defer registry.Stop()
+
+	test.Poll(t, 100*time.Millisecond, []string{
+		path.Join(pluginDir, "/plugin1"),
+		path.Join(pluginDir, "/plugin2"),
+	},
+		func() interface{} {
+			registry.Lock()
+			defer registry.Unlock()
+			result := []string{}
+			for _, p := range registry.plugins {
+				result = append(result, p.path)
+			}
+			return result
+		})
+}
+
+func TestPluginRPC(t *testing.T) {
+	stdoutr, stdoutw := io.Pipe()
+	stdinr, stdinw := io.Pipe()
+	exec_hook.Mock(func(name string, args ...string) exec_hook.Cmd {
+		if name != "/foo/bar" {
+			t.Fatal(name)
+		}
+		return exec.NewMockCmd(stdoutr, stdinw)
+	})
+	defer exec_hook.Restore()
+	go func() {
+		req, err := http.ReadRequest(bufio.NewReader(stdinr))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if req.URL.Path != "/report" {
+			t.Fatal(req.URL.Path)
+		}
+		buf := bytes.Buffer{}
+		if err := json.NewEncoder(&buf).Encode(fixture.Report); err != nil {
+			t.Fatal(err)
+		}
+		resp := http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(&buf),
+		}
+		resp.Write(stdoutw)
+	}()
+
+	plugin := plugin{
+		path: "/foo/bar",
+	}
+	report, err := plugin.report()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(fixture.Report, report) {
+		test.Diff(fixture.Report, report)
+	}
+}

--- a/scope
+++ b/scope
@@ -90,8 +90,10 @@ check_not_running() {
 }
 
 launch_command() {
-    echo docker run --privileged -d --name=$SCOPE_CONTAINER_NAME --net=host --pid=host \
+    echo docker run --privileged -d --name=$SCOPE_CONTAINER_NAME \
+            --net=host --pid=host \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -v /etc/scope/plugins:/etc/scope/plugins \
             $WEAVESCOPE_DOCKER_ARGS $SCOPE_IMAGE --probe.docker true "$@"
 }
 

--- a/test/fs/fs.go
+++ b/test/fs/fs.go
@@ -28,6 +28,7 @@ type File struct {
 	FName     string
 	FContents string
 	FStat     syscall.Stat_t
+	FMode     os.FileMode
 }
 
 // Entry is an entry in the mock filesystem
@@ -168,6 +169,9 @@ func (p File) Name() string { return p.FName }
 
 // IsDir implements os.FileInfo
 func (p File) IsDir() bool { return false }
+
+// Mode implements os.FileInfo
+func (p File) Mode() os.FileMode { return p.FMode }
 
 // ReadDir implements FS
 func (p File) ReadDir(path string) ([]os.FileInfo, error) {


### PR DESCRIPTION
Fixes #554 

Probe plugins are little scripts that live on the user's hosts and can generate or tag reports. This PR adds plumbing to the probe to periodically discover and execute these scripts.

The probe<->plugin interface is define as HTTP / JSON over stdin & stdout.  When the probe execs a plugin, it writes a HTTP request to the plugins stdin, and reads a HTTP response on the plugins stdout.  Current support 'rpcs' are:
- POST /tag with the report encoded as JSON in the body of the request
- GET /report

TODO:
- [ ] Implement a method for controls & pipes
- [ ] Once details panel redesign is in, make it possible for stuff coming from plugins to appear in the details panel.
- [ ] Sysdig example.
- [ ] Document.
- [ ] Add tests