### PR TITLE
Ensure connection rows have unique IDs.

### DIFF
--- a/client/app/scripts/components/node-details.js
+++ b/client/app/scripts/components/node-details.js
@@ -180,8 +180,7 @@ export default class NodeDetails extends React.Component {
 
           {details.connections && details.connections.map(connections => <div
             className="node-details-content-section" key={connections.id}>
-              <NodeDetailsTable {...connections} nodes={connections.rows}
-                topologyId={connections.topology_id} />
+              <NodeDetailsTable {...connections} nodes={connections.rows} nodeIdKey="nodeId" />
             </div>
           )}
 

--- a/client/app/scripts/components/node-details.js
+++ b/client/app/scripts/components/node-details.js
@@ -180,7 +180,8 @@ export default class NodeDetails extends React.Component {
 
           {details.connections && details.connections.map(connections => <div
             className="node-details-content-section" key={connections.id}>
-              <NodeDetailsTable {...connections} />
+              <NodeDetailsTable {...connections} nodes={connections.rows}
+                topologyId={connections.topology_id} />
             </div>
           )}
 

--- a/client/app/scripts/components/node-details.js
+++ b/client/app/scripts/components/node-details.js
@@ -180,7 +180,8 @@ export default class NodeDetails extends React.Component {
 
           {details.connections && details.connections.map(connections => <div
             className="node-details-content-section" key={connections.id}>
-              <NodeDetailsTable {...connections} nodes={connections.rows} nodeIdKey="nodeId" />
+              <NodeDetailsTable {...connections} nodes={connections.connections}
+                nodeIdKey="nodeId" />
             </div>
           )}
 

--- a/client/app/scripts/components/node-details/node-details-table-node-link.js
+++ b/client/app/scripts/components/node-details/node-details-table-node-link.js
@@ -14,7 +14,7 @@ export default class NodeDetailsTableNodeLink extends React.Component {
 
   handleClick(ev) {
     ev.preventDefault();
-    clickRelative(this.props.id, this.props.topologyId, this.props.label,
+    clickRelative(this.props.nodeId, this.props.topologyId, this.props.label,
       ReactDOM.findDOMNode(this).getBoundingClientRect());
   }
 

--- a/client/app/scripts/components/node-details/node-details-table.js
+++ b/client/app/scripts/components/node-details/node-details-table.js
@@ -172,7 +172,7 @@ export default class NodeDetailsTable extends React.Component {
             const values = this.renderValues(node);
             const nodeId = node[nodeIdKey];
             return (
-              <tr className="node-details-table-node" key={nodeId}>
+              <tr className="node-details-table-node" key={node.id}>
                 <td className="node-details-table-node-label truncate">
                   <NodeDetailsTableNodeLink {...node} topologyId={this.props.topologyId}
                     nodeId={nodeId} />

--- a/client/app/scripts/components/node-details/node-details-table.js
+++ b/client/app/scripts/components/node-details/node-details-table.js
@@ -169,10 +169,12 @@ export default class NodeDetailsTable extends React.Component {
           <tbody>
           {nodes && nodes.map(node => {
             const values = this.renderValues(node);
+            const nodeId = node.node_id || node.id;
             return (
-              <tr className="node-details-table-node" key={node.id}>
+              <tr className="node-details-table-node" key={nodeId}>
                 <td className="node-details-table-node-label truncate">
-                  <NodeDetailsTableNodeLink topologyId={this.props.topologyId} {...node} />
+                  <NodeDetailsTableNodeLink {...node} topologyId={this.props.topologyId}
+                    nodeId={nodeId} />
                 </td>
                 {values}
               </tr>

--- a/client/app/scripts/components/node-details/node-details-table.js
+++ b/client/app/scripts/components/node-details/node-details-table.js
@@ -191,5 +191,5 @@ export default class NodeDetailsTable extends React.Component {
 }
 
 NodeDetailsTable.defaultProps = {
-  nodeIdKey: 'id'
+  nodeIdKey: 'id' // key to identify a node in a row (used for topology links)
 };

--- a/client/app/scripts/components/node-details/node-details-table.js
+++ b/client/app/scripts/components/node-details/node-details-table.js
@@ -148,6 +148,7 @@ export default class NodeDetailsTable extends React.Component {
 
   render() {
     const headers = this.renderHeaders();
+    const { nodeIdKey } = this.props;
     let nodes = _.sortBy(this.props.nodes, this.getValueForSortBy, 'label',
       this.getMetaDataSorters());
     const limited = nodes && this.state.limit > 0 && nodes.length > this.state.limit;
@@ -169,7 +170,7 @@ export default class NodeDetailsTable extends React.Component {
           <tbody>
           {nodes && nodes.map(node => {
             const values = this.renderValues(node);
-            const nodeId = node.node_id || node.id;
+            const nodeId = node[nodeIdKey];
             return (
               <tr className="node-details-table-node" key={nodeId}>
                 <td className="node-details-table-node-label truncate">
@@ -188,3 +189,7 @@ export default class NodeDetailsTable extends React.Component {
     );
   }
 }
+
+NodeDetailsTable.defaultProps = {
+  nodeIdKey: 'id'
+};

--- a/render/detailed/connections.go
+++ b/render/detailed/connections.go
@@ -30,46 +30,46 @@ var (
 	}
 )
 
-// ConnectionsTable is the table of connection to/form a node
-type ConnectionsTable struct {
-	ID         string           `json:"id"`
-	TopologyID string           `json:"topology_id"`
-	Label      string           `json:"label"`
-	Columns    []Column         `json:"columns"`
-	Rows       []ConnectionsRow `json:"rows"`
+// ConnectionsSummary is the table of connection to/form a node
+type ConnectionsSummary struct {
+	ID          string       `json:"id"`
+	TopologyID  string       `json:"topologyId"`
+	Label       string       `json:"label"`
+	Columns     []Column     `json:"columns"`
+	Connections []Connection `json:"connections"`
 }
 
-// ConnectionsRow is a row in the connections table.
-type ConnectionsRow struct {
-	ID       string        `json:"id"`
-	NodeID   string        `json:"node_id"`
+// Connection is a row in the connections table.
+type Connection struct {
+	ID       string        `json:"id"`     // ID of this element in the UI.  Must be unique for a given ConnectionsSummary.
+	NodeID   string        `json:"nodeId"` // ID of a node in the topology. Optional, must be set if linkable is true.
 	Label    string        `json:"label"`
 	Linkable bool          `json:"linkable"`
 	Metadata []MetadataRow `json:"metadata,omitempty"`
 }
 
-type connectionsRowsByID []ConnectionsRow
+type connectionsByID []Connection
 
-func (s connectionsRowsByID) Len() int           { return len(s) }
-func (s connectionsRowsByID) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-func (s connectionsRowsByID) Less(i, j int) bool { return s[i].ID < s[j].ID }
+func (s connectionsByID) Len() int           { return len(s) }
+func (s connectionsByID) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s connectionsByID) Less(i, j int) bool { return s[i].ID < s[j].ID }
 
 // Intermediate type used as a key to dedupe rows
-type connectionsRow struct {
+type connection struct {
 	remoteNode, localNode *report.Node
 	remoteAddr, localAddr string
 	port                  string // always the server-side port
 }
 
-func (row connectionsRow) ID() string {
+func (row connection) ID() string {
 	return fmt.Sprintf("%s:%s-%s:%s-%s", row.remoteNode.ID, row.remoteAddr, row.localNode.ID, row.localAddr, row.port)
 }
 
-func incomingConnectionsTable(topologyID string, n report.Node, ns report.Nodes) ConnectionsTable {
+func incomingConnectionsSummary(topologyID string, n report.Node, ns report.Nodes) ConnectionsSummary {
 	localEndpointIDs := endpointChildIDsOf(n)
 
 	// For each node which has an edge TO me
-	counts := map[connectionsRow]int{}
+	counts := map[connection]int{}
 	for _, node := range ns {
 		if !node.Adjacency.Contains(n.ID) {
 			continue
@@ -88,7 +88,7 @@ func incomingConnectionsTable(topologyID string, n report.Node, ns report.Nodes)
 				if !ok {
 					continue
 				}
-				key := connectionsRow{
+				key := connection{
 					localNode:  &n,
 					remoteNode: &remoteNode,
 					port:       port,
@@ -105,20 +105,20 @@ func incomingConnectionsTable(topologyID string, n report.Node, ns report.Nodes)
 	if isInternetNode(n) {
 		columnHeaders = InternetColumns
 	}
-	return ConnectionsTable{
-		ID:         "incoming-connections",
-		TopologyID: topologyID,
-		Label:      "Inbound",
-		Columns:    columnHeaders,
-		Rows:       connectionRows(counts, isInternetNode(n)),
+	return ConnectionsSummary{
+		ID:          "incoming-connections",
+		TopologyID:  topologyID,
+		Label:       "Inbound",
+		Columns:     columnHeaders,
+		Connections: connectionRows(counts, isInternetNode(n)),
 	}
 }
 
-func outgoingConnectionsTable(topologyID string, n report.Node, ns report.Nodes) ConnectionsTable {
+func outgoingConnectionsSummary(topologyID string, n report.Node, ns report.Nodes) ConnectionsSummary {
 	localEndpoints := endpointChildrenOf(n)
 
 	// For each node which has an edge FROM me
-	counts := map[connectionsRow]int{}
+	counts := map[connection]int{}
 	for _, id := range n.Adjacency {
 		node, ok := ns[id]
 		if !ok {
@@ -138,7 +138,7 @@ func outgoingConnectionsTable(topologyID string, n report.Node, ns report.Nodes)
 				if !ok {
 					continue
 				}
-				key := connectionsRow{
+				key := connection{
 					localNode:  &n,
 					remoteNode: &remoteNode,
 					port:       port,
@@ -155,12 +155,12 @@ func outgoingConnectionsTable(topologyID string, n report.Node, ns report.Nodes)
 	if isInternetNode(n) {
 		columnHeaders = InternetColumns
 	}
-	return ConnectionsTable{
-		ID:         "outgoing-connections",
-		TopologyID: topologyID,
-		Label:      "Outbound",
-		Columns:    columnHeaders,
-		Rows:       connectionRows(counts, isInternetNode(n)),
+	return ConnectionsSummary{
+		ID:          "outgoing-connections",
+		TopologyID:  topologyID,
+		Label:       "Outbound",
+		Columns:     columnHeaders,
+		Connections: connectionRows(counts, isInternetNode(n)),
 	}
 }
 
@@ -188,32 +188,32 @@ func isInternetNode(n report.Node) bool {
 	return n.ID == render.IncomingInternetID || n.ID == render.OutgoingInternetID
 }
 
-func connectionRows(in map[connectionsRow]int, includeLocal bool) []ConnectionsRow {
-	output := []ConnectionsRow{}
+func connectionRows(in map[connection]int, includeLocal bool) []Connection {
+	output := []Connection{}
 	for row, count := range in {
 		// Use MakeNodeSummary to render the id and label of this node
 		// TODO(paulbellamy): Would be cleaner if we hade just a
 		// MakeNodeID(*row.remoteode). As we don't need the whole summary.
 		summary, ok := MakeNodeSummary(*row.remoteNode)
-		connectionsRow := ConnectionsRow{
+		connection := Connection{
 			ID:       row.ID(),
 			NodeID:   summary.ID,
 			Label:    summary.Label,
 			Linkable: true,
 		}
 		if !ok && row.remoteAddr != "" {
-			connectionsRow.Label = row.remoteAddr
-			connectionsRow.Linkable = false
+			connection.Label = row.remoteAddr
+			connection.Linkable = false
 		}
 		if includeLocal {
-			connectionsRow.Metadata = append(connectionsRow.Metadata,
+			connection.Metadata = append(connection.Metadata,
 				MetadataRow{
 					ID:       "foo",
 					Value:    row.localAddr,
 					Datatype: number,
 				})
 		}
-		connectionsRow.Metadata = append(connectionsRow.Metadata,
+		connection.Metadata = append(connection.Metadata,
 			MetadataRow{
 				ID:       portKey,
 				Value:    row.port,
@@ -225,8 +225,8 @@ func connectionRows(in map[connectionsRow]int, includeLocal bool) []ConnectionsR
 				Datatype: number,
 			},
 		)
-		output = append(output, connectionsRow)
+		output = append(output, connection)
 	}
-	sort.Sort(connectionsRowsByID(output))
+	sort.Sort(connectionsByID(output))
 	return output
 }

--- a/render/detailed/node.go
+++ b/render/detailed/node.go
@@ -18,7 +18,7 @@ type Node struct {
 	Controls    []ControlInstance  `json:"controls"`
 	Children    []NodeSummaryGroup `json:"children,omitempty"`
 	Parents     []Parent           `json:"parents,omitempty"`
-	Connections []NodeSummaryGroup `json:"connections,omitempty"`
+	Connections []ConnectionsTable `json:"connections,omitempty"`
 }
 
 // ControlInstance contains a control description, and all the info
@@ -83,7 +83,7 @@ func MakeNode(topologyID string, r report.Report, ns report.Nodes, n report.Node
 		Controls:    controls(r, n),
 		Children:    children(n),
 		Parents:     Parents(r, n),
-		Connections: []NodeSummaryGroup{
+		Connections: []ConnectionsTable{
 			incomingConnectionsTable(topologyID, n, ns),
 			outgoingConnectionsTable(topologyID, n, ns),
 		},

--- a/render/detailed/node.go
+++ b/render/detailed/node.go
@@ -15,10 +15,10 @@ import (
 // we want deep information about an individual node.
 type Node struct {
 	NodeSummary
-	Controls    []ControlInstance  `json:"controls"`
-	Children    []NodeSummaryGroup `json:"children,omitempty"`
-	Parents     []Parent           `json:"parents,omitempty"`
-	Connections []ConnectionsTable `json:"connections,omitempty"`
+	Controls    []ControlInstance    `json:"controls"`
+	Children    []NodeSummaryGroup   `json:"children,omitempty"`
+	Parents     []Parent             `json:"parents,omitempty"`
+	Connections []ConnectionsSummary `json:"connections,omitempty"`
 }
 
 // ControlInstance contains a control description, and all the info
@@ -83,9 +83,9 @@ func MakeNode(topologyID string, r report.Report, ns report.Nodes, n report.Node
 		Controls:    controls(r, n),
 		Children:    children(n),
 		Parents:     Parents(r, n),
-		Connections: []ConnectionsTable{
-			incomingConnectionsTable(topologyID, n, ns),
-			outgoingConnectionsTable(topologyID, n, ns),
+		Connections: []ConnectionsSummary{
+			incomingConnectionsSummary(topologyID, n, ns),
+			outgoingConnectionsSummary(topologyID, n, ns),
 		},
 	}
 }

--- a/render/detailed/node_test.go
+++ b/render/detailed/node_test.go
@@ -1,6 +1,7 @@
 package detailed_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/weaveworks/scope/probe/docker"
@@ -113,28 +114,25 @@ func TestMakeDetailedHostNode(t *testing.T) {
 				Nodes: []detailed.NodeSummary{containerImageNodeSummary},
 			},
 		},
-		Connections: []detailed.NodeSummaryGroup{
+		Connections: []detailed.ConnectionsTable{
 			{
 				ID:         "incoming-connections",
 				TopologyID: "hosts",
 				Label:      "Inbound",
 				Columns:    detailed.NormalColumns,
-				Nodes:      []detailed.NodeSummary{},
+				Rows:       []detailed.ConnectionsRow{},
 			},
 			{
 				ID:         "outgoing-connections",
 				TopologyID: "hosts",
 				Label:      "Outbound",
 				Columns:    detailed.NormalColumns,
-				Nodes: []detailed.NodeSummary{
+				Rows: []detailed.ConnectionsRow{
 					{
-						ID:         fixture.ServerHostNodeID,
-						Label:      "server",
-						LabelMinor: "hostname.com",
-						Rank:       "hostname.com",
-						Shape:      "circle",
-						Linkable:   true,
-						Adjacency:  report.MakeIDList(render.OutgoingInternetID),
+						ID:       fmt.Sprintf("%s:%s-%s:%s-%d", fixture.ServerHostNodeID, "", fixture.ClientHostNodeID, "", 80),
+						NodeID:   fixture.ServerHostNodeID,
+						Label:    "server",
+						Linkable: true,
 						Metadata: []detailed.MetadataRow{
 							{
 								ID:       "port",
@@ -223,20 +221,18 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 				TopologyID: "hosts",
 			},
 		},
-		Connections: []detailed.NodeSummaryGroup{
+		Connections: []detailed.ConnectionsTable{
 			{
 				ID:         "incoming-connections",
 				TopologyID: "containers",
 				Label:      "Inbound",
 				Columns:    detailed.NormalColumns,
-				Nodes: []detailed.NodeSummary{
+				Rows: []detailed.ConnectionsRow{
 					{
-						ID:         fixture.ClientContainerNodeID,
-						Label:      "client",
-						LabelMinor: "client.hostname.com",
-						Shape:      "hexagon",
-						Linkable:   true,
-						Adjacency:  report.MakeIDList(fixture.ServerContainerNodeID),
+						ID:       fmt.Sprintf("%s:%s-%s:%s-%d", fixture.ClientContainerNodeID, "", fixture.ServerContainerNodeID, "", 80),
+						NodeID:   fixture.ClientContainerNodeID,
+						Label:    "client",
+						Linkable: true,
 						Metadata: []detailed.MetadataRow{
 							{
 								ID:       "port",
@@ -251,14 +247,10 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 						},
 					},
 					{
-						ID:         render.IncomingInternetID,
-						Label:      render.InboundMajor,
-						LabelMinor: render.InboundMinor,
-						Rank:       render.IncomingInternetID,
-						Shape:      "cloud",
-						Linkable:   true,
-						Pseudo:     true,
-						Adjacency:  report.MakeIDList(fixture.ServerContainerNodeID),
+						ID:       fmt.Sprintf("%s:%s-%s:%s-%d", render.IncomingInternetID, "", fixture.ServerContainerNodeID, "", 80),
+						NodeID:   render.IncomingInternetID,
+						Label:    render.InboundMajor,
+						Linkable: true,
 						Metadata: []detailed.MetadataRow{
 							{
 								ID:       "port",
@@ -279,7 +271,7 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 				TopologyID: "containers",
 				Label:      "Outbound",
 				Columns:    detailed.NormalColumns,
-				Nodes:      []detailed.NodeSummary{},
+				Rows:       []detailed.ConnectionsRow{},
 			},
 		},
 	}

--- a/render/detailed/node_test.go
+++ b/render/detailed/node_test.go
@@ -114,20 +114,20 @@ func TestMakeDetailedHostNode(t *testing.T) {
 				Nodes: []detailed.NodeSummary{containerImageNodeSummary},
 			},
 		},
-		Connections: []detailed.ConnectionsTable{
+		Connections: []detailed.ConnectionsSummary{
 			{
-				ID:         "incoming-connections",
-				TopologyID: "hosts",
-				Label:      "Inbound",
-				Columns:    detailed.NormalColumns,
-				Rows:       []detailed.ConnectionsRow{},
+				ID:          "incoming-connections",
+				TopologyID:  "hosts",
+				Label:       "Inbound",
+				Columns:     detailed.NormalColumns,
+				Connections: []detailed.Connection{},
 			},
 			{
 				ID:         "outgoing-connections",
 				TopologyID: "hosts",
 				Label:      "Outbound",
 				Columns:    detailed.NormalColumns,
-				Rows: []detailed.ConnectionsRow{
+				Connections: []detailed.Connection{
 					{
 						ID:       fmt.Sprintf("%s:%s-%s:%s-%d", fixture.ServerHostNodeID, "", fixture.ClientHostNodeID, "", 80),
 						NodeID:   fixture.ServerHostNodeID,
@@ -221,13 +221,13 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 				TopologyID: "hosts",
 			},
 		},
-		Connections: []detailed.ConnectionsTable{
+		Connections: []detailed.ConnectionsSummary{
 			{
 				ID:         "incoming-connections",
 				TopologyID: "containers",
 				Label:      "Inbound",
 				Columns:    detailed.NormalColumns,
-				Rows: []detailed.ConnectionsRow{
+				Connections: []detailed.Connection{
 					{
 						ID:       fmt.Sprintf("%s:%s-%s:%s-%d", fixture.ClientContainerNodeID, "", fixture.ServerContainerNodeID, "", 80),
 						NodeID:   fixture.ClientContainerNodeID,
@@ -267,11 +267,11 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 				},
 			},
 			{
-				ID:         "outgoing-connections",
-				TopologyID: "containers",
-				Label:      "Outbound",
-				Columns:    detailed.NormalColumns,
-				Rows:       []detailed.ConnectionsRow{},
+				ID:          "outgoing-connections",
+				TopologyID:  "containers",
+				Label:       "Outbound",
+				Columns:     detailed.NormalColumns,
+				Connections: []detailed.Connection{},
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #1218 

Introduces a new type for ConnectionsTable and ConnectionsRow.

TODO(@davkal)
- [x] update UI for `node_id` and field name changes.