### PR TITLE
circle.yml: disable GCE builds when credentials are missing

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ dependencies:
       cp -r $(pwd)/ $SRCDIR
     - "cd $SRCDIR/client; ../tools/rebuild-image weaveworks/scope-ui-build . Dockerfile package.json webpack.production.config.js .eslintrc .babelrc && touch $SRCDIR/.scope_ui_build.uptodate"
     - "cd $SRCDIR/backend; ../tools/rebuild-image weaveworks/scope-backend-build . Dockerfile build.sh && touch $SRCDIR/.scope_backend_build.uptodate"
-    - cd $SRCDIR/integration; ./gce.sh make_template:
+    - test -z "$SECRET_PASSWORD" || (cd $SRCDIR/integration; ./gce.sh make_template):
         parallel: false
 
 test:


### PR DESCRIPTION
Another call to gce.sh was added in commit abebb0f197f3 ("Build new test VM
(to pickup latest Docker version)") but without the guard on
$SECRET_PASSWORD. Add the guard to be able to test on CircleCI without
Weaveworks' credentials.