### PR TITLE
Apply topology options also to sub-topologies

### DIFF
--- a/client/app/scripts/stores/__tests__/app-store-test.js
+++ b/client/app/scripts/stores/__tests__/app-store-test.js
@@ -206,8 +206,13 @@ describe('AppStore', () => {
     expect(AppStore.getActiveTopologyOptions().get('option1')).toBe('off');
     expect(AppStore.getAppState().topologyOptions.topo1.option1).toBe('off');
 
-    // other topology w/o options dont return options, but keep in app state
+    // sub-topology should retain main topo options
     registeredCallback(ClickSubTopologyAction);
+    expect(AppStore.getActiveTopologyOptions().get('option1')).toBe('off');
+    expect(AppStore.getAppState().topologyOptions.topo1.option1).toBe('off');
+
+    // other topology w/o options dont return options, but keep in app state
+    registeredCallback(ClickTopology2Action);
     expect(AppStore.getActiveTopologyOptions()).toBeUndefined();
     expect(AppStore.getAppState().topologyOptions.topo1.option1).toBe('off');
   });

--- a/client/app/scripts/utils/topology-utils.js
+++ b/client/app/scripts/utils/topology-utils.js
@@ -24,13 +24,16 @@ export function updateNodeDegrees(nodes, edges) {
   });
 }
 
-/* set topology.id in place on each topology */
-export function updateTopologyIds(topologies) {
+/* set topology.id and parentId for sub-topologies in place */
+export function updateTopologyIds(topologies, parentId) {
   return topologies.map(topology => {
     const result = Object.assign({}, topology);
     result.id = topology.url.split('/').pop();
+    if (parentId) {
+      result.parentId = parentId;
+    }
     if (topology.sub_topologies) {
-      result.sub_topologies = updateTopologyIds(topology.sub_topologies);
+      result.sub_topologies = updateTopologyIds(topology.sub_topologies, result.id);
     }
     return result;
   });


### PR DESCRIPTION
Subtopologies inherit the applied options if the keys are the same.
The labels are still determined by the topology itself.

Fixes #1221