### PR TITLE
Add local_networks to weave Overlay nodes

### DIFF
--- a/common/weave/client.go
+++ b/common/weave/client.go
@@ -28,23 +28,30 @@ type Client interface {
 type Status struct {
 	Router Router
 	DNS    DNS
+	IPAM   IPAM
 }
 
 // Router describes the status of the Weave Router
 type Router struct {
+	Name  string
 	Peers []struct {
 		Name     string
 		NickName string
 	}
 }
 
-// DNS descirbes the status of Weave DNS
+// DNS describes the status of Weave DNS
 type DNS struct {
 	Entries []struct {
 		Hostname    string
 		ContainerID string
 		Tombstone   int64
 	}
+}
+
+// IPAM describes the status of Weave IPAM
+type IPAM struct {
+	DefaultSubnet string
 }
 
 var weavePsMatch = regexp.MustCompile(`^([0-9a-f]{12}) ((?:[0-9a-f][0-9a-f]\:){5}(?:[0-9a-f][0-9a-f]))(.*)$`)

--- a/probe/overlay/weave.go
+++ b/probe/overlay/weave.go
@@ -8,6 +8,7 @@ import (
 	"github.com/weaveworks/scope/common/backoff"
 	"github.com/weaveworks/scope/common/weave"
 	"github.com/weaveworks/scope/probe/docker"
+	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -177,6 +178,14 @@ func (w *Weave) Report() (report.Report, error) {
 			WeavePeerName:     peer.Name,
 			WeavePeerNickName: peer.NickName,
 		}))
+	}
+	if w.statusCache.IPAM.DefaultSubnet != "" {
+		r.Overlay.AddNode(
+			report.MakeOverlayNodeID(w.statusCache.Router.Name),
+			report.MakeNode().WithSets(
+				report.MakeSets().Add(host.LocalNetworks, report.MakeStringSet(w.statusCache.IPAM.DefaultSubnet)),
+			),
+		)
 	}
 	return r, nil
 }

--- a/probe/overlay/weave_test.go
+++ b/probe/overlay/weave_test.go
@@ -5,9 +5,11 @@ import (
 	"time"
 
 	"github.com/weaveworks/scope/probe/docker"
+	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/probe/overlay"
 	"github.com/weaveworks/scope/report"
 	"github.com/weaveworks/scope/test"
+	"github.com/weaveworks/scope/test/reflect"
 	"github.com/weaveworks/scope/test/weave"
 )
 
@@ -43,6 +45,9 @@ func TestWeaveTaggerOverlayTopology(t *testing.T) {
 		}
 		if peerNick, ok := node.Latest.Lookup(overlay.WeavePeerNickName); !ok || peerNick != weave.MockWeavePeerNickName {
 			t.Errorf("Expected weave peer nickname %q, got %q", weave.MockWeavePeerNickName, peerNick)
+		}
+		if localNetworks, ok := node.Sets.Lookup(host.LocalNetworks); !ok || !reflect.DeepEqual(localNetworks, report.MakeStringSet(weave.MockWeaveDefaultSubnet)) {
+			t.Errorf("Expected weave node local_networks %q, got %q", report.MakeStringSet(weave.MockWeaveDefaultSubnet), localNetworks)
 		}
 	}
 

--- a/render/theinternet.go
+++ b/render/theinternet.go
@@ -17,17 +17,19 @@ func LocalNetworks(r report.Report) report.Networks {
 		networks = map[string]struct{}{}
 	)
 
-	for _, md := range r.Host.Nodes {
-		nets, _ := md.Sets.Lookup(host.LocalNetworks)
-		for _, s := range nets {
-			_, ipNet, err := net.ParseCIDR(s)
-			if err != nil {
-				continue
-			}
-			_, ok := networks[ipNet.String()]
-			if !ok {
-				result = append(result, ipNet)
-				networks[ipNet.String()] = struct{}{}
+	for _, topology := range []report.Topology{r.Host, r.Overlay} {
+		for _, md := range topology.Nodes {
+			nets, _ := md.Sets.Lookup(host.LocalNetworks)
+			for _, s := range nets {
+				_, ipNet, err := net.ParseCIDR(s)
+				if err != nil {
+					continue
+				}
+				_, ok := networks[ipNet.String()]
+				if !ok {
+					result = append(result, ipNet)
+					networks[ipNet.String()] = struct{}{}
+				}
 			}
 		}
 	}

--- a/render/theinternet_test.go
+++ b/render/theinternet_test.go
@@ -22,10 +22,18 @@ func TestReportLocalNetworks(t *testing.T) {
 				),
 			},
 		},
+		Overlay: report.Topology{
+			Nodes: report.Nodes{
+				"router": report.MakeNode().WithSets(report.EmptySets.
+					Add(host.LocalNetworks, report.MakeStringSet("10.32.0.1/12")),
+				),
+			},
+		},
 	})
 	want := report.Networks([]*net.IPNet{
 		mustParseCIDR("10.0.0.1/8"),
 		mustParseCIDR("192.168.1.1/24"),
+		mustParseCIDR("10.32.0.1/12"),
 	})
 	have := render.LocalNetworks(r)
 	if !reflect.DeepEqual(want, have) {

--- a/test/weave/mock.go
+++ b/test/weave/mock.go
@@ -8,12 +8,13 @@ import (
 
 // Constants used for testing
 const (
-	MockWeavePeerName     = "winnebago"
-	MockWeavePeerNickName = "winny"
-	MockContainerID       = "83183a667c01"
-	MockContainerMAC      = "d6:f2:5a:12:36:a8"
-	MockContainerIP       = "10.0.0.123"
-	MockHostname          = "hostname.weave.local"
+	MockWeavePeerName      = "winnebago"
+	MockWeavePeerNickName  = "winny"
+	MockWeaveDefaultSubnet = "10.32.0.1/12"
+	MockContainerID        = "83183a667c01"
+	MockContainerMAC       = "d6:f2:5a:12:36:a8"
+	MockContainerIP        = "10.0.0.123"
+	MockHostname           = "hostname.weave.local"
 )
 
 // MockClient is a mock version of weave.Client
@@ -23,6 +24,7 @@ type MockClient struct{}
 func (MockClient) Status() (weave.Status, error) {
 	return weave.Status{
 		Router: weave.Router{
+			Name: MockWeavePeerName,
 			Peers: []struct {
 				Name     string
 				NickName string
@@ -45,6 +47,9 @@ func (MockClient) Status() (weave.Status, error) {
 					Tombstone:   0,
 				},
 			},
+		},
+		IPAM: weave.IPAM{
+			DefaultSubnet: MockWeaveDefaultSubnet,
 		},
 	}, nil
 }


### PR DESCRIPTION
So we can track weave without an exposed weave ip (e.g. in probe-only mode).

Fixes #1162 