### PR TITLE
Reduce amount of objects allocated by the codec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ RUN_FLAGS=-ti
 BUILD_IN_CONTAINER=true
 GO ?= env GO15VENDOREXPERIMENT=1 go
 GO_BUILD_INSTALL_DEPS=-i
-GO_BUILD_TAGS=-tags netgo
+GO_BUILD_TAGS=-tags 'netgo unsafe'
 GO_BUILD_FLAGS=$(GO_BUILD_INSTALL_DEPS) -ldflags "-extldflags \"-static\" -X main.version=$(SCOPE_VERSION)" $(GO_BUILD_TAGS)
 
 all: $(SCOPE_EXPORT)

--- a/vendor/github.com/ugorji/go/codec/encode.go
+++ b/vendor/github.com/ugorji/go/codec/encode.go
@@ -141,13 +141,16 @@ type simpleIoEncWriterWriter struct {
 	w  io.Writer
 	bw io.ByteWriter
 	sw ioEncStringWriter
+	bs [1]byte
 }
 
 func (o *simpleIoEncWriterWriter) WriteByte(c byte) (err error) {
 	if o.bw != nil {
 		return o.bw.WriteByte(c)
 	}
-	_, err = o.w.Write([]byte{c})
+	// _, err = o.w.Write([]byte{c})
+	o.bs[0] = c
+	_, err = o.w.Write(o.bs[:])
 	return
 }
 

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -796,7 +796,7 @@
 		{
 			"importpath": "github.com/ugorji/go/codec",
 			"repository": "https://github.com/ugorji/go",
-			"revision": "9f21f8ea305046b8d17a799e2c73069533a99d24",
+			"revision": "03b46f3d7a8e0457836a5ecd906b4961a5815a63",
 			"branch": "master",
 			"path": "/codec"
 		},


### PR DESCRIPTION
Closes #972 . Improves #812 and #854 

Results in the probe generating ~20% less objects. See https://github.com/ugorji/go/issues/143