### PR TITLE
Fixes nodes w/ a slash under a path-prefixed scope.

### DIFF
--- a/client/app/scripts/utils/router-utils.js
+++ b/client/app/scripts/utils/router-utils.js
@@ -3,6 +3,12 @@ import page from 'page';
 import { route } from '../actions/app-actions';
 import AppStore from '../stores/app-store';
 
+//
+// page.js won't match the routes below if ":state" has a slash in it, so replace those before we
+// load the state into the URL.
+//
+const SLASH_REPLACEMENT = '<SLASH>';
+
 function shouldReplaceState(prevState, nextState) {
   // Opening a new terminal while an existing one is open.
   const terminalToTerminal = (prevState.controlPipe && nextState.controlPipe);
@@ -14,12 +20,12 @@ function shouldReplaceState(prevState, nextState) {
 
 export function updateRoute() {
   const state = AppStore.getAppState();
-  const stateUrl = encodeURIComponent(encodeURIComponent(JSON.stringify(state)));
+  const stateUrl = JSON.stringify(state).replace('/', SLASH_REPLACEMENT);
   const dispatch = false;
   const urlStateString = window.location.hash
     .replace('#!/state/', '')
     .replace('#!/', '') || '{}';
-  const prevState = JSON.parse(decodeURIComponent(decodeURIComponent(urlStateString)));
+  const prevState = JSON.parse(decodeURIComponent(urlStateString.replace(SLASH_REPLACEMENT, '/')));
 
   if (shouldReplaceState(prevState, state)) {
     // Replace the top of the history rather than pushing on a new item.

--- a/client/app/scripts/utils/router-utils.js
+++ b/client/app/scripts/utils/router-utils.js
@@ -14,12 +14,12 @@ function shouldReplaceState(prevState, nextState) {
 
 export function updateRoute() {
   const state = AppStore.getAppState();
-  const stateUrl = JSON.stringify(state);
+  const stateUrl = encodeURIComponent(encodeURIComponent(JSON.stringify(state)));
   const dispatch = false;
   const urlStateString = window.location.hash
     .replace('#!/state/', '')
     .replace('#!/', '') || '{}';
-  const prevState = JSON.parse(decodeURIComponent(urlStateString));
+  const prevState = JSON.parse(decodeURIComponent(decodeURIComponent(urlStateString)));
 
   if (shouldReplaceState(prevState, state)) {
     // Replace the top of the history rather than pushing on a new item.


### PR DESCRIPTION
E.g. localhost:4043/scoped/{state:{label:"/zing"...

Double encode is solution!
 - https://github.com/visionmedia/page.js/issues/187

Fixes #1335 