### PR TITLE
Loop in the http.DefaultServeMux for pprof.

### DIFF
--- a/app/router.go
+++ b/app/router.go
@@ -84,6 +84,9 @@ func TopologyHandler(c Reporter, preRoutes *mux.Router, postRoutes http.Handler)
 		topologyRegistry.captureRenderer(c, handleWs)) // NB not gzip!
 	get.HandleFunc("/api/report", gzipHandler(makeRawReportHandler(c)))
 
+	// We pull in the http.DefaultServeMux to get the pprof routes
+	preRoutes.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)
+
 	if postRoutes != nil {
 		preRoutes.PathPrefix("/").Handler(postRoutes)
 	}


### PR DESCRIPTION
Other than copy and pasting the [init() method from pprof](https://golang.org/src/net/http/pprof/pprof.go#L67) I couldn't think of a better way of doing this.

Fixes #832 