### PR TITLE
Add "# Containers" column to container images as children

### DIFF
--- a/render/detailed/labels.go
+++ b/render/detailed/labels.go
@@ -8,6 +8,7 @@ import (
 	"github.com/weaveworks/scope/probe/kubernetes"
 	"github.com/weaveworks/scope/probe/overlay"
 	"github.com/weaveworks/scope/probe/process"
+	"github.com/weaveworks/scope/render"
 )
 
 var labels = map[string]string{
@@ -44,6 +45,7 @@ var labels = map[string]string{
 	process.PID:                  "PID",
 	process.PPID:                 "Parent PID",
 	process.Threads:              "# Threads",
+	render.ContainersKey:         "# Containers",
 }
 
 // Label maps from the internal keys to the human-readable label for a piece

--- a/render/detailed/metadata.go
+++ b/render/detailed/metadata.go
@@ -2,6 +2,7 @@ package detailed
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 
 	"github.com/weaveworks/scope/probe/docker"
@@ -9,6 +10,7 @@ import (
 	"github.com/weaveworks/scope/probe/kubernetes"
 	"github.com/weaveworks/scope/probe/overlay"
 	"github.com/weaveworks/scope/probe/process"
+	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -34,6 +36,7 @@ var (
 	)
 	containerImageNodeMetadata = renderMetadata(
 		ltst(docker.ImageID),
+		counter(render.ContainersKey),
 	)
 	podNodeMetadata = renderMetadata(
 		ltst(kubernetes.PodID),
@@ -116,6 +119,15 @@ func ltst(id string) func(report.Node) []MetadataRow {
 	return func(n report.Node) []MetadataRow {
 		if val, ok := n.Latest.Lookup(id); ok {
 			return []MetadataRow{{ID: id, Value: val}}
+		}
+		return nil
+	}
+}
+
+func counter(id string) func(report.Node) []MetadataRow {
+	return func(n report.Node) []MetadataRow {
+		if val, ok := n.Counters.Lookup(id); ok {
+			return []MetadataRow{{ID: id, Value: strconv.Itoa(val)}}
 		}
 		return nil
 	}

--- a/render/detailed/node.go
+++ b/render/detailed/node.go
@@ -85,7 +85,7 @@ var (
 	}{
 		{report.Host, NodeSummaryGroup{TopologyID: "hosts", Label: "Hosts", Columns: []string{host.CPUUsage, host.MemoryUsage}}},
 		{report.Pod, NodeSummaryGroup{TopologyID: "pods", Label: "Pods", Columns: []string{}}},
-		{report.ContainerImage, NodeSummaryGroup{TopologyID: "containers-by-image", Label: "Container Images", Columns: []string{}}},
+		{report.ContainerImage, NodeSummaryGroup{TopologyID: "containers-by-image", Label: "Container Images", Columns: []string{render.ContainersKey}}},
 		{report.Container, NodeSummaryGroup{TopologyID: "containers", Label: "Containers", Columns: []string{docker.CPUTotalUsage, docker.MemoryUsage}}},
 		{report.Process, NodeSummaryGroup{TopologyID: "processes", Label: "Processes", Columns: []string{process.PID, process.CPUUsage, process.MemoryUsage}}},
 	}

--- a/render/detailed/node_test.go
+++ b/render/detailed/node_test.go
@@ -18,7 +18,9 @@ func TestMakeDetailedHostNode(t *testing.T) {
 	renderableNode := render.HostRenderer.Render(fixture.Report)[render.MakeHostID(fixture.ClientHostID)]
 	have := detailed.MakeNode(fixture.Report, renderableNode)
 
-	containerImageNodeSummary, _ := detailed.MakeNodeSummary(fixture.Report.ContainerImage.Nodes[fixture.ClientContainerImageNodeID])
+	containerImageNodeSummary, _ := detailed.MakeNodeSummary(
+		render.ContainerImageRenderer.Render(fixture.Report)[render.MakeContainerImageID(fixture.ClientContainerImageName)].Node,
+	)
 	containerNodeSummary, _ := detailed.MakeNodeSummary(fixture.Report.Container.Nodes[fixture.ClientContainerNodeID])
 	process1NodeSummary, _ := detailed.MakeNodeSummary(fixture.Report.Process.Nodes[fixture.ClientProcess1NodeID])
 	process1NodeSummary.Linkable = true
@@ -83,7 +85,7 @@ func TestMakeDetailedHostNode(t *testing.T) {
 			{
 				Label:      "Container Images",
 				TopologyID: "containers-by-image",
-				Columns:    []string{},
+				Columns:    []string{render.ContainersKey},
 				Nodes:      []detailed.NodeSummary{containerImageNodeSummary},
 			},
 			{

--- a/render/mapping.go
+++ b/render/mapping.go
@@ -23,7 +23,7 @@ const (
 	TheInternetID    = "theinternet"
 	TheInternetMajor = "The Internet"
 
-	containersKey = "containers"
+	ContainersKey = "containers"
 	ipsKey        = "ips"
 	podsKey       = "pods"
 	processesKey  = "processes"
@@ -520,7 +520,7 @@ func MapContainer2ContainerImage(n RenderableNode, _ report.Networks) Renderable
 	// Add container id key to the counters, which will later be counted to produce the minor label
 	id := MakeContainerImageID(imageID)
 	result := NewDerivedNode(id, n.WithParents(report.EmptySets))
-	result.Node.Counters = result.Node.Counters.Add(containersKey, 1)
+	result.Node.Counters = result.Node.Counters.Add(ContainersKey, 1)
 
 	// Add the container as a child of the new image node
 	result.Children = result.Children.Add(n.Node)
@@ -653,7 +653,7 @@ func MapContainer2Pod(n RenderableNode, _ report.Networks) RenderableNodes {
 	// Add container-<id> key to NMD, which will later be counted to produce the
 	// minor label
 	result := NewRenderableNodeWith(id, "", "", podID, n.WithParents(report.EmptySets))
-	result.Counters = result.Counters.Add(containersKey, 1)
+	result.Counters = result.Counters.Add(ContainersKey, 1)
 
 	// Due to a bug in kubernetes, addon pods on the master node are not returned
 	// from the API. This is a workaround until
@@ -690,7 +690,7 @@ func MapContainer2Hostname(n RenderableNode, _ report.Networks) RenderableNodes 
 	result.Rank = id
 
 	// Add container id key to the counters, which will later be counted to produce the minor label
-	result.Counters = result.Counters.Add(containersKey, 1)
+	result.Counters = result.Counters.Add(ContainersKey, 1)
 
 	result.Node.Topology = "container_hostname"
 	result.Node.ID = id
@@ -708,7 +708,7 @@ func MapCountContainers(n RenderableNode, _ report.Networks) RenderableNodes {
 		return RenderableNodes{n.ID: n}
 	}
 
-	containers, _ := n.Node.Counters.Lookup(containersKey)
+	containers, _ := n.Node.Counters.Lookup(ContainersKey)
 	if containers == 1 {
 		n.LabelMinor = "1 container"
 	} else {

--- a/render/topologies.go
+++ b/render/topologies.go
@@ -192,14 +192,7 @@ var AddressRenderer = MakeMap(
 var HostRenderer = MakeReduce(
 	MakeMap(
 		MapX2Host,
-		MakeMap(
-			MapContainerImageIdentity,
-			SelectContainerImage,
-		),
-	),
-	MakeMap(
-		MapX2Host,
-		FilterPseudo(ContainerRenderer),
+		FilterPseudo(ContainerImageRenderer),
 	),
 	MakeMap(
 		MapX2Host,


### PR DESCRIPTION
Side effect of the way it's implemented is that it also adds it to the container image details panel. Could fix, but adds a bit of work to the implementation.

Fixes #821

The column when container images are children:
<img width="436" alt="screen shot 2016-02-05 at 09 26 50" src="https://cloud.githubusercontent.com/assets/250199/12842507/26727be8-cbeb-11e5-8a0a-ee0e86dd8ad0.png">


The container count listed in metadata:
<img width="431" alt="screen shot 2016-02-05 at 09 27 07" src="https://cloud.githubusercontent.com/assets/250199/12842484/1164cda0-cbeb-11e5-90b4-81a6df9070b7.png">

@tomwilkie wdyt?

