### PR TITLE
Use reverse-resolved DNS info in the connections table.

### DIFF
--- a/client/app/scripts/components/node-details/node-details-table.js
+++ b/client/app/scripts/components/node-details/node-details-table.js
@@ -153,7 +153,8 @@ export default class NodeDetailsTable extends React.Component {
       if (field) {
         if (field.valueType === 'metadata') {
           return (
-            <td className="node-details-table-node-value" key={field.id}>
+            <td className="node-details-table-node-value truncate" title={field.value}
+              key={field.id}>
               {field.value}
             </td>
           );

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -16,10 +16,11 @@ import (
 
 // Node metadata keys.
 const (
-	Addr        = "addr" // typically IPv4
-	Port        = "port"
-	Conntracked = "conntracked"
-	Procspied   = "procspied"
+	Addr            = "addr" // typically IPv4
+	Port            = "port"
+	Conntracked     = "conntracked"
+	Procspied       = "procspied"
+	ReverseDNSNames = "reverse_dns_names"
 )
 
 // Reporter generates Reports containing the Endpoint topology.
@@ -182,7 +183,7 @@ func (r *Reporter) addConnection(rpt *report.Report, t fourTuple, extraFromNode,
 	// In case we have a reverse resolution for the IP, we can use it for
 	// the name...
 	if toNames, err := r.reverseResolver.get(t.toAddr); err == nil {
-		toNode = toNode.WithSet("name", report.MakeStringSet(toNames...))
+		toNode = toNode.WithSet(ReverseDNSNames, report.MakeStringSet(toNames...))
 	}
 
 	if extraFromNode != nil {

--- a/render/detailed/connections.go
+++ b/render/detailed/connections.go
@@ -214,7 +214,7 @@ func connectionRows(r report.Report, in map[connection]int, includeLocal bool) [
 			// Does localNode have a DNS record in it?
 			label := row.localAddr
 			if set, ok := row.localNode.Sets.Lookup(endpoint.ReverseDNSNames); ok && len(set) > 0 {
-				label = set[0]
+				label = fmt.Sprintf("%s (%s)", set[0], label)
 			}
 			connection.Metadata = append(connection.Metadata,
 				report.MetadataRow{


### PR DESCRIPTION
Fixes #1121 

![screen shot 2016-04-20 at 17 12 21](https://cloud.githubusercontent.com/assets/444037/14681920/0ed46b66-071b-11e6-9eb6-52d1ff8a7223.png)

<s>@davkal / @foot I added the `truncate` class to the details table cells, but I don't see to get tooltips.  Mind having a look?</s>