### PR TITLE
set TERM=xterm on execs to work around docker issue 9299

### DIFF
--- a/probe/docker/controls.go
+++ b/probe/docker/controls.go
@@ -99,7 +99,7 @@ func (r *registry) execContainer(containerID string, req xfer.Request) xfer.Resp
 		AttachStdout: true,
 		AttachStderr: true,
 		Tty:          true,
-		Cmd:          []string{"/bin/sh"},
+		Cmd:          []string{"/bin/sh", "-c", "TERM=xterm exec /bin/sh"},
 		Container:    containerID,
 	})
 	if err != nil {


### PR DESCRIPTION
Fixes #759

`docker run -t ...` injects `TERM=xterm` into the container, but `docker exec -t ...` doesn't. We can inject it ourselves via env to work around this issue.