### PR TITLE
circle.yml: add variable $DOCKER_ORGANIZATION

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -66,6 +66,6 @@ deployment:
       - >
         test -z "${DOCKER_USER}" || (
           docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS &&
-          (test "${DOCKER_USER}" == "weaveworks" || docker tag weaveworks/scope:latest $DOCKER_USER/scope:latest) &&
-          docker push $DOCKER_USER/scope
+          (test "${DOCKER_ORGANIZATION:-$DOCKER_USER}" == "weaveworks" || docker tag weaveworks/scope:latest ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope:latest) &&
+          docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope
         )


### PR DESCRIPTION
With this patch, CircleCI will push by default to the Docker repository
$DOCKER_ORGANIZATION/scope. If $DOCKER_ORGANIZATION is not defined, it
will use $DOCKER_USER/scope.

----

See previous PR: https://github.com/weaveworks/scope/pull/1055

@tomwilkie: with this patch, adding `DOCKER_ORGANIZATION=weaveworks` in the CircleCI settings should be enough.

/cc @iaguis
