### PR TITLE
Don't show non-internet pseudo nodes.

### DIFF
--- a/app/api_topology_test.go
+++ b/app/api_topology_test.go
@@ -147,7 +147,7 @@ func TestAPITopologyWebsocket(t *testing.T) {
 	if err := decoder.Decode(&d); err != nil {
 		t.Fatalf("JSON parse error: %s", err)
 	}
-	equals(t, 8, len(d.Add))
+	equals(t, 6, len(d.Add))
 	equals(t, 0, len(d.Update))
 	equals(t, 0, len(d.Remove))
 }

--- a/render/detailed/summary_test.go
+++ b/render/detailed/summary_test.go
@@ -28,8 +28,6 @@ func TestSummaries(t *testing.T) {
 			fixture.ClientProcess2NodeID,
 			fixture.ServerProcessNodeID,
 			fixture.NonContainerProcessNodeID,
-			expected.UnknownPseudoNode1ID,
-			expected.UnknownPseudoNode2ID,
 			render.IncomingInternetID,
 			render.OutgoingInternetID,
 		}

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -102,9 +102,10 @@ var (
 				RenderedEndpoints[fixture.NonContainerNodeID],
 			)),
 
-		UnknownPseudoNode1ID: unknownPseudoNode1(fixture.ServerProcessNodeID),
-		UnknownPseudoNode2ID: unknownPseudoNode2(fixture.ServerProcessNodeID),
-
+		// due to https://github.com/weaveworks/scope/issues/1323 we are dropping
+		// all non-internet pseudo nodes for now.
+		// UnknownPseudoNode1ID: unknownPseudoNode1(fixture.ServerProcessNodeID),
+		// UnknownPseudoNode2ID: unknownPseudoNode2(fixture.ServerProcessNodeID),
 		render.IncomingInternetID: theIncomingInternetNode(fixture.ServerProcessNodeID),
 		render.OutgoingInternetID: theOutgoingInternetNode,
 	}
@@ -130,8 +131,10 @@ var (
 				RenderedProcesses[fixture.NonContainerProcessNodeID],
 			)),
 
-		UnknownPseudoNode1ID:      unknownPseudoNode1(fixture.ServerName),
-		UnknownPseudoNode2ID:      unknownPseudoNode2(fixture.ServerName),
+		// due to https://github.com/weaveworks/scope/issues/1323 we are dropping
+		// all non-internet pseudo nodes for now.
+		// UnknownPseudoNode1ID:      unknownPseudoNode1(fixture.ServerName),
+		// UnknownPseudoNode2ID:      unknownPseudoNode2(fixture.ServerName),
 		render.IncomingInternetID: theIncomingInternetNode(fixture.ServerName),
 		render.OutgoingInternetID: theOutgoingInternetNode,
 	}
@@ -224,8 +227,10 @@ var (
 				//RenderedPods[fixture.ServerPodNodeID], #1142
 			)),
 
-		UnknownPseudoNode1ID:      unknownPseudoNode1(fixture.ServerHostNodeID),
-		UnknownPseudoNode2ID:      unknownPseudoNode2(fixture.ServerHostNodeID),
+		// due to https://github.com/weaveworks/scope/issues/1323 we are dropping
+		// all non-internet pseudo nodes for now.
+		// UnknownPseudoNode1ID:      unknownPseudoNode1(fixture.ServerHostNodeID),
+		// UnknownPseudoNode2ID:      unknownPseudoNode2(fixture.ServerHostNodeID),
 		render.IncomingInternetID: theIncomingInternetNode(fixture.ServerHostNodeID),
 		render.OutgoingInternetID: theOutgoingInternetNode,
 	}

--- a/render/mapping.go
+++ b/render/mapping.go
@@ -175,7 +175,10 @@ func MapEndpoint2Pseudo(n report.Node, local report.Networks) report.Nodes {
 		// internet node
 		node = theInternetNode(n)
 	} else {
-		node = NewDerivedPseudoNode(MakePseudoNodeID(addr), n)
+		// due to https://github.com/weaveworks/scope/issues/1323 we are dropping
+		// all non-internet pseudo nodes for now.
+		// node = NewDerivedPseudoNode(MakePseudoNodeID(addr), n)
+		return report.Nodes{}
 	}
 	return report.Nodes{node.ID: node}
 }
@@ -221,14 +224,9 @@ func MapEndpoint2Process(n report.Node, local report.Networks) report.Nodes {
 // It does not have enough info to do that, and the resulting graph
 // must be merged with a container graph to get that info.
 func MapProcess2Container(n report.Node, _ report.Networks) report.Nodes {
-	// Propagate the internet pseudo node
-	if strings.HasSuffix(n.ID, TheInternetID) {
-		return report.Nodes{n.ID: n}
-	}
-
-	// Don't propagate non-internet pseudo nodes
+	// Propagate pseudo nodes
 	if n.Topology == Pseudo {
-		return report.Nodes{}
+		return report.Nodes{n.ID: n}
 	}
 
 	// Otherwise, if the process is not in a container, group it
@@ -313,8 +311,7 @@ func ImageNameWithoutVersion(name string) string {
 	return parts[0]
 }
 
-// MapX2Host maps any Nodes to host
-// Nodes.
+// MapX2Host maps any Nodes to host Nodes.
 //
 // If this function is given a node without a hostname
 // (including other pseudo nodes), it will drop the node.

--- a/render/topologies.go
+++ b/render/topologies.go
@@ -71,6 +71,7 @@ var ProcessNameRenderer = MakeMap(
 var ContainerRenderer = MakeReduce(
 	MakeSilentFilter(
 		func(n report.Node) bool {
+			// Drop unconnected pseudo nodes (could appear due to filtering)
 			_, isConnected := n.Latest.Lookup(IsConnected)
 			return n.Topology != Pseudo || isConnected
 		},
@@ -225,6 +226,7 @@ var HostRenderer = MakeReduce(
 var PodRenderer = MakeReduce(
 	MakeSilentFilter(
 		func(n report.Node) bool {
+			// Drop unconnected pseudo nodes (could appear due to filtering)
 			_, isConnected := n.Latest.Lookup(IsConnected)
 			return n.Topology != Pseudo || isConnected
 		},


### PR DESCRIPTION
Fixes #1311 

This PR hides all non-internet, non-uncontained pseudo nodes due to what I believe is a bug in procspy (#1323).  It is intended as a temporary measure until we can fix this bug, and only affects the process and hosts view in the UI.