### PR TITLE
Taking a read lock twice only works most of the time.

### DIFF
--- a/probe/overlay/weave.go
+++ b/probe/overlay/weave.go
@@ -207,8 +207,6 @@ func (w *Weave) Tag(r report.Report) (report.Report, error) {
 	}
 
 	// Put information from weave ps on the container nodes
-	w.mtx.RLock()
-	defer w.mtx.RUnlock()
 	for id, node := range r.Container.Nodes {
 		prefix, _ := node.Latest.Lookup(docker.ContainerID)
 		prefix = prefix[:12]


### PR DESCRIPTION
This explains #881 - if we try and take a write lock during this window, we lock up the reporter thread, and that causes a bunch of data structures to grow linearly.

We should also stop these DSes growing linearly.