### PR TITLE
A 1ms window is ludicrously small; GC can take longer.

### DIFF
--- a/app/collector_test.go
+++ b/app/collector_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestCollector(t *testing.T) {
 	ctx := context.Background()
-	window := time.Millisecond
+	window := 10 * time.Second
 	c := app.NewCollector(window)
 
 	r1 := report.MakeReport()
@@ -33,7 +33,6 @@ func TestCollector(t *testing.T) {
 	}
 
 	c.Add(ctx, r2)
-
 	merged := report.MakeReport()
 	merged = merged.Merge(r1)
 	merged = merged.Merge(r2)


### PR DESCRIPTION
Fixes #933 