### PR TITLE
Fixing grouped node count for filtered children nodes

### DIFF
--- a/app/router.go
+++ b/app/router.go
@@ -93,7 +93,7 @@ func RegisterTopologyRoutes(router *mux.Router, r Reporter) {
 	get.HandleFunc("/api/topology/{topology}/ws",
 		requestContextDecorator(topologyRegistry.captureRenderer(r, handleWs))) // NB not gzip!
 	get.MatcherFunc(URLMatcher("/api/topology/{topology}/{id}")).HandlerFunc(
-		gzipHandler(requestContextDecorator(topologyRegistry.captureRendererWithoutFilters(r, handleNode))))
+		gzipHandler(requestContextDecorator(topologyRegistry.captureRenderer(r, handleNode))))
 	get.HandleFunc("/api/report",
 		gzipHandler(requestContextDecorator(makeRawReportHandler(r))))
 	get.HandleFunc("/api/probes",

--- a/experimental/graphviz/render.go
+++ b/experimental/graphviz/render.go
@@ -19,5 +19,5 @@ func renderTo(rpt report.Report, topology string) (detailed.NodeSummaries, error
 	if !ok {
 		return detailed.NodeSummaries{}, fmt.Errorf("unknown topology %v", topology)
 	}
-	return detailed.Summaries(rpt, renderer.Render(rpt)), nil
+	return detailed.Summaries(rpt, renderer.Render(rpt, render.FilterNoop)), nil
 }

--- a/render/benchmark_test.go
+++ b/render/benchmark_test.go
@@ -38,22 +38,31 @@ func BenchmarkContainerWithImageNameRender(b *testing.B) {
 func BenchmarkContainerWithImageNameStats(b *testing.B) {
 	benchmarkStats(b, render.ContainerWithImageNameRenderer)
 }
-func BenchmarkContainerImageRender(b *testing.B) { benchmarkRender(b, render.ContainerImageRenderer) }
-func BenchmarkContainerImageStats(b *testing.B)  { benchmarkStats(b, render.ContainerImageRenderer) }
+func BenchmarkContainerImageRender(b *testing.B) {
+	benchmarkRender(b, render.ContainerImageRenderer)
+}
+func BenchmarkContainerImageStats(b *testing.B) {
+	benchmarkStats(b, render.ContainerImageRenderer)
+}
 func BenchmarkContainerHostnameRender(b *testing.B) {
 	benchmarkRender(b, render.ContainerHostnameRenderer)
 }
 func BenchmarkContainerHostnameStats(b *testing.B) {
 	benchmarkStats(b, render.ContainerHostnameRenderer)
 }
-func BenchmarkHostRender(b *testing.B)       { benchmarkRender(b, render.HostRenderer) }
-func BenchmarkHostStats(b *testing.B)        { benchmarkStats(b, render.HostRenderer) }
-func BenchmarkPodRender(b *testing.B)        { benchmarkRender(b, render.PodRenderer) }
-func BenchmarkPodStats(b *testing.B)         { benchmarkStats(b, render.PodRenderer) }
-func BenchmarkPodServiceRender(b *testing.B) { benchmarkRender(b, render.PodServiceRenderer) }
-func BenchmarkPodServiceStats(b *testing.B)  { benchmarkStats(b, render.PodServiceRenderer) }
+func BenchmarkHostRender(b *testing.B) { benchmarkRender(b, render.HostRenderer) }
+func BenchmarkHostStats(b *testing.B)  { benchmarkStats(b, render.HostRenderer) }
+func BenchmarkPodRender(b *testing.B)  { benchmarkRender(b, render.PodRenderer) }
+func BenchmarkPodStats(b *testing.B)   { benchmarkStats(b, render.PodRenderer) }
+func BenchmarkPodServiceRender(b *testing.B) {
+	benchmarkRender(b, render.PodServiceRenderer)
+}
+func BenchmarkPodServiceStats(b *testing.B) {
+	benchmarkStats(b, render.PodServiceRenderer)
+}
 
 func benchmarkRender(b *testing.B, r render.Renderer) {
+
 	report, err := loadReport()
 	if err != nil {
 		b.Fatal(err)
@@ -65,7 +74,7 @@ func benchmarkRender(b *testing.B, r render.Renderer) {
 		b.StopTimer()
 		render.ResetCache()
 		b.StartTimer()
-		benchmarkRenderResult = r.Render(report)
+		benchmarkRenderResult = r.Render(report, render.FilterNoop)
 		if len(benchmarkRenderResult) == 0 {
 			b.Errorf("Rendered topology contained no nodes")
 		}
@@ -85,7 +94,7 @@ func benchmarkStats(b *testing.B, r render.Renderer) {
 		b.StopTimer()
 		render.ResetCache()
 		b.StartTimer()
-		benchmarkStatsResult = r.Stats(report)
+		benchmarkStatsResult = r.Stats(report, render.FilterNoop)
 	}
 }
 

--- a/render/container_test.go
+++ b/render/container_test.go
@@ -47,8 +47,8 @@ func testMap(t *testing.T, f render.MapFunc, input testcase) {
 }
 
 func TestContainerRenderer(t *testing.T) {
-	have := render.ContainerRenderer.Render(fixture.Report).Prune()
-	want := expected.RenderedContainers.Prune()
+	have := Prune(render.ContainerRenderer.Render(fixture.Report))
+	want := Prune(expected.RenderedContainers)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}
@@ -61,8 +61,8 @@ func TestContainerFilterRenderer(t *testing.T) {
 	input.Container.Nodes[fixture.ClientContainerNodeID] = input.Container.Nodes[fixture.ClientContainerNodeID].WithLatests(map[string]string{
 		docker.LabelPrefix + "works.weave.role": "system",
 	})
-	have := render.FilterSystem(render.ContainerRenderer).Render(input).Prune()
-	want := expected.RenderedContainers.Copy().Prune()
+	have := Prune(render.FilterSystem(render.ContainerRenderer).Render(input))
+	want := Prune(expected.RenderedContainers.Copy())
 	delete(want, fixture.ClientContainerNodeID)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -92,8 +92,8 @@ func TestContainerWithHostIPsRenderer(t *testing.T) {
 }
 
 func TestContainerImageRenderer(t *testing.T) {
-	have := render.ContainerImageRenderer.Render(fixture.Report).Prune()
-	want := expected.RenderedContainerImages.Prune()
+	have := Prune(render.ContainerImageRenderer.Render(fixture.Report))
+	want := Prune(expected.RenderedContainerImages)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}

--- a/render/container_test.go
+++ b/render/container_test.go
@@ -98,3 +98,33 @@ func TestContainerImageRenderer(t *testing.T) {
 		t.Error(test.Diff(want, have))
 	}
 }
+
+func TestContainerImageFilterRenderer(t *testing.T) {
+	// add a system container into the topology and ensure
+	// it is filtered out correctly.
+	input := fixture.Report.Copy()
+
+	// TODO: Add a process and endpoint here to make this test fail, so we can fix it.
+
+	clientContainer2ID = "f6g7h8i9j1"
+	clientContainer2NodeID = report.MakeContainerNodeID(fixture.ClientContainerID)
+	input.Container.AddNode(report.MakeNodeWith(clientContainer2NodeID, map[string]string{
+		docker.LabelPrefix + "works.weave.role": "system",
+
+		docker.ImageID:    fixture.ClientContainerImageID,
+		docker.ImageName:  fixture.ClientContainerImageName,
+		report.HostNodeID: fixture.ClientHostNodeID,
+	}).
+		WithParents(report.EmptySets.
+			Add("host", report.MakeStringSet(fixture.ClientHostNodeID)),
+		).WithTopology(report.ContainerImage))
+
+	have := Prune(render.FilterSystem(render.ContainerImageRenderer).Render(input))
+	want := Prune(expected.RenderedContainerImages.Copy())
+	// Test works by virtue of the RenderedContainerImage only having a container
+	// counter == 1
+
+	if !reflect.DeepEqual(want, have) {
+		t.Error(test.Diff(want, have))
+	}
+}

--- a/render/detailed/node_test.go
+++ b/render/detailed/node_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func child(t *testing.T, r render.Renderer, id string) detailed.NodeSummary {
-	s, ok := detailed.MakeNodeSummary(fixture.Report, r.Render(fixture.Report)[id])
+	s, ok := detailed.MakeNodeSummary(fixture.Report, r.Render(fixture.Report, render.FilterNoop)[id])
 	if !ok {
 		t.Fatalf("Expected node %s to be summarizable, but wasn't", id)
 	}
@@ -24,7 +24,7 @@ func child(t *testing.T, r render.Renderer, id string) detailed.NodeSummary {
 }
 
 func TestMakeDetailedHostNode(t *testing.T) {
-	renderableNodes := render.HostRenderer.Render(fixture.Report)
+	renderableNodes := render.HostRenderer.Render(fixture.Report, render.FilterNoop)
 	renderableNode := renderableNodes[fixture.ClientHostNodeID]
 	have := detailed.MakeNode("hosts", fixture.Report, renderableNodes, renderableNode)
 
@@ -171,7 +171,7 @@ func TestMakeDetailedHostNode(t *testing.T) {
 
 func TestMakeDetailedContainerNode(t *testing.T) {
 	id := fixture.ServerContainerNodeID
-	renderableNodes := render.ContainerRenderer.Render(fixture.Report)
+	renderableNodes := render.ContainerRenderer.Render(fixture.Report, render.FilterNoop)
 	renderableNode, ok := renderableNodes[id]
 	if !ok {
 		t.Fatalf("Node not found: %s", id)
@@ -298,14 +298,14 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 
 func TestMakeDetailedPodNode(t *testing.T) {
 	id := fixture.ServerPodNodeID
-	renderableNodes := render.PodRenderer.Render(fixture.Report)
+	renderableNodes := render.PodRenderer.Render(fixture.Report, render.FilterNoop)
 	renderableNode, ok := renderableNodes[id]
 	if !ok {
 		t.Fatalf("Node not found: %s", id)
 	}
 	have := detailed.MakeNode("pods", fixture.Report, renderableNodes, renderableNode)
 
-	containerNodeSummary := child(t, render.ContainerRenderer, fixture.ServerContainerNodeID)
+	containerNodeSummary := child(t, render.ContainerWithImageNameRenderer, fixture.ServerContainerNodeID)
 	serverProcessNodeSummary := child(t, render.ProcessRenderer, fixture.ServerProcessNodeID)
 	serverProcessNodeSummary.Linkable = true // Temporary workaround for: https://github.com/weaveworks/scope/issues/1295
 	want := detailed.Node{

--- a/render/detailed/parents_test.go
+++ b/render/detailed/parents_test.go
@@ -20,30 +20,30 @@ func TestParents(t *testing.T) {
 	}{
 		{
 			name: "Node accidentally tagged with itself",
-			node: render.HostRenderer.Render(fixture.Report)[fixture.ClientHostNodeID].WithParents(
+			node: render.HostRenderer.Render(fixture.Report, render.FilterNoop)[fixture.ClientHostNodeID].WithParents(
 				report.EmptySets.Add(report.Host, report.MakeStringSet(fixture.ClientHostNodeID)),
 			),
 			want: nil,
 		},
 		{
-			node: render.HostRenderer.Render(fixture.Report)[fixture.ClientHostNodeID],
+			node: render.HostRenderer.Render(fixture.Report, render.FilterNoop)[fixture.ClientHostNodeID],
 			want: nil,
 		},
 		{
-			node: render.ContainerImageRenderer.Render(fixture.Report)[fixture.ClientContainerImageNodeID],
+			node: render.ContainerImageRenderer.Render(fixture.Report, render.FilterNoop)[fixture.ClientContainerImageNodeID],
 			want: []detailed.Parent{
 				{ID: fixture.ClientHostNodeID, Label: fixture.ClientHostName, TopologyID: "hosts"},
 			},
 		},
 		{
-			node: render.ContainerRenderer.Render(fixture.Report)[fixture.ClientContainerNodeID],
+			node: render.ContainerRenderer.Render(fixture.Report, render.FilterNoop)[fixture.ClientContainerNodeID],
 			want: []detailed.Parent{
 				{ID: fixture.ClientContainerImageNodeID, Label: fixture.ClientContainerImageName, TopologyID: "containers-by-image"},
 				{ID: fixture.ClientHostNodeID, Label: fixture.ClientHostName, TopologyID: "hosts"},
 			},
 		},
 		{
-			node: render.ProcessRenderer.Render(fixture.Report)[fixture.ClientProcess1NodeID],
+			node: render.ProcessRenderer.Render(fixture.Report, render.FilterNoop)[fixture.ClientProcess1NodeID],
 			want: []detailed.Parent{
 				{ID: fixture.ClientContainerNodeID, Label: fixture.ClientContainerName, TopologyID: "containers"},
 				{ID: fixture.ClientContainerImageNodeID, Label: fixture.ClientContainerImageName, TopologyID: "containers-by-image"},

--- a/render/detailed/summary_test.go
+++ b/render/detailed/summary_test.go
@@ -21,7 +21,7 @@ import (
 func TestSummaries(t *testing.T) {
 	{
 		// Just a convenient source of some rendered nodes
-		have := detailed.Summaries(fixture.Report, render.ProcessRenderer.Render(fixture.Report))
+		have := detailed.Summaries(fixture.Report, render.ProcessRenderer.Render(fixture.Report, render.FilterNoop))
 		// The ids of the processes rendered above
 		expectedIDs := []string{
 			fixture.ClientProcess1NodeID,
@@ -51,7 +51,7 @@ func TestSummaries(t *testing.T) {
 		input := fixture.Report.Copy()
 
 		input.Process.Nodes[fixture.ClientProcess1NodeID] = input.Process.Nodes[fixture.ClientProcess1NodeID].WithMetrics(report.Metrics{process.CPUUsage: metric})
-		have := detailed.Summaries(input, render.ProcessRenderer.Render(input))
+		have := detailed.Summaries(input, render.ProcessRenderer.Render(input, render.FilterNoop))
 
 		node, ok := have[fixture.ClientProcess1NodeID]
 		if !ok {

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -27,15 +27,16 @@ var (
 			return n
 		}
 	}
-	pseudo          = node(render.Pseudo)
-	endpoint        = node(report.Endpoint)
-	processNode     = node(report.Process)
-	processNameNode = node(render.MakeGroupNodeTopology(report.Process, process.Name))
-	container       = node(report.Container)
-	containerImage  = node(report.ContainerImage)
-	pod             = node(report.Pod)
-	service         = node(report.Service)
-	hostNode        = node(report.Host)
+	pseudo                = node(render.Pseudo)
+	endpoint              = node(report.Endpoint)
+	processNode           = node(report.Process)
+	processNameNode       = node(render.MakeGroupNodeTopology(report.Process, process.Name))
+	container             = node(report.Container)
+	containerHostnameNode = node(render.MakeGroupNodeTopology(report.Container, docker.ContainerHostname))
+	containerImage        = node(report.ContainerImage)
+	pod                   = node(report.Pod)
+	service               = node(report.Service)
+	hostNode              = node(report.Host)
 
 	UnknownPseudoNode1ID = render.MakePseudoNodeID(fixture.UnknownClient1IP)
 	UnknownPseudoNode2ID = render.MakePseudoNodeID(fixture.UnknownClient3IP)
@@ -173,6 +174,37 @@ var (
 
 		uncontainedServerID:       uncontainedServerNode,
 		render.IncomingInternetID: theIncomingInternetNode(fixture.ServerContainerNodeID),
+		render.OutgoingInternetID: theOutgoingInternetNode,
+	}
+
+	RenderedContainerHostnames = report.Nodes{
+		fixture.ClientContainerHostname: containerHostnameNode(fixture.ClientContainerHostname, fixture.ServerContainerHostname).
+			WithLatests(map[string]string{
+				docker.ContainerHostname: fixture.ClientContainerHostname,
+			}).
+			WithCounters(map[string]int{
+				report.Container: 1,
+			}).
+			WithChildren(report.MakeNodeSet(
+				RenderedEndpoints[fixture.Client54001NodeID],
+				RenderedEndpoints[fixture.Client54002NodeID],
+				RenderedProcesses[fixture.ClientProcess1NodeID],
+				RenderedProcesses[fixture.ClientProcess2NodeID],
+				RenderedContainers[fixture.ClientContainerNodeID],
+			)),
+
+		fixture.ServerContainerHostname: containerHostnameNode(fixture.ServerContainerHostname).
+			WithLatests(map[string]string{
+				docker.ContainerHostname: fixture.ServerContainerHostname,
+			}).
+			WithChildren(report.MakeNodeSet(
+				RenderedEndpoints[fixture.Server80NodeID],
+				RenderedProcesses[fixture.ServerProcessNodeID],
+				RenderedContainers[fixture.ServerContainerNodeID],
+			)),
+
+		uncontainedServerID:       uncontainedServerNode,
+		render.IncomingInternetID: theIncomingInternetNode(fixture.ServerContainerHostname),
 		render.OutgoingInternetID: theOutgoingInternetNode,
 	}
 

--- a/render/filters.go
+++ b/render/filters.go
@@ -19,8 +19,8 @@ type CustomRenderer struct {
 }
 
 // Render implements Renderer
-func (c CustomRenderer) Render(rpt report.Report) report.Nodes {
-	return c.RenderFunc(c.Renderer.Render(rpt))
+func (c CustomRenderer) Render(rpt report.Report, dct Decorator) report.Nodes {
+	return c.RenderFunc(c.Renderer.Render(rpt, dct))
 }
 
 // ColorConnected colors nodes with the IsConnected key if
@@ -55,41 +55,46 @@ func ColorConnected(r Renderer) Renderer {
 	}
 }
 
+// FilterFunc is the function type used by Filters
+type FilterFunc func(report.Node) bool
+
+// ComposeFilterFuncs composes filterfuncs into a single FilterFunc checking all.
+func ComposeFilterFuncs(fs ...FilterFunc) FilterFunc {
+	return func(n report.Node) bool {
+		for _, f := range fs {
+			if !f(n) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
 // Filter removes nodes from a view based on a predicate.
 type Filter struct {
 	Renderer
-	FilterFunc func(report.Node) bool
-	Silent     bool // true means we don't report stats for how many are filtered
+	FilterFunc FilterFunc
 }
 
 // MakeFilter makes a new Filter.
-func MakeFilter(f func(report.Node) bool, r Renderer) Renderer {
+func MakeFilter(f FilterFunc, r Renderer) Renderer {
 	return Memoise(&Filter{
 		Renderer:   r,
 		FilterFunc: f,
-	})
-}
-
-// MakeSilentFilter makes a new Filter which does not report how many nodes it filters in Stats.
-func MakeSilentFilter(f func(report.Node) bool, r Renderer) Renderer {
-	return Memoise(&Filter{
-		Renderer:   r,
-		FilterFunc: f,
-		Silent:     true,
 	})
 }
 
 // Render implements Renderer
-func (f *Filter) Render(rpt report.Report) report.Nodes {
-	nodes, _ := f.render(rpt)
+func (f *Filter) Render(rpt report.Report, dct Decorator) report.Nodes {
+	nodes, _ := f.render(rpt, dct)
 	return nodes
 }
 
-func (f *Filter) render(rpt report.Report) (report.Nodes, int) {
+func (f *Filter) render(rpt report.Report, dct Decorator) (report.Nodes, int) {
 	output := report.Nodes{}
 	inDegrees := map[string]int{}
 	filtered := 0
-	for id, node := range f.Renderer.Render(rpt) {
+	for id, node := range f.Renderer.Render(rpt, dct) {
 		if f.FilterFunc(node) {
 			output[id] = node
 			inDegrees[id] = 0
@@ -126,14 +131,13 @@ func (f *Filter) render(rpt report.Report) (report.Nodes, int) {
 	return output, filtered
 }
 
-// Stats implements Renderer
-func (f Filter) Stats(rpt report.Report) Stats {
-	var upstream = f.Renderer.Stats(rpt)
-	if !f.Silent {
-		_, filtered := f.render(rpt)
-		upstream.FilteredNodes += filtered
-	}
-	return upstream
+// Stats implements Renderer. General logic is to take the first (i.e.
+// highest-level) stats we find, so upstream stats are ignored. This means that
+// if we want to count the stats from multiple filters we need to compose their
+// FilterFuncs, into a single Filter.
+func (f Filter) Stats(rpt report.Report, dct Decorator) Stats {
+	_, filtered := f.render(rpt, dct)
+	return Stats{FilteredNodes: filtered}
 }
 
 // IsConnected is the key added to Node.Metadata by ColorConnected
@@ -142,7 +146,7 @@ const IsConnected = "is_connected"
 
 // Complement takes a FilterFunc f and returns a FilterFunc that has the same
 // effects, if any, and returns the opposite truth value.
-func Complement(f func(report.Node) bool) func(report.Node) bool {
+func Complement(f FilterFunc) FilterFunc {
 	return func(node report.Node) bool { return !f(node) }
 }
 
@@ -169,27 +173,11 @@ func FilterUnconnected(r Renderer) Renderer {
 	)
 }
 
-// SilentFilterUnconnected produces a renderer that filters unconnected nodes
-// from the given renderer; nodes filtered by this are not reported in stats.
-func SilentFilterUnconnected(r Renderer) Renderer {
-	return MakeSilentFilter(
-		func(node report.Node) bool {
-			_, ok := node.Latest.Lookup(IsConnected)
-			return ok
-		},
-		ColorConnected(r),
-	)
-}
+// Noop allows all nodes through
+func Noop(_ report.Node) bool { return true }
 
 // FilterNoop does nothing.
-func FilterNoop(in Renderer) Renderer {
-	return in
-}
-
-// FilterStopped filters out stopped containers.
-func FilterStopped(r Renderer) Renderer {
-	return MakeFilter(IsRunning, r)
-}
+func FilterNoop(r Renderer) Renderer { return r }
 
 // IsRunning checks if the node is a running docker container
 func IsRunning(n report.Node) bool {
@@ -197,14 +185,22 @@ func IsRunning(n report.Node) bool {
 	return !ok || (state == docker.StateRunning || state == docker.StateRestarting || state == docker.StatePaused)
 }
 
+// IsStopped checks if the node is *not* a running docker container
+var IsStopped = Complement(IsRunning)
+
+// FilterStopped filters out stopped containers.
+func FilterStopped(r Renderer) Renderer {
+	return MakeFilter(IsStopped, r)
+}
+
 // FilterRunning filters out running containers.
 func FilterRunning(r Renderer) Renderer {
-	return MakeFilter(Complement(IsRunning), r)
+	return MakeFilter(IsRunning, r)
 }
 
 // FilterNonProcspied removes endpoints which were not found in procspy.
 func FilterNonProcspied(r Renderer) Renderer {
-	return MakeSilentFilter(
+	return MakeFilter(
 		func(node report.Node) bool {
 			_, ok := node.Latest.Lookup(endpoint.Procspied)
 			return ok
@@ -213,8 +209,8 @@ func FilterNonProcspied(r Renderer) Renderer {
 	)
 }
 
-// IsSystem checks if the node is a "system" node
-func IsSystem(n report.Node) bool {
+// IsApplication checks if the node is an "application" node
+func IsApplication(n report.Node) bool {
 	containerName, _ := n.Latest.Lookup(docker.ContainerName)
 	if _, ok := systemContainerNames[containerName]; ok {
 		return false
@@ -239,14 +235,40 @@ func IsSystem(n report.Node) bool {
 	return true
 }
 
+// IsSystem checks if the node is a "system" node
+var IsSystem = Complement(IsApplication)
+
 // FilterSystem is a Renderer which filters out system nodes.
 func FilterSystem(r Renderer) Renderer {
 	return MakeFilter(IsSystem, r)
 }
 
-// FilterApplication is a Renderer which filters out system nodes.
+// FilterApplication is a Renderer which filters out application nodes.
 func FilterApplication(r Renderer) Renderer {
-	return MakeFilter(Complement(IsSystem), r)
+	return MakeFilter(IsApplication, r)
+}
+
+// FilterEmpty is a Renderer which filters out nodes which have no children
+// from the specified topology.
+func FilterEmpty(topology string, r Renderer) Renderer {
+	return MakeFilter(HasChildren(topology), r)
+}
+
+// HasChildren returns true if the node has no children from the specified
+// topology.
+func HasChildren(topology string) FilterFunc {
+	return func(n report.Node) bool {
+		if n.Topology == Pseudo {
+			return true
+		}
+		count := 0
+		n.Children.ForEach(func(child report.Node) {
+			if child.Topology == topology {
+				count++
+			}
+		})
+		return count > 0
+	}
 }
 
 var systemContainerNames = map[string]struct{}{

--- a/render/host_test.go
+++ b/render/host_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func TestHostRenderer(t *testing.T) {
-	have := render.HostRenderer.Render(fixture.Report).Prune()
-	want := expected.RenderedHosts.Prune()
+	have := Prune(render.HostRenderer.Render(fixture.Report))
+	want := Prune(expected.RenderedHosts)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}

--- a/render/host_test.go
+++ b/render/host_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestHostRenderer(t *testing.T) {
-	have := Prune(render.HostRenderer.Render(fixture.Report))
+	have := Prune(render.HostRenderer.Render(fixture.Report, render.FilterNoop))
 	want := Prune(expected.RenderedHosts)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))

--- a/render/memoise.go
+++ b/render/memoise.go
@@ -27,13 +27,17 @@ func Memoise(r Renderer) Renderer {
 // Render produces a set of Nodes given a Report.
 // Ideally, it just retrieves it from the cache, otherwise it calls through to
 // `r` and stores the result.
-func (m *memoise) Render(rpt report.Report) report.Nodes {
+func (m *memoise) Render(rpt report.Report, dct Decorator) report.Nodes {
 	key := fmt.Sprintf("%s-%s", rpt.ID, m.id)
-	if result, err := renderCache.Get(key); err == nil {
-		return result.(report.Nodes)
+	if dct == nil {
+		if result, err := renderCache.Get(key); err == nil {
+			return result.(report.Nodes)
+		}
 	}
-	output := m.Renderer.Render(rpt)
-	renderCache.Set(key, output)
+	output := m.Renderer.Render(rpt, dct)
+	if dct == nil {
+		renderCache.Set(key, output)
+	}
 	return output
 }
 

--- a/render/memoise_test.go
+++ b/render/memoise_test.go
@@ -11,8 +11,8 @@ import (
 
 type renderFunc func(r report.Report) report.Nodes
 
-func (f renderFunc) Render(r report.Report) report.Nodes { return f(r) }
-func (f renderFunc) Stats(r report.Report) render.Stats  { return render.Stats{} }
+func (f renderFunc) Render(r report.Report, _ render.Decorator) report.Nodes { return f(r) }
+func (f renderFunc) Stats(r report.Report, _ render.Decorator) render.Stats  { return render.Stats{} }
 
 func TestMemoise(t *testing.T) {
 	calls := 0
@@ -23,7 +23,7 @@ func TestMemoise(t *testing.T) {
 	m := render.Memoise(r)
 	rpt1 := report.MakeReport()
 
-	result1 := m.Render(rpt1)
+	result1 := m.Render(rpt1, nil)
 	// it should have rendered it.
 	if _, ok := result1[rpt1.ID]; !ok {
 		t.Errorf("Expected rendered report to contain a node, but got: %v", result1)
@@ -32,7 +32,7 @@ func TestMemoise(t *testing.T) {
 		t.Errorf("Expected renderer to have been called the first time")
 	}
 
-	result2 := m.Render(rpt1)
+	result2 := m.Render(rpt1, nil)
 	if !reflect.DeepEqual(result1, result2) {
 		t.Errorf("Expected memoised result to be returned: %s", test.Diff(result1, result2))
 	}
@@ -41,7 +41,7 @@ func TestMemoise(t *testing.T) {
 	}
 
 	rpt2 := report.MakeReport()
-	result3 := m.Render(rpt2)
+	result3 := m.Render(rpt2, nil)
 	if reflect.DeepEqual(result1, result3) {
 		t.Errorf("Expected different result for different report, but were the same")
 	}
@@ -50,7 +50,7 @@ func TestMemoise(t *testing.T) {
 	}
 
 	render.ResetCache()
-	result4 := m.Render(rpt1)
+	result4 := m.Render(rpt1, nil)
 	if !reflect.DeepEqual(result1, result4) {
 		t.Errorf("Expected original result to be returned: %s", test.Diff(result1, result4))
 	}

--- a/render/pod.go
+++ b/render/pod.go
@@ -15,29 +15,33 @@ const (
 
 // PodRenderer is a Renderer which produces a renderable kubernetes
 // graph by merging the container graph and the pods topology.
-var PodRenderer = MakeReduce(
-	MakeSilentFilter(
-		func(n report.Node) bool {
-			// Drop unconnected pseudo nodes (could appear due to filtering)
-			_, isConnected := n.Latest.Lookup(IsConnected)
-			return n.Topology != Pseudo || isConnected
-		},
-		ColorConnected(MakeMap(
-			MapContainer2Pod,
-			ContainerRenderer,
-		)),
+var PodRenderer = FilterEmpty(report.Container,
+	MakeReduce(
+		MakeFilter(
+			func(n report.Node) bool {
+				// Drop unconnected pseudo nodes (could appear due to filtering)
+				_, isConnected := n.Latest.Lookup(IsConnected)
+				return n.Topology != Pseudo || isConnected
+			},
+			ColorConnected(MakeMap(
+				MapContainer2Pod,
+				ContainerWithImageNameRenderer,
+			)),
+		),
+		SelectPod,
 	),
-	SelectPod,
 )
 
 // PodServiceRenderer is a Renderer which produces a renderable kubernetes services
 // graph by merging the pods graph and the services topology.
-var PodServiceRenderer = MakeReduce(
-	MakeMap(
-		MapPod2Service,
-		PodRenderer,
+var PodServiceRenderer = FilterEmpty(report.Pod,
+	MakeReduce(
+		MakeMap(
+			MapPod2Service,
+			PodRenderer,
+		),
+		SelectService,
 	),
-	SelectService,
 )
 
 // MapContainer2Pod maps container Nodes to pod

--- a/render/pod_test.go
+++ b/render/pod_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestPodRenderer(t *testing.T) {
-	have := render.PodRenderer.Render(fixture.Report).Prune()
-	want := expected.RenderedPods.Prune()
+	have := Prune(render.PodRenderer.Render(fixture.Report))
+	want := Prune(expected.RenderedPods)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}
@@ -32,8 +32,8 @@ func TestPodFilterRenderer(t *testing.T) {
 	input.Container.Nodes[fixture.ClientContainerNodeID] = input.Container.Nodes[fixture.ClientContainerNodeID].WithLatests(map[string]string{
 		docker.LabelPrefix + "io.kubernetes.pod.name": "kube-system/foo",
 	})
-	have := render.FilterSystem(render.PodRenderer).Render(input).Prune()
-	want := expected.RenderedPods.Copy().Prune()
+	have := Prune(render.FilterSystem(render.PodRenderer).Render(input))
+	want := Prune(expected.RenderedPods.Copy())
 	delete(want, fixture.ClientPodNodeID)
 	delete(want, fixture.ClientContainerNodeID)
 	if !reflect.DeepEqual(want, have) {
@@ -42,8 +42,8 @@ func TestPodFilterRenderer(t *testing.T) {
 }
 
 func TestPodServiceRenderer(t *testing.T) {
-	have := render.PodServiceRenderer.Render(fixture.Report).Prune()
-	want := expected.RenderedPodServices.Prune()
+	have := Prune(render.PodServiceRenderer.Render(fixture.Report))
+	want := Prune(expected.RenderedPodServices)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}

--- a/render/process.go
+++ b/render/process.go
@@ -42,9 +42,9 @@ type processWithContainerNameRenderer struct {
 	Renderer
 }
 
-func (r processWithContainerNameRenderer) Render(rpt report.Report) report.Nodes {
-	processes := r.Renderer.Render(rpt)
-	containers := SelectContainer.Render(rpt)
+func (r processWithContainerNameRenderer) Render(rpt report.Report, dct Decorator) report.Nodes {
+	processes := r.Renderer.Render(rpt, dct)
+	containers := SelectContainer.Render(rpt, dct)
 
 	outputs := report.Nodes{}
 	for id, p := range processes {

--- a/render/process_test.go
+++ b/render/process_test.go
@@ -11,24 +11,24 @@ import (
 )
 
 func TestEndpointRenderer(t *testing.T) {
-	have := render.EndpointRenderer.Render(fixture.Report).Prune()
-	want := expected.RenderedEndpoints.Prune()
+	have := Prune(render.EndpointRenderer.Render(fixture.Report))
+	want := Prune(expected.RenderedEndpoints)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}
 }
 
 func TestProcessRenderer(t *testing.T) {
-	have := render.ProcessRenderer.Render(fixture.Report).Prune()
-	want := expected.RenderedProcesses.Prune()
+	have := Prune(render.ProcessRenderer.Render(fixture.Report))
+	want := Prune(expected.RenderedProcesses)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}
 }
 
 func TestProcessNameRenderer(t *testing.T) {
-	have := render.ProcessNameRenderer.Render(fixture.Report).Prune()
-	want := expected.RenderedProcessNames.Prune()
+	have := Prune(render.ProcessNameRenderer.Render(fixture.Report))
+	want := Prune(expected.RenderedProcessNames)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}

--- a/render/process_test.go
+++ b/render/process_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestEndpointRenderer(t *testing.T) {
-	have := Prune(render.EndpointRenderer.Render(fixture.Report))
+	have := Prune(render.EndpointRenderer.Render(fixture.Report, render.FilterNoop))
 	want := Prune(expected.RenderedEndpoints)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -19,7 +19,7 @@ func TestEndpointRenderer(t *testing.T) {
 }
 
 func TestProcessRenderer(t *testing.T) {
-	have := Prune(render.ProcessRenderer.Render(fixture.Report))
+	have := Prune(render.ProcessRenderer.Render(fixture.Report, render.FilterNoop))
 	want := Prune(expected.RenderedProcesses)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -27,7 +27,7 @@ func TestProcessRenderer(t *testing.T) {
 }
 
 func TestProcessNameRenderer(t *testing.T) {
-	have := Prune(render.ProcessNameRenderer.Render(fixture.Report))
+	have := Prune(render.ProcessNameRenderer.Render(fixture.Report, render.FilterNoop))
 	want := Prune(expected.RenderedProcessNames)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -16,6 +16,31 @@ type mockRenderer struct {
 func (m mockRenderer) Render(rpt report.Report) report.Nodes { return m.Nodes }
 func (m mockRenderer) Stats(rpt report.Report) render.Stats  { return render.Stats{} }
 
+// Prune returns a copy of the Nodes with all information not strictly
+// necessary for rendering nodes and edges in the UI cut away.
+func Prune(nodes report.Nodes) report.Nodes {
+	result := report.Nodes{}
+	for id, node := range nodes {
+		result[id] = PruneNode(node)
+	}
+	return result
+}
+
+// PruneNode returns a copy of the Node with all information not strictly
+// necessary for rendering nodes and edges stripped away. Specifically, that
+// means cutting out parts of the Node.
+func PruneNode(node report.Node) report.Node {
+	prunedChildren := report.MakeNodeSet()
+	node.Children.ForEach(func(child report.Node) {
+		prunedChildren = prunedChildren.Add(PruneNode(child))
+	})
+	return report.MakeNode(
+		node.ID).
+		WithTopology(node.Topology).
+		WithAdjacent(node.Adjacency.Copy()...).
+		WithChildren(prunedChildren)
+}
+
 func TestReduceRender(t *testing.T) {
 	renderer := render.Reduce([]render.Renderer{
 		mockRenderer{Nodes: report.Nodes{"foo": report.MakeNode("foo")}},

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -13,8 +13,13 @@ type mockRenderer struct {
 	report.Nodes
 }
 
-func (m mockRenderer) Render(rpt report.Report) report.Nodes { return m.Nodes }
-func (m mockRenderer) Stats(rpt report.Report) render.Stats  { return render.Stats{} }
+func (m mockRenderer) Render(rpt report.Report, d render.Decorator) report.Nodes {
+	if d != nil {
+		return d(mockRenderer{m.Nodes}).Render(rpt, nil)
+	}
+	return m.Nodes
+}
+func (m mockRenderer) Stats(rpt report.Report, _ render.Decorator) render.Stats { return render.Stats{} }
 
 // Prune returns a copy of the Nodes with all information not strictly
 // necessary for rendering nodes and edges in the UI cut away.
@@ -51,7 +56,7 @@ func TestReduceRender(t *testing.T) {
 		"foo": report.MakeNode("foo"),
 		"bar": report.MakeNode("bar"),
 	}
-	have := renderer.Render(report.MakeReport())
+	have := renderer.Render(report.MakeReport(), render.FilterNoop)
 	if !reflect.DeepEqual(want, have) {
 		t.Errorf("want %+v, have %+v", want, have)
 	}
@@ -68,7 +73,7 @@ func TestMapRender1(t *testing.T) {
 		}},
 	}
 	want := report.Nodes{}
-	have := mapper.Render(report.MakeReport())
+	have := mapper.Render(report.MakeReport(), render.FilterNoop)
 	if !reflect.DeepEqual(want, have) {
 		t.Errorf("want %+v, have %+v", want, have)
 	}
@@ -90,7 +95,7 @@ func TestMapRender2(t *testing.T) {
 	want := report.Nodes{
 		"bar": report.MakeNode("bar"),
 	}
-	have := mapper.Render(report.MakeReport())
+	have := mapper.Render(report.MakeReport(), render.FilterNoop)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}
@@ -112,7 +117,7 @@ func TestMapRender3(t *testing.T) {
 		"_foo": report.MakeNode("_foo").WithAdjacent("_baz"),
 		"_baz": report.MakeNode("_baz").WithAdjacent("_foo"),
 	}
-	have := mapper.Render(report.MakeReport())
+	have := mapper.Render(report.MakeReport(), render.FilterNoop)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}

--- a/render/selectors.go
+++ b/render/selectors.go
@@ -9,13 +9,13 @@ import (
 type TopologySelector string
 
 // Render implements Renderer
-func (t TopologySelector) Render(r report.Report) report.Nodes {
+func (t TopologySelector) Render(r report.Report, _ Decorator) report.Nodes {
 	topology, _ := r.Topology(string(t))
 	return topology.Nodes
 }
 
 // Stats implements Renderer
-func (t TopologySelector) Stats(r report.Report) Stats {
+func (t TopologySelector) Stats(r report.Report, _ Decorator) Stats {
 	return Stats{}
 }
 

--- a/render/short_lived_connections_test.go
+++ b/render/short_lived_connections_test.go
@@ -73,7 +73,7 @@ var (
 )
 
 func TestShortLivedInternetNodeConnections(t *testing.T) {
-	have := Prune(render.ContainerWithImageNameRenderer.Render(rpt))
+	have := Prune(render.ContainerWithImageNameRenderer.Render(rpt, render.FilterNoop))
 
 	// Conntracked-only connections from the internet should be assigned to the internet pseudonode
 	internet, ok := have[render.IncomingInternetID]

--- a/render/short_lived_connections_test.go
+++ b/render/short_lived_connections_test.go
@@ -73,7 +73,7 @@ var (
 )
 
 func TestShortLivedInternetNodeConnections(t *testing.T) {
-	have := render.ContainerWithImageNameRenderer.Render(rpt).Prune()
+	have := Prune(render.ContainerWithImageNameRenderer.Render(rpt))
 
 	// Conntracked-only connections from the internet should be assigned to the internet pseudonode
 	internet, ok := have[render.IncomingInternetID]

--- a/report/node.go
+++ b/report/node.go
@@ -214,18 +214,3 @@ func (n Node) Merge(other Node) Node {
 	cp.Children = cp.Children.Merge(other.Children)
 	return cp
 }
-
-// Prune returns a copy of the Node with all information not strictly necessary
-// for rendering nodes and edges stripped away. Specifically, that means
-// cutting out parts of the Node.
-func (n Node) Prune() Node {
-	prunedChildren := MakeNodeSet()
-	n.Children.ForEach(func(child Node) {
-		prunedChildren = prunedChildren.Add(child.Prune())
-	})
-	return MakeNode(
-		n.ID).
-		WithTopology(n.Topology).
-		WithAdjacent(n.Adjacency.Copy()...).
-		WithChildren(prunedChildren)
-}

--- a/report/node_set.go
+++ b/report/node_set.go
@@ -40,6 +40,22 @@ func (n NodeSet) Add(nodes ...Node) NodeSet {
 	return NodeSet{result}
 }
 
+// Delete deletes the nodes from the NodeSet by ID. Delete is the only valid
+// way to shrink a NodeSet. Delete returns the NodeSet to enable chaining.
+func (n NodeSet) Delete(ids ...string) NodeSet {
+	if n.Size() == 0 {
+		return n
+	}
+	result := n.psMap
+	for _, id := range ids {
+		result = result.Delete(id)
+	}
+	if result.Size() == 0 {
+		return EmptyNodeSet
+	}
+	return NodeSet{result}
+}
+
 // Merge combines the two NodeSets and returns a new result.
 func (n NodeSet) Merge(other NodeSet) NodeSet {
 	nSize, otherSize := n.Size(), other.Size()

--- a/report/node_set_test.go
+++ b/report/node_set_test.go
@@ -167,6 +167,63 @@ func BenchmarkNodeSetAdd(b *testing.B) {
 	}
 }
 
+func TestNodeSetDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		input report.NodeSet
+		nodes []string
+		want  report.NodeSet
+	}{
+		{
+			input: report.NodeSet{},
+			nodes: []string{},
+			want:  report.NodeSet{},
+		},
+		{
+			input: report.EmptyNodeSet,
+			nodes: []string{},
+			want:  report.EmptyNodeSet,
+		},
+		{
+			input: report.MakeNodeSet(report.MakeNode("a")),
+			nodes: []string{},
+			want:  report.MakeNodeSet(report.MakeNode("a")),
+		},
+		{
+			input: report.EmptyNodeSet,
+			nodes: []string{"a"},
+			want:  report.EmptyNodeSet,
+		},
+		{
+			input: report.MakeNodeSet(report.MakeNode("a")),
+			nodes: []string{"a"},
+			want:  report.EmptyNodeSet,
+		},
+		{
+			input: report.MakeNodeSet(report.MakeNode("b")),
+			nodes: []string{"a", "b"},
+			want:  report.EmptyNodeSet,
+		},
+		{
+			input: report.MakeNodeSet(report.MakeNode("a")),
+			nodes: []string{"c", "b"},
+			want:  report.MakeNodeSet(report.MakeNode("a")),
+		},
+		{
+			input: report.MakeNodeSet(report.MakeNode("a"), report.MakeNode("c")),
+			nodes: []string{"a", "a", "a"},
+			want:  report.MakeNodeSet(report.MakeNode("c")),
+		},
+	} {
+		originalLen := testcase.input.Size()
+		if want, have := testcase.want, testcase.input.Delete(testcase.nodes...); !reflect.DeepEqual(want, have) {
+			t.Errorf("%v + %v: want %v, have %v", testcase.input, testcase.nodes, want, have)
+		}
+		if testcase.input.Size() != originalLen {
+			t.Errorf("%v + %v: modified the original input!", testcase.input, testcase.nodes)
+		}
+	}
+}
+
 func TestNodeSetMerge(t *testing.T) {
 	for _, testcase := range []struct {
 		input report.NodeSet

--- a/report/topology.go
+++ b/report/topology.go
@@ -185,16 +185,6 @@ func (n Nodes) Merge(other Nodes) Nodes {
 	return cp
 }
 
-// Prune returns a copy of the Nodes with all information not strictly
-// necessary for rendering nodes and edges in the UI cut away.
-func (n Nodes) Prune() Nodes {
-	result := Nodes{}
-	for id, node := range n {
-		result[id] = node.Prune()
-	}
-	return result
-}
-
 // Validate checks the topology for various inconsistencies.
 func (t Topology) Validate() error {
 	errs := []string{}

--- a/test/fixture/report_fixture.go
+++ b/test/fixture/report_fixture.go
@@ -75,8 +75,12 @@ var (
 	ClientContainerID     = "a1b2c3d4e5"
 	ClientContainerName   = "client"
 	ServerContainerID     = "5e4d3c2b1a"
+	ServerContainerName   = "task-name-5-server-aceb93e2f2b797caba01"
 	ClientContainerNodeID = report.MakeContainerNodeID(ClientContainerID)
 	ServerContainerNodeID = report.MakeContainerNodeID(ServerContainerID)
+
+	ClientContainerHostname = ClientContainerName + ".hostname.com"
+	ServerContainerHostname = ServerContainerName + ".hostname.com"
 
 	ClientContainerImageID     = "imageid123"
 	ServerContainerImageID     = "imageid456"
@@ -256,6 +260,7 @@ var (
 					ClientContainerNodeID, map[string]string{
 						docker.ContainerID:                            ClientContainerID,
 						docker.ContainerName:                          ClientContainerName,
+						docker.ContainerHostname:                      ClientContainerHostname,
 						docker.ImageID:                                ClientContainerImageID,
 						report.HostNodeID:                             ClientHostNodeID,
 						docker.LabelPrefix + "io.kubernetes.pod.name": ClientPodID,
@@ -276,7 +281,8 @@ var (
 
 					ServerContainerNodeID, map[string]string{
 						docker.ContainerID:                                        ServerContainerID,
-						docker.ContainerName:                                      "task-name-5-server-aceb93e2f2b797caba01",
+						docker.ContainerName:                                      ServerContainerName,
+						docker.ContainerHostname:                                  ServerContainerHostname,
 						docker.ContainerState:                                     docker.StateRunning,
 						docker.ContainerStateHuman:                                docker.StateRunning,
 						docker.ImageID:                                            ServerContainerImageID,


### PR DESCRIPTION
Fixes #1219, Fixes #1130

Does *not* fix #815 

Filtered children are still shown in the details panel, because otherwise one of them stopping could make the detail panel go empty, when the node disappears, which is slightly odd. But this means that a container image could say "1 container" (if it has 4 stopped and one running), then show all 5 containers in the detail panel, which is also slightly odd.

I'm not really sure about the naming of `APITopologyDesc.filteredRenderer`, or about having two different fields for this. I was hoping to have just one field, so all the renderers would have the same signature. But, since only some of them need the filters injected, it feels odd to force that requirement on the others.

This will (at the moment) also break memoisation for some of the rendering pipelines. There is an assumption that the map/reduce pipelines survive between requests, but this is no longer the case for all pipelines.

Will squash stuff before merging.