### PR TITLE
Add a button to download the report as JSON

### DIFF
--- a/client/app/scripts/components/footer.js
+++ b/client/app/scripts/components/footer.js
@@ -63,6 +63,9 @@ export default function Footer(props) {
         <a className="footer-icon" onClick={clickDownloadGraph} title="Save canvas as SVG">
           <span className="fa fa-download" />
         </a>
+        <a className="footer-icon" href="api/report" download title="Save raw data as JSON">
+          <span className="fa fa-code" />
+        </a>
         <a className="footer-icon" href={otherContrastModeUrl} title={otherContrastModeTitle}>
           <span className="fa fa-adjust" />
         </a>


### PR DESCRIPTION
![screen shot 2016-04-21 at 15 04 19](https://cloud.githubusercontent.com/assets/250199/14711781/93d99f36-07d2-11e6-8a84-e77d82ff4e9d.png)

Tooltip says: "Save report as JSON"

Thoughts @davkal ? I'm not sure about the icon, but didn't know which would be a better one. Maybe it would be better to have one button that saves both report and svg?