### PR TITLE
Tag shortcut reports.

### DIFF
--- a/probe/probe.go
+++ b/probe/probe.go
@@ -95,6 +95,7 @@ func (p *Probe) Stop() {
 // Publish will queue a report for immediate publication,
 // bypassing the spy tick
 func (p *Probe) Publish(rpt report.Report) {
+	rpt = p.tag(rpt)
 	p.shortcutReports <- rpt
 }
 


### PR DESCRIPTION
Fixes #1065.  I believe it might help with #1090 too.