### PR TITLE
Don't show blank IPs metadata row for containers with no IP

### DIFF
--- a/probe/docker/container.go
+++ b/probe/docker/container.go
@@ -318,7 +318,10 @@ func (c *container) GetNode(hostID string, localAddrs []net.IP) report.Node {
 	c.RLock()
 	defer c.RUnlock()
 
-	ips := append(c.container.NetworkSettings.SecondaryIPAddresses, c.container.NetworkSettings.IPAddress)
+	ips := c.container.NetworkSettings.SecondaryIPAddresses
+	if c.container.NetworkSettings.IPAddress != "" {
+		ips = append(ips, c.container.NetworkSettings.IPAddress)
+	}
 	// Treat all Docker IPs as local scoped.
 	ipsWithScopes := []string{}
 	for _, ip := range ips {

--- a/probe/docker/container.go
+++ b/probe/docker/container.go
@@ -33,6 +33,7 @@ const (
 	ContainerState         = "docker_container_state"
 	ContainerUptime        = "docker_container_uptime"
 	ContainerRestartCount  = "docker_container_restart_count"
+	ContainerNetworkMode   = "docker_container_network_mode"
 
 	NetworkRxDropped = "network_rx_dropped"
 	NetworkRxBytes   = "network_rx_bytes"
@@ -57,6 +58,8 @@ const (
 	StateRunning = "running"
 	StateStopped = "stopped"
 	StatePaused  = "paused"
+
+	NetworkModeHost = "host"
 
 	stopTimeout = 10
 )
@@ -355,6 +358,7 @@ func (c *container) GetNode(hostID string, localAddrs []net.IP) report.Node {
 		result = result.WithLatests(map[string]string{
 			ContainerUptime:       uptime.String(),
 			ContainerRestartCount: strconv.Itoa(c.container.RestartCount),
+			ContainerNetworkMode:  c.container.HostConfig.NetworkMode,
 		})
 		result = result.WithControls(
 			RestartContainer, StopContainer, PauseContainer, AttachContainer, ExecContainer,

--- a/probe/docker/container.go
+++ b/probe/docker/container.go
@@ -355,10 +355,14 @@ func (c *container) GetNode(hostID string, localAddrs []net.IP) report.Node {
 		result = result.WithControls(UnpauseContainer)
 	} else if c.container.State.Running {
 		uptime := (mtime.Now().Sub(c.container.State.StartedAt) / time.Second) * time.Second
+		networkMode := ""
+		if c.container.HostConfig != nil {
+			networkMode = c.container.HostConfig.NetworkMode
+		}
 		result = result.WithLatests(map[string]string{
 			ContainerUptime:       uptime.String(),
 			ContainerRestartCount: strconv.Itoa(c.container.RestartCount),
-			ContainerNetworkMode:  c.container.HostConfig.NetworkMode,
+			ContainerNetworkMode:  networkMode,
 		})
 		result = result.WithControls(
 			RestartContainer, StopContainer, PauseContainer, AttachContainer, ExecContainer,

--- a/render/topologies.go
+++ b/render/topologies.go
@@ -137,35 +137,28 @@ func (r containerWithHostIPsRenderer) Render(rpt report.Report) RenderableNodes 
 			continue
 		}
 
-		ips, ok := c.Node.Sets.Lookup(docker.ContainerIPs)
-		if ok && len(ips) > 0 {
-			continue
-		}
-
 		h, ok := hosts[MakeHostID(report.ExtractHostID(c.Node))]
 		if !ok {
 			continue
 		}
 
-		hostNetworks, ok := h.Sets.Lookup(host.LocalNetworks)
-		if !ok {
-			continue
-		}
-
-		hostIPs := report.MakeStringSet()
+		newIPs := report.MakeStringSet()
+		hostNetworks, _ := h.Sets.Lookup(host.LocalNetworks)
 		for _, cidr := range hostNetworks {
 			if ip, _, err := net.ParseCIDR(cidr); err == nil {
-				hostIPs = hostIPs.Add(ip.String())
+				newIPs = newIPs.Add(ip.String())
 			}
 		}
 
-		c.Sets = c.Sets.Add(docker.ContainerIPs, hostIPs)
+		c.Sets = c.Sets.Add(docker.ContainerIPs, newIPs)
 		containers[id] = c
 	}
 
 	return containers
 }
 
+// ContainerWithHostIPsRenderer is a Renderer which produces a container graph
+// enriched with host IPs on containers where NetworkMode is Host
 var ContainerWithHostIPsRenderer = containerWithHostIPsRenderer{ContainerRenderer}
 
 type containerWithImageNameRenderer struct {


### PR DESCRIPTION
Previously we were adding the blank default IP, and showing that (an empty row), but we should skip the row if there are no IPs.

@2opremio ptal