### PR TITLE
Don't show container labels on container images

### DIFF
--- a/probe/docker/registry_test.go
+++ b/probe/docker/registry_test.go
@@ -224,7 +224,14 @@ var (
 	apiContainer1       = client.APIContainers{ID: "ping"}
 	apiContainer2       = client.APIContainers{ID: "wiff"}
 	renamedAPIContainer = client.APIContainers{ID: "renamed"}
-	apiImage1           = client.APIImages{ID: "baz", RepoTags: []string{"bang", "not-chosen"}}
+	apiImage1           = client.APIImages{
+		ID:       "baz",
+		RepoTags: []string{"bang", "not-chosen"},
+		Labels: map[string]string{
+			"imgfoo1": "bar1",
+			"imgfoo2": "bar2",
+		},
+	}
 )
 
 func newMockClient() *mockDockerClient {

--- a/probe/docker/reporter.go
+++ b/probe/docker/reporter.go
@@ -12,8 +12,9 @@ import (
 
 // Keys for use in Node
 const (
-	ImageID   = "docker_image_id"
-	ImageName = "docker_image_name"
+	ImageID          = "docker_image_id"
+	ImageName        = "docker_image_name"
+	ImageLabelPrefix = "docker_image_label_"
 )
 
 // Exposed for testing
@@ -46,7 +47,7 @@ var (
 	}
 
 	ContainerImageTableTemplates = report.TableTemplates{
-		LabelPrefix: {ID: LabelPrefix, Label: "Docker Labels", Prefix: LabelPrefix},
+		ImageLabelPrefix: {ID: ImageLabelPrefix, Label: "Docker Labels", Prefix: ImageLabelPrefix},
 	}
 )
 
@@ -169,7 +170,7 @@ func (r *Reporter) containerImageTopology() report.Topology {
 		node := report.MakeNodeWith(nodeID, map[string]string{
 			ImageID: imageID,
 		})
-		node = node.AddTable(LabelPrefix, image.Labels)
+		node = node.AddTable(ImageLabelPrefix, image.Labels)
 
 		if len(image.RepoTags) > 0 {
 			node = node.WithLatests(map[string]string{ImageName: image.RepoTags[0]})

--- a/probe/docker/reporter_test.go
+++ b/probe/docker/reporter_test.go
@@ -96,8 +96,10 @@ func TestReporter(t *testing.T) {
 		}
 
 		for k, want := range map[string]string{
-			docker.ImageID:   "baz",
-			docker.ImageName: "bang",
+			docker.ImageID:                      "baz",
+			docker.ImageName:                    "bang",
+			docker.ImageLabelPrefix + "imgfoo1": "bar1",
+			docker.ImageLabelPrefix + "imgfoo2": "bar2",
 		} {
 			if have, ok := node.Latest.Lookup(k); !ok || have != want {
 				t.Errorf("Expected container image %s latest %q: %q, got %q", containerImageNodeID, k, want, have)

--- a/render/filters.go
+++ b/render/filters.go
@@ -228,6 +228,10 @@ func IsSystem(n report.Node) bool {
 	if roleLabel == "system" {
 		return false
 	}
+	roleLabel, _ = n.Latest.Lookup(docker.ImageLabelPrefix + "works.weave.role")
+	if roleLabel == "system" {
+		return false
+	}
 	namespace, _ := n.Latest.Lookup(kubernetes.Namespace)
 	if namespace == "kube-system" {
 		return false


### PR DESCRIPTION
Fixes #815

Images have their own labels. We can still use the container labels for
filtering, as the filters are "System Containers", not "System Images".