### PR TITLE
Refactoring for multitenancy

### DIFF
--- a/app/api_report.go
+++ b/app/api_report.go
@@ -9,6 +9,11 @@ import (
 // Raw report handler
 func makeRawReportHandler(rep Reporter) CtxHandlerFunc {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-		respondWith(w, http.StatusOK, rep.Report(ctx))
+		report, err := rep.Report(ctx)
+		if err != nil {
+			respondWith(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		respondWith(w, http.StatusOK, report)
 	}
 }

--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -195,7 +195,12 @@ func (r *registry) walk(f func(APITopologyDesc)) {
 // makeTopologyList returns a handler that yields an APITopologyList.
 func (r *registry) makeTopologyList(rep Reporter) CtxHandlerFunc {
 	return func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
-		topologies := r.renderTopologies(rep.Report(ctx), req)
+		report, err := rep.Report(ctx)
+		if err != nil {
+			respondWith(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		topologies := r.renderTopologies(report, req)
 		respondWith(w, http.StatusOK, topologies)
 	}
 }

--- a/app/collector_test.go
+++ b/app/collector_test.go
@@ -23,12 +23,20 @@ func TestCollector(t *testing.T) {
 	r2 := report.MakeReport()
 	r2.Endpoint.AddNode("bar", report.MakeNode())
 
-	if want, have := report.MakeReport(), c.Report(ctx); !reflect.DeepEqual(want, have) {
+	have, err := c.Report(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+	if want := report.MakeReport(); !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}
 
 	c.Add(ctx, r1)
-	if want, have := r1, c.Report(ctx); !reflect.DeepEqual(want, have) {
+	have, err = c.Report(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+	if want := r1; !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}
 
@@ -36,7 +44,11 @@ func TestCollector(t *testing.T) {
 	merged := report.MakeReport()
 	merged = merged.Merge(r1)
 	merged = merged.Merge(r2)
-	if want, have := merged, c.Report(ctx); !reflect.DeepEqual(want, have) {
+	have, err = c.Report(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+	if want := merged; !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}
 }

--- a/app/mock_reporter_test.go
+++ b/app/mock_reporter_test.go
@@ -10,7 +10,7 @@ import (
 // StaticReport is used as a fixture in tests. It emulates an xfer.Collector.
 type StaticReport struct{}
 
-func (s StaticReport) Report(context.Context) report.Report  { return fixture.Report }
-func (s StaticReport) Add(context.Context, report.Report)    {}
-func (s StaticReport) WaitOn(context.Context, chan struct{}) {}
-func (s StaticReport) UnWait(context.Context, chan struct{}) {}
+func (s StaticReport) Report(context.Context) (report.Report, error) { return fixture.Report, nil }
+func (s StaticReport) Add(context.Context, report.Report) error      { return nil }
+func (s StaticReport) WaitOn(context.Context, chan struct{})         {}
+func (s StaticReport) UnWait(context.Context, chan struct{})         {}

--- a/app/pipes_internal_test.go
+++ b/app/pipes_internal_test.go
@@ -33,9 +33,9 @@ func TestPipeTimeout(t *testing.T) {
 	// create a new pipe.
 	id := "foo"
 	ctx := context.Background()
-	pipe, _, ok := pr.Get(ctx, id, UIEnd)
-	if !ok {
-		t.Fatalf("not ok")
+	pipe, _, err := pr.Get(ctx, id, UIEnd)
+	if err != nil {
+		t.Fatalf("not ok: %v", err)
 	}
 
 	// move time forward such that the new pipe should timeout

--- a/app/router_test.go
+++ b/app/router_test.go
@@ -75,7 +75,11 @@ func TestReportPostHandler(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		if want, have := fixture.Report.Endpoint.Nodes, c.Report(ctx).Endpoint.Nodes; len(have) == 0 || len(want) != len(have) {
+		report, err := c.Report(ctx)
+		if err != nil {
+			t.Error(err)
+		}
+		if want, have := fixture.Report.Endpoint.Nodes, report.Endpoint.Nodes; len(have) == 0 || len(want) != len(have) {
 			t.Fatalf("Content-Type %s: %v", contentType, test.Diff(have, want))
 		}
 	}


### PR DESCRIPTION
Part of #996 

Allows collectors and pipe routers to return errors.