### PR TITLE
Periodically check for newer versions of scope.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ the Internet.  Additionally traffic between the app and the probe is currently
 insecure and should not traverse the internet.
 
 Scope will periodically check with our servers to see if a new version is
-availible.  To disable this, run:
+available.  To disable this, run:
 
 ```
 CHECKPOINT_DISABLE=true scope launch

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ such, the Scope app endpoint (port 4040) should not be made accessible on
 the Internet.  Additionally traffic between the app and the probe is currently
 insecure and should not traverse the internet.
 
+Scope will periodically check with our servers to see if a new version is
+availible.  To disable this, run:
+
+```
+CHECKPOINT_DISABLE=true scope launch
+```
+
 ## <a name="architecture"></a>Architecture
 
 Weave Scope consists of two components: the app and the probe. These two

--- a/prog/app.go
+++ b/prog/app.go
@@ -44,14 +44,13 @@ func appMain() {
 	defer log.Print("app exiting")
 
 	// Start background version checking
-	params := checkpoint.CheckParams{
+	checkpoint.CheckInterval(&checkpoint.CheckParams{
 		Product:       "scope-app",
 		Version:       app.Version,
 		SignatureFile: signatureFile,
-	}
-	checkpoint.CheckInterval(&params, versionCheckPeriod, func(r *checkpoint.CheckResponse, err error) {
+	}, versionCheckPeriod, func(r *checkpoint.CheckResponse, err error) {
 		if r.Outdated {
-			log.Printf("Scope version %s is availible; please update at %s",
+			log.Printf("Scope version %s is available; please update at %s",
 				r.CurrentVersion, r.CurrentDownloadURL)
 		}
 	})

--- a/prog/app.go
+++ b/prog/app.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/weaveworks/go-checkpoint"
 	"github.com/weaveworks/weave/common"
 
 	"github.com/weaveworks/scope/app"
@@ -41,6 +42,19 @@ func appMain() {
 	log.SetPrefix(*logPrefix)
 
 	defer log.Print("app exiting")
+
+	// Start background version checking
+	params := checkpoint.CheckParams{
+		Product:       "scope-app",
+		Version:       app.Version,
+		SignatureFile: signatureFile,
+	}
+	checkpoint.CheckInterval(&params, versionCheckPeriod, func(r *checkpoint.CheckResponse, err error) {
+		if r.Outdated {
+			log.Printf("Scope version %s is availible; please update at %s",
+				r.CurrentVersion, r.CurrentDownloadURL)
+		}
+	})
 
 	rand.Seed(time.Now().UnixNano())
 	app.UniqueID = strconv.FormatInt(rand.Int63(), 16)

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	signatureFile      = "/etc/weave/signature"
-	versionCheckPeriod = 6 * 60 * time.Minute
+	versionCheckPeriod = 6 * time.Hour
 )
 
 func check() {

--- a/scope
+++ b/scope
@@ -92,6 +92,8 @@ check_not_running() {
 launch_command() {
     echo docker run --privileged -d --name=$SCOPE_CONTAINER_NAME --net=host --pid=host \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -v /etc/weave:/etc/weave \
+            -e CHECKPOINT_DISABLE \
             $WEAVESCOPE_DOCKER_ARGS $SCOPE_IMAGE --probe.docker true "$@"
 }
 

--- a/scope
+++ b/scope
@@ -90,9 +90,13 @@ check_not_running() {
 }
 
 launch_command() {
+    local args="-v /etc/weave:/etc/weave"
+    if  (set +u; [ -n "$CHECKPOINT_DISABLE" ]); then
+        args=
+    fi
     echo docker run --privileged -d --name=$SCOPE_CONTAINER_NAME --net=host --pid=host \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -v /etc/weave:/etc/weave \
+            $args \
             -e CHECKPOINT_DISABLE \
             $WEAVESCOPE_DOCKER_ARGS $SCOPE_IMAGE --probe.docker true "$@"
 }

--- a/tools/lint
+++ b/tools/lint
@@ -35,7 +35,7 @@ function spell_check {
 	filename="$1"
 	local lint_result=0
 
-	if grep -iH --color=always psueod "${filename}"; then
+	if grep -iH --color=always 'psueod\|availible' "${filename}"; then
 		echo "${filename}: spelling mistake"
 		lint_result=1
 	fi

--- a/tools/runner/runner.go
+++ b/tools/runner/runner.go
@@ -63,10 +63,10 @@ func (ts tests) Less(i, j int) bool {
 	return ts[i].name < ts[j].name
 }
 
-func (ts *tests) pick(availible int) (test, bool) {
-	// pick the first test that fits in the availible hosts
+func (ts *tests) pick(available int) (test, bool) {
+	// pick the first test that fits in the available hosts
 	for i, test := range *ts {
-		if test.hosts <= availible {
+		if test.hosts <= available {
 			*ts = append((*ts)[:i], (*ts)[i+1:]...)
 			return test, true
 		}

--- a/vendor/github.com/hashicorp/go-cleanhttp/LICENSE
+++ b/vendor/github.com/hashicorp/go-cleanhttp/LICENSE
@@ -1,0 +1,363 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. "Contributor"
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+
+     means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the terms of
+        a Secondary License.
+
+1.6. "Executable Form"
+
+     means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+
+     means a work that combines Covered Software with other material, in a
+     separate file or files, that is not Covered Software.
+
+1.8. "License"
+
+     means this document.
+
+1.9. "Licensable"
+
+     means having the right to grant, to the maximum extent possible, whether
+     at the time of the initial grant or subsequently, any and all of the
+     rights conveyed by this License.
+
+1.10. "Modifications"
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor
+
+      means any patent claim(s), including without limitation, method,
+      process, and apparatus claims, in any patent Licensable by such
+      Contributor that would be infringed, but for the grant of the License,
+      by the making, using, selling, offering for sale, having made, import,
+      or transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License"
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form"
+
+      means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, "You" includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, "control" means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its
+        Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution
+     become effective for each Contribution on the date the Contributor first
+     distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under
+     this License. No additional rights or licenses will be implied from the
+     distribution or licensing of Covered Software under this License.
+     Notwithstanding Section 2.1(b) above, no patent license is granted by a
+     Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party's
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of
+        its Contributions.
+
+     This License does not grant any rights in the trademarks, service marks,
+     or logos of any Contributor (except as may be necessary to comply with
+     the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this
+     License (see Section 10.2) or under the terms of a Secondary License (if
+     permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its
+     Contributions are its original creation(s) or it has sufficient rights to
+     grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under
+     applicable copyright doctrines of fair use, fair dealing, or other
+     equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under
+     the terms of this License. You must inform recipients that the Source
+     Code Form of the Covered Software is governed by the terms of this
+     License, and how they can obtain a copy of this License. You may not
+     attempt to alter or restrict the recipients' rights in the Source Code
+     Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this
+        License, or sublicense it under different terms, provided that the
+        license for the Executable Form does not attempt to limit or alter the
+        recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for
+     the Covered Software. If the Larger Work is a combination of Covered
+     Software with a work governed by one or more Secondary Licenses, and the
+     Covered Software is not Incompatible With Secondary Licenses, this
+     License permits You to additionally distribute such Covered Software
+     under the terms of such Secondary License(s), so that the recipient of
+     the Larger Work may, at their option, further distribute the Covered
+     Software under the terms of either this License or such Secondary
+     License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices
+     (including copyright notices, patent notices, disclaimers of warranty, or
+     limitations of liability) contained within the Source Code Form of the
+     Covered Software, except that You may alter any license notices to the
+     extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on
+     behalf of any Contributor. You must make it absolutely clear that any
+     such warranty, support, indemnity, or liability obligation is offered by
+     You alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute,
+   judicial order, or regulation then You must: (a) comply with the terms of
+   this License to the maximum extent possible; and (b) describe the
+   limitations and the code they affect. Such description must be placed in a
+   text file included with all distributions of the Covered Software under
+   this License. Except to the extent prohibited by statute or regulation,
+   such description must be sufficiently detailed for a recipient of ordinary
+   skill to be able to understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing
+     basis, if such Contributor fails to notify You of the non-compliance by
+     some reasonable means prior to 60 days after You have come back into
+     compliance. Moreover, Your grants from a particular Contributor are
+     reinstated on an ongoing basis if such Contributor notifies You of the
+     non-compliance by some reasonable means, this is the first time You have
+     received notice of non-compliance with this License from such
+     Contributor, and You become compliant prior to 30 days after Your receipt
+     of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions,
+     counter-claims, and cross-claims) alleging that a Contributor Version
+     directly or indirectly infringes any patent, then the rights granted to
+     You by any and all Contributors for the Covered Software under Section
+     2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an "as is" basis,
+   without warranty of any kind, either expressed, implied, or statutory,
+   including, without limitation, warranties that the Covered Software is free
+   of defects, merchantable, fit for a particular purpose or non-infringing.
+   The entire risk as to the quality and performance of the Covered Software
+   is with You. Should any Covered Software prove defective in any respect,
+   You (not any Contributor) assume the cost of any necessary servicing,
+   repair, or correction. This disclaimer of warranty constitutes an essential
+   part of this License. No use of  any Covered Software is authorized under
+   this License except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from
+   such party's negligence to the extent applicable law prohibits such
+   limitation. Some jurisdictions do not allow the exclusion or limitation of
+   incidental or consequential damages, so this exclusion and limitation may
+   not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts
+   of a jurisdiction where the defendant maintains its principal place of
+   business and such litigation shall be governed by laws of that
+   jurisdiction, without reference to its conflict-of-law provisions. Nothing
+   in this Section shall prevent a party's ability to bring cross-claims or
+   counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject
+   matter hereof. If any provision of this License is held to be
+   unenforceable, such provision shall be reformed only to the extent
+   necessary to make it enforceable. Any law or regulation which provides that
+   the language of a contract shall be construed against the drafter shall not
+   be used to construe this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version
+      of the License under which You originally received the Covered Software,
+      or under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a
+      modified version of this License if you rename the license and remove
+      any references to the name of the license steward (except to note that
+      such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+      Licenses If You choose to distribute Source Code Form that is
+      Incompatible With Secondary Licenses under the terms of this version of
+      the License, the notice described in Exhibit B of this License must be
+      attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a
+notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+      This Source Code Form is "Incompatible
+      With Secondary Licenses", as defined by
+      the Mozilla Public License, v. 2.0.
+

--- a/vendor/github.com/hashicorp/go-cleanhttp/README.md
+++ b/vendor/github.com/hashicorp/go-cleanhttp/README.md
@@ -1,0 +1,30 @@
+# cleanhttp
+
+Functions for accessing "clean" Go http.Client values
+
+-------------
+
+The Go standard library contains a default `http.Client` called
+`http.DefaultClient`. It is a common idiom in Go code to start with
+`http.DefaultClient` and tweak it as necessary, and in fact, this is
+encouraged; from the `http` package documentation:
+
+> The Client's Transport typically has internal state (cached TCP connections),
+so Clients should be reused instead of created as needed. Clients are safe for
+concurrent use by multiple goroutines.
+
+Unfortunately, this is a shared value, and it is not uncommon for libraries to
+assume that they are free to modify it at will. With enough dependencies, it
+can be very easy to encounter strange problems and race conditions due to
+manipulation of this shared value across libraries and goroutines (clients are
+safe for concurrent use, but writing values to the client struct itself is not
+protected).
+
+Making things worse is the fact that a bare `http.Client` will use a default
+`http.Transport` called `http.DefaultTransport`, which is another global value
+that behaves the same way. So it is not simply enough to replace
+`http.DefaultClient` with `&http.Client{}`.
+
+This repository provides some simple functions to get a "clean" `http.Client`
+-- one that uses the same default values as the Go standard library, but
+returns a client that does not share any state with other clients.

--- a/vendor/github.com/hashicorp/go-cleanhttp/cleanhttp.go
+++ b/vendor/github.com/hashicorp/go-cleanhttp/cleanhttp.go
@@ -1,0 +1,40 @@
+package cleanhttp
+
+import (
+	"net"
+	"net/http"
+	"runtime"
+	"time"
+)
+
+// DefaultTransport returns a new http.Transport with the same default values
+// as http.DefaultTransport
+func DefaultTransport() *http.Transport {
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+	SetTransportFinalizer(transport)
+	return transport
+}
+
+// DefaultClient returns a new http.Client with the same default values as
+// http.Client, but with a non-shared Transport
+func DefaultClient() *http.Client {
+	return &http.Client{
+		Transport: DefaultTransport(),
+	}
+}
+
+// SetTransportFinalizer sets a finalizer on the transport to ensure that
+// idle connections are closed prior to garbage collection; otherwise
+// these may leak
+func SetTransportFinalizer(transport *http.Transport) {
+	runtime.SetFinalizer(&transport, func(t **http.Transport) {
+		(*t).CloseIdleConnections()
+	})
+}

--- a/vendor/github.com/weaveworks/go-checkpoint/LICENSE
+++ b/vendor/github.com/weaveworks/go-checkpoint/LICENSE
@@ -1,0 +1,354 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. “Contributor”
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. “Contributor Version”
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor’s Contribution.
+
+1.3. “Contribution”
+
+     means Covered Software of a particular Contributor.
+
+1.4. “Covered Software”
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. “Incompatible With Secondary Licenses”
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of version
+        1.1 or earlier of the License, but not also under the terms of a
+        Secondary License.
+
+1.6. “Executable Form”
+
+     means any form of the work other than Source Code Form.
+
+1.7. “Larger Work”
+
+     means a work that combines Covered Software with other material, in a separate
+     file or files, that is not Covered Software.
+
+1.8. “License”
+
+     means this document.
+
+1.9. “Licensable”
+
+     means having the right to grant, to the maximum extent possible, whether at the
+     time of the initial grant or subsequently, any and all of the rights conveyed by
+     this License.
+
+1.10. “Modifications”
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to, deletion
+        from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. “Patent Claims” of a Contributor
+
+      means any patent claim(s), including without limitation, method, process,
+      and apparatus claims, in any patent Licensable by such Contributor that
+      would be infringed, but for the grant of the License, by the making,
+      using, selling, offering for sale, having made, import, or transfer of
+      either its Contributions or its Contributor Version.
+
+1.12. “Secondary License”
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. “Source Code Form”
+
+      means the form of the work preferred for making modifications.
+
+1.14. “You” (or “Your”)
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, “You” includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, “control” means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or as
+        part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its Contributions
+        or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution become
+     effective for each Contribution on the date the Contributor first distributes
+     such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under this
+     License. No additional rights or licenses will be implied from the distribution
+     or licensing of Covered Software under this License. Notwithstanding Section
+     2.1(b) above, no patent license is granted by a Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party’s
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of its
+        Contributions.
+
+     This License does not grant any rights in the trademarks, service marks, or
+     logos of any Contributor (except as may be necessary to comply with the
+     notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this License
+     (see Section 10.2) or under the terms of a Secondary License (if permitted
+     under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its Contributions
+     are its original creation(s) or it has sufficient rights to grant the
+     rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under applicable
+     copyright doctrines of fair use, fair dealing, or other equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under the
+     terms of this License. You must inform recipients that the Source Code Form
+     of the Covered Software is governed by the terms of this License, and how
+     they can obtain a copy of this License. You may not attempt to alter or
+     restrict the recipients’ rights in the Source Code Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this License,
+        or sublicense it under different terms, provided that the license for
+        the Executable Form does not attempt to limit or alter the recipients’
+        rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for the
+     Covered Software. If the Larger Work is a combination of Covered Software
+     with a work governed by one or more Secondary Licenses, and the Covered
+     Software is not Incompatible With Secondary Licenses, this License permits
+     You to additionally distribute such Covered Software under the terms of
+     such Secondary License(s), so that the recipient of the Larger Work may, at
+     their option, further distribute the Covered Software under the terms of
+     either this License or such Secondary License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices (including
+     copyright notices, patent notices, disclaimers of warranty, or limitations
+     of liability) contained within the Source Code Form of the Covered
+     Software, except that You may alter any license notices to the extent
+     required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on behalf
+     of any Contributor. You must make it absolutely clear that any such
+     warranty, support, indemnity, or liability obligation is offered by You
+     alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute, judicial
+   order, or regulation then You must: (a) comply with the terms of this License
+   to the maximum extent possible; and (b) describe the limitations and the code
+   they affect. Such description must be placed in a text file included with all
+   distributions of the Covered Software under this License. Except to the
+   extent prohibited by statute or regulation, such description must be
+   sufficiently detailed for a recipient of ordinary skill to be able to
+   understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+     if such Contributor fails to notify You of the non-compliance by some
+     reasonable means prior to 60 days after You have come back into compliance.
+     Moreover, Your grants from a particular Contributor are reinstated on an
+     ongoing basis if such Contributor notifies You of the non-compliance by
+     some reasonable means, this is the first time You have received notice of
+     non-compliance with this License from such Contributor, and You become
+     compliant prior to 30 days after Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions, counter-claims,
+     and cross-claims) alleging that a Contributor Version directly or
+     indirectly infringes any patent, then the rights granted to You by any and
+     all Contributors for the Covered Software under Section 2.1 of this License
+     shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an “as is” basis, without
+   warranty of any kind, either expressed, implied, or statutory, including,
+   without limitation, warranties that the Covered Software is free of defects,
+   merchantable, fit for a particular purpose or non-infringing. The entire
+   risk as to the quality and performance of the Covered Software is with You.
+   Should any Covered Software prove defective in any respect, You (not any
+   Contributor) assume the cost of any necessary servicing, repair, or
+   correction. This disclaimer of warranty constitutes an essential part of this
+   License. No use of  any Covered Software is authorized under this License
+   except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from such
+   party’s negligence to the extent applicable law prohibits such limitation.
+   Some jurisdictions do not allow the exclusion or limitation of incidental or
+   consequential damages, so this exclusion and limitation may not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts of
+   a jurisdiction where the defendant maintains its principal place of business
+   and such litigation shall be governed by laws of that jurisdiction, without
+   reference to its conflict-of-law provisions. Nothing in this Section shall
+   prevent a party’s ability to bring cross-claims or counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject matter
+   hereof. If any provision of this License is held to be unenforceable, such
+   provision shall be reformed only to the extent necessary to make it
+   enforceable. Any law or regulation which provides that the language of a
+   contract shall be construed against the drafter shall not be used to construe
+   this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version of
+      the License under which You originally received the Covered Software, or
+      under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a modified
+      version of this License if you rename the license and remove any
+      references to the name of the license steward (except to note that such
+      modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+      If You choose to distribute Source Code Form that is Incompatible With
+      Secondary Licenses under the terms of this version of the License, the
+      notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file, then
+You may include the notice in a location (such as a LICENSE file in a relevant
+directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+      This Source Code Form is “Incompatible
+      With Secondary Licenses”, as defined by
+      the Mozilla Public License, v. 2.0.
+

--- a/vendor/github.com/weaveworks/go-checkpoint/README.md
+++ b/vendor/github.com/weaveworks/go-checkpoint/README.md
@@ -1,0 +1,22 @@
+# Go Checkpoint Client
+
+[Checkpoint](http://checkpoint.hashicorp.com) is an internal service at
+Hashicorp that we use to check version information, broadcoast security
+bulletins, etc.
+
+We understand that software making remote calls over the internet
+for any reason can be undesirable. Because of this, Checkpoint can be
+disabled in all of our software that includes it. You can view the source
+of this client to see that we're not sending any private information.
+
+Each Hashicorp application has it's specific configuration option
+to disable chekpoint calls, but the `CHECKPOINT_DISABLE` makes
+the underlying checkpoint component itself disabled. For example
+in the case of packer:
+```
+CHECKPOINT_DISABLE=1 packer build 
+```
+
+**Note:** This repository is probably useless outside of internal HashiCorp
+use. It is open source for disclosure and because our open source projects
+must be able to link to it.

--- a/vendor/github.com/weaveworks/go-checkpoint/checkpoint.go
+++ b/vendor/github.com/weaveworks/go-checkpoint/checkpoint.go
@@ -1,0 +1,359 @@
+// checkpoint is a package for checking version information and alerts
+// for a HashiCorp product.
+package checkpoint
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	mrand "math/rand"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-cleanhttp"
+)
+
+var magicBytes [4]byte = [4]byte{0x35, 0x77, 0x69, 0xFB}
+
+// CheckParams are the parameters for configuring a check request.
+type CheckParams struct {
+	// Product and version are used to lookup the correct product and
+	// alerts for the proper version. The version is also used to perform
+	// a version check.
+	Product string
+	Version string
+
+	// Arch and OS are used to filter alerts potentially only to things
+	// affecting a specific os/arch combination. If these aren't specified,
+	// they'll be automatically filled in.
+	Arch string
+	OS   string
+
+	// Signature is some random signature that should be stored and used
+	// as a cookie-like value. This ensures that alerts aren't repeated.
+	// If the signature is changed, repeat alerts may be sent down. The
+	// signature should NOT be anything identifiable to a user (such as
+	// a MAC address). It should be random.
+	//
+	// If SignatureFile is given, then the signature will be read from this
+	// file. If the file doesn't exist, then a random signature will
+	// automatically be generated and stored here. SignatureFile will be
+	// ignored if Signature is given.
+	Signature     string
+	SignatureFile string
+
+	// CacheFile, if specified, will cache the result of a check. The
+	// duration of the cache is specified by CacheDuration, and defaults
+	// to 48 hours if not specified. If the CacheFile is newer than the
+	// CacheDuration, than the Check will short-circuit and use those
+	// results.
+	//
+	// If the CacheFile directory doesn't exist, it will be created with
+	// permissions 0755.
+	CacheFile     string
+	CacheDuration time.Duration
+
+	// Force, if true, will force the check even if CHECKPOINT_DISABLE
+	// is set. Within HashiCorp products, this is ONLY USED when the user
+	// specifically requests it. This is never automatically done without
+	// the user's consent.
+	Force bool
+}
+
+// CheckResponse is the response for a check request.
+type CheckResponse struct {
+	Product             string
+	CurrentVersion      string `json:"current_version"`
+	CurrentReleaseDate  int    `json:"current_release_date"`
+	CurrentDownloadURL  string `json:"current_download_url"`
+	CurrentChangelogURL string `json:"current_changelog_url"`
+	ProjectWebsite      string `json:"project_website"`
+	Outdated            bool   `json:"outdated"`
+	Alerts              []*CheckAlert
+}
+
+// CheckAlert is a single alert message from a check request.
+//
+// These never have to be manually constructed, and are typically populated
+// into a CheckResponse as a result of the Check request.
+type CheckAlert struct {
+	ID      int
+	Date    int
+	Message string
+	URL     string
+	Level   string
+}
+
+// Check checks for alerts and new version information.
+func Check(p *CheckParams) (*CheckResponse, error) {
+	if disabled := os.Getenv("CHECKPOINT_DISABLE"); disabled != "" && !p.Force {
+		return &CheckResponse{}, nil
+	}
+
+	// If we have a cached result, then use that
+	if r, err := checkCache(p.Version, p.CacheFile, p.CacheDuration); err != nil {
+		return nil, err
+	} else if r != nil {
+		defer r.Close()
+		return checkResult(r)
+	}
+
+	var u url.URL
+
+	if p.Arch == "" {
+		p.Arch = runtime.GOARCH
+	}
+	if p.OS == "" {
+		p.OS = runtime.GOOS
+	}
+
+	// If we're given a SignatureFile, then attempt to read that.
+	signature := p.Signature
+	if p.Signature == "" && p.SignatureFile != "" {
+		var err error
+		signature, err = checkSignature(p.SignatureFile)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	v := u.Query()
+	v.Set("version", p.Version)
+	v.Set("arch", p.Arch)
+	v.Set("os", p.OS)
+	v.Set("signature", signature)
+
+	u.Scheme = "https"
+	u.Host = "checkpoint-api.weave.works"
+	u.Path = fmt.Sprintf("/v1/check/%s", p.Product)
+	u.RawQuery = v.Encode()
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("User-Agent", "HashiCorp/go-checkpoint")
+
+	client := cleanhttp.DefaultClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Unknown status: %d", resp.StatusCode)
+	}
+
+	var r io.Reader = resp.Body
+	if p.CacheFile != "" {
+		// Make sure the directory holding our cache exists.
+		if err := os.MkdirAll(filepath.Dir(p.CacheFile), 0755); err != nil {
+			return nil, err
+		}
+
+		// We have to cache the result, so write the response to the
+		// file as we read it.
+		f, err := os.Create(p.CacheFile)
+		if err != nil {
+			return nil, err
+		}
+
+		// Write the cache header
+		if err := writeCacheHeader(f, p.Version); err != nil {
+			f.Close()
+			os.Remove(p.CacheFile)
+			return nil, err
+		}
+
+		defer f.Close()
+		r = io.TeeReader(r, f)
+	}
+
+	return checkResult(r)
+}
+
+// CheckInterval is used to check for a response on a given interval duration.
+// The interval is not exact, and checks are randomized to prevent a thundering
+// herd. However, it is expected that on average one check is performed per
+// interval. The returned channel may be closed to stop background checks.
+func CheckInterval(p *CheckParams, interval time.Duration, cb func(*CheckResponse, error)) chan struct{} {
+	doneCh := make(chan struct{})
+
+	if disabled := os.Getenv("CHECKPOINT_DISABLE"); disabled != "" {
+		return doneCh
+	}
+
+	go func() {
+		for {
+			select {
+			case <-time.After(randomStagger(interval)):
+				resp, err := Check(p)
+				cb(resp, err)
+			case <-doneCh:
+				return
+			}
+		}
+	}()
+
+	return doneCh
+}
+
+// randomStagger returns an interval that is between 3/4 and 5/4 of
+// the given interval. The expected value is the interval.
+func randomStagger(interval time.Duration) time.Duration {
+	stagger := time.Duration(mrand.Int63()) % (interval / 2)
+	return 3*(interval/4) + stagger
+}
+
+func checkCache(current string, path string, d time.Duration) (io.ReadCloser, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// File doesn't exist, not a problem
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	if d == 0 {
+		d = 48 * time.Hour
+	}
+
+	if fi.ModTime().Add(d).Before(time.Now()) {
+		// Cache is busted, delete the old file and re-request. We ignore
+		// errors here because re-creating the file is fine too.
+		os.Remove(path)
+		return nil, nil
+	}
+
+	// File looks good so far, open it up so we can inspect the contents.
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check the signature of the file
+	var sig [4]byte
+	if err := binary.Read(f, binary.LittleEndian, sig[:]); err != nil {
+		f.Close()
+		return nil, err
+	}
+	if !reflect.DeepEqual(sig, magicBytes) {
+		// Signatures don't match. Reset.
+		f.Close()
+		return nil, nil
+	}
+
+	// Check the version. If it changed, then rewrite
+	var length uint32
+	if err := binary.Read(f, binary.LittleEndian, &length); err != nil {
+		f.Close()
+		return nil, err
+	}
+	data := make([]byte, length)
+	if _, err := io.ReadFull(f, data); err != nil {
+		f.Close()
+		return nil, err
+	}
+	if string(data) != current {
+		// Version changed, reset
+		f.Close()
+		return nil, nil
+	}
+
+	return f, nil
+}
+
+func checkResult(r io.Reader) (*CheckResponse, error) {
+	var result CheckResponse
+	dec := json.NewDecoder(r)
+	if err := dec.Decode(&result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+func checkSignature(path string) (string, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		// The file exists, read it out
+		sigBytes, err := ioutil.ReadFile(path)
+		if err != nil {
+			return "", err
+		}
+
+		// Split the file into lines
+		lines := strings.SplitN(string(sigBytes), "\n", 2)
+		if len(lines) > 0 {
+			return strings.TrimSpace(lines[0]), nil
+		}
+	}
+
+	// If this isn't a non-exist error, then return that.
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	// The file doesn't exist, so create a signature.
+	var b [16]byte
+	n := 0
+	for n < 16 {
+		n2, err := rand.Read(b[n:])
+		if err != nil {
+			return "", err
+		}
+
+		n += n2
+	}
+	signature := fmt.Sprintf(
+		"%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+
+	// Make sure the directory holding our signature exists.
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return "", err
+	}
+
+	// Write the signature
+	if err := ioutil.WriteFile(path, []byte(signature+"\n\n"+userMessage+"\n"), 0644); err != nil {
+		return "", err
+	}
+
+	return signature, nil
+}
+
+func writeCacheHeader(f io.Writer, v string) error {
+	// Write our signature first
+	if err := binary.Write(f, binary.LittleEndian, magicBytes); err != nil {
+		return err
+	}
+
+	// Write out our current version length
+	var length uint32 = uint32(len(v))
+	if err := binary.Write(f, binary.LittleEndian, length); err != nil {
+		return err
+	}
+
+	_, err := f.Write([]byte(v))
+	return err
+}
+
+// userMessage is suffixed to the signature file to provide feedback.
+var userMessage = `
+This signature is a randomly generated UUID used to de-duplicate
+alerts and version information. This signature is random, it is
+not based on any personally identifiable information. To create
+a new signature, you can simply delete this file at any time.
+See the documentation for the software using Checkpoint for more
+information on how to disable it.
+`

--- a/vendor/github.com/weaveworks/go-checkpoint/checkpoint_test.go
+++ b/vendor/github.com/weaveworks/go-checkpoint/checkpoint_test.go
@@ -1,0 +1,201 @@
+package checkpoint
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestCheck(t *testing.T) {
+	expected := &CheckResponse{
+		Product:             "test",
+		CurrentVersion:      "1.0",
+		CurrentReleaseDate:  0,
+		CurrentDownloadURL:  "http://www.hashicorp.com",
+		CurrentChangelogURL: "http://www.hashicorp.com",
+		ProjectWebsite:      "http://www.hashicorp.com",
+		Outdated:            false,
+		Alerts:              []*CheckAlert{},
+	}
+
+	actual, err := Check(&CheckParams{
+		Product: "test",
+		Version: "1.0",
+	})
+
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
+func TestCheck_disabled(t *testing.T) {
+	os.Setenv("CHECKPOINT_DISABLE", "1")
+	defer os.Setenv("CHECKPOINT_DISABLE", "")
+
+	expected := &CheckResponse{}
+
+	actual, err := Check(&CheckParams{
+		Product: "test",
+		Version: "1.0",
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("expected %+v to equal %+v", actual, expected)
+	}
+}
+
+func TestCheck_cache(t *testing.T) {
+	dir, err := ioutil.TempDir("", "checkpoint")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := &CheckResponse{
+		Product:             "test",
+		CurrentVersion:      "1.0",
+		CurrentReleaseDate:  0,
+		CurrentDownloadURL:  "http://www.hashicorp.com",
+		CurrentChangelogURL: "http://www.hashicorp.com",
+		ProjectWebsite:      "http://www.hashicorp.com",
+		Outdated:            false,
+		Alerts:              []*CheckAlert{},
+	}
+
+	var actual *CheckResponse
+	for i := 0; i < 5; i++ {
+		var err error
+		actual, err = Check(&CheckParams{
+			Product:   "test",
+			Version:   "1.0",
+			CacheFile: filepath.Join(dir, "cache"),
+		})
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
+func TestCheck_cacheNested(t *testing.T) {
+	dir, err := ioutil.TempDir("", "checkpoint")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := &CheckResponse{
+		Product:             "test",
+		CurrentVersion:      "1.0",
+		CurrentReleaseDate:  0,
+		CurrentDownloadURL:  "http://www.hashicorp.com",
+		CurrentChangelogURL: "http://www.hashicorp.com",
+		ProjectWebsite:      "http://www.hashicorp.com",
+		Outdated:            false,
+		Alerts:              []*CheckAlert{},
+	}
+
+	var actual *CheckResponse
+	for i := 0; i < 5; i++ {
+		var err error
+		actual, err = Check(&CheckParams{
+			Product:   "test",
+			Version:   "1.0",
+			CacheFile: filepath.Join(dir, "nested", "cache"),
+		})
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
+func TestCheckInterval(t *testing.T) {
+	expected := &CheckResponse{
+		Product:             "test",
+		CurrentVersion:      "1.0",
+		CurrentReleaseDate:  0,
+		CurrentDownloadURL:  "http://www.hashicorp.com",
+		CurrentChangelogURL: "http://www.hashicorp.com",
+		ProjectWebsite:      "http://www.hashicorp.com",
+		Outdated:            false,
+		Alerts:              []*CheckAlert{},
+	}
+
+	params := &CheckParams{
+		Product: "test",
+		Version: "1.0",
+	}
+
+	calledCh := make(chan struct{})
+	checkFn := func(actual *CheckResponse, err error) {
+		defer close(calledCh)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		if !reflect.DeepEqual(actual, expected) {
+			t.Fatalf("bad: %#v", actual)
+		}
+	}
+
+	doneCh := CheckInterval(params, 500*time.Millisecond, checkFn)
+	defer close(doneCh)
+
+	select {
+	case <-calledCh:
+	case <-time.After(time.Second):
+		t.Fatalf("timeout")
+	}
+}
+
+func TestCheckInterval_disabled(t *testing.T) {
+	os.Setenv("CHECKPOINT_DISABLE", "1")
+	defer os.Setenv("CHECKPOINT_DISABLE", "")
+
+	params := &CheckParams{
+		Product: "test",
+		Version: "1.0",
+	}
+
+	calledCh := make(chan struct{})
+	checkFn := func(actual *CheckResponse, err error) {
+		defer close(calledCh)
+	}
+
+	doneCh := CheckInterval(params, 500*time.Millisecond, checkFn)
+	defer close(doneCh)
+
+	select {
+	case <-calledCh:
+		t.Fatal("expected callback to not invoke")
+	case <-time.After(time.Second):
+	}
+}
+
+func TestRandomStagger(t *testing.T) {
+	intv := 24 * time.Hour
+	min := 18 * time.Hour
+	max := 30 * time.Hour
+	for i := 0; i < 1000; i++ {
+		out := randomStagger(intv)
+		if out < min || out > max {
+			t.Fatalf("bad: %v", out)
+		}
+	}
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -607,6 +607,12 @@
 			"branch": "master"
 		},
 		{
+			"importpath": "github.com/hashicorp/go-cleanhttp",
+			"repository": "https://github.com/hashicorp/go-cleanhttp",
+			"revision": "ce617e79981a8fff618bb643d155133a8f38db96",
+			"branch": "master"
+		},
+		{
 			"importpath": "github.com/hashicorp/go-version",
 			"repository": "https://github.com/hashicorp/go-version",
 			"revision": "7e3c02b30806fa5779d3bdfc152ce4c6f40e7b38",
@@ -733,6 +739,12 @@
 			"revision": "8a2a3a8c488c3ebd98f422a965260278267a0551",
 			"branch": "master",
 			"path": "/codec"
+		},
+		{
+			"importpath": "github.com/weaveworks/go-checkpoint",
+			"repository": "https://github.com/weaveworks/go-checkpoint",
+			"revision": "285991b3508f51033aa288a38d242b9ad26c5274",
+			"branch": "master"
 		},
 		{
 			"importpath": "github.com/weaveworks/go-odp/odp",


### PR DESCRIPTION
Every 2 hours, hit https://checkpoint-api.weave.works looking for current versions of Scope.  If a new version is found, log it.

Reuses the same library as Hashicorp's products.