### PR TITLE
Fixes metric-on-canvas-hover text highlight.

### DIFF
--- a/client/app/styles/main.less
+++ b/client/app/styles/main.less
@@ -342,7 +342,7 @@ h2 {
       fill-opacity: 0;
     }
 
-    &.hovered text {
+    &.hovered .node-label, &.hovered .node-sublabel {
       stroke: @background-average-color;
       stroke-width: 8px;
       stroke-opacity: 0.7;


### PR DESCRIPTION
Label grey-bg style was leaking onto the middle!