### PR TITLE
circle.yml: deploy on a personal hub account

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -62,7 +62,10 @@ test:
 deployment:
   hub:
     branch: master
-    owner: weaveworks
     commands:
-      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-      - docker push weaveworks/scope
+      - >
+        test -z "${DOCKER_USER}" || (
+          docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS &&
+          (test "${DOCKER_USER}" == "weaveworks" || docker tag weaveworks/scope:latest $DOCKER_USER/scope:latest) &&
+          docker push $DOCKER_USER/scope
+        )


### PR DESCRIPTION
I would to do some changes in Scope and test my changes in Kubernetes,
following the guide on:
https://github.com/weaveworks/scope#using-weave-scope-with-kubernetes

For that, I need a Docker image of Scope hosted on a Docker hub and
reference that Docker image in my Kubernetes resource yaml file. Instead
of building Scope on my laptop and pushing it manually on my Docker Hub
account, I am using my CircleCI account to do this automatically.

This patch adds a deployment target in circle.yml. It uses the
environment variable $DEPLOY_PRIVATE_HUB_BRANCH from my CircleCI
settings and any push on a branch with a name matching ".*master" (the
branch name must end with "master") will trigger the deployment.

This change should not impact the build of the official Scope Docker
image because $DEPLOY_PRIVATE_HUB_BRANCH is not defined in the official
CircleCI settings (https://circleci.com/gh/weaveworks/scope).