### PR TITLE
Disable npm progress to speed up build

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:4.2.2
 WORKDIR /home/weave
 COPY package.json /home/weave/
-ENV NPM_CONFIG_LOGLEVEL warn
+ENV NPM_CONFIG_LOGLEVEL=warn NPM_CONFIG_PROGRESS=false
 # Dont install optional developer tools
 RUN npm install --no-optional
 COPY webpack.local.config.js webpack.production.config.js server.js .babelrc .eslintrc .eslintignore /home/weave/


### PR DESCRIPTION
Seems to shave 1 min off the ui-build:

Before: https://circleci.com/gh/weaveworks/scope/2734
After: https://circleci.com/gh/weaveworks/scope/2733

But that's only one data point.