### PR TITLE
Fix embedded logo size for Safari

### DIFF
--- a/client/app/scripts/charts/nodes-chart.js
+++ b/client/app/scripts/charts/nodes-chart.js
@@ -227,7 +227,9 @@ export default class NodesChart extends React.Component {
         {errorEmpty}
         {errorMaxNodesExceeded}
         <svg width="100%" height="100%" id="nodes-chart-canvas" className={svgClassNames} onClick={this.handleMouseClick}>
-          <Logo/>
+          <g transform="translate(24,24) scale(0.25)">
+            <Logo/>
+          </g>
           <g className="canvas" transform={transform}>
             <g className="edges">
               {edgeElements}

--- a/client/app/styles/main.less
+++ b/client/app/styles/main.less
@@ -165,6 +165,12 @@ h2 {
   height: 80px;
   z-index: 20;
   display: flex;
+
+  .logo {
+    margin: -8px 0 0 64px;
+    height: 64px;
+    width: 250px;
+  }
 }
 
 .footer {
@@ -204,12 +210,6 @@ h2 {
       }
     }
   }
-}
-
-.logo {
-  margin: -8px 0 0 64px;
-  height: 64px;
-  width: 250px;
 }
 
 .topologies {
@@ -297,7 +297,6 @@ h2 {
   svg.exported {
     .logo {
       display: inline;
-      transform: translate(24px, 24px) scale(0.25);
     }
   }
 


### PR DESCRIPTION
* CSS transform is ignored in Safari, using SVG transform instead

Fixes #1071 

![screen shot 2016-03-01 at 16 14 12](https://cloud.githubusercontent.com/assets/859729/13431199/a7fb9136-dfc8-11e5-8bd4-7d16a159a973.png)
