### PR TITLE
Fixes some fields overflowing badly.

### DIFF
--- a/client/app/styles/main.less
+++ b/client/app/styles/main.less
@@ -644,6 +644,8 @@ h2 {
       &-value {
         font-size: 105%;
         flex: 1;
+        // Now required (from chrome 48) to get overflow + flexbox behaving:
+        min-width: 0;
         color: @text-color;
       }
     }


### PR DESCRIPTION
The Chrome guys have implmeneted a new change (in Chrome 48) in the CSS
flexbox spec, min-width now defaults to auto instead of 0. "auto" has
some complicated behaviour described in the table here:
https://drafts.csswg.org/css-flexbox/#min-size-auto

This results in a very long min-width (I don't understand why). So we
have to let the browser know it can make it smaller if it wants to,
which in this case would be great.

Here's another person's experience with the issue.
 - https://code.google.com/p/chromium/issues/detail?id=551336


Fixes #864