### PR TITLE
More complete node summary

### DIFF
--- a/app/api_topology.go
+++ b/app/api_topology.go
@@ -104,7 +104,7 @@ func handleWebsocket(
 	}(conn)
 
 	var (
-		previousTopo render.RenderableNodes
+		previousTopo detailed.NodeSummaries
 		tick         = time.Tick(loop)
 		wait         = make(chan struct{}, 1)
 	)
@@ -117,8 +117,8 @@ func handleWebsocket(
 			log.Errorf("Error generating report: %v", err)
 			return
 		}
-		newTopo := renderer.Render(report).Prune()
-		diff := render.TopoDiff(previousTopo, newTopo)
+		newTopo := detailed.Summaries(renderer.Render(report))
+		diff := detailed.TopoDiff(previousTopo, newTopo)
 		previousTopo = newTopo
 
 		if err := conn.WriteJSON(diff); err != nil {

--- a/app/api_topology.go
+++ b/app/api_topology.go
@@ -18,7 +18,7 @@ const (
 
 // APITopology is returned by the /api/topology/{name} handler.
 type APITopology struct {
-	Nodes render.RenderableNodes `json:"nodes"`
+	Nodes detailed.NodeSummaries `json:"nodes"`
 }
 
 // APINode is returned by the /api/topology/{name}/{id} handler.
@@ -34,7 +34,7 @@ func handleTopology(ctx context.Context, rep Reporter, renderer render.Renderer,
 		return
 	}
 	respondWith(w, http.StatusOK, APITopology{
-		Nodes: renderer.Render(report).Prune(),
+		Nodes: detailed.Summaries(renderer.Render(report)),
 	})
 }
 

--- a/app/api_topology_test.go
+++ b/app/api_topology_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ugorji/go/codec"
 
 	"github.com/weaveworks/scope/app"
-	"github.com/weaveworks/scope/render"
+	"github.com/weaveworks/scope/render/detailed"
 	"github.com/weaveworks/scope/render/expected"
 	"github.com/weaveworks/scope/test/fixture"
 )
@@ -142,7 +142,7 @@ func TestAPITopologyWebsocket(t *testing.T) {
 
 	_, p, err := ws.ReadMessage()
 	ok(t, err)
-	var d render.Diff
+	var d detailed.Diff
 	decoder := codec.NewDecoderBytes(p, &codec.JsonHandle{})
 	if err := decoder.Decode(&d); err != nil {
 		t.Fatalf("JSON parse error: %s", err)

--- a/app/api_topology_test.go
+++ b/app/api_topology_test.go
@@ -3,7 +3,6 @@ package app_test
 import (
 	"fmt"
 	"net/url"
-	"reflect"
 	"testing"
 
 	"github.com/gorilla/websocket"
@@ -12,7 +11,6 @@ import (
 	"github.com/weaveworks/scope/app"
 	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/scope/render/expected"
-	"github.com/weaveworks/scope/test"
 	"github.com/weaveworks/scope/test/fixture"
 )
 
@@ -98,8 +96,11 @@ func TestAPITopologyHosts(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if want, have := expected.RenderedHosts, topo.Nodes.Prune(); !reflect.DeepEqual(want, have) {
-			t.Error(test.Diff(want, have))
+		// Should have the rendered host nodes
+		for id := range expected.RenderedHosts {
+			if _, ok := topo.Nodes[id]; !ok {
+				t.Errorf("Expected output to include node: %s, but wasn't found", id)
+			}
 		}
 	}
 	{

--- a/client/app/scripts/charts/nodes-chart.js
+++ b/client/app/scripts/charts/nodes-chart.js
@@ -244,7 +244,7 @@ export default class NodesChart extends React.Component {
     // copy relevant fields to state nodes
     return topology.map((node, id) => makeMap({
       id,
-      label: node.get('label_major'),
+      label: node.get('label'),
       pseudo: node.get('pseudo'),
       subLabel: node.get('label_minor'),
       nodeCount: node.get('node_count'),

--- a/client/app/scripts/components/debug-toolbar.js
+++ b/client/app/scripts/components/debug-toolbar.js
@@ -21,7 +21,7 @@ const deltaAdd = (name, adjacency = [], shape = 'circle', stack = false, nodeCou
   stack,
   node_count: nodeCount,
   id: name,
-  label_major: name,
+  label: name,
   label_minor: 'weave-1',
   latest: {},
   metadata: {},

--- a/client/app/scripts/components/embedded-terminal.js
+++ b/client/app/scripts/components/embedded-terminal.js
@@ -8,9 +8,9 @@ import { DETAILS_PANEL_WIDTH, DETAILS_PANEL_MARGINS,
 export default function EmeddedTerminal({pipe, nodeId, details}) {
   const node = details.get(nodeId);
   const d = node && node.details;
-  const titleBarColor = d && getNodeColorDark(d.rank, d.label_major);
-  const statusBarColor = d && getNodeColor(d.rank, d.label_major);
-  const title = d && d.label_major;
+  const titleBarColor = d && getNodeColorDark(d.rank, d.label);
+  const statusBarColor = d && getNodeColor(d.rank, d.label);
+  const title = d && d.label;
 
   const style = {
     right: DETAILS_PANEL_MARGINS.right + DETAILS_PANEL_WIDTH + 10 +

--- a/client/app/scripts/components/node-details.js
+++ b/client/app/scripts/components/node-details.js
@@ -54,7 +54,7 @@ export default class NodeDetails extends React.Component {
 
   renderLoading() {
     const node = this.props.nodes.get(this.props.nodeId);
-    const label = node ? node.get('label_major') : this.props.label;
+    const label = node ? node.get('label') : this.props.label;
     const nodeColor = (node ?
                        getNodeColorDark(node.get('rank'), label, node.get('pseudo')) :
                        getNeutralColor());

--- a/client/app/scripts/stores/__tests__/app-store-test.js
+++ b/client/app/scripts/stores/__tests__/app-store-test.js
@@ -17,7 +17,7 @@ describe('AppStore', () => {
       rank: undefined,
       adjacency: ['n1', 'n2'],
       pseudo: undefined,
-      label_major: undefined,
+      label: undefined,
       label_minor: undefined
     },
     n2: {
@@ -25,7 +25,7 @@ describe('AppStore', () => {
       rank: undefined,
       adjacency: undefined,
       pseudo: undefined,
-      label_major: undefined,
+      label: undefined,
       label_minor: undefined
     }
   };

--- a/client/app/scripts/stores/app-store.js
+++ b/client/app/scripts/stores/app-store.js
@@ -21,7 +21,7 @@ const error = debug('scope:error');
 function makeNode(node) {
   return {
     id: node.id,
-    label_major: node.label_major,
+    label: node.label,
     label_minor: node.label_minor,
     node_count: node.node_count,
     rank: node.rank,

--- a/experimental/graphviz/handlers.go
+++ b/experimental/graphviz/handlers.go
@@ -21,7 +21,7 @@ func dot(w io.Writer, t render.RenderableNodes) {
 	fmt.Fprintf(w, "\tnode [style=filled];\n")
 	fmt.Fprintf(w, "\t\n")
 	for id, rn := range t {
-		label := rn.LabelMajor
+		label := rn.Label
 		if len(label) > 20 {
 			label = label[:20] + "..."
 		}

--- a/integration/config.sh
+++ b/integration/config.sh
@@ -39,7 +39,7 @@ has() {
 	local host=$2
 	local name=$3
 	local count=${4:-1}
-	assert "curl -s http://${host}:4040/api/topology/${view}?system=show | jq -r '[.nodes[] | select(.label_major == \"${name}\")] | length'" $count
+	assert "curl -s http://${host}:4040/api/topology/${view}?system=show | jq -r '[.nodes[] | select(.label == \"${name}\")] | length'" $count
 }
 
 # this checks we have a named container
@@ -51,7 +51,7 @@ node_id() {
     local view="$1"
 	local host="$2"
 	local name="$3"
-	echo $(curl -s http://${host}:4040/api/topology/${view}?system=show | jq -r ".nodes[] | select(.label_major == \"${name}\") | .id")
+	echo $(curl -s http://${host}:4040/api/topology/${view}?system=show | jq -r ".nodes[] | select(.label == \"${name}\") | .id")
 }
 
 container_id() {
@@ -103,7 +103,7 @@ wait_for() {
 		local nodes="$(curl -s http://$host:4040/api/topology/${view}?system=show)"
 		local found=0
 		for name in "$@"; do
-			local count=$(echo "${nodes}" | jq -r "[.nodes[] | select(.label_major == \"${name}\")] | length")
+			local count=$(echo "${nodes}" | jq -r "[.nodes[] | select(.label == \"${name}\")] | length")
 			if [ -n "${count}" ] && [ "${count}" -ge 1 ]; then
 				found=$(( found + 1 ))
 			fi

--- a/render/detailed/connections.go
+++ b/render/detailed/connections.go
@@ -160,7 +160,7 @@ func isInternetNode(n render.RenderableNode) bool {
 func connectionRows(in map[connectionsRow]int, includeLocal bool) []NodeSummary {
 	nodes := []NodeSummary{}
 	for row, count := range in {
-		id, label, linkable := row.remoteNode.ID, row.remoteNode.LabelMajor, true
+		id, label, linkable := row.remoteNode.ID, row.remoteNode.Label, true
 		if row.remoteAddr != "" {
 			id, label, linkable = row.remoteAddr+":"+row.port, row.remoteAddr, false
 		}

--- a/render/detailed/metadata.go
+++ b/render/detailed/metadata.go
@@ -119,10 +119,7 @@ type MetadataRow struct {
 
 // Copy returns a value copy of a metadata row.
 func (m MetadataRow) Copy() MetadataRow {
-	return MetadataRow{
-		ID:    m.ID,
-		Value: m.Value,
-	}
+	return m
 }
 
 // MarshalJSON shouldn't be used, use CodecEncodeSelf instead

--- a/render/detailed/metadata_test.go
+++ b/render/detailed/metadata_test.go
@@ -47,3 +47,29 @@ func TestNodeMetadata(t *testing.T) {
 		}
 	}
 }
+
+func TestMetadataRowCopy(t *testing.T) {
+	var (
+		row = detailed.MetadataRow{
+			ID:       "id",
+			Value:    "value",
+			Prime:    true,
+			Datatype: "datatype",
+		}
+		cp = row.Copy()
+	)
+
+	// copy should be identical
+	if !reflect.DeepEqual(row, cp) {
+		t.Error(test.Diff(row, cp))
+	}
+
+	// changing the copy should not change the original
+	cp.ID = ""
+	cp.Value = ""
+	cp.Prime = false
+	cp.Datatype = ""
+	if row.ID != "id" || row.Value != "value" || row.Prime != true || row.Datatype != "datatype" {
+		t.Errorf("Expected changing the copy not to modify the original")
+	}
+}

--- a/render/detailed/metrics.go
+++ b/render/detailed/metrics.go
@@ -47,6 +47,22 @@ type MetricRow struct {
 	Metric *report.Metric
 }
 
+// Summary returns a copy of the MetricRow, without the samples, just the value if there is one.
+func (m MetricRow) Summary() MetricRow {
+	row := MetricRow{
+		ID:     m.ID,
+		Format: m.Format,
+		Group:  m.Group,
+		Value:  m.Value,
+	}
+	if m.Metric != nil {
+		var metric = m.Metric.Copy()
+		metric.Samples = nil
+		row.Metric = &metric
+	}
+	return row
+}
+
 // Copy returns a value copy of the MetricRow
 func (m MetricRow) Copy() MetricRow {
 	row := MetricRow{

--- a/render/detailed/metrics_test.go
+++ b/render/detailed/metrics_test.go
@@ -3,6 +3,7 @@ package detailed_test
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/weaveworks/scope/probe/docker"
 	"github.com/weaveworks/scope/probe/host"
@@ -108,5 +109,32 @@ func TestNodeMetrics(t *testing.T) {
 		if !reflect.DeepEqual(input.want, have) {
 			t.Errorf("%s: %s", input.name, test.Diff(input.want, have))
 		}
+	}
+}
+
+func TestMetricRowSummary(t *testing.T) {
+	var (
+		now    = time.Now()
+		metric = report.MakeMetric().Add(now, 1.234)
+		row    = detailed.MetricRow{
+			ID:     "id",
+			Format: "format",
+			Group:  "group",
+			Value:  1.234,
+			Metric: &metric,
+		}
+		summary = row.Summary()
+	)
+	// summary should have all the same fields
+	if row.ID != summary.ID || row.Format != summary.Format || row.Group != summary.Group || row.Value != summary.Value {
+		t.Errorf("Expected summary to have same fields as original: %#v, but had %#v", row, summary)
+	}
+	// summary should not have any samples
+	if summary.Metric.Len() != 0 {
+		t.Errorf("Expected summary to have no samples, but had %d", summary.Metric.Len())
+	}
+	// original metric should still have its samples
+	if metric.Len() != 1 {
+		t.Errorf("Expected original metric to still have it's samples, but had %d", metric.Len())
 	}
 }

--- a/render/detailed/node.go
+++ b/render/detailed/node.go
@@ -1,6 +1,7 @@
 package detailed
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/ugorji/go/codec"
@@ -16,8 +17,6 @@ import (
 // we want deep information about an individual node.
 type Node struct {
 	NodeSummary
-	Rank        string             `json:"rank,omitempty"`
-	Pseudo      bool               `json:"pseudo,omitempty"`
 	Controls    []ControlInstance  `json:"controls"`
 	Children    []NodeSummaryGroup `json:"children,omitempty"`
 	Parents     []Parent           `json:"parents,omitempty"`
@@ -80,14 +79,15 @@ func (c *ControlInstance) CodecDecodeSelf(decoder *codec.Decoder) {
 // MakeNode transforms a renderable node to a detailed node. It uses
 // aggregate metadata, plus the set of origin node IDs, to produce tables.
 func MakeNode(topologyID string, r report.Report, ns render.RenderableNodes, n render.RenderableNode) Node {
-	summary, _ := MakeNodeSummary(n)
+	summary, ok := MakeNodeSummary(n)
+	if !ok {
+		fmt.Printf("[DEBUG] MakeNodeSummary(%#v) !ok\n", n)
+	}
 	summary.ID = n.ID
 	summary.Label = n.Label
 
 	return Node{
 		NodeSummary: summary,
-		Rank:        n.Rank,
-		Pseudo:      n.Pseudo,
 		Controls:    controls(r, n),
 		Children:    children(n),
 		Parents:     Parents(r, n),

--- a/render/detailed/node.go
+++ b/render/detailed/node.go
@@ -82,7 +82,7 @@ func (c *ControlInstance) CodecDecodeSelf(decoder *codec.Decoder) {
 func MakeNode(topologyID string, r report.Report, ns render.RenderableNodes, n render.RenderableNode) Node {
 	summary, _ := MakeNodeSummary(n)
 	summary.ID = n.ID
-	summary.Label = n.LabelMajor
+	summary.Label = n.Label
 
 	return Node{
 		NodeSummary: summary,

--- a/render/detailed/node.go
+++ b/render/detailed/node.go
@@ -1,7 +1,6 @@
 package detailed
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/ugorji/go/codec"
@@ -79,10 +78,7 @@ func (c *ControlInstance) CodecDecodeSelf(decoder *codec.Decoder) {
 // MakeNode transforms a renderable node to a detailed node. It uses
 // aggregate metadata, plus the set of origin node IDs, to produce tables.
 func MakeNode(topologyID string, r report.Report, ns render.RenderableNodes, n render.RenderableNode) Node {
-	summary, ok := MakeNodeSummary(n)
-	if !ok {
-		fmt.Printf("[DEBUG] MakeNodeSummary(%#v) !ok\n", n)
-	}
+	summary, _ := MakeNodeSummary(n)
 	summary.ID = n.ID
 	summary.Label = n.Label
 
@@ -196,7 +192,7 @@ func children(n render.RenderableNode) []NodeSummaryGroup {
 	n.Children.ForEach(func(child render.RenderableNode) {
 		if child.ID != n.ID {
 			if summary, ok := MakeNodeSummary(child); ok {
-				summaries[child.Topology] = append(summaries[child.Topology], summary)
+				summaries[child.Topology] = append(summaries[child.Topology], summary.SummarizeMetrics())
 			}
 		}
 	})

--- a/render/detailed/node_test.go
+++ b/render/detailed/node_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/scope/render/detailed"
 	"github.com/weaveworks/scope/render/expected"
+	"github.com/weaveworks/scope/report"
 	"github.com/weaveworks/scope/test"
 	"github.com/weaveworks/scope/test/fixture"
 )
@@ -36,9 +37,14 @@ func TestMakeDetailedHostNode(t *testing.T) {
 	process2NodeSummary.Linkable = true
 	want := detailed.Node{
 		NodeSummary: detailed.NodeSummary{
-			ID:       render.MakeHostID(fixture.ClientHostID),
-			Label:    "client",
-			Linkable: true,
+			ID:         render.MakeHostID(fixture.ClientHostID),
+			Label:      "client",
+			LabelMinor: "hostname.com",
+			Rank:       "hostname.com",
+			Pseudo:     false,
+			Shape:      "circle",
+			Linkable:   true,
+			Adjacency:  report.MakeIDList("host:server.hostname.com"),
 			Metadata: []detailed.MetadataRow{
 				{
 					ID:    "host_name",
@@ -86,8 +92,6 @@ func TestMakeDetailedHostNode(t *testing.T) {
 				},
 			},
 		},
-		Rank:     "hostname.com",
-		Pseudo:   false,
 		Controls: []detailed.ControlInstance{},
 		Children: []detailed.NodeSummaryGroup{
 			{
@@ -161,9 +165,12 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 	have := detailed.MakeNode("containers", fixture.Report, renderableNodes, renderableNode)
 	want := detailed.Node{
 		NodeSummary: detailed.NodeSummary{
-			ID:       id,
-			Label:    "server",
-			Linkable: true,
+			ID:         id,
+			Label:      "server",
+			LabelMinor: "server.hostname.com",
+			Shape:      "hexagon",
+			Linkable:   true,
+			Pseudo:     false,
 			Metadata: []detailed.MetadataRow{
 				{ID: "docker_container_id", Value: fixture.ServerContainerID, Prime: true},
 				{ID: "docker_container_state", Value: "running", Prime: true},
@@ -190,7 +197,6 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 				},
 			},
 		},
-		Pseudo:   false,
 		Controls: []detailed.ControlInstance{},
 		Children: []detailed.NodeSummaryGroup{
 			{
@@ -199,9 +205,12 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 				Columns:    []detailed.Column{detailed.MakeColumn(process.PID), detailed.MakeColumn(process.CPUUsage), detailed.MakeColumn(process.MemoryUsage)},
 				Nodes: []detailed.NodeSummary{
 					{
-						ID:       fmt.Sprintf("process:%s:%s", "server.hostname.com", fixture.ServerPID),
-						Label:    "apache",
-						Linkable: true,
+						ID:         fmt.Sprintf("process:%s:%s", "server.hostname.com", fixture.ServerPID),
+						Label:      "apache",
+						LabelMinor: "server.hostname.com (215)",
+						Rank:       "apache",
+						Shape:      "square",
+						Linkable:   true,
 						Metadata: []detailed.MetadataRow{
 							{ID: process.PID, Value: fixture.ServerPID, Prime: true, Datatype: "number"},
 						},

--- a/render/detailed/node_test.go
+++ b/render/detailed/node_test.go
@@ -21,19 +21,18 @@ func TestMakeDetailedHostNode(t *testing.T) {
 	renderableNode := renderableNodes[render.MakeHostID(fixture.ClientHostID)]
 	have := detailed.MakeNode("hosts", fixture.Report, renderableNodes, renderableNode)
 
-	containerImageNodeSummary, _ := detailed.MakeNodeSummary(
-		render.ContainerImageRenderer.Render(fixture.Report)[expected.ClientContainerImageID],
-	)
-	containerNodeSummary, _ := detailed.MakeNodeSummary(
-		render.ContainerRenderer.Render(fixture.Report)[expected.ClientContainerID],
-	)
-	process1NodeSummary, _ := detailed.MakeNodeSummary(
-		render.ProcessRenderer.Render(fixture.Report)[expected.ClientProcess1ID],
-	)
+	child := func(r render.Renderer, id string) detailed.NodeSummary {
+		s, ok := detailed.MakeNodeSummary(r.Render(fixture.Report)[id])
+		if !ok {
+			t.Fatalf("Expected node %s to be summarizable, but wasn't", id)
+		}
+		return s.SummarizeMetrics()
+	}
+	containerImageNodeSummary := child(render.ContainerImageRenderer, expected.ClientContainerImageID)
+	containerNodeSummary := child(render.ContainerRenderer, expected.ClientContainerID)
+	process1NodeSummary := child(render.ProcessRenderer, expected.ClientProcess1ID)
 	process1NodeSummary.Linkable = true
-	process2NodeSummary, _ := detailed.MakeNodeSummary(
-		render.ProcessRenderer.Render(fixture.Report)[expected.ClientProcess2ID],
-	)
+	process2NodeSummary := child(render.ProcessRenderer, expected.ClientProcess2ID)
 	process2NodeSummary.Linkable = true
 	want := detailed.Node{
 		NodeSummary: detailed.NodeSummary{
@@ -214,7 +213,6 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 						Metadata: []detailed.MetadataRow{
 							{ID: process.PID, Value: fixture.ServerPID, Prime: true, Datatype: "number"},
 						},
-						Metrics: []detailed.MetricRow{},
 					},
 				},
 			},

--- a/render/detailed/summary.go
+++ b/render/detailed/summary.go
@@ -86,6 +86,16 @@ func MakeNodeSummary(n render.RenderableNode) (NodeSummary, bool) {
 	return summary, true
 }
 
+// SummarizeMetrics returns a copy of the NodeSummary where the metrics are
+// replaced with their summaries
+func (n NodeSummary) SummarizeMetrics() NodeSummary {
+	cp := n.Copy()
+	for i, m := range cp.Metrics {
+		cp.Metrics[i] = m.Summary()
+	}
+	return cp
+}
+
 // Copy returns a value copy of the NodeSummary
 func (n NodeSummary) Copy() NodeSummary {
 	result := NodeSummary{
@@ -147,6 +157,9 @@ func Summaries(rns render.RenderableNodes) NodeSummaries {
 	result := NodeSummaries{}
 	for id, node := range rns {
 		if summary, ok := MakeNodeSummary(node); ok {
+			for i, m := range summary.Metrics {
+				summary.Metrics[i] = m.Summary()
+			}
 			result[id] = summary
 		}
 	}

--- a/render/detailed/summary.go
+++ b/render/detailed/summary.go
@@ -151,8 +151,10 @@ func (s nodeSummariesByID) Len() int           { return len(s) }
 func (s nodeSummariesByID) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s nodeSummariesByID) Less(i, j int) bool { return s[i].ID < s[j].ID }
 
+// NodeSummaries is a set of NodeSummaries indexed by ID.
 type NodeSummaries map[string]NodeSummary
 
+// Summaries converts RenderableNodes into a set of NodeSummaries
 func Summaries(rns render.RenderableNodes) NodeSummaries {
 	result := NodeSummaries{}
 	for id, node := range rns {

--- a/render/detailed/summary.go
+++ b/render/detailed/summary.go
@@ -48,7 +48,7 @@ type NodeSummary struct {
 	ID           string        `json:"id"`
 	Label        string        `json:"label"`
 	LabelMinor   string        `json:"label_minor"`
-	Rank         string        `json:"rank,omitempty"`
+	Rank         string        `json:"rank"`
 	Shape        string        `json:"shape,omitempty"`
 	Stack        bool          `json:"stack,omitempty"`
 	Linkable     bool          `json:"linkable,omitempty"` // Whether this node can be linked-to

--- a/render/detailed/topology_diff.go
+++ b/render/detailed/topology_diff.go
@@ -1,19 +1,19 @@
-package render
+package detailed
 
 import (
 	"reflect"
 )
 
 // Diff is returned by TopoDiff. It represents the changes between two
-// RenderableNode maps.
+// NodeSummary maps.
 type Diff struct {
-	Add    []RenderableNode `json:"add"`
-	Update []RenderableNode `json:"update"`
-	Remove []string         `json:"remove"`
+	Add    []NodeSummary `json:"add"`
+	Update []NodeSummary `json:"update"`
+	Remove []string      `json:"remove"`
 }
 
 // TopoDiff gives you the diff to get from A to B.
-func TopoDiff(a, b RenderableNodes) Diff {
+func TopoDiff(a, b NodeSummaries) Diff {
 	diff := Diff{}
 
 	notSeen := map[string]struct{}{}

--- a/render/detailed/topology_diff_test.go
+++ b/render/detailed/topology_diff_test.go
@@ -1,43 +1,40 @@
-package render_test
+package detailed_test
 
 import (
 	"reflect"
 	"sort"
 	"testing"
 
-	"github.com/weaveworks/scope/render"
+	"github.com/weaveworks/scope/render/detailed"
 	"github.com/weaveworks/scope/report"
 	"github.com/weaveworks/scope/test"
 )
 
-// ByID is a sort interface for a RenderableNode slice.
-type ByID []render.RenderableNode
+// ByID is a sort interface for a NodeSummary slice.
+type ByID []detailed.NodeSummary
 
 func (r ByID) Len() int           { return len(r) }
 func (r ByID) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
 func (r ByID) Less(i, j int) bool { return r[i].ID < r[j].ID }
 
 func TestTopoDiff(t *testing.T) {
-	nodea := render.RenderableNode{
+	nodea := detailed.NodeSummary{
 		ID:         "nodea",
 		Label:      "Node A",
 		LabelMinor: "'ts an a",
 		Pseudo:     false,
-		Node:       report.MakeNode().WithAdjacent("nodeb"),
+		Adjacency:  report.MakeIDList("nodeb"),
 	}
-	nodeap := nodea
-	nodeap.Adjacency = []string{
-		"nodeb",
-		"nodeq", // not the same anymore
-	}
-	nodeb := render.RenderableNode{
+	nodeap := nodea.Copy()
+	nodeap.Adjacency = report.MakeIDList("nodeb", "nodeq") // not the same anymore
+	nodeb := detailed.NodeSummary{
 		ID:    "nodeb",
 		Label: "Node B",
 	}
 
 	// Helper to make RenderableNode maps.
-	nodes := func(ns ...render.RenderableNode) render.RenderableNodes {
-		r := render.RenderableNodes{}
+	nodes := func(ns ...detailed.NodeSummary) detailed.NodeSummaries {
+		r := detailed.NodeSummaries{}
 		for _, n := range ns {
 			r[n.ID] = n
 		}
@@ -46,40 +43,40 @@ func TestTopoDiff(t *testing.T) {
 
 	for _, c := range []struct {
 		label      string
-		have, want render.Diff
+		have, want detailed.Diff
 	}{
 		{
 			label: "basecase: empty -> something",
-			have:  render.TopoDiff(nodes(), nodes(nodea, nodeb)),
-			want: render.Diff{
-				Add: []render.RenderableNode{nodea, nodeb},
+			have:  detailed.TopoDiff(nodes(), nodes(nodea, nodeb)),
+			want: detailed.Diff{
+				Add: []detailed.NodeSummary{nodea, nodeb},
 			},
 		},
 		{
 			label: "basecase: something -> empty",
-			have:  render.TopoDiff(nodes(nodea, nodeb), nodes()),
-			want: render.Diff{
+			have:  detailed.TopoDiff(nodes(nodea, nodeb), nodes()),
+			want: detailed.Diff{
 				Remove: []string{"nodea", "nodeb"},
 			},
 		},
 		{
 			label: "add and remove",
-			have:  render.TopoDiff(nodes(nodea), nodes(nodeb)),
-			want: render.Diff{
-				Add:    []render.RenderableNode{nodeb},
+			have:  detailed.TopoDiff(nodes(nodea), nodes(nodeb)),
+			want: detailed.Diff{
+				Add:    []detailed.NodeSummary{nodeb},
 				Remove: []string{"nodea"},
 			},
 		},
 		{
 			label: "no change",
-			have:  render.TopoDiff(nodes(nodea), nodes(nodea)),
-			want:  render.Diff{},
+			have:  detailed.TopoDiff(nodes(nodea), nodes(nodea)),
+			want:  detailed.Diff{},
 		},
 		{
 			label: "change a single node",
-			have:  render.TopoDiff(nodes(nodea), nodes(nodeap)),
-			want: render.Diff{
-				Update: []render.RenderableNode{nodeap},
+			have:  detailed.TopoDiff(nodes(nodea), nodes(nodeap)),
+			want: detailed.Diff{
+				Update: []detailed.NodeSummary{nodeap},
 			},
 		},
 	} {

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -112,11 +112,11 @@ var (
 
 	unknownPseudoNode1 = func(adjacent string) render.RenderableNode {
 		return render.RenderableNode{
-			ID:         unknownPseudoNode1ID,
-			LabelMajor: fixture.UnknownClient1IP,
-			Pseudo:     true,
-			Shape:      circle,
-			Node:       report.MakeNode().WithAdjacent(adjacent),
+			ID:     unknownPseudoNode1ID,
+			Label:  fixture.UnknownClient1IP,
+			Pseudo: true,
+			Shape:  circle,
+			Node:   report.MakeNode().WithAdjacent(adjacent),
 			Children: render.MakeRenderableNodeSet(
 				RenderedEndpoints[UnknownClient1EndpointID],
 				RenderedEndpoints[UnknownClient2EndpointID],
@@ -129,11 +129,11 @@ var (
 	}
 	unknownPseudoNode2 = func(adjacent string) render.RenderableNode {
 		return render.RenderableNode{
-			ID:         unknownPseudoNode2ID,
-			LabelMajor: fixture.UnknownClient3IP,
-			Pseudo:     true,
-			Shape:      circle,
-			Node:       report.MakeNode().WithAdjacent(adjacent),
+			ID:     unknownPseudoNode2ID,
+			Label:  fixture.UnknownClient3IP,
+			Pseudo: true,
+			Shape:  circle,
+			Node:   report.MakeNode().WithAdjacent(adjacent),
 			Children: render.MakeRenderableNodeSet(
 				RenderedEndpoints[UnknownClient3EndpointID],
 			),
@@ -146,7 +146,7 @@ var (
 	theIncomingInternetNode = func(adjacent string) render.RenderableNode {
 		return render.RenderableNode{
 			ID:         render.IncomingInternetID,
-			LabelMajor: render.InboundMajor,
+			Label:      render.InboundMajor,
 			LabelMinor: render.InboundMinor,
 			Pseudo:     true,
 			Shape:      cloud,
@@ -162,7 +162,7 @@ var (
 	}
 	theOutgoingInternetNode = render.RenderableNode{
 		ID:           render.OutgoingInternetID,
-		LabelMajor:   render.OutboundMajor,
+		Label:        render.OutboundMajor,
 		LabelMinor:   render.OutboundMinor,
 		Pseudo:       true,
 		Shape:        cloud,
@@ -176,7 +176,7 @@ var (
 	RenderedProcesses = (render.RenderableNodes{
 		ClientProcess1ID: {
 			ID:         ClientProcess1ID,
-			LabelMajor: fixture.Client1Name,
+			Label:      fixture.Client1Name,
 			LabelMinor: fmt.Sprintf("%s (%s)", fixture.ClientHostID, fixture.Client1PID),
 			Rank:       fixture.Client1Name,
 			Shape:      square,
@@ -191,7 +191,7 @@ var (
 		},
 		ClientProcess2ID: {
 			ID:         ClientProcess2ID,
-			LabelMajor: fixture.Client2Name,
+			Label:      fixture.Client2Name,
 			LabelMinor: fmt.Sprintf("%s (%s)", fixture.ClientHostID, fixture.Client2PID),
 			Rank:       fixture.Client2Name,
 			Shape:      square,
@@ -206,7 +206,7 @@ var (
 		},
 		ServerProcessID: {
 			ID:         ServerProcessID,
-			LabelMajor: fixture.ServerName,
+			Label:      fixture.ServerName,
 			LabelMinor: fmt.Sprintf("%s (%s)", fixture.ServerHostID, fixture.ServerPID),
 			Rank:       fixture.ServerName,
 			Shape:      square,
@@ -221,7 +221,7 @@ var (
 		},
 		nonContainerProcessID: {
 			ID:         nonContainerProcessID,
-			LabelMajor: fixture.NonContainerName,
+			Label:      fixture.NonContainerName,
 			LabelMinor: fmt.Sprintf("%s (%s)", fixture.ServerHostID, fixture.NonContainerPID),
 			Rank:       fixture.NonContainerName,
 			Shape:      square,
@@ -240,7 +240,7 @@ var (
 	RenderedProcessNames = (render.RenderableNodes{
 		fixture.Client1Name: {
 			ID:         fixture.Client1Name,
-			LabelMajor: fixture.Client1Name,
+			Label:      fixture.Client1Name,
 			LabelMinor: "2 processes",
 			Rank:       fixture.Client1Name,
 			Shape:      square,
@@ -259,7 +259,7 @@ var (
 		},
 		fixture.ServerName: {
 			ID:         fixture.ServerName,
-			LabelMajor: fixture.ServerName,
+			Label:      fixture.ServerName,
 			LabelMinor: "1 process",
 			Rank:       fixture.ServerName,
 			Shape:      square,
@@ -276,7 +276,7 @@ var (
 		},
 		fixture.NonContainerName: {
 			ID:         fixture.NonContainerName,
-			LabelMajor: fixture.NonContainerName,
+			Label:      fixture.NonContainerName,
 			LabelMinor: "1 process",
 			Rank:       fixture.NonContainerName,
 			Shape:      square,
@@ -301,7 +301,7 @@ var (
 	RenderedContainers = (render.RenderableNodes{
 		ClientContainerID: {
 			ID:         ClientContainerID,
-			LabelMajor: "client",
+			Label:      "client",
 			LabelMinor: fixture.ClientHostName,
 			Shape:      hexagon,
 			Children: render.MakeRenderableNodeSet(
@@ -319,7 +319,7 @@ var (
 		},
 		ServerContainerID: {
 			ID:         ServerContainerID,
-			LabelMajor: "server",
+			Label:      "server",
 			LabelMinor: fixture.ServerHostName,
 			Shape:      hexagon,
 			Children: render.MakeRenderableNodeSet(
@@ -335,7 +335,7 @@ var (
 		},
 		uncontainedServerID: {
 			ID:         uncontainedServerID,
-			LabelMajor: render.UncontainedMajor,
+			Label:      render.UncontainedMajor,
 			LabelMinor: fixture.ServerHostName,
 			Shape:      square,
 			Stack:      true,
@@ -359,7 +359,7 @@ var (
 	RenderedContainerImages = (render.RenderableNodes{
 		ClientContainerImageID: {
 			ID:         ClientContainerImageID,
-			LabelMajor: fixture.ClientContainerImageName,
+			Label:      fixture.ClientContainerImageName,
 			LabelMinor: "1 container",
 			Rank:       fixture.ClientContainerImageName,
 			Shape:      hexagon,
@@ -379,7 +379,7 @@ var (
 		},
 		ServerContainerImageID: {
 			ID:         ServerContainerImageID,
-			LabelMajor: fixture.ServerContainerImageName,
+			Label:      fixture.ServerContainerImageName,
 			LabelMinor: "1 container",
 			Rank:       fixture.ServerContainerImageName,
 			Shape:      hexagon,
@@ -397,7 +397,7 @@ var (
 		},
 		uncontainedServerID: {
 			ID:         uncontainedServerID,
-			LabelMajor: render.UncontainedMajor,
+			Label:      render.UncontainedMajor,
 			LabelMinor: fixture.ServerHostName,
 			Shape:      square,
 			Stack:      true,
@@ -421,7 +421,7 @@ var (
 	RenderedPods = (render.RenderableNodes{
 		ClientPodRenderedID: {
 			ID:         ClientPodRenderedID,
-			LabelMajor: "pong-a",
+			Label:      "pong-a",
 			LabelMinor: "1 container",
 			Rank:       "ping/pong-a",
 			Shape:      heptagon,
@@ -440,7 +440,7 @@ var (
 		},
 		ServerPodRenderedID: {
 			ID:         ServerPodRenderedID,
-			LabelMajor: "pong-b",
+			Label:      "pong-b",
 			LabelMinor: "1 container",
 			Rank:       "ping/pong-b",
 			Shape:      heptagon,
@@ -457,7 +457,7 @@ var (
 		},
 		uncontainedServerID: {
 			ID:         uncontainedServerID,
-			LabelMajor: render.UncontainedMajor,
+			Label:      render.UncontainedMajor,
 			LabelMinor: fixture.ServerHostName,
 			Pseudo:     true,
 			Shape:      square,
@@ -481,7 +481,7 @@ var (
 	RenderedHosts = (render.RenderableNodes{
 		ClientHostID: {
 			ID:         ClientHostID,
-			LabelMajor: "client",       // before first .
+			Label:      "client",       // before first .
 			LabelMinor: "hostname.com", // after first .
 			Rank:       "hostname.com",
 			Shape:      circle,
@@ -502,7 +502,7 @@ var (
 		},
 		ServerHostID: {
 			ID:         ServerHostID,
-			LabelMajor: "server",       // before first .
+			Label:      "server",       // before first .
 			LabelMinor: "hostname.com", // after first .
 			Rank:       "hostname.com",
 			Shape:      circle,
@@ -532,7 +532,7 @@ var (
 	RenderedPodServices = (render.RenderableNodes{
 		ServiceRenderedID: {
 			ID:         ServiceRenderedID,
-			LabelMajor: "pongservice",
+			Label:      "pongservice",
 			LabelMinor: "2 pods",
 			Rank:       fixture.ServiceID,
 			Shape:      heptagon,
@@ -559,7 +559,7 @@ var (
 		},
 		uncontainedServerID: {
 			ID:         uncontainedServerID,
-			LabelMajor: render.UncontainedMajor,
+			Label:      render.UncontainedMajor,
 			LabelMinor: fixture.ServerHostName,
 			Pseudo:     true,
 			Shape:      square,

--- a/render/mapping.go
+++ b/render/mapping.go
@@ -50,11 +50,11 @@ func theInternetNode(m RenderableNode) RenderableNode {
 	// emit one internet node for incoming, one for outgoing
 	if len(m.Adjacency) > 0 {
 		node.ID = IncomingInternetID
-		node.LabelMajor = InboundMajor
+		node.Label = InboundMajor
 		node.LabelMinor = InboundMinor
 	} else {
 		node.ID = OutgoingInternetID
-		node.LabelMajor = OutboundMajor
+		node.Label = OutboundMajor
 		node.LabelMinor = OutboundMinor
 	}
 	return node
@@ -96,12 +96,12 @@ func MapProcessIdentity(m RenderableNode, _ report.Networks) RenderableNodes {
 
 	var (
 		id       = MakeProcessID(report.ExtractHostID(m.Node), pid)
-		major, _ = m.Latest.Lookup(process.Name)
+		label, _ = m.Latest.Lookup(process.Name)
 		minor    = fmt.Sprintf("%s (%s)", report.ExtractHostID(m.Node), pid)
 		rank, _  = m.Latest.Lookup(process.Name)
 	)
 
-	node := NewRenderableNodeWith(id, major, minor, rank, m)
+	node := NewRenderableNodeWith(id, label, minor, rank, m)
 	node.Shape = Square
 	return RenderableNodes{id: node}
 }
@@ -117,11 +117,11 @@ func MapContainerIdentity(m RenderableNode, _ report.Networks) RenderableNodes {
 
 	var (
 		id       = MakeContainerID(containerID)
-		major, _ = GetRenderableContainerName(m.Node)
+		label, _ = GetRenderableContainerName(m.Node)
 		minor    = report.ExtractHostID(m.Node)
 	)
 
-	node := NewRenderableNodeWith(id, major, minor, "", m)
+	node := NewRenderableNodeWith(id, label, minor, "", m)
 	node.ControlNode = m.ID
 	node.Shape = Hexagon
 	return RenderableNodes{id: node}
@@ -162,11 +162,11 @@ func MapContainerImageIdentity(m RenderableNode, _ report.Networks) RenderableNo
 
 	var (
 		id       = MakeContainerImageID(imageID)
-		major, _ = m.Latest.Lookup(docker.ImageName)
+		label, _ = m.Latest.Lookup(docker.ImageName)
 		rank     = imageID
 	)
 
-	node := NewRenderableNodeWith(id, major, "", rank, m)
+	node := NewRenderableNodeWith(id, label, "", rank, m)
 	node.Shape = Hexagon
 	node.Stack = true
 	return RenderableNodes{id: node}
@@ -183,11 +183,11 @@ func MapPodIdentity(m RenderableNode, _ report.Networks) RenderableNodes {
 
 	var (
 		id       = MakePodID(podID)
-		major, _ = m.Latest.Lookup(kubernetes.PodName)
+		label, _ = m.Latest.Lookup(kubernetes.PodName)
 		rank, _  = m.Latest.Lookup(kubernetes.PodID)
 	)
 
-	node := NewRenderableNodeWith(id, major, "", rank, m)
+	node := NewRenderableNodeWith(id, label, "", rank, m)
 	node.Shape = Heptagon
 	return RenderableNodes{id: node}
 }
@@ -203,11 +203,11 @@ func MapServiceIdentity(m RenderableNode, _ report.Networks) RenderableNodes {
 
 	var (
 		id       = MakeServiceID(serviceID)
-		major, _ = m.Latest.Lookup(kubernetes.ServiceName)
+		label, _ = m.Latest.Lookup(kubernetes.ServiceName)
 		rank, _  = m.Latest.Lookup(kubernetes.ServiceID)
 	)
 
-	node := NewRenderableNodeWith(id, major, "", rank, m)
+	node := NewRenderableNodeWith(id, label, "", rank, m)
 	node.Shape = Heptagon
 	node.Stack = true
 	return RenderableNodes{id: node}
@@ -221,16 +221,16 @@ func MapHostIdentity(m RenderableNode, _ report.Networks) RenderableNodes {
 		id                 = MakeHostID(report.ExtractHostID(m.Node))
 		hostname, _        = m.Latest.Lookup(host.HostName)
 		parts              = strings.SplitN(hostname, ".", 2)
-		major, minor, rank = "", "", ""
+		label, minor, rank = "", "", ""
 	)
 
 	if len(parts) == 2 {
-		major, minor, rank = parts[0], parts[1], parts[1]
+		label, minor, rank = parts[0], parts[1], parts[1]
 	} else {
-		major = hostname
+		label = hostname
 	}
 
-	node := NewRenderableNodeWith(id, major, minor, rank, m)
+	node := NewRenderableNodeWith(id, label, minor, rank, m)
 	node.Shape = Circle
 	return RenderableNodes{id: node}
 }
@@ -468,7 +468,7 @@ func MapProcess2Name(n RenderableNode, _ report.Networks) RenderableNodes {
 	}
 
 	node := NewDerivedNode(name, n)
-	node.LabelMajor = name
+	node.Label = name
 	node.Rank = name
 	node.Counters = node.Node.Counters.Add(processesKey, 1)
 	node.Node.Topology = "process_name"
@@ -567,7 +567,7 @@ func MapContainerImage2Name(n RenderableNode, _ report.Networks) RenderableNodes
 	id := MakeContainerImageID(name)
 
 	node := NewDerivedNode(id, n)
-	node.LabelMajor = name
+	node.Label = name
 	node.Rank = name
 	node.Node = n.Node.Copy() // Propagate NMD for container counting.
 	node.Shape = Hexagon
@@ -650,7 +650,7 @@ func MapContainer2Pod(n RenderableNode, _ report.Networks) RenderableNodes {
 	// from the API. This is a workaround until
 	// https://github.com/kubernetes/kubernetes/issues/14738 is fixed.
 	if s := strings.SplitN(podID, "/", 2); len(s) == 2 {
-		result.LabelMajor = s[1]
+		result.Label = s[1]
 		result.Node = result.Node.WithLatests(map[string]string{
 			kubernetes.Namespace: s[0],
 			kubernetes.PodName:   s[1],
@@ -713,7 +713,7 @@ func MapContainer2Hostname(n RenderableNode, _ report.Networks) RenderableNodes 
 	}
 
 	result := NewDerivedNode(id, n)
-	result.LabelMajor = id
+	result.Label = id
 	result.Rank = id
 
 	// Add container id key to the counters, which will later be counted to produce the minor label

--- a/render/renderable_node.go
+++ b/render/renderable_node.go
@@ -9,7 +9,7 @@ import (
 // to rendering a node when there are many nodes visible at once.
 type RenderableNode struct {
 	ID          string            `json:"id"`                    //
-	LabelMajor  string            `json:"label_major"`           // e.g. "process", human-readable
+	Label       string            `json:"label"`                 // e.g. "process", human-readable
 	LabelMinor  string            `json:"label_minor,omitempty"` // e.g. "hostname", human-readable, optional
 	Rank        string            `json:"rank"`                  // to help the layout engine
 	Pseudo      bool              `json:"pseudo,omitempty"`      // sort-of a placeholder node, for rendering purposes
@@ -35,7 +35,7 @@ const (
 func NewRenderableNode(id string) RenderableNode {
 	return RenderableNode{
 		ID:           id,
-		LabelMajor:   "",
+		Label:        "",
 		LabelMinor:   "",
 		Rank:         "",
 		Pseudo:       false,
@@ -46,10 +46,10 @@ func NewRenderableNode(id string) RenderableNode {
 }
 
 // NewRenderableNodeWith makes a new RenderableNode with some fields filled in
-func NewRenderableNodeWith(id, major, minor, rank string, node RenderableNode) RenderableNode {
+func NewRenderableNodeWith(id, label, minor, rank string, node RenderableNode) RenderableNode {
 	return RenderableNode{
 		ID:           id,
-		LabelMajor:   major,
+		Label:        label,
 		LabelMinor:   minor,
 		Rank:         rank,
 		Pseudo:       false,
@@ -64,7 +64,7 @@ func NewRenderableNodeWith(id, major, minor, rank string, node RenderableNode) R
 func NewDerivedNode(id string, node RenderableNode) RenderableNode {
 	return RenderableNode{
 		ID:           id,
-		LabelMajor:   "",
+		Label:        "",
 		LabelMinor:   "",
 		Rank:         "",
 		Pseudo:       node.Pseudo,
@@ -76,10 +76,10 @@ func NewDerivedNode(id string, node RenderableNode) RenderableNode {
 	}
 }
 
-func newDerivedPseudoNode(id, major string, node RenderableNode) RenderableNode {
+func newDerivedPseudoNode(id, label string, node RenderableNode) RenderableNode {
 	return RenderableNode{
 		ID:           id,
-		LabelMajor:   major,
+		Label:        label,
 		LabelMinor:   "",
 		Rank:         "",
 		Pseudo:       true,
@@ -108,8 +108,8 @@ func (rn RenderableNode) WithParents(p report.Sets) RenderableNode {
 func (rn RenderableNode) Merge(other RenderableNode) RenderableNode {
 	result := rn.Copy()
 
-	if result.LabelMajor == "" {
-		result.LabelMajor = other.LabelMajor
+	if result.Label == "" {
+		result.Label = other.Label
 	}
 
 	if result.LabelMinor == "" {
@@ -140,7 +140,7 @@ func (rn RenderableNode) Merge(other RenderableNode) RenderableNode {
 func (rn RenderableNode) Copy() RenderableNode {
 	return RenderableNode{
 		ID:           rn.ID,
-		LabelMajor:   rn.LabelMajor,
+		Label:        rn.Label,
 		LabelMinor:   rn.LabelMinor,
 		Rank:         rn.Rank,
 		Pseudo:       rn.Pseudo,

--- a/render/renderable_node_test.go
+++ b/render/renderable_node_test.go
@@ -32,7 +32,7 @@ func TestMergeRenderableNodes(t *testing.T) {
 func TestMergeRenderableNode(t *testing.T) {
 	node1 := render.RenderableNode{
 		ID:         "foo",
-		LabelMajor: "",
+		Label:      "",
 		LabelMinor: "minor",
 		Rank:       "",
 		Pseudo:     false,
@@ -41,7 +41,7 @@ func TestMergeRenderableNode(t *testing.T) {
 	}
 	node2 := render.RenderableNode{
 		ID:         "foo",
-		LabelMajor: "major",
+		Label:      "label",
 		LabelMinor: "",
 		Rank:       "rank",
 		Pseudo:     false,
@@ -50,7 +50,7 @@ func TestMergeRenderableNode(t *testing.T) {
 	}
 	want := render.RenderableNode{
 		ID:           "foo",
-		LabelMajor:   "major",
+		Label:        "label",
 		LabelMinor:   "minor",
 		Rank:         "rank",
 		Pseudo:       false,

--- a/render/short_lived_connections_test.go
+++ b/render/short_lived_connections_test.go
@@ -72,7 +72,7 @@ var (
 	want = (render.RenderableNodes{
 		render.IncomingInternetID: {
 			ID:         render.IncomingInternetID,
-			LabelMajor: render.InboundMajor,
+			Label:      render.InboundMajor,
 			LabelMinor: render.InboundMinor,
 			Pseudo:     true,
 			Shape:      "cloud",
@@ -80,7 +80,7 @@ var (
 		},
 		render.MakeContainerID(containerID): {
 			ID:          render.MakeContainerID(containerID),
-			LabelMajor:  containerName,
+			Label:       containerName,
 			LabelMinor:  serverHostID,
 			Rank:        "",
 			Pseudo:      false,

--- a/render/topologies.go
+++ b/render/topologies.go
@@ -58,7 +58,7 @@ func (r processWithContainerNameRenderer) Render(rpt report.Report) RenderableNo
 			continue
 		}
 		output := p.Copy()
-		output.LabelMinor = fmt.Sprintf("%s (%s:%s)", report.ExtractHostID(p.Node), container.LabelMajor, pid)
+		output.LabelMinor = fmt.Sprintf("%s (%s:%s)", report.ExtractHostID(p.Node), container.Label, pid)
 		outputs[id] = output
 	}
 	return outputs
@@ -191,7 +191,7 @@ func (r containerWithImageNameRenderer) Render(rpt report.Report) RenderableNode
 			continue
 		}
 		output := c.Copy()
-		output.Rank = ImageNameWithoutVersion(image.LabelMajor)
+		output.Rank = ImageNameWithoutVersion(image.Label)
 		output.Latest = image.Latest.Merge(c.Latest)
 		outputs[id] = output
 	}

--- a/render/topology_diff_test.go
+++ b/render/topology_diff_test.go
@@ -20,7 +20,7 @@ func (r ByID) Less(i, j int) bool { return r[i].ID < r[j].ID }
 func TestTopoDiff(t *testing.T) {
 	nodea := render.RenderableNode{
 		ID:         "nodea",
-		LabelMajor: "Node A",
+		Label:      "Node A",
 		LabelMinor: "'ts an a",
 		Pseudo:     false,
 		Node:       report.MakeNode().WithAdjacent("nodeb"),
@@ -31,8 +31,8 @@ func TestTopoDiff(t *testing.T) {
 		"nodeq", // not the same anymore
 	}
 	nodeb := render.RenderableNode{
-		ID:         "nodeb",
-		LabelMajor: "Node B",
+		ID:    "nodeb",
+		Label: "Node B",
 	}
 
 	// Helper to make RenderableNode maps.

--- a/report/metrics.go
+++ b/report/metrics.go
@@ -216,8 +216,8 @@ func (m Metric) LastSample() *Sample {
 
 // WireMetrics is the on-the-wire representation of Metrics.
 type WireMetrics struct {
-	Samples []Sample `json:"samples"` // On the wire, samples are sorted oldest to newest,
-	Min     float64  `json:"min"`     // the opposite order to how we store them internally.
+	Samples []Sample `json:"samples,omitempty"` // On the wire, samples are sorted oldest to newest,
+	Min     float64  `json:"min"`               // the opposite order to how we store them internally.
 	Max     float64  `json:"max"`
 	First   string   `json:"first,omitempty"`
 	Last    string   `json:"last,omitempty"`


### PR DESCRIPTION
Base work for #1105 and #1159

Could use more refactoring eventually, as the RenderableNode json rendering is never really used after this. We either render the NodeSummary or the detailed.Node. Might also be worth splitting `detailed` and `summary` into different packages, but that will conflict with changes in #1126.

With this change the topology views (and deltas) include the nodes' metadata and metrics (sans samples). e.g.
```js
{ nodes: [
  process:scope:1716: {
    id: "process:scope:1716",
    label: "/home/weave/weaver",
    label_minor: "scope (weave:1716)",
    rank: "/home/weave/weaver",
    shape: "square",
    linkable: true,
    metadata: [
      {
        id: "threads",
        label: "# Threads",
        value: "12",
        prime: true
      },
      ...
    ],
    metrics: [
      {
        id: "process_memory_usage_bytes",
        label: "Memory",
        format: "filesize",
        value: 46587904,
        samples: [ ],
        min: 0,
        max: 46587904,
        first: "2016-03-15T12:00:58.106201326Z",
        last: "2016-03-15T12:01:12.065987896Z"
      },
      ...
    ]
  }
]}
```

@tomwilkie, wdyt?