### PR TITLE
Add the basics for a Weave-specific topology.

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -147,6 +147,13 @@ func init() {
 			Name:     "Hosts",
 			Rank:     4,
 		},
+		APITopologyDesc{
+			id:       "weave",
+			parent:   "hosts",
+			renderer: render.WeaveRenderer,
+			Name:     "Weave",
+			Rank:     3,
+		},
 	)
 }
 

--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -152,7 +152,6 @@ func init() {
 			parent:   "hosts",
 			renderer: render.WeaveRenderer,
 			Name:     "Weave Net",
-			Rank:     3,
 		},
 	)
 }

--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -151,7 +151,7 @@ func init() {
 			id:       "weave",
 			parent:   "hosts",
 			renderer: render.WeaveRenderer,
-			Name:     "Weave",
+			Name:     "Weave Net",
 			Rank:     3,
 		},
 	)

--- a/app/api_topology.go
+++ b/app/api_topology.go
@@ -84,7 +84,7 @@ func handleWebsocket(
 		for { // just discard everything the browser sends
 			if _, _, err := c.ReadMessage(); err != nil {
 				if !xfer.IsExpectedWSCloseError(err) {
-					log.Println("err:", err)
+					log.Error("err:", err)
 				}
 				close(quit)
 				break

--- a/common/weave/client.go
+++ b/common/weave/client.go
@@ -34,8 +34,15 @@ type Status struct {
 type Router struct {
 	Name  string
 	Peers []struct {
-		Name     string
-		NickName string
+		Name        string
+		NickName    string
+		Connections []struct {
+			Name        string
+			NickName    string
+			Address     string
+			Outbound    bool
+			Established bool
+		}
 	}
 }
 

--- a/common/weave/client.go
+++ b/common/weave/client.go
@@ -25,9 +25,10 @@ type Client interface {
 
 // Status describes whats happen in the Weave Net router.
 type Status struct {
-	Router Router
-	DNS    DNS
-	IPAM   IPAM
+	Version string
+	Router  Router
+	DNS     DNS
+	IPAM    IPAM
 }
 
 // Router describes the status of the Weave Router

--- a/common/weave/client_test.go
+++ b/common/weave/client_test.go
@@ -67,6 +67,14 @@ func TestStatus(t *testing.T) {
 			Peers: []struct {
 				Name     string
 				NickName string
+				// TODO, extend
+				Connections []struct {
+					Name        string
+					NickName    string
+					Address     string
+					Outbound    bool
+					Established bool
+				}
 			}{
 				{
 					Name:     mockWeavePeerName,

--- a/common/weave/client_test.go
+++ b/common/weave/client_test.go
@@ -65,9 +65,8 @@ func TestStatus(t *testing.T) {
 	want := weave.Status{
 		Router: weave.Router{
 			Peers: []struct {
-				Name     string
-				NickName string
-				// TODO, extend
+				Name        string
+				NickName    string
 				Connections []struct {
 					Name        string
 					NickName    string

--- a/probe/docker/reporter.go
+++ b/probe/docker/reporter.go
@@ -13,11 +13,10 @@ import (
 
 // Keys for use in Node
 const (
-	ImageID           = "docker_image_id"
-	ImageName         = "docker_image_name"
-	ImageLabelPrefix  = "docker_image_label_"
-	OverlayPeerPrefix = "docker_peer_"
-	IsInHostNetwork   = "docker_is_in_host_network"
+	ImageID          = "docker_image_id"
+	ImageName        = "docker_image_name"
+	ImageLabelPrefix = "docker_image_label_"
+	IsInHostNetwork  = "docker_is_in_host_network"
 )
 
 // Exposed for testing
@@ -261,10 +260,9 @@ func (r *Reporter) overlayTopology() report.Topology {
 		}
 
 	})
-	peerID := OverlayPeerPrefix + r.hostID
 	// Add both local and global networks to the LocalNetworks Set
 	// since we treat container IPs as local
-	node := report.MakeNode(report.MakeOverlayNodeID(peerID)).WithSets(
+	node := report.MakeNode(report.MakeOverlayNodeID(report.DockerOverlayPeerPrefix, r.hostID)).WithSets(
 		report.MakeSets().Add(host.LocalNetworks, report.MakeStringSet(subnets...)))
 	return report.MakeTopology().AddNode(node)
 }

--- a/probe/docker/reporter_test.go
+++ b/probe/docker/reporter_test.go
@@ -134,8 +134,7 @@ func TestReporter(t *testing.T) {
 
 	// Reporter should add a container network
 	{
-		peerID := docker.OverlayPeerPrefix + hostID
-		overlayNodeID := report.MakeOverlayNodeID(peerID)
+		overlayNodeID := report.MakeOverlayNodeID(report.DockerOverlayPeerPrefix, hostID)
 		node, ok := rpt.Overlay.Nodes[overlayNodeID]
 		if !ok {
 			t.Fatalf("Expected report to have overlay node  %q, but not found", overlayNodeID)

--- a/probe/host/tagger.go
+++ b/probe/host/tagger.go
@@ -29,9 +29,9 @@ func (t Tagger) Tag(r report.Report) (report.Report, error) {
 		parents  = report.EmptySets.Add(report.Host, report.MakeStringSet(t.hostNodeID))
 	)
 
-	// Explicitly don't tag Endpoints and Addresses - These topologies include pseudo nodes,
-	// and as such do their own host tagging
-	for _, topology := range []report.Topology{r.Process, r.Container, r.ContainerImage, r.Host, r.Overlay, r.Pod} {
+	// Explicitly don't tag Endpoints, Addresses and Overlay nodes - These topologies include pseudo nodes,
+	// and as such do their own host tagging.
+	for _, topology := range []report.Topology{r.Process, r.Container, r.ContainerImage, r.Host, r.Pod} {
 		for _, node := range topology.Nodes {
 			topology.AddNode(node.WithLatests(metadata).WithParents(parents))
 		}

--- a/probe/overlay/weave.go
+++ b/probe/overlay/weave.go
@@ -164,24 +164,25 @@ func (w *Weave) Report() (report.Report, error) {
 		WeaveDNSHostname: {ID: WeaveDNSHostname, Label: "Weave DNS Name", From: report.FromLatest, Priority: 18},
 	})
 	for _, peer := range w.statusCache.Router.Peers {
-		node := report.MakeNodeWith(report.MakeOverlayNodeID(peer.Name), map[string]string{
-			WeavePeerName:     peer.Name,
-			WeavePeerNickName: peer.NickName,
-		})
+		node := report.MakeNodeWith(report.MakeOverlayNodeID(report.WeaveOverlayPeerPrefix, peer.Name),
+			map[string]string{
+				WeavePeerName:     peer.Name,
+				WeavePeerNickName: peer.NickName,
+			})
 		if peer.Name == w.statusCache.Router.Name {
 			node = node.WithLatest(report.HostNodeID, mtime.Now(), w.hostID)
 			node = node.WithParents(report.EmptySets.Add(report.Host, report.MakeStringSet(w.hostID)))
 		}
 		for _, conn := range peer.Connections {
 			if conn.Outbound {
-				node = node.WithAdjacent(report.MakeOverlayNodeID(conn.Name))
+				node = node.WithAdjacent(report.MakeOverlayNodeID(report.WeaveOverlayPeerPrefix, conn.Name))
 			}
 		}
 		r.Overlay.AddNode(node)
 	}
 	if w.statusCache.IPAM.DefaultSubnet != "" {
 		r.Overlay.AddNode(
-			report.MakeNode(report.MakeOverlayNodeID(w.statusCache.Router.Name)).WithSets(
+			report.MakeNode(report.MakeOverlayNodeID(report.WeaveOverlayPeerPrefix, w.statusCache.Router.Name)).WithSets(
 				report.MakeSets().Add(host.LocalNetworks, report.MakeStringSet(w.statusCache.IPAM.DefaultSubnet)),
 			),
 		)

--- a/probe/overlay/weave_test.go
+++ b/probe/overlay/weave_test.go
@@ -35,7 +35,7 @@ func TestWeaveTaggerOverlayTopology(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		nodeID := report.MakeOverlayNodeID(weave.MockWeavePeerName)
+		nodeID := report.MakeOverlayNodeID(report.WeaveOverlayPeerPrefix, weave.MockWeavePeerName)
 		node, ok := have.Overlay.Nodes[nodeID]
 		if !ok {
 			t.Errorf("Expected overlay node %q, but not found", nodeID)

--- a/render/selectors.go
+++ b/render/selectors.go
@@ -31,4 +31,5 @@ var (
 	SelectService        = TopologySelector(report.Service)
 	SelectDeployment     = TopologySelector(report.Deployment)
 	SelectReplicaSet     = TopologySelector(report.ReplicaSet)
+	SelectOverlay        = TopologySelector(report.Overlay)
 )

--- a/render/weave.go
+++ b/render/weave.go
@@ -13,17 +13,20 @@ var WeaveRenderer = MakeMap(
 
 // MapWeaveIdentity maps an overlay topology node to a weave topology node.
 func MapWeaveIdentity(m report.Node, _ report.Networks) report.Nodes {
-
-	peerPrefix, peerName := report.ParseOverlayNodeID(m.ID)
+	peerPrefix, _ := report.ParseOverlayNodeID(m.ID)
 	if peerPrefix != report.WeaveOverlayPeerPrefix {
 		return nil
 	}
 
-	var node = NewDerivedNode(peerName, m)
+	var (
+		node        = m
+		nickname, _ = m.Latest.Lookup(overlay.WeavePeerNickName)
+	)
+
 	if _, ok := node.Latest.Lookup(report.HostNodeID); !ok {
-		nickname, _ := m.Latest.Lookup(overlay.WeavePeerNickName)
 		id := MakePseudoNodeID(UnmanagedID, nickname)
 		node = NewDerivedPseudoNode(id, m)
 	}
-	return report.Nodes{peerName: node}
+
+	return report.Nodes{node.ID: node}
 }

--- a/render/weave.go
+++ b/render/weave.go
@@ -13,11 +13,17 @@ var WeaveRenderer = MakeMap(
 
 // MapWeaveIdentity maps an overlay topology node to a weave topology node.
 func MapWeaveIdentity(m report.Node, _ report.Networks) report.Nodes {
-	var node = m
-	if _, ok := m.Latest.Lookup(report.HostNodeID); !ok {
+
+	peerPrefix, peerName := report.ParseOverlayNodeID(m.ID)
+	if peerPrefix != report.WeaveOverlayPeerPrefix {
+		return nil
+	}
+
+	var node = NewDerivedNode(peerName, m)
+	if _, ok := node.Latest.Lookup(report.HostNodeID); !ok {
 		nickname, _ := m.Latest.Lookup(overlay.WeavePeerNickName)
 		id := MakePseudoNodeID(UnmanagedID, nickname)
 		node = NewDerivedPseudoNode(id, m)
 	}
-	return report.Nodes{node.ID: node}
+	return report.Nodes{peerName: node}
 }

--- a/render/weave.go
+++ b/render/weave.go
@@ -1,0 +1,23 @@
+package render
+
+import (
+	"github.com/weaveworks/scope/probe/overlay"
+	"github.com/weaveworks/scope/report"
+)
+
+// WeaveRenderer is a Renderer which produces a renderable weave topology.
+var WeaveRenderer = MakeMap(
+	MapWeaveIdentity,
+	SelectOverlay,
+)
+
+// MapWeaveIdentity maps an overlay topology node to a weave topology node.
+func MapWeaveIdentity(m report.Node, _ report.Networks) report.Nodes {
+	var node = m
+	if _, ok := m.Latest.Lookup(report.HostNodeID); !ok {
+		nickname, _ := m.Latest.Lookup(overlay.WeavePeerNickName)
+		id := MakePseudoNodeID(UnmanagedID, nickname)
+		node = NewDerivedPseudoNode(id, m)
+	}
+	return report.Nodes{node.ID: node}
+}

--- a/render/weave.go
+++ b/render/weave.go
@@ -23,6 +23,9 @@ func MapWeaveIdentity(m report.Node, _ report.Networks) report.Nodes {
 		nickname, _ = m.Latest.Lookup(overlay.WeavePeerNickName)
 	)
 
+	// Nodes without a host id indicate they are not monitored by Scope
+	// (their info doesn't come from a probe monitoring that peer directly)
+	// , display them as pseudo nodes.
 	if _, ok := node.Latest.Lookup(report.HostNodeID); !ok {
 		id := MakePseudoNodeID(UnmanagedID, nickname)
 		node = NewDerivedPseudoNode(id, m)

--- a/report/id.go
+++ b/report/id.go
@@ -22,6 +22,12 @@ const (
 
 	// Key added to nodes to prevent them being joined with conntracked connections
 	DoesNotMakeConnections = "does_not_make_connections"
+
+	// WeaveOverlayPeerPrefix is the prefix for weave peers in the overlay network
+	WeaveOverlayPeerPrefix = ""
+
+	// DockerOverlayPeerPrefix is the prefix for docker peers in the overlay network
+	DockerOverlayPeerPrefix = "docker_peer_"
 )
 
 // MakeEndpointNodeID produces an endpoint node ID from its composite parts.
@@ -134,9 +140,26 @@ func parseSingleComponentID(tag string) func(string) (string, bool) {
 }
 
 // MakeOverlayNodeID produces an overlay topology node ID from a router peer's
-// name, which is assumed to be globally unique.
-func MakeOverlayNodeID(peerName string) string {
-	return "#" + peerName
+// prefix and name, which is assumed to be globally unique.
+func MakeOverlayNodeID(peerPrefix, peerName string) string {
+	return "#" + peerPrefix + peerName
+}
+
+// ParseOverlayNodeID produces the overlay type and peer name.
+func ParseOverlayNodeID(id string) (overlayPrefix string, peerName string) {
+
+	if !strings.HasPrefix(id, "#") {
+		// Best we can do
+		return "", ""
+	}
+
+	id = id[1:]
+
+	if strings.HasPrefix(id, DockerOverlayPeerPrefix) {
+		return DockerOverlayPeerPrefix, id[len(DockerOverlayPeerPrefix):]
+	}
+
+	return WeaveOverlayPeerPrefix, peerName
 }
 
 // ParseNodeID produces the host ID and remainder (typically an address) from

--- a/report/id.go
+++ b/report/id.go
@@ -159,7 +159,7 @@ func ParseOverlayNodeID(id string) (overlayPrefix string, peerName string) {
 		return DockerOverlayPeerPrefix, id[len(DockerOverlayPeerPrefix):]
 	}
 
-	return WeaveOverlayPeerPrefix, peerName
+	return WeaveOverlayPeerPrefix, id
 }
 
 // ParseNodeID produces the host ID and remainder (typically an address) from

--- a/test/weave/mock.go
+++ b/test/weave/mock.go
@@ -26,8 +26,15 @@ func (MockClient) Status() (weave.Status, error) {
 		Router: weave.Router{
 			Name: MockWeavePeerName,
 			Peers: []struct {
-				Name     string
-				NickName string
+				Name        string
+				NickName    string
+				Connections []struct {
+					Name        string
+					NickName    string
+					Address     string
+					Outbound    bool
+					Established bool
+				}
 			}{
 				{
 					Name:     MockWeavePeerName,


### PR DESCRIPTION
This is very much an early prototype.  Fixes #1132.

![screen shot 2016-03-17 at 16 03 18](https://cloud.githubusercontent.com/assets/444037/13852410/cf7ebc72-ec59-11e5-96c8-0385c4faa460.png)

It uses the information from `weave report` to build a topology of nodes and edges.  It honours the edge direction from `weave report`.  Peers from `weave report` which are not running scope are shown as pseudo nodes (fixes #778).

I'd like to be able to:
- [ ] get metrics about traffic on various connections between weave routers (@awh, @rade, @bboreham?)
- [ ] show more useful info in the details panel (like what?)
- [x] ~~ensure the weave topology is shown as selected in the UI (@davkals, could you take a look?)~~ (this was a non-issue when @2opremio revived the PR)
- [x] ~~rename occurrences of overlay to weave~~ (not applicable anymore since the overlay topology includes docker nodes)
- [x] make it obvious when weave is installed on a host and scope is not (done through pseudo nodes).
- [ ] controls (forget, connect, rmpeer?)