### PR TITLE
Do not enforce tags on `make deps`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,8 +157,10 @@ clean:
 clean-codecgen:
 	rm -rf $(CODECGEN_TARGETS) $(CODECGEN_DIR)/bin
 
+# Dependencies are intentionally build without enforcing any tags
+# since they are build on the host
 deps:
-	$(GO) get -u -f -tags $(GO_BUILD_TAGS) \
+	$(GO) get -u -f \
 		github.com/FiloSottile/gvt \
 		github.com/mattn/goveralls \
 		github.com/weaveworks/github-release \


### PR DESCRIPTION
Dependencies are built out of the build container and we shouldn't enforce
specific tags.

It breaks the release process (see https://github.com/weaveworks/scope/wiki/Release-Process#go-to-a-linux-host)
in machines with standard Go installations resulting in:

```
go install net: open /usr/local/go/pkg/linux_amd64/net.a: permission denied
```