### PR TITLE
Refactor app for multitenancy

### DIFF
--- a/app/api_report.go
+++ b/app/api_report.go
@@ -2,12 +2,13 @@ package app
 
 import (
 	"net/http"
+
+	"golang.org/x/net/context"
 )
 
 // Raw report handler
-func makeRawReportHandler(rep Reporter) func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		// r.ParseForm()
-		respondWith(w, http.StatusOK, rep.Report())
+func makeRawReportHandler(rep Reporter) CtxHandlerFunc {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		respondWith(w, http.StatusOK, rep.Report(ctx))
 	}
 }

--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/gorilla/mux"
+	"golang.org/x/net/context"
 
 	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/scope/report"
@@ -192,9 +193,9 @@ func (r *registry) walk(f func(APITopologyDesc)) {
 }
 
 // makeTopologyList returns a handler that yields an APITopologyList.
-func (r *registry) makeTopologyList(rep Reporter) func(w http.ResponseWriter, r *http.Request) {
-	return func(w http.ResponseWriter, req *http.Request) {
-		topologies := r.renderTopologies(rep.Report(), req)
+func (r *registry) makeTopologyList(rep Reporter) CtxHandlerFunc {
+	return func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+		topologies := r.renderTopologies(rep.Report(ctx), req)
 		respondWith(w, http.StatusOK, topologies)
 	}
 }
@@ -252,27 +253,27 @@ func renderedForRequest(r *http.Request, topology APITopologyDesc) render.Render
 	return renderer
 }
 
-type reportRenderHandler func(Reporter, render.Renderer, http.ResponseWriter, *http.Request)
+type reportRenderHandler func(context.Context, Reporter, render.Renderer, http.ResponseWriter, *http.Request)
 
-func (r *registry) captureRenderer(rep Reporter, f reportRenderHandler) http.HandlerFunc {
-	return func(w http.ResponseWriter, req *http.Request) {
+func (r *registry) captureRenderer(rep Reporter, f reportRenderHandler) CtxHandlerFunc {
+	return func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
 		topology, ok := r.get(mux.Vars(req)["topology"])
 		if !ok {
 			http.NotFound(w, req)
 			return
 		}
 		renderer := renderedForRequest(req, topology)
-		f(rep, renderer, w, req)
+		f(ctx, rep, renderer, w, req)
 	}
 }
 
-func (r *registry) captureRendererWithoutFilters(rep Reporter, topologyID string, f reportRenderHandler) http.HandlerFunc {
-	return func(w http.ResponseWriter, req *http.Request) {
+func (r *registry) captureRendererWithoutFilters(rep Reporter, topologyID string, f reportRenderHandler) CtxHandlerFunc {
+	return func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
 		topology, ok := r.get(topologyID)
 		if !ok {
 			http.NotFound(w, req)
 			return
 		}
-		f(rep, topology.renderer, w, req)
+		f(ctx, rep, topology.renderer, w, req)
 	}
 }

--- a/app/collector_test.go
+++ b/app/collector_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/weaveworks/scope/app"
 	"github.com/weaveworks/scope/report"
 	"github.com/weaveworks/scope/test"
@@ -11,6 +13,7 @@ import (
 )
 
 func TestCollector(t *testing.T) {
+	ctx := context.Background()
 	window := time.Millisecond
 	c := app.NewCollector(window)
 
@@ -20,32 +23,33 @@ func TestCollector(t *testing.T) {
 	r2 := report.MakeReport()
 	r2.Endpoint.AddNode("bar", report.MakeNode())
 
-	if want, have := report.MakeReport(), c.Report(); !reflect.DeepEqual(want, have) {
+	if want, have := report.MakeReport(), c.Report(ctx); !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}
 
-	c.Add(r1)
-	if want, have := r1, c.Report(); !reflect.DeepEqual(want, have) {
+	c.Add(ctx, r1)
+	if want, have := r1, c.Report(ctx); !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}
 
-	c.Add(r2)
+	c.Add(ctx, r2)
 
 	merged := report.MakeReport()
 	merged = merged.Merge(r1)
 	merged = merged.Merge(r2)
-	if want, have := merged, c.Report(); !reflect.DeepEqual(want, have) {
+	if want, have := merged, c.Report(ctx); !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}
 }
 
 func TestCollectorWait(t *testing.T) {
+	ctx := context.Background()
 	window := time.Millisecond
 	c := app.NewCollector(window)
 
 	waiter := make(chan struct{}, 1)
-	c.WaitOn(waiter)
-	defer c.UnWait(waiter)
+	c.WaitOn(ctx, waiter)
+	defer c.UnWait(ctx, waiter)
 	c.(interface {
 		Broadcast()
 	}).Broadcast()

--- a/app/control_router.go
+++ b/app/control_router.go
@@ -1,0 +1,69 @@
+package app
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+
+	"golang.org/x/net/context"
+
+	"github.com/weaveworks/scope/common/xfer"
+)
+
+// ControlRouter is a thing that can route control requests and responses
+// between the UI and a probe.
+type ControlRouter interface {
+	Handle(ctx context.Context, probeID string, req xfer.Request) (xfer.Response, error)
+	Register(ctx context.Context, probeID string, handler xfer.ControlHandlerFunc) (int64, error)
+	Deregister(ctx context.Context, probeID string, id int64) error
+}
+
+// NewLocalControlRouter creates a new ControlRouter that does everything
+// locally, in memory.
+func NewLocalControlRouter() ControlRouter {
+	return &localControlRouter{
+		probes: map[string]probe{},
+	}
+}
+
+type localControlRouter struct {
+	sync.Mutex
+	probes map[string]probe
+}
+
+type probe struct {
+	id      int64
+	handler xfer.ControlHandlerFunc
+}
+
+func (l *localControlRouter) Handle(_ context.Context, probeID string, req xfer.Request) (xfer.Response, error) {
+	l.Lock()
+	probe, ok := l.probes[probeID]
+	l.Unlock()
+	if !ok {
+		return xfer.Response{}, fmt.Errorf("Probe %s is not connected right now...", probeID)
+	}
+	return probe.handler(req), nil
+}
+
+func (l *localControlRouter) Register(_ context.Context, probeID string, handler xfer.ControlHandlerFunc) (int64, error) {
+	l.Lock()
+	defer l.Unlock()
+	id := rand.Int63()
+	l.probes[probeID] = probe{
+		id:      id,
+		handler: handler,
+	}
+	return id, nil
+}
+
+func (l *localControlRouter) Deregister(_ context.Context, probeID string, id int64) error {
+	l.Lock()
+	defer l.Unlock()
+	// NB probe might have reconnected in the mean time, need to ensure we do not
+	// delete new connection!  Also, it might have connected then deleted itself!
+	if l.probes[probeID].id == id {
+		delete(l.probes, probeID)
+	}
+	return nil
+}

--- a/app/controls_test.go
+++ b/app/controls_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestControl(t *testing.T) {
 	router := mux.NewRouter()
-	app.RegisterControlRoutes(router)
+	app.RegisterControlRoutes(router, app.NewLocalControlRouter())
 	server := httptest.NewServer(router)
 	defer server.Close()
 

--- a/app/mock_reporter_test.go
+++ b/app/mock_reporter_test.go
@@ -3,12 +3,14 @@ package app_test
 import (
 	"github.com/weaveworks/scope/report"
 	"github.com/weaveworks/scope/test/fixture"
+
+	"golang.org/x/net/context"
 )
 
 // StaticReport is used as a fixture in tests. It emulates an xfer.Collector.
 type StaticReport struct{}
 
-func (s StaticReport) Report() report.Report { return fixture.Report }
-func (s StaticReport) Add(report.Report)     {}
-func (s StaticReport) WaitOn(chan struct{})  {}
-func (s StaticReport) UnWait(chan struct{})  {}
+func (s StaticReport) Report(context.Context) report.Report  { return fixture.Report }
+func (s StaticReport) Add(context.Context, report.Report)    {}
+func (s StaticReport) WaitOn(context.Context, chan struct{}) {}
+func (s StaticReport) UnWait(context.Context, chan struct{}) {}

--- a/app/pipe_router.go
+++ b/app/pipe_router.go
@@ -1,0 +1,180 @@
+package app
+
+import (
+	"io"
+	"sync"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
+
+	"github.com/weaveworks/scope/common/mtime"
+	"github.com/weaveworks/scope/common/xfer"
+)
+
+const (
+	gcInterval  = 30 * time.Second // we check all the pipes every 30s
+	pipeTimeout = 1 * time.Minute  // pipes are closed when a client hasn't been connected for 1 minute
+	gcTimeout   = 10 * time.Minute // after another 10 minutes, tombstoned pipes are forgotten
+)
+
+// End is an enum for either end of the pipe.
+type End int
+
+// Valid values of type End
+const (
+	UIEnd = iota
+	ProbeEnd
+)
+
+// PipeRouter stores pipes and allows you to connect to either end of them.
+type PipeRouter interface {
+	Get(context.Context, string, End) (xfer.Pipe, io.ReadWriter, bool)
+	Release(context.Context, string, End)
+	Delete(context.Context, string)
+	Stop()
+}
+
+// PipeRouter connects incoming and outgoing pipes.
+type localPipeRouter struct {
+	sync.Mutex
+	wait  sync.WaitGroup
+	quit  chan struct{}
+	pipes map[string]*pipe
+}
+
+// for each end of the pipe, we keep a reference count & lastUsedTIme,
+// such that we can timeout pipes when either end is inactive.
+type pipe struct {
+	xfer.Pipe
+
+	tombstoneTime time.Time
+
+	ui, probe end
+}
+
+type end struct {
+	refCount     int
+	lastUsedTime time.Time
+}
+
+func (p *pipe) end(end End) (*end, io.ReadWriter) {
+	ui, probe := p.Ends()
+	if end == UIEnd {
+		return &p.ui, ui
+	}
+	return &p.probe, probe
+}
+
+// NewLocalPipeRouter returns a new local (in-memory) pipe router.
+func NewLocalPipeRouter() PipeRouter {
+	pipeRouter := &localPipeRouter{
+		quit:  make(chan struct{}),
+		pipes: map[string]*pipe{},
+	}
+	pipeRouter.wait.Add(1)
+	go pipeRouter.gcLoop()
+	return pipeRouter
+}
+
+func (pr *localPipeRouter) Get(_ context.Context, id string, e End) (xfer.Pipe, io.ReadWriter, bool) {
+	pr.Lock()
+	defer pr.Unlock()
+	p, ok := pr.pipes[id]
+	if !ok {
+		log.Infof("Creating pipe id %s", id)
+		p = &pipe{
+			ui:    end{lastUsedTime: mtime.Now()},
+			probe: end{lastUsedTime: mtime.Now()},
+			Pipe:  xfer.NewPipe(),
+		}
+		pr.pipes[id] = p
+	}
+	if p.Closed() {
+		return nil, nil, false
+	}
+	end, endIO := p.end(e)
+	end.refCount++
+	return p, endIO, true
+}
+
+func (pr *localPipeRouter) Release(_ context.Context, id string, e End) {
+	pr.Lock()
+	defer pr.Unlock()
+
+	p, ok := pr.pipes[id]
+	if !ok {
+		// uh oh
+		return
+	}
+
+	end, _ := p.end(e)
+	end.refCount--
+	if end.refCount > 0 {
+		return
+	}
+
+	if !p.Closed() {
+		end.lastUsedTime = mtime.Now()
+	}
+}
+
+func (pr *localPipeRouter) Delete(_ context.Context, id string) {
+	pr.Lock()
+	defer pr.Unlock()
+	p, ok := pr.pipes[id]
+	if !ok {
+		return
+	}
+	p.Close()
+	p.tombstoneTime = mtime.Now()
+}
+
+func (pr *localPipeRouter) Stop() {
+	close(pr.quit)
+	pr.wait.Wait()
+}
+
+func (pr *localPipeRouter) gcLoop() {
+	defer pr.wait.Done()
+	ticker := time.Tick(gcInterval)
+	for {
+		select {
+		case <-pr.quit:
+			return
+		case <-ticker:
+		}
+
+		pr.timeout()
+		pr.garbageCollect()
+	}
+}
+
+func (pr *localPipeRouter) timeout() {
+	pr.Lock()
+	defer pr.Unlock()
+	now := mtime.Now()
+	for id, pipe := range pr.pipes {
+		if pipe.Closed() || (pipe.ui.refCount > 0 && pipe.probe.refCount > 0) {
+			continue
+		}
+
+		if (pipe.ui.refCount == 0 && now.Sub(pipe.ui.lastUsedTime) >= pipeTimeout) ||
+			(pipe.probe.refCount == 0 && now.Sub(pipe.probe.lastUsedTime) >= pipeTimeout) {
+			log.Infof("Timing out pipe %s", id)
+			pipe.Close()
+			pipe.tombstoneTime = now
+		}
+	}
+}
+
+func (pr *localPipeRouter) garbageCollect() {
+	pr.Lock()
+	defer pr.Unlock()
+	now := mtime.Now()
+	for pipeID, pipe := range pr.pipes {
+		if pipe.Closed() && now.Sub(pipe.tombstoneTime) >= gcTimeout {
+			delete(pr.pipes, pipeID)
+		}
+	}
+}

--- a/app/pipes.go
+++ b/app/pipes.go
@@ -1,199 +1,54 @@
 package app
 
 import (
-	"io"
 	"net/http"
-	"sync"
-	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
-
-	"github.com/weaveworks/scope/common/mtime"
-	"github.com/weaveworks/scope/common/xfer"
+	"golang.org/x/net/context"
 )
-
-const (
-	gcInterval  = 30 * time.Second // we check all the pipes every 30s
-	pipeTimeout = 1 * time.Minute  // pipes are closed when a client hasn't been connected for 1 minute
-	gcTimeout   = 10 * time.Minute // after another 10 minutes, tombstoned pipes are forgotten
-)
-
-// PipeRouter connects incoming and outgoing pipes.
-type PipeRouter struct {
-	sync.Mutex
-	wait  sync.WaitGroup
-	quit  chan struct{}
-	pipes map[string]*pipe
-}
-
-// for each end of the pipe, we keep a reference count & lastUsedTIme,
-// such that we can timeout pipes when either end is inactive.
-type end struct {
-	refCount     int
-	lastUsedTime time.Time
-}
-
-type pipe struct {
-	ui, probe     end
-	tombstoneTime time.Time
-
-	xfer.Pipe
-}
 
 // RegisterPipeRoutes registers the pipe routes
-func RegisterPipeRoutes(router *mux.Router) *PipeRouter {
-	pipeRouter := &PipeRouter{
-		quit:  make(chan struct{}),
-		pipes: map[string]*pipe{},
-	}
-	pipeRouter.wait.Add(1)
-	go pipeRouter.gcLoop()
+func RegisterPipeRoutes(router *mux.Router, pr PipeRouter) {
 	router.Methods("GET").
 		Path("/api/pipe/{pipeID}").
-		HandlerFunc(pipeRouter.handleWs(func(p *pipe) (*end, io.ReadWriter) {
-		uiEnd, _ := p.Ends()
-		return &p.ui, uiEnd
-	}))
+		HandlerFunc(requestContextDecorator(handlePipeWs(pr, UIEnd)))
+
 	router.Methods("GET").
 		Path("/api/pipe/{pipeID}/probe").
-		HandlerFunc(pipeRouter.handleWs(func(p *pipe) (*end, io.ReadWriter) {
-		_, probeEnd := p.Ends()
-		return &p.probe, probeEnd
-	}))
+		HandlerFunc(requestContextDecorator(handlePipeWs(pr, ProbeEnd)))
+
 	router.Methods("DELETE", "POST").
 		Path("/api/pipe/{pipeID}").
-		HandlerFunc(pipeRouter.delete)
-	return pipeRouter
+		HandlerFunc(requestContextDecorator(deletePipe(pr)))
 }
 
-// Stop stops the pipeRouter
-func (pr *PipeRouter) Stop() {
-	close(pr.quit)
-	pr.wait.Wait()
-}
-
-func (pr *PipeRouter) gcLoop() {
-	defer pr.wait.Done()
-	ticker := time.Tick(gcInterval)
-	for {
-		select {
-		case <-pr.quit:
-			return
-		case <-ticker:
-		}
-
-		pr.timeout()
-		pr.garbageCollect()
-	}
-}
-
-func (pr *PipeRouter) timeout() {
-	pr.Lock()
-	defer pr.Unlock()
-	now := mtime.Now()
-	for id, pipe := range pr.pipes {
-		if pipe.Closed() || (pipe.ui.refCount > 0 && pipe.probe.refCount > 0) {
-			continue
-		}
-
-		if (pipe.ui.refCount == 0 && now.Sub(pipe.ui.lastUsedTime) >= pipeTimeout) ||
-			(pipe.probe.refCount == 0 && now.Sub(pipe.probe.lastUsedTime) >= pipeTimeout) {
-			log.Infof("Timing out pipe %s", id)
-			pipe.Close()
-			pipe.tombstoneTime = now
-		}
-	}
-}
-
-func (pr *PipeRouter) garbageCollect() {
-	pr.Lock()
-	defer pr.Unlock()
-	now := mtime.Now()
-	for pipeID, pipe := range pr.pipes {
-		if pipe.Closed() && now.Sub(pipe.tombstoneTime) >= gcTimeout {
-			delete(pr.pipes, pipeID)
-		}
-	}
-}
-
-func (pr *PipeRouter) getOrCreate(id string) (*pipe, bool) {
-	pr.Lock()
-	defer pr.Unlock()
-	p, ok := pr.pipes[id]
-	if !ok {
-		log.Infof("Creating pipe id %s", id)
-		p = &pipe{
-			ui:    end{lastUsedTime: mtime.Now()},
-			probe: end{lastUsedTime: mtime.Now()},
-			Pipe:  xfer.NewPipe(),
-		}
-		pr.pipes[id] = p
-	}
-	if p.Closed() {
-		return nil, false
-	}
-	return p, true
-}
-
-func (pr *PipeRouter) retain(id string, pipe *pipe, end *end) bool {
-	pr.Lock()
-	defer pr.Unlock()
-	if pipe.Closed() {
-		return false
-	}
-	end.refCount++
-	return true
-}
-
-func (pr *PipeRouter) release(id string, pipe *pipe, end *end) {
-	pr.Lock()
-	defer pr.Unlock()
-
-	end.refCount--
-	if end.refCount != 0 {
-		return
-	}
-
-	if !pipe.Closed() {
-		end.lastUsedTime = mtime.Now()
-	}
-}
-
-func (pr *PipeRouter) handleWs(endSelector func(*pipe) (*end, io.ReadWriter)) func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		pipeID := mux.Vars(r)["pipeID"]
-		pipe, ok := pr.getOrCreate(pipeID)
+func handlePipeWs(pr PipeRouter, end End) CtxHandlerFunc {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		id := mux.Vars(r)["pipeID"]
+		pipe, endIO, ok := pr.Get(ctx, id, end)
 		if !ok {
 			http.NotFound(w, r)
 			return
 		}
-
-		endRef, endIO := endSelector(pipe)
-		if !pr.retain(pipeID, pipe, endRef) {
-			http.NotFound(w, r)
-			return
-		}
-		defer pr.release(pipeID, pipe, endRef)
+		defer pr.Release(ctx, id, end)
 
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
-			log.Errorf("Error upgrading to websocket: %v", err)
+			log.Errorf("Error upgrading pipe %s (%d) websocket: %v", id, end, err)
 			return
 		}
 		defer conn.Close()
 
+		log.Infof("Pipe success %s (%d)", id, end)
 		pipe.CopyToWebsocket(endIO, conn)
 	}
 }
 
-func (pr *PipeRouter) delete(w http.ResponseWriter, r *http.Request) {
-	pipeID := mux.Vars(r)["pipeID"]
-	pipe, ok := pr.getOrCreate(pipeID)
-	if ok && pr.retain(pipeID, pipe, &pipe.ui) {
+func deletePipe(pr PipeRouter) CtxHandlerFunc {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		pipeID := mux.Vars(r)["pipeID"]
 		log.Infof("Closing pipe %s", pipeID)
-		pipe.Close()
-		pipe.tombstoneTime = mtime.Now()
-		pr.release(pipeID, pipe, &pipe.ui)
+		pr.Delete(ctx, pipeID)
 	}
 }

--- a/app/router_test.go
+++ b/app/router_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/ugorji/go/codec"
+	"golang.org/x/net/context"
 
 	"github.com/weaveworks/scope/app"
 	"github.com/weaveworks/scope/test"
@@ -73,7 +74,8 @@ func TestReportPostHandler(t *testing.T) {
 			t.Fatalf("Error posting report: %d", resp.StatusCode)
 		}
 
-		if want, have := fixture.Report.Endpoint.Nodes, c.Report().Endpoint.Nodes; len(have) == 0 || len(want) != len(have) {
+		ctx := context.Background()
+		if want, have := fixture.Report.Endpoint.Nodes, c.Report(ctx).Endpoint.Nodes; len(have) == 0 || len(want) != len(have) {
 			t.Fatalf("Content-Type %s: %v", contentType, test.Diff(have, want))
 		}
 	}

--- a/prog/app.go
+++ b/prog/app.go
@@ -23,8 +23,8 @@ import (
 func router(c app.Collector) http.Handler {
 	router := mux.NewRouter()
 	app.RegisterReportPostHandler(c, router)
-	app.RegisterControlRoutes(router)
-	app.RegisterPipeRoutes(router)
+	app.RegisterControlRoutes(router, app.NewLocalControlRouter())
+	app.RegisterPipeRoutes(router, app.NewLocalPipeRouter())
 	return app.TopologyHandler(c, router, http.FileServer(FS(false)))
 }
 


### PR DESCRIPTION
- Add interfaces to allow for alternative implementations for Collector, ControlRouter
  and PipeRouter.
- Pass contexts on http handlers to these interfaces.  Although not used by the current
  (local, in-memory) implementations, the idea is this will be used to pass headers to
  implementations which support multitenancy (by, for instance, putting an authenticating
  reverse proxy in form of the app, and then inspecting the headers of the request for
  a used id).