### PR TITLE
Various improvements to build & test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all deps static clean client-lint client-test client-sync backend frontend shell
+.PHONY: all deps static clean client-lint client-test client-sync backend frontend shell lint
 
 # If you can use Docker without being root, you can `make SUDO= <target>`
 SUDO=sudo -E
@@ -42,7 +42,7 @@ $(SCOPE_EXE): $(shell find ./ -path ./vendor -prune -o -type f -name *.go) prog/
 
 ifeq ($(BUILD_IN_CONTAINER),true)
 
-$(SCOPE_EXE) $(RUNSVINIT) tests shell: $(SCOPE_BACKEND_BUILD_UPTODATE)
+$(SCOPE_EXE) $(RUNSVINIT) lint tests shell: $(SCOPE_BACKEND_BUILD_UPTODATE)
 	@mkdir -p $(shell pwd)/.pkg
 	$(SUDO) docker run $(RM) $(RUN_FLAGS) \
 		-v $(shell pwd):/go/src/github.com/weaveworks/scope \
@@ -72,6 +72,9 @@ shell:
 
 tests:
 	./tools/test -no-go-get
+
+lint:
+	./tools/lint .
 
 endif
 
@@ -122,9 +125,6 @@ clean:
 
 deps:
 	go get -u -f -tags netgo \
-		github.com/golang/lint/golint \
-		github.com/fzipp/gocyclo \
 		github.com/mattn/goveralls \
 		github.com/mjibson/esc \
-		github.com/kisielk/errcheck \
 		github.com/weaveworks/github-release

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,5 +2,9 @@ FROM golang:1.5.3
 ENV GO15VENDOREXPERIMENT 1
 RUN apt-get update && apt-get install -y libpcap-dev python-requests time
 RUN go clean -i net && go install -tags netgo std &&  go install -race -tags netgo std
+RUN go get -tags netgo \
+		github.com/golang/lint/golint \
+		github.com/fzipp/gocyclo \
+		github.com/kisielk/errcheck
 COPY build.sh /
 ENTRYPOINT ["/build.sh"]

--- a/circle.yml
+++ b/circle.yml
@@ -29,13 +29,11 @@ dependencies:
 
 test:
   override:
-    - cd $SRCDIR; ./tools/lint .:
+    - cd $SRCDIR; make RM= lint:
         parallel: true
     - cd $SRCDIR; COVERDIR=./coverage make RM= tests:
         parallel: true
-    - cd $SRCDIR; make RM= client-test:
-        parallel: true
-    - cd $SRCDIR; make RM= static:
+    - cd $SRCDIR; make RM= client-test static:
         parallel: true
     - cd $SRCDIR; rm -f prog/scope; if [ "$CIRCLE_NODE_INDEX" = "0" ]; then GOARCH=arm make GO_BUILD_INSTALL_DEPS= RM= prog/scope; else GOOS=darwin make GO_BUILD_INSTALL_DEPS= RM= prog/scope; fi:
         parallel: true

--- a/integration/config.sh
+++ b/integration/config.sh
@@ -87,7 +87,7 @@ wait_for() {
 	local view="$1"
 	local host="$2"
 	local timeout="$3"
-	shift 2
+	shift 3
 
 	for i in $(seq ${timeout}); do
 		local nodes="$(curl -s http://$host:4040/api/topology/${view}?system=show)"

--- a/integration/gce.sh
+++ b/integration/gce.sh
@@ -6,5 +6,5 @@ set -e
 
 export PROJECT=scope-integration-tests
 export TEMPLATE_NAME="test-template-4"
-export NUM_HOSTS=2
+export NUM_HOSTS=3
 . "../tools/integration/gce.sh" "$@"


### PR DESCRIPTION
- Fix wait in test - this is what has been causing the integration tests to take 2mins each.
- Run lint in build container (get the go1.5 vet rules)
- Increase VMs to 3 per shard
- Merge a few short step in circle.yml