### PR TITLE
Show k8s service IP in details panel

### DIFF
--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -20,7 +20,7 @@ var (
 		ServiceID:      {ID: ServiceID, Label: "ID", From: report.FromLatest, Priority: 1},
 		Namespace:      {ID: Namespace, Label: "Namespace", From: report.FromLatest, Priority: 2},
 		ServiceCreated: {ID: ServiceCreated, Label: "Created", From: report.FromLatest, Priority: 3},
-		ServiceIP:      {ID: ServiceIP, Label: "IP", From: report.FromLatest, Priority: 4},
+		ServiceIP:      {ID: ServiceIP, Label: "Internal IP", From: report.FromLatest, Priority: 4},
 	}
 )
 

--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -20,6 +20,7 @@ var (
 		ServiceID:      {ID: ServiceID, Label: "ID", From: report.FromLatest, Priority: 1},
 		Namespace:      {ID: Namespace, Label: "Namespace", From: report.FromLatest, Priority: 2},
 		ServiceCreated: {ID: ServiceCreated, Label: "Created", From: report.FromLatest, Priority: 3},
+		ServiceIP:      {ID: ServiceIP, Label: "IP", From: report.FromLatest, Priority: 4},
 	}
 )
 

--- a/probe/kubernetes/service.go
+++ b/probe/kubernetes/service.go
@@ -13,6 +13,7 @@ const (
 	ServiceID      = "kubernetes_service_id"
 	ServiceName    = "kubernetes_service_name"
 	ServiceCreated = "kubernetes_service_created"
+	ServiceIP      = "kubernetes_service_ip"
 )
 
 // Service represents a Kubernetes service
@@ -58,5 +59,6 @@ func (s *service) GetNode() report.Node {
 		ServiceName:    s.Name(),
 		ServiceCreated: s.ObjectMeta.CreationTimestamp.Format(time.RFC822),
 		Namespace:      s.Namespace(),
+		ServiceIP:      s.Spec.ClusterIP,
 	})
 }


### PR DESCRIPTION
As part of #1066, it occurs to me that showing the service's virtual IP might be useful.