### PR TITLE
Memoise & cache the result of renderers, so we don't recalculate views multiple times.

### DIFF
--- a/app/benchmark_internal_test.go
+++ b/app/benchmark_internal_test.go
@@ -1,0 +1,55 @@
+package app
+
+import (
+	"encoding/json"
+	"flag"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/weaveworks/scope/render"
+	"github.com/weaveworks/scope/report"
+	"github.com/weaveworks/scope/test/fixture"
+)
+
+// StaticReport is used as a fixture in tests. It emulates an xfer.Collector.
+type StaticReporter struct{ r report.Report }
+
+func (s StaticReporter) Report() report.Report { return s.r }
+func (s StaticReporter) WaitOn(chan struct{})  {}
+func (s StaticReporter) UnWait(chan struct{})  {}
+
+var (
+	benchReportFile = flag.String("bench-report-file", "", "json report file to use for benchmarking (relative to this package)")
+)
+
+func loadReport() (report.Report, error) {
+	if *benchReportFile == "" {
+		return fixture.Report, nil
+	}
+
+	b, err := ioutil.ReadFile(*benchReportFile)
+	if err != nil {
+		return fixture.Report, err
+	}
+	rpt := report.MakeReport()
+	err = json.Unmarshal(b, &rpt)
+	return rpt, err
+}
+
+func BenchmarkTopologyList(b *testing.B) {
+	report, err := loadReport()
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	request := &http.Request{
+		Form: url.Values{},
+	}
+	for i := 0; i < b.N; i++ {
+		render.ResetCache()
+		topologyRegistry.renderTopologies(report, request)
+	}
+}

--- a/app/collector.go
+++ b/app/collector.go
@@ -1,8 +1,11 @@
 package app
 
 import (
+	"fmt"
 	"sync"
 	"time"
+
+	"github.com/spaolacci/murmur3"
 
 	"github.com/weaveworks/scope/report"
 )
@@ -97,9 +100,12 @@ func (c *collector) Report() report.Report {
 	c.reports = clean(c.reports, c.window)
 
 	rpt := report.MakeReport()
+	id := murmur3.New64()
 	for _, tr := range c.reports {
 		rpt = rpt.Merge(tr.report)
+		id.Write([]byte(tr.report.ID))
 	}
+	rpt.ID = fmt.Sprintf("%x", id.Sum64())
 	return rpt
 }
 

--- a/app/collector_test.go
+++ b/app/collector_test.go
@@ -1,13 +1,13 @@
 package app_test
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/weaveworks/scope/app"
 	"github.com/weaveworks/scope/report"
 	"github.com/weaveworks/scope/test"
+	"github.com/weaveworks/scope/test/reflect"
 )
 
 func TestCollector(t *testing.T) {

--- a/probe/probe_internal_test.go
+++ b/probe/probe_internal_test.go
@@ -4,12 +4,12 @@ import (
 	"compress/gzip"
 	"encoding/gob"
 	"io"
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/weaveworks/scope/report"
 	"github.com/weaveworks/scope/test"
+	"github.com/weaveworks/scope/test/reflect"
 )
 
 func TestApply(t *testing.T) {

--- a/render/benchmark_test.go
+++ b/render/benchmark_test.go
@@ -61,6 +61,7 @@ func benchmarkRender(b *testing.B, r render.Renderer) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
+		render.ResetCache()
 		benchmarkRenderResult = r.Render(report)
 		if len(benchmarkRenderResult) == 0 {
 			b.Errorf("Rendered topology contained no nodes")
@@ -78,6 +79,7 @@ func benchmarkStats(b *testing.B, r render.Renderer) {
 
 	for i := 0; i < b.N; i++ {
 		// No way to tell if this was successful :(
+		render.ResetCache()
 		benchmarkStatsResult = r.Stats(report)
 	}
 }

--- a/render/benchmark_test.go
+++ b/render/benchmark_test.go
@@ -87,11 +87,11 @@ func loadReport() (report.Report, error) {
 		return fixture.Report, nil
 	}
 
-	var rpt report.Report
 	b, err := ioutil.ReadFile(*benchReportFile)
 	if err != nil {
 		return rpt, err
 	}
+	rpt := report.MakeReport()
 	err = json.Unmarshal(b, &rpt)
 	return rpt, err
 }

--- a/render/render.go
+++ b/render/render.go
@@ -1,8 +1,34 @@
 package render
 
 import (
+	"fmt"
+	"reflect"
+
+	"github.com/bluele/gcache"
+
 	"github.com/weaveworks/scope/report"
 )
+
+var renderCache = gcache.New(100).LRU().Build()
+
+func memoisedRender(r Renderer, rpt report.Report) RenderableNodes {
+	key := ""
+	v := reflect.ValueOf(r)
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Func:
+		key = fmt.Sprintf("%s-%x", rpt.ID, v.Pointer())
+	default:
+		return r.Render(rpt)
+	}
+	if result, err := renderCache.Get(key); err == nil {
+		//fmt.Println("Hit", key)
+		return result.(RenderableNodes)
+	}
+	//fmt.Println("Miss", key)
+	output := r.Render(rpt)
+	renderCache.Set(key, output)
+	return output
+}
 
 // Renderer is something that can render a report to a set of RenderableNodes.
 type Renderer interface {
@@ -27,22 +53,23 @@ type Reduce []Renderer
 
 // MakeReduce is the only sane way to produce a Reduce Renderer.
 func MakeReduce(renderers ...Renderer) Renderer {
-	return Reduce(renderers)
+	r := Reduce(renderers)
+	return &r
 }
 
 // Render produces a set of RenderableNodes given a Report.
-func (r Reduce) Render(rpt report.Report) RenderableNodes {
+func (r *Reduce) Render(rpt report.Report) RenderableNodes {
 	result := RenderableNodes{}
-	for _, renderer := range r {
-		result = result.Merge(renderer.Render(rpt))
+	for _, renderer := range *r {
+		result = result.Merge(memoisedRender(renderer, rpt))
 	}
 	return result
 }
 
 // Stats implements Renderer
-func (r Reduce) Stats(rpt report.Report) Stats {
+func (r *Reduce) Stats(rpt report.Report) Stats {
 	var result Stats
-	for _, renderer := range r {
+	for _, renderer := range *r {
 		result = result.merge(renderer.Stats(rpt))
 	}
 	return result
@@ -55,24 +82,29 @@ type Map struct {
 	Renderer
 }
 
+// MakeMap makes a new Map
+func MakeMap(f MapFunc, r Renderer) Renderer {
+	return &Map{f, r}
+}
+
 // Render transforms a set of RenderableNodes produces by another Renderer.
 // using a map function
-func (m Map) Render(rpt report.Report) RenderableNodes {
+func (m *Map) Render(rpt report.Report) RenderableNodes {
 	output, _ := m.render(rpt)
 	return output
 }
 
 // Stats implements Renderer
-func (m Map) Stats(rpt report.Report) Stats {
+func (m *Map) Stats(rpt report.Report) Stats {
 	// There doesn't seem to be an instance where we want stats to recurse
 	// through Maps - for instance we don't want to see the number of filtered
 	// processes in the container renderer.
 	return Stats{}
 }
 
-func (m Map) render(rpt report.Report) (RenderableNodes, map[string]report.IDList) {
+func (m *Map) render(rpt report.Report) (RenderableNodes, map[string]report.IDList) {
 	var (
-		input         = m.Renderer.Render(rpt)
+		input         = memoisedRender(m.Renderer, rpt)
 		output        = RenderableNodes{}
 		mapped        = map[string]report.IDList{} // input node ID -> output node IDs
 		adjacencies   = map[string]report.IDList{} // output node ID -> input node Adjacencies

--- a/render/render.go
+++ b/render/render.go
@@ -3,6 +3,7 @@ package render
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/bluele/gcache"
 
@@ -10,22 +11,30 @@ import (
 )
 
 var renderCache = gcache.New(100).LRU().Build()
+var depth = 0
 
 func memoisedRender(r Renderer, rpt report.Report) RenderableNodes {
+	fmt.Printf("%sRendering: %#v\n", strings.Repeat("  ", depth), r)
+
 	key := ""
 	v := reflect.ValueOf(r)
 	switch v.Kind() {
 	case reflect.Ptr, reflect.Func:
 		key = fmt.Sprintf("%s-%x", rpt.ID, v.Pointer())
 	default:
+		fmt.Printf("%s- Cannot memoise: %v\n", strings.Repeat("  ", depth), r)
 		return r.Render(rpt)
 	}
 	if result, err := renderCache.Get(key); err == nil {
-		//fmt.Println("Hit", key)
+		fmt.Printf("%s- Hit %s\n", strings.Repeat("  ", depth), key)
 		return result.(RenderableNodes)
 	}
-	//fmt.Println("Miss", key)
+	fmt.Printf("%s- Miss %s\n", strings.Repeat("  ", depth), key)
+
+	depth += 1
 	output := r.Render(rpt)
+	depth -= 1
+
 	renderCache.Set(key, output)
 	return output
 }

--- a/render/render.go
+++ b/render/render.go
@@ -30,6 +30,10 @@ func memoisedRender(r Renderer, rpt report.Report) RenderableNodes {
 	return output
 }
 
+func ResetCache() {
+	renderCache.Purge()
+}
+
 // Renderer is something that can render a report to a set of RenderableNodes.
 type Renderer interface {
 	Render(report.Report) RenderableNodes

--- a/report/report.go
+++ b/report/report.go
@@ -83,8 +83,10 @@ type Report struct {
 	Shortcut bool
 
 	// ID a random identifier for this report, used when caching
-	// rendered views of the report
-	ID string
+	// rendered views of the report.  Reports with the same id
+	// must be equal, but we don't require that equal reports have
+	// the same id.
+	ID string `deepequal:"skip"`
 }
 
 // MakeReport makes a clean report, ready to Merge() other reports into.

--- a/report/report.go
+++ b/report/report.go
@@ -2,6 +2,7 @@ package report
 
 import (
 	"fmt"
+	"math/rand"
 	"strings"
 	"time"
 )
@@ -80,6 +81,10 @@ type Report struct {
 	// Shortcut reports should be propogated to the UI as quickly as possible,
 	// bypassing the usual spy interval, publish interval and app ws interval.
 	Shortcut bool
+
+	// ID a random identifier for this report, used when caching
+	// rendered views of the report
+	ID string
 }
 
 // MakeReport makes a clean report, ready to Merge() other reports into.
@@ -96,6 +101,7 @@ func MakeReport() Report {
 		Overlay:        MakeTopology(),
 		Sampling:       Sampling{},
 		Window:         0,
+		ID:             fmt.Sprintf("%d", rand.Int63()),
 	}
 }
 
@@ -113,6 +119,7 @@ func (r Report) Copy() Report {
 		Overlay:        r.Overlay.Copy(),
 		Sampling:       r.Sampling,
 		Window:         r.Window,
+		ID:             fmt.Sprintf("%d", rand.Int63()),
 	}
 }
 

--- a/test/fixture/report_fixture.go
+++ b/test/fixture/report_fixture.go
@@ -121,6 +121,7 @@ var (
 	ServerHostLoad15Metric = report.MakeMetric().Add(Now, 0.16).WithFirst(Now.Add(-16 * time.Second))
 
 	Report = report.Report{
+		ID: "test-report",
 		Endpoint: report.Topology{
 			Nodes: report.Nodes{
 				// Node is arbitrary. We're free to put only precisely what we

--- a/test/reflect/deepequal.go
+++ b/test/reflect/deepequal.go
@@ -105,6 +105,9 @@ func deepValueEqual(v1, v2 reflect.Value, visited map[visit]bool, depth int) boo
 		return deepValueEqual(v1.Elem(), v2.Elem(), visited, depth+1)
 	case reflect.Struct:
 		for i, n := 0, v1.NumField(); i < n; i++ {
+			if v1.Type().Field(i).Tag.Get("deepequal") == "skip" {
+				continue
+			}
 			if !deepValueEqual(v1.Field(i), v2.Field(i), visited, depth+1) {
 				return false
 			}


### PR DESCRIPTION
Fixes #854

The idea is that to render hosts, you have to render processes, containers, pods etc.  All of these in turn render processes.  As the rendering pipeline is deterministic, ie rendering the same report will give you the same result, we can cache intermediate steps.   I introduce a random report ID and use reflection to get the address of the renderer, and use these two as a key for the cache.

Results in an 750% increase in performance of the host renderer, although this test might not be fair...

Before:
```
Toms-MacBook-Pro:render twilkie$ go test -bench . -- -bench-report-file report.json 
PASS
BenchmarkEndpointRender-8                	   10000	    133761 ns/op	   52781 B/op	     736 allocs/op
BenchmarkEndpointStats-8                 	100000000	        18.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkProcessRender-8                 	    5000	    275635 ns/op	  114848 B/op	    1427 allocs/op
BenchmarkProcessStats-8                  	20000000	        65.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkProcessWithContainerNameRender-8	    5000	    324229 ns/op	  131566 B/op	    1612 allocs/op
BenchmarkProcessWithContainerNameStats-8 	20000000	        75.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkProcessNameRender-8             	    3000	    367554 ns/op	  146392 B/op	    1726 allocs/op
BenchmarkProcessNameStats-8              	100000000	        19.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkContainerRender-8               	    2000	    521885 ns/op	  213154 B/op	    2540 allocs/op
BenchmarkContainerStats-8                	    3000	    433637 ns/op	  176031 B/op	    2255 allocs/op
BenchmarkContainerWithImageNameRender-8  	    2000	    554605 ns/op	  228969 B/op	    2707 allocs/op
BenchmarkContainerWithImageNameStats-8   	    3000	    432879 ns/op	  176003 B/op	    2255 allocs/op
BenchmarkContainerImageRender-8          	    2000	    686163 ns/op	  291427 B/op	    3150 allocs/op
BenchmarkContainerImageStats-8           	100000000	        18.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkContainerHostnameRender-8       	    2000	    532886 ns/op	  220428 B/op	    2634 allocs/op
BenchmarkContainerHostnameStats-8        	100000000	        18.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkHostRender-8                    	    2000	    879954 ns/op	  373453 B/op	    4044 allocs/op
BenchmarkHostStats-8                     	10000000	       126 ns/op	       0 B/op	       0 allocs/op
BenchmarkPodRender-8                     	    2000	    646618 ns/op	  268650 B/op	    3008 allocs/op
BenchmarkPodStats-8                      	100000000	        18.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkPodServiceRender-8              	    2000	    773566 ns/op	  326606 B/op	    3418 allocs/op
BenchmarkPodServiceStats-8               	100000000	        18.7 ns/op	       0 B/op	       0 allocs/op
ok  	github.com/weaveworks/scope/render	34.022s
```

After:

```
Toms-MacBook-Pro:render twilkie$ go test -bench . -- -bench-report-file report.json 
PASS
BenchmarkEndpointRender-8                	   20000	     74163 ns/op	   29659 B/op	     377 allocs/op
BenchmarkEndpointStats-8                 	100000000	        10.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkProcessRender-8                 	   30000	     44996 ns/op	   22172 B/op	     204 allocs/op
BenchmarkProcessStats-8                  	30000000	        39.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkProcessWithContainerNameRender-8	   20000	     72938 ns/op	   31491 B/op	     319 allocs/op
BenchmarkProcessWithContainerNameStats-8 	20000000	        50.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkProcessNameRender-8             	  100000	     16413 ns/op	    7403 B/op	      76 allocs/op
BenchmarkProcessNameStats-8              	100000000	        10.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkContainerRender-8               	   30000	     41609 ns/op	   21403 B/op	     135 allocs/op
BenchmarkContainerStats-8                	  100000	     10727 ns/op	    2969 B/op	      54 allocs/op
BenchmarkContainerWithImageNameRender-8  	   20000	     70158 ns/op	   32224 B/op	     236 allocs/op
BenchmarkContainerWithImageNameStats-8   	  100000	     10807 ns/op	    2969 B/op	      54 allocs/op
BenchmarkContainerImageRender-8          	  100000	     12298 ns/op	    5514 B/op	      62 allocs/op
BenchmarkContainerImageStats-8           	100000000	        10.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkContainerHostnameRender-8       	  200000	      8771 ns/op	    3657 B/op	      50 allocs/op
BenchmarkContainerHostnameStats-8        	100000000	        10.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkHostRender-8                    	   10000	    116569 ns/op	   59922 B/op	     327 allocs/op
BenchmarkHostStats-8                     	20000000	        80.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkPodRender-8                     	  100000	     12679 ns/op	    5514 B/op	      62 allocs/op
BenchmarkPodStats-8                      	100000000	        10.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkPodServiceRender-8              	  100000	     11310 ns/op	    4634 B/op	      59 allocs/op
BenchmarkPodServiceStats-8               	100000000	        10.3 ns/op	       0 B/op	       0 allocs/op
ok  	github.com/weaveworks/scope/render	31.782s
```