### PR TITLE
Add buffer to mockPublisher channel to prevent deadlock between Publish() and Stop()

### DIFF
--- a/probe/probe_internal_test.go
+++ b/probe/probe_internal_test.go
@@ -96,7 +96,7 @@ func TestProbe(t *testing.T) {
 		LastSeen: now,
 	}
 
-	pub := mockPublisher{make(chan report.Report)}
+	pub := mockPublisher{make(chan report.Report, 10)}
 
 	p := New(probeID, 10*time.Millisecond, 100*time.Millisecond, pub)
 	p.AddReporter(mockReporter{want})


### PR DESCRIPTION
Fixes #1324 