### PR TITLE
Reorder the children tables in the details panel

### DIFF
--- a/render/detailed/node.go
+++ b/render/detailed/node.go
@@ -85,9 +85,9 @@ var (
 	}{
 		{report.Host, NodeSummaryGroup{TopologyID: "hosts", Label: "Hosts", Columns: []string{host.CPUUsage, host.MemoryUsage}}},
 		{report.Pod, NodeSummaryGroup{TopologyID: "pods", Label: "Pods", Columns: []string{}}},
-		{report.ContainerImage, NodeSummaryGroup{TopologyID: "containers-by-image", Label: "Container Images", Columns: []string{render.ContainersKey}}},
 		{report.Container, NodeSummaryGroup{TopologyID: "containers", Label: "Containers", Columns: []string{docker.CPUTotalUsage, docker.MemoryUsage}}},
 		{report.Process, NodeSummaryGroup{TopologyID: "processes", Label: "Processes", Columns: []string{process.PID, process.CPUUsage, process.MemoryUsage}}},
+		{report.ContainerImage, NodeSummaryGroup{TopologyID: "containers-by-image", Label: "Container Images", Columns: []string{render.ContainersKey}}},
 	}
 )
 

--- a/render/detailed/node_test.go
+++ b/render/detailed/node_test.go
@@ -83,12 +83,6 @@ func TestMakeDetailedHostNode(t *testing.T) {
 		Controls: []detailed.ControlInstance{},
 		Children: []detailed.NodeSummaryGroup{
 			{
-				Label:      "Container Images",
-				TopologyID: "containers-by-image",
-				Columns:    []string{render.ContainersKey},
-				Nodes:      []detailed.NodeSummary{containerImageNodeSummary},
-			},
-			{
 				Label:      "Containers",
 				TopologyID: "containers",
 				Columns:    []string{docker.CPUTotalUsage, docker.MemoryUsage},
@@ -99,6 +93,12 @@ func TestMakeDetailedHostNode(t *testing.T) {
 				TopologyID: "processes",
 				Columns:    []string{process.PID, process.CPUUsage, process.MemoryUsage},
 				Nodes:      []detailed.NodeSummary{process1NodeSummary, process2NodeSummary},
+			},
+			{
+				Label:      "Container Images",
+				TopologyID: "containers-by-image",
+				Columns:    []string{render.ContainersKey},
+				Nodes:      []detailed.NodeSummary{containerImageNodeSummary},
 			},
 		},
 	}


### PR DESCRIPTION
The Container images was first on hosts, but is probably the least
useful, so this moves it to the bottom.

In general, it needs more thought put into the detail panel contents,
but this is a quick fix to re-prioritize the data.

Fixes #923