### PR TITLE
k8s: Filter out pause as a system container

### DIFF
--- a/render/filters.go
+++ b/render/filters.go
@@ -184,10 +184,12 @@ var systemContainerNames = map[string]struct{}{
 }
 
 var systemImagePrefixes = map[string]struct{}{
-	"weaveworks/scope":        {},
-	"weaveworks/weavedns":     {},
-	"weaveworks/weave":        {},
-	"weaveworks/weaveproxy":   {},
-	"weaveworks/weaveexec":    {},
-	"amazon/amazon-ecs-agent": {},
+	"weaveworks/scope":                    {},
+	"weaveworks/weavedns":                 {},
+	"weaveworks/weave":                    {},
+	"weaveworks/weaveproxy":               {},
+	"weaveworks/weaveexec":                {},
+	"amazon/amazon-ecs-agent":             {},
+	"beta.gcr.io/google_containers/pause": {},
+	"gcr.io/google_containers/pause":      {},
 }


### PR DESCRIPTION
This makes a huge difference when viewing containers in a kubernetes cluster since every pod contains a pause container, completely cluttering the view.

Fixes #733 

@tomwilkie @paulbellamy PTAL (although the change is trivial)