### PR TITLE
Immediately remove deleted containers from the UI.

### DIFF
--- a/probe/docker/container_test.go
+++ b/probe/docker/container_test.go
@@ -51,7 +51,8 @@ func TestContainer(t *testing.T) {
 		return connection
 	}
 
-	c := docker.NewContainer(container1)
+	const hostID = "scope"
+	c := docker.NewContainer(container1, hostID)
 	err := c.StartGatheringStats()
 	if err != nil {
 		t.Errorf("%v", err)
@@ -101,7 +102,7 @@ func TestContainer(t *testing.T) {
 	)
 
 	test.Poll(t, 100*time.Millisecond, want, func() interface{} {
-		node := c.GetNode("scope", []net.IP{})
+		node := c.GetNode([]net.IP{})
 		node.Latest.ForEach(func(k, v string) {
 			if v == "0" || v == "" {
 				node.Latest = node.Latest.Delete(k)
@@ -116,7 +117,7 @@ func TestContainer(t *testing.T) {
 	if c.PID() != 2 {
 		t.Errorf("%d != 2", c.PID())
 	}
-	if have := docker.ExtractContainerIPs(c.GetNode("", []net.IP{})); !reflect.DeepEqual(have, []string{"1.2.3.4"}) {
+	if have := docker.ExtractContainerIPs(c.GetNode([]net.IP{})); !reflect.DeepEqual(have, []string{"1.2.3.4"}) {
 		t.Errorf("%v != %v", have, []string{"1.2.3.4"})
 	}
 }

--- a/probe/docker/controls_test.go
+++ b/probe/docker/controls_test.go
@@ -16,7 +16,7 @@ import (
 func TestControls(t *testing.T) {
 	mdc := newMockClient()
 	setupStubs(mdc, func() {
-		registry, _ := docker.NewRegistry(10*time.Second, nil, false)
+		registry, _ := docker.NewRegistry(10*time.Second, nil, false, "")
 		defer registry.Stop()
 
 		for _, tc := range []struct{ command, result string }{
@@ -56,7 +56,7 @@ func TestPipes(t *testing.T) {
 
 	mdc := newMockClient()
 	setupStubs(mdc, func() {
-		registry, _ := docker.NewRegistry(10*time.Second, nil, false)
+		registry, _ := docker.NewRegistry(10*time.Second, nil, false, "")
 		defer registry.Stop()
 
 		test.Poll(t, 100*time.Millisecond, true, func() interface{} {

--- a/probe/docker/registry_test.go
+++ b/probe/docker/registry_test.go
@@ -52,7 +52,7 @@ func (c *mockContainer) StartGatheringStats() error {
 
 func (c *mockContainer) StopGatheringStats() {}
 
-func (c *mockContainer) GetNode(_ string, _ []net.IP) report.Node {
+func (c *mockContainer) GetNode(_ []net.IP) report.Node {
 	return report.MakeNodeWith(report.MakeContainerNodeID(c.c.ID), map[string]string{
 		docker.ContainerID:   c.c.ID,
 		docker.ContainerName: c.c.Name,
@@ -237,7 +237,7 @@ func setupStubs(mdc *mockDockerClient, f func()) {
 		return mdc, nil
 	}
 
-	docker.NewContainerStub = func(c *client.Container) docker.Container {
+	docker.NewContainerStub = func(c *client.Container, _ string) docker.Container {
 		return &mockContainer{c}
 	}
 
@@ -270,7 +270,7 @@ func allImages(r docker.Registry) []*client.APIImages {
 func TestRegistry(t *testing.T) {
 	mdc := newMockClient()
 	setupStubs(mdc, func() {
-		registry, _ := docker.NewRegistry(10*time.Second, nil, true)
+		registry, _ := docker.NewRegistry(10*time.Second, nil, true, "")
 		defer registry.Stop()
 		runtime.Gosched()
 
@@ -293,7 +293,7 @@ func TestRegistry(t *testing.T) {
 func TestLookupByPID(t *testing.T) {
 	mdc := newMockClient()
 	setupStubs(mdc, func() {
-		registry, _ := docker.NewRegistry(10*time.Second, nil, true)
+		registry, _ := docker.NewRegistry(10*time.Second, nil, true, "")
 		defer registry.Stop()
 
 		want := docker.Container(&mockContainer{container1})
@@ -310,7 +310,7 @@ func TestLookupByPID(t *testing.T) {
 func TestRegistryEvents(t *testing.T) {
 	mdc := newMockClient()
 	setupStubs(mdc, func() {
-		registry, _ := docker.NewRegistry(10*time.Second, nil, true)
+		registry, _ := docker.NewRegistry(10*time.Second, nil, true, "")
 		defer registry.Stop()
 		runtime.Gosched()
 

--- a/probe/docker/reporter.go
+++ b/probe/docker/reporter.go
@@ -4,7 +4,6 @@ import (
 	"net"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	docker_client "github.com/fsouza/go-dockerclient"
 
 	"github.com/weaveworks/scope/probe"
@@ -75,17 +74,11 @@ func NewReporter(registry Registry, hostID string, probeID string, probe *probe.
 func (Reporter) Name() string { return "Docker" }
 
 // ContainerUpdated should be called whenever a container is updated.
-func (r *Reporter) ContainerUpdated(c Container) {
-	localAddrs, err := report.LocalAddresses()
-	if err != nil {
-		log.Errorf("Error getting local address: %v", err)
-		return
-	}
-
+func (r *Reporter) ContainerUpdated(n report.Node) {
 	// Publish a 'short cut' report container just this container
 	rpt := report.MakeReport()
 	rpt.Shortcut = true
-	rpt.Container.AddNode(c.GetNode(r.hostID, localAddrs))
+	rpt.Container.AddNode(n)
 	r.probe.Publish(rpt)
 }
 
@@ -146,7 +139,7 @@ func (r *Reporter) containerTopology(localAddrs []net.IP) report.Topology {
 	metadata := map[string]string{report.ControlProbeID: r.probeID}
 
 	r.registry.WalkContainers(func(c Container) {
-		result.AddNode(c.GetNode(r.hostID, localAddrs).WithLatests(metadata))
+		result.AddNode(c.GetNode(localAddrs).WithLatests(metadata))
 	})
 
 	return result

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -132,7 +132,7 @@ func probeMain(flags probeFlags) {
 		if err := report.AddLocalBridge(flags.dockerBridge); err != nil {
 			log.Errorf("Docker: problem with bridge %s: %v", flags.dockerBridge, err)
 		}
-		if registry, err := docker.NewRegistry(flags.dockerInterval, clients, true); err == nil {
+		if registry, err := docker.NewRegistry(flags.dockerInterval, clients, true, hostID); err == nil {
 			defer registry.Stop()
 			p.AddTagger(docker.NewTagger(registry, processCache))
 			p.AddReporter(docker.NewReporter(registry, hostID, probeID, p))


### PR DESCRIPTION
Fixes #1072 

Introduces a new container state "deleted" which is filtered out in the app.  A stripped down container node with its state set to "deleted" is pushed to the app in a shortcut report when we receive a DestroyEvent from docker.

Note this is not 100% reliable - report delivery can fail, as can the docker events subscription.