### PR TITLE
Stop hiding kubernetes topologies in the backend.

### DIFF
--- a/app/api_topologies_test.go
+++ b/app/api_topologies_test.go
@@ -27,7 +27,7 @@ func TestAPITopology(t *testing.T) {
 	if err := decoder.Decode(&topologies); err != nil {
 		t.Fatalf("JSON parse error: %s", err)
 	}
-	equals(t, 3, len(topologies))
+	equals(t, 4, len(topologies))
 
 	for _, topology := range topologies {
 		is200(t, ts, topology.URL)
@@ -65,7 +65,7 @@ func TestAPITopologyAddsKubernetes(t *testing.T) {
 	if err := decoder.Decode(&topologies); err != nil {
 		t.Fatalf("JSON parse error: %s", err)
 	}
-	equals(t, 3, len(topologies))
+	equals(t, 4, len(topologies))
 
 	// Enable the kubernetes topologies
 	rpt := report.MakeReport()

--- a/app/router.go
+++ b/app/router.go
@@ -157,9 +157,6 @@ func RegisterReportPostHandler(a Adder, router *mux.Router) {
 			return
 		}
 		a.Add(ctx, rpt)
-		if len(rpt.Pod.Nodes) > 0 {
-			topologyRegistry.enableKubernetesTopologies()
-		}
 		w.WriteHeader(http.StatusOK)
 	}))
 }

--- a/client/app/scripts/stores/app-store.js
+++ b/client/app/scripts/stores/app-store.js
@@ -6,7 +6,8 @@ import { Store } from 'flux/utils';
 import AppDispatcher from '../dispatcher/app-dispatcher';
 import ActionTypes from '../constants/action-types';
 import { EDGE_ID_SEPARATOR } from '../constants/naming';
-import { findTopologyById, setTopologyUrlsById, updateTopologyIds } from '../utils/topology-utils';
+import { findTopologyById, setTopologyUrlsById, updateTopologyIds,
+  filterHiddenTopologies } from '../utils/topology-utils';
 
 const makeList = List;
 const makeMap = Map;
@@ -62,8 +63,11 @@ const topologySorter = topology => topology.get('rank');
 // adds ID field to topology (based on last part of URL path) and save urls in
 // map for easy lookup
 function processTopologies(nextTopologies) {
+  // filter out hidden topos
+  const visibleTopologies = filterHiddenTopologies(nextTopologies);
+
   // add IDs to topology objects in-place
-  const topologiesWithId = updateTopologyIds(nextTopologies);
+  const topologiesWithId = updateTopologyIds(visibleTopologies);
 
   // cache URLs by ID
   topologyUrlsById = setTopologyUrlsById(topologyUrlsById, topologiesWithId);

--- a/client/app/scripts/utils/__tests__/topology-utils-test.js
+++ b/client/app/scripts/utils/__tests__/topology-utils-test.js
@@ -106,4 +106,18 @@ describe('TopologyUtils', () => {
     expect(nodes.n2.degree).toEqual(0);
     expect(nodes.n3.degree).toEqual(0);
   });
+
+  describe('filterHiddenTopologies', () => {
+    it('should filter out empty topos that set hidden_if_empty=true', () => {
+      const topos = [
+        {id: 'a', hidden_if_empty: true, stats: {node_count: 0, filtered_nodes:0}},
+        {id: 'b', hidden_if_empty: true, stats: {node_count: 1, filtered_nodes:0}},
+        {id: 'c', hidden_if_empty: true, stats: {node_count: 0, filtered_nodes:1}},
+        {id: 'd', hidden_if_empty: false, stats: {node_count: 0, filtered_nodes:0}}
+      ];
+
+      const res = TopologyUtils.filterHiddenTopologies(topos);
+      expect(res.map(t => t.id)).toEqual(['b', 'c', 'd']);
+    });
+  })
 });

--- a/client/app/scripts/utils/topology-utils.js
+++ b/client/app/scripts/utils/topology-utils.js
@@ -50,3 +50,8 @@ export function setTopologyUrlsById(topologyUrlsById, topologies) {
   });
   return urlMap;
 }
+
+export function filterHiddenTopologies(topologies) {
+  return topologies.filter(t => (!t.hidden_if_empty || t.stats.node_count > 0 ||
+                               t.stats.filtered_nodes > 0));
+}


### PR DESCRIPTION
Fixes #1181

TODO:
- [x] hide in the frontend if empty (using the `hide_if_empty` flag)