### PR TITLE
Fix bug in container image reporting, we can't strip the prefix off until after finding the image

### DIFF
--- a/integration/115_topologies_test.sh
+++ b/integration/115_topologies_test.sh
@@ -1,0 +1,36 @@
+#! /bin/bash
+
+. ./config.sh
+
+start_suite "Test some key topologies are not empty"
+
+scope_on $HOST1 launch
+
+wait_for_containers $HOST1 60 weavescope
+
+topology_is_not_empty() {
+	local host="$1"
+	local topology="$2"
+	local timeout="${5:-60}"
+
+	for i in $(seq $timeout); do
+		local report="$(curl -s http://$host:4040/api/report)"
+		local count=$(echo "$report" | jq -r ".$topology.nodes | length > 0" 2>/dev/null)
+		if [ "$count" = "true" ]; then
+      assert "curl -s http://$host:4040/api/report | jq -r '.$topology.nodes | length > 0'" true
+			return
+		fi
+		sleep 1
+	done
+
+	echo "Failed to find any nodes in the $topology topology after $timeout secs"
+  assert "curl -s http://$host:4040/api/report | jq -r '.$topology.nodes | length > 0'" true
+}
+
+topology_is_not_empty $HOST1 Endpoint
+topology_is_not_empty $HOST1 Process
+topology_is_not_empty $HOST1 Container
+topology_is_not_empty $HOST1 ContainerImage
+topology_is_not_empty $HOST1 Host
+
+scope_end_suite

--- a/probe/docker/registry.go
+++ b/probe/docker/registry.go
@@ -230,7 +230,7 @@ func (r *registry) updateImages() error {
 
 	for i := range images {
 		image := &images[i]
-		r.images[image.ID] = image
+		r.images[trimImageID(image.ID)] = image
 	}
 
 	return nil


### PR DESCRIPTION
@tom, ptal

Bug was introduced in https://github.com/weaveworks/scope/commit/1f6652e1c3f1d10bfe09ef7226771ae57b1a1434