### PR TITLE
Various websocket and pipe fixes.

### DIFF
--- a/client/app/scripts/utils/web-api-utils.js
+++ b/client/app/scripts/utils/web-api-utils.js
@@ -225,8 +225,8 @@ export function getPipeStatus(pipeId) {
     },
     success: function(res) {
       const status = {
-        200: 'PIPE_ALIVE',
-        204: 'PIPE_DELETED'
+        204: 'PIPE_ALIVE',
+        404: 'PIPE_DELETED'
       }[res.status];
 
       if (!status) {

--- a/common/xfer/websocket.go
+++ b/common/xfer/websocket.go
@@ -71,7 +71,7 @@ type WSDialer interface {
 func DialWS(d WSDialer, urlStr string, requestHeader http.Header) (Websocket, *http.Response, error) {
 	wsConn, resp, err := d.Dial(urlStr, requestHeader)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	return Ping(wsConn), resp, nil
 }
@@ -91,6 +91,7 @@ func (p *pingingWebsocket) ping() {
 	if err := p.conn.WriteControl(websocket.PingMessage, nil, mtime.Now().Add(writeWait)); err != nil {
 		log.Errorf("websocket ping error: %v", err)
 		p.Close()
+		return
 	}
 	p.pinger.Reset(pingPeriod)
 }


### PR DESCRIPTION
- return 404 from /api/pipe/foo/check when pipe is not found, 204 when it is
- ensure the websocket pinger is shutdown correctly
- return the response when a websocket dial returns 404, so the probe knows to stop (fixes #1114)