### PR TITLE
Tests for Consul Pipe Router.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ releases
 # Architecture specific extensions/prefixes
 *.[568vq]
 [568vq].out
+.DS_Store
 
 *.cgo1.go
 *.cgo2.c

--- a/app/multitenant/consul_pipe_router_internal_test.go
+++ b/app/multitenant/consul_pipe_router_internal_test.go
@@ -1,0 +1,206 @@
+package multitenant
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/weaveworks/scope/app"
+	"github.com/weaveworks/scope/common/xfer"
+	"github.com/weaveworks/scope/probe/appclient"
+)
+
+type adapter struct {
+	c appclient.AppClient
+}
+
+func (a adapter) PipeConnection(_, pipeID string, pipe xfer.Pipe) error {
+	a.c.PipeConnection(pipeID, pipe)
+	return nil
+}
+
+func (a adapter) PipeClose(_, pipeID string) error {
+	return a.c.PipeClose(pipeID)
+}
+
+type pipeconn struct {
+	id                string
+	uiPR, probePR     app.PipeRouter
+	uiPipe, probePipe xfer.Pipe
+	uiIO, probeIO     io.ReadWriter
+}
+
+func (p *pipeconn) test(t *testing.T) {
+	msg := []byte("hello " + p.id)
+	wait := sync.WaitGroup{}
+	wait.Add(2)
+
+	go func() {
+		defer wait.Done()
+
+		// write something to the probe end
+		_, err := p.probeIO.Write(msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	go func() {
+		defer wait.Done()
+
+		// read it back off the other end
+		buf := make([]byte, len(msg))
+		n, err := p.uiIO.Read(buf)
+		if n != len(buf) {
+			t.Fatalf("only read %d", n)
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(buf, msg) {
+			t.Fatalf("Got: %v, Expected: %v", buf, msg)
+		}
+	}()
+
+	wait.Wait()
+}
+
+type pipeTest struct {
+	prs   []app.PipeRouter
+	pipes []*pipeconn
+}
+
+func (pt *pipeTest) newPipe(t *testing.T) {
+	// make a new pipe id
+	id := fmt.Sprintf("pipe-%d", rand.Int63())
+	log.Printf(">>>> newPipe %s", id)
+
+	// pick a random PR to connect app to
+	uiIndex := rand.Intn(len(pt.prs))
+	uiPR := pt.prs[uiIndex]
+	uiPipe, uiIO, err := uiPR.Get(context.Background(), id, app.UIEnd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// pick a random PR to connect probe to
+	probeIndex := rand.Intn(len(pt.prs))
+	for probeIndex == uiIndex {
+		probeIndex = rand.Intn(len(pt.prs))
+	}
+	probePR := pt.prs[probeIndex]
+	probePipe, probeIO, err := probePR.Get(context.Background(), id, app.ProbeEnd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pipe := &pipeconn{
+		id:        id,
+		uiPR:      uiPR,
+		uiPipe:    uiPipe,
+		uiIO:      uiIO,
+		probePR:   probePR,
+		probePipe: probePipe,
+		probeIO:   probeIO,
+	}
+	pipe.test(t)
+	pt.pipes = append(pt.pipes, pipe)
+}
+
+func (pt *pipeTest) deletePipe(t *testing.T) {
+	// pick a random pipe
+	i := rand.Intn(len(pt.pipes))
+	pipe := pt.pipes[i]
+	log.Printf(">>>> deletePipe %s", pipe.id)
+
+	if err := pipe.uiPR.Release(context.Background(), pipe.id, app.UIEnd); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := pipe.probePR.Release(context.Background(), pipe.id, app.ProbeEnd); err != nil {
+		t.Fatal(err)
+	}
+
+	// remove from list
+	pt.pipes = pt.pipes[:i+copy(pt.pipes[i:], pt.pipes[i+1:])]
+}
+
+func (pt *pipeTest) reconnectPipe(t *testing.T) {
+	// pick a random pipe
+	pipe := pt.pipes[rand.Intn(len(pt.pipes))]
+	log.Printf(">>>> reconnectPipe %s", pipe.id)
+
+	// pick a random PR to connect to
+	newPR := pt.prs[rand.Intn(len(pt.prs))]
+
+	// pick a random end
+	if rand.Float32() < 0.5 {
+		if err := pipe.uiPR.Release(context.Background(), pipe.id, app.UIEnd); err != nil {
+			t.Fatal(err)
+		}
+
+		uiPipe, uiIO, err := newPR.Get(context.Background(), pipe.id, app.UIEnd)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		pipe.uiPR, pipe.uiPipe, pipe.uiIO = newPR, uiPipe, uiIO
+	} else {
+		if err := pipe.probePR.Release(context.Background(), pipe.id, app.ProbeEnd); err != nil {
+			t.Fatal(err)
+		}
+
+		probePipe, probeIO, err := newPR.Get(context.Background(), pipe.id, app.ProbeEnd)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		pipe.probePR, pipe.probePipe, pipe.probeIO = newPR, probePipe, probeIO
+	}
+}
+
+func TestPipeRouter(t *testing.T) {
+	var (
+		consul     = newMockConsulClient()
+		replicas   = 2
+		iterations = 50
+		pt         = pipeTest{}
+	)
+
+	for i := 0; i < replicas; i++ {
+		pr := NewConsulPipeRouter(consul, "", fmt.Sprintf("127.0.0.1:44%02d", i), NoopUserIDer)
+		defer pr.Stop()
+		pt.prs = append(pt.prs, pr)
+	}
+
+	for i := 0; i < iterations; i++ {
+		log.Printf("Iteration %d", i)
+		pt.newPipe(t)
+		pt.deletePipe(t)
+	}
+}
+
+//func TestPipeHard(t *testing.T) {
+//	if len(pipes) <= 0 {
+//		newPipe()
+//		continue
+//	} else if len(pipes) >= 2 {
+//		deletePipe()
+//		continue
+//	}
+//	r := rand.Float32()
+//	switch {
+//	case 0.0 < r && r <= 0.3:
+//		newPipe()
+//	case 0.3 < r && r <= 0.6:
+//		deletePipe()
+//	case 0.6 < r && r <= 1.0:
+//		reconnectPipe()
+//	}
+//}

--- a/app/multitenant/mock_consul_client_internal_test.go
+++ b/app/multitenant/mock_consul_client_internal_test.go
@@ -1,0 +1,98 @@
+package multitenant
+
+import (
+	"sync"
+	"time"
+
+	consul "github.com/hashicorp/consul/api"
+)
+
+type mockKV struct {
+	mtx  sync.Mutex
+	cond *sync.Cond
+	kvps map[string]*consul.KVPair
+	next uint64 // the next update will have this 'index in the the log'
+}
+
+func newMockConsulClient() ConsulClient {
+	m := mockKV{
+		kvps: map[string]*consul.KVPair{},
+	}
+	m.cond = sync.NewCond(&m.mtx)
+	go m.loop()
+	return &consulClient{&m}
+}
+
+func copyKVPair(in *consul.KVPair) *consul.KVPair {
+	value := make([]byte, len(in.Value))
+	copy(value, in.Value)
+	return &consul.KVPair{
+		Key:         in.Key,
+		CreateIndex: in.CreateIndex,
+		ModifyIndex: in.ModifyIndex,
+		LockIndex:   in.LockIndex,
+		Flags:       in.Flags,
+		Value:       value,
+		Session:     in.Session,
+	}
+}
+
+// periodic loop to wake people up, so they can honour timeouts
+func (m *mockKV) loop() {
+	for range time.Tick(1 * time.Second) {
+		m.mtx.Lock()
+		m.cond.Broadcast()
+		m.mtx.Unlock()
+	}
+}
+
+func (m *mockKV) CAS(p *consul.KVPair, q *consul.WriteOptions) (bool, *consul.WriteMeta, error) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	existing, ok := m.kvps[p.Key]
+	if ok && existing.ModifyIndex != p.ModifyIndex {
+		return false, nil, nil
+	}
+	if ok {
+		existing.Value = p.Value
+	} else {
+		m.kvps[p.Key] = copyKVPair(p)
+	}
+	m.kvps[p.Key].ModifyIndex++
+	m.kvps[p.Key].LockIndex = m.next
+	m.next++
+	m.cond.Broadcast()
+	return true, nil, nil
+}
+
+func (m *mockKV) Get(key string, q *consul.QueryOptions) (*consul.KVPair, *consul.QueryMeta, error) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	value, ok := m.kvps[key]
+	if !ok {
+		return nil, nil, nil
+	}
+	for q.WaitIndex >= value.ModifyIndex {
+		m.cond.Wait()
+	}
+	return copyKVPair(value), nil, nil
+}
+
+func (m *mockKV) List(prefix string, q *consul.QueryOptions) (consul.KVPairs, *consul.QueryMeta, error) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	deadline := time.Now().Add(q.WaitTime)
+	for m.next <= q.WaitIndex && time.Now().Before(deadline) {
+		m.cond.Wait()
+	}
+	if time.Now().After(deadline) {
+		return nil, &consul.QueryMeta{LastIndex: q.WaitIndex}, nil
+	}
+	result := consul.KVPairs{}
+	for _, kvp := range m.kvps {
+		if kvp.LockIndex >= q.WaitIndex {
+			result = append(result, copyKVPair(kvp))
+		}
+	}
+	return result, &consul.QueryMeta{LastIndex: m.next}, nil
+}

--- a/common/xfer/websocket.go
+++ b/common/xfer/websocket.go
@@ -90,7 +90,7 @@ func (p *pingingWebsocket) ping() {
 	defer p.writeLock.Unlock()
 	if err := p.conn.WriteControl(websocket.PingMessage, nil, mtime.Now().Add(writeWait)); err != nil {
 		log.Errorf("websocket ping error: %v", err)
-		p.Close()
+		p.conn.Close()
 		return
 	}
 	p.pinger.Reset(pingPeriod)
@@ -158,6 +158,8 @@ func (p *pingingWebsocket) ReadJSON(v interface{}) error {
 
 // Close closes the connection
 func (p *pingingWebsocket) Close() error {
+	p.writeLock.Lock()
+	defer p.writeLock.Unlock()
 	p.pinger.Stop()
 	return p.conn.Close()
 }

--- a/prog/app.go
+++ b/prog/app.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaveworks/scope/app"
 	"github.com/weaveworks/scope/app/multitenant"
 	"github.com/weaveworks/scope/common/middleware"
+	"github.com/weaveworks/scope/common/network"
 	"github.com/weaveworks/scope/common/weave"
 	"github.com/weaveworks/scope/common/xfer"
 	"github.com/weaveworks/scope/probe/docker"
@@ -129,7 +130,12 @@ func pipeRouterFactory(userIDer multitenant.UserIDer, pipeRouterURL, consulInf s
 		if err != nil {
 			return nil, err
 		}
-		return multitenant.NewConsulPipeRouter(consulClient, strings.TrimPrefix(parsed.Path, "/"), consulInf, userIDer)
+		advertise, err := network.GetFirstAddressOf(consulInf)
+		if err != nil {
+			return nil, err
+		}
+		addr := fmt.Sprintf("%s:4444", advertise)
+		return multitenant.NewConsulPipeRouter(consulClient, strings.TrimPrefix(parsed.Path, "/"), addr, userIDer), nil
 	}
 
 	return nil, fmt.Errorf("Invalid pipe router '%s'", pipeRouterURL)


### PR DESCRIPTION
Various fixes (mainly to how stuff is shutdown) and a test for the consul pipe router.
- Don't share a pointer in consul client
- Wait for the actor thread to make the pipe before returning it.
- Ensure every shutsdown correctly
- Make logging more consistent