### PR TITLE
Better error message when plugin responses are too large

### DIFF
--- a/probe/plugins/max_bytes_reader.go
+++ b/probe/plugins/max_bytes_reader.go
@@ -1,0 +1,43 @@
+package plugins
+
+import (
+	"io"
+)
+
+// MaxBytesReader is similar to net/http.MaxBytesReader, but lets us choose how
+// to handle an overflow by providing an error. net/http.MaxBytesReader uses
+// net/http internals to render a naff error message. There are other
+// discrepancies with how this detects overflows. Not sure if that will cause
+// issues. If you want to use it as part of an HTTP server, it's probably best
+// to change it so you can provide a callback func, which renders your error
+// message, as returning an error into the middle of the net/http server will
+// not be useful.
+func MaxBytesReader(r io.ReadCloser, maxBytes int64, err error) io.ReadCloser {
+	if r == nil {
+		return nil
+	}
+
+	return &maxBytesReader{
+		ReadCloser:     r,
+		bytesRemaining: maxBytes,
+		err:            err,
+	}
+}
+
+type maxBytesReader struct {
+	io.ReadCloser
+	bytesRemaining int64
+	err            error // Callback when overflowing
+}
+
+func (r *maxBytesReader) Read(p []byte) (int, error) {
+	if r.bytesRemaining <= 0 {
+		return 0, r.err
+	}
+	if int64(len(p)) > r.bytesRemaining {
+		p = p[0:r.bytesRemaining]
+	}
+	n, err := r.ReadCloser.Read(p)
+	r.bytesRemaining -= int64(n)
+	return n, err
+}

--- a/probe/plugins/max_bytes_reader_internal_test.go
+++ b/probe/plugins/max_bytes_reader_internal_test.go
@@ -1,0 +1,89 @@
+package plugins
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+func TestMaxBytesReaderReturnsAllDataIfSmaller(t *testing.T) {
+	result, err := ioutil.ReadAll(MaxBytesReader(ioutil.NopCloser(strings.NewReader("some data")), 1024, errors.New("test error")))
+	if err != nil {
+		t.Error(err)
+	}
+	if string(result) != "some data" {
+		t.Errorf("Expected %q, got %q", "some data", string(result))
+	}
+}
+
+func TestMaxBytesReaderReturnsNilIfNil(t *testing.T) {
+	result := MaxBytesReader(nil, 1024, errors.New("test error"))
+	if result != nil {
+		t.Errorf("Expected nil, got: %q", result)
+	}
+}
+
+func TestMaxBytesReaderReturnsErrorIfLarger(t *testing.T) {
+	input := &bytes.Buffer{}
+	for i := int64(0); i <= 1024; i++ {
+		input.WriteByte(byte(i))
+	}
+
+	result, err := ioutil.ReadAll(MaxBytesReader(ioutil.NopCloser(input), 1024, errors.New("test error")))
+	if err.Error() != "test error" {
+		t.Errorf("Expected error to be %q, got: %q", "test error", err.Error())
+	}
+	if len(result) != 1024 {
+		t.Errorf("Expected result length to be 1024, but got: %d", len(result))
+	}
+}
+
+func TestMaxBytesReaderReturnsErrorIfLargerAndMassiveBufferGiven(t *testing.T) {
+	input := &bytes.Buffer{}
+	for i := int64(0); i <= 1024; i++ {
+		input.WriteByte(byte(i))
+	}
+
+	buffer := make([]byte, 1024+2)
+	reader := MaxBytesReader(ioutil.NopCloser(input), 1024, errors.New("test error"))
+
+	// First read is scoped down to the maximum
+	readCount, err := reader.Read(buffer)
+	if err != nil {
+		t.Error(err)
+	}
+	if readCount != 1024 {
+		t.Errorf("Expected result length to be 1024, but got: %d", readCount)
+	}
+
+	// Second read returns an error
+	readCount, err = reader.Read(buffer)
+	if err.Error() != "test error" {
+		t.Errorf("Expected error to be %q, got: %q", "test error", err.Error())
+	}
+	if readCount != 0 {
+		t.Errorf("Expected result length to be 0, but got: %d", readCount)
+	}
+}
+
+type testReadCloser struct {
+	closeError error
+}
+
+func (c testReadCloser) Read(p []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (c testReadCloser) Close() error {
+	return c.closeError
+}
+
+func TestMaxBytesReaderPassesThroughErrorsWhenClosing(t *testing.T) {
+	readcloser := testReadCloser{errors.New("test error")}
+	err := MaxBytesReader(readcloser, 1024, errors.New("overflow")).Close()
+	if err == nil || err.Error() != "test error" {
+		t.Errorf("Expected error to be %q, got: %q", "test error", err)
+	}
+}


### PR DESCRIPTION
Fixes #1270 

There is a behavioural change, where plugins appear by socket filename until they have completed a successful report, and set their id/description/etc. This is so we can report errors better. Previously they would not have been shown.