### PR TITLE
Stops scope crashing chrome when we get "long" edges.

### DIFF
--- a/client/app/scripts/charts/edge.js
+++ b/client/app/scripts/charts/edge.js
@@ -84,11 +84,11 @@ export default class Edge extends React.Component {
   }
 
   ensureSameLength(points) {
-    // Spring needs constant list length, hoping that dagre will insert never more than 10
-    const length = 10;
+    // Spring needs constant list length, hoping that dagre will insert never more than 30
+    const length = 30;
     let missing = length - points.length;
 
-    while (missing) {
+    while (missing > 0) {
       points.unshift(points[0]);
       missing = length - points.length;
     }

--- a/client/app/scripts/charts/nodes-layout.js
+++ b/client/app/scripts/charts/nodes-layout.js
@@ -359,6 +359,9 @@ export function doLayout(immNodes, immEdges, opts) {
     const graph = cache.graph;
     const nodesWithDegrees = updateNodeDegrees(immNodes, immEdges);
     layout = runLayoutEngine(graph, nodesWithDegrees, immEdges, opts);
+    if (!layout) {
+      return layout;
+    }
     layout = layoutSingleNodes(layout, opts);
     layout = shiftLayoutToCenter(layout, opts);
   }

--- a/client/app/scripts/components/app.js
+++ b/client/app/scripts/components/app.js
@@ -12,6 +12,7 @@ import Details from './details';
 import Nodes from './nodes';
 import EmbeddedTerminal from './embedded-terminal';
 import { getRouter } from '../utils/router-utils';
+import { showingDebugToolbar, DebugToolbar } from './debug-toolbar.js';
 
 const ESC_KEY_CODE = 27;
 
@@ -79,6 +80,7 @@ export default class App extends React.Component {
 
     return (
       <div className="app">
+        {showingDebugToolbar() && <DebugToolbar />}
         {showingDetails && <Details nodes={this.state.nodes}
           controlError={this.state.controlError}
           controlPending={this.state.controlPending}

--- a/client/app/scripts/components/debug-toolbar.js
+++ b/client/app/scripts/components/debug-toolbar.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import _ from 'lodash';
+
+import debug from 'debug';
+const log = debug('scope:debug-panel');
+
+import { receiveNodesDelta } from '../actions/app-actions';
+import AppStore from '../stores/app-store';
+
+
+const sample = function(collection) {
+  return _.range(_.random(4)).map(() => _.sample(collection));
+};
+
+const deltaAdd = function(name, adjacency = []) {
+  return {
+    'adjacency': adjacency,
+    'controls': {},
+    'id': name,
+    'label_major': name,
+    'label_minor': 'weave-1',
+    'latest': {},
+    'metadata': {},
+    'origins': [],
+    'rank': 'alpine'
+  };
+};
+
+function addNodes(n) {
+  const ns = AppStore.getNodes();
+  const nodeNames = ns.keySeq().toJS();
+  const newNodeNames = _.range(ns.size, ns.size + n).map((i) => 'zing' + i);
+  const allNodes = _(nodeNames).concat(newNodeNames).value();
+
+  receiveNodesDelta({
+    add: newNodeNames.map((name) => deltaAdd(name, sample(allNodes)))
+  });
+}
+
+export function showingDebugToolbar() {
+  return Boolean(localStorage.debugToolbar);
+}
+
+export class DebugToolbar extends React.Component {
+
+  constructor(props, context) {
+    super(props, context);
+    this.onChange = this.onChange.bind(this);
+    this.state = {
+      nodesToAdd: 30
+    };
+  }
+
+  onChange(ev) {
+    this.setState({nodesToAdd: parseInt(ev.target.value, 10)});
+  }
+
+  render() {
+    log('rending debug panel');
+
+    return (
+      <div className="debug-panel">
+        <label>Add nodes </label>
+        <button onClick={() => addNodes(1)}>+1</button>
+        <button onClick={() => addNodes(10)}>+10</button>
+        <input type="number" onChange={this.onChange} value={this.state.nodesToAdd} />
+        <button onClick={() => addNodes(this.state.nodesToAdd)}>+</button>
+      </div>
+    );
+  }
+}

--- a/client/app/styles/main.less
+++ b/client/app/styles/main.less
@@ -715,3 +715,17 @@ h2 {
     color: @text-color;
   }
 }
+
+//
+// Debug panel!
+//
+
+.debug-panel {
+  .shadow-2;
+  background-color: #fff;
+  top: 10px;
+  position: absolute;
+  padding: 10px;
+  left: 10px;
+  z-index: 10000;
+}


### PR DESCRIPTION
Long edges are those w/ a lot of points on them (control points, as in, the edge meanders around a lot). 

Which can pop up in heavily connected layouts.

Fixes #830 