### PR TITLE
Fixes the terminal loading when the node doesn't have a rank.

### DIFF
--- a/client/app/scripts/utils/color-utils.js
+++ b/client/app/scripts/utils/color-utils.js
@@ -43,7 +43,7 @@ export function getNeutralColor() {
   return PSEUDO_COLOR;
 }
 
-export function getNodeColor(text, secondText, isPseudo = false) {
+export function getNodeColor(text = '', secondText = '', isPseudo = false) {
   if (isPseudo) {
     return PSEUDO_COLOR;
   }


### PR DESCRIPTION
- Safen up the color lookup, so we return a nice brown if we don't have
  anything else to work with.

Fixes #1195 