### PR TITLE
Filter by Kubernetes Namespaces

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -276,8 +276,8 @@ func (r *registry) renderTopologies(rpt report.Report, req *http.Request) []APIT
 	r.walk(func(desc APITopologyDesc) {
 		renderer, decorator, _ := r.rendererForTopology(desc.id, values, rpt)
 		desc.Stats = decorateWithStats(rpt, renderer, decorator)
-		for i := range desc.SubTopologies {
-			renderer, decorator, _ := r.rendererForTopology(desc.id, values, rpt)
+		for i, sub := range desc.SubTopologies {
+			renderer, decorator, _ := r.rendererForTopology(sub.id, values, rpt)
 			desc.SubTopologies[i].Stats = decorateWithStats(rpt, renderer, decorator)
 		}
 		topologies = append(topologies, desc)

--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -30,7 +30,7 @@ func init() {
 			Options: []APITopologyOption{
 				{"system", "System containers", render.IsSystem},
 				{"application", "Application containers", render.IsApplication},
-				{"both", "Both", render.Noop},
+				{"both", "Both", nil},
 			},
 		},
 		{
@@ -39,7 +39,7 @@ func init() {
 			Options: []APITopologyOption{
 				{"stopped", "Stopped containers", render.IsStopped},
 				{"running", "Running containers", render.IsRunning},
-				{"both", "Both", render.Noop},
+				{"both", "Both", nil},
 			},
 		},
 	}
@@ -124,7 +124,7 @@ func kubernetesFilters(namespaces ...string) APITopologyOptionGroup {
 	for _, namespace := range namespaces {
 		options.Options = append(options.Options, APITopologyOption{namespace, namespace, render.IsNamespace(namespace)})
 	}
-	options.Options = append(options.Options, APITopologyOption{"all", "All Namespaces", render.Noop})
+	options.Options = append(options.Options, APITopologyOption{"all", "All Namespaces", nil})
 	return options
 }
 

--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -134,6 +134,9 @@ func updateFilters(rpt report.Report, topologies []APITopologyDesc) []APITopolog
 	namespaces := map[string]struct{}{}
 	for _, t := range []report.Topology{rpt.Pod, rpt.Service} {
 		for _, n := range t.Nodes {
+			if state, ok := n.Latest.Lookup(kubernetes.PodState); ok && state == kubernetes.StateDeleted {
+				continue
+			}
 			if namespace, ok := n.Latest.Lookup(kubernetes.Namespace); ok {
 				namespaces[namespace] = struct{}{}
 			}

--- a/app/router.go
+++ b/app/router.go
@@ -89,11 +89,11 @@ func RegisterTopologyRoutes(router *mux.Router, r Reporter) {
 	get.HandleFunc("/api/topology",
 		gzipHandler(requestContextDecorator(topologyRegistry.makeTopologyList(r))))
 	get.HandleFunc("/api/topology/{topology}",
-		gzipHandler(requestContextDecorator(topologyRegistry.captureRenderer(r, handleTopology))))
+		gzipHandler(requestContextDecorator(captureReporter(r, handleTopology))))
 	get.HandleFunc("/api/topology/{topology}/ws",
-		requestContextDecorator(topologyRegistry.captureRenderer(r, handleWs))) // NB not gzip!
+		requestContextDecorator(captureReporter(r, handleWs))) // NB not gzip!
 	get.MatcherFunc(URLMatcher("/api/topology/{topology}/{id}")).HandlerFunc(
-		gzipHandler(requestContextDecorator(topologyRegistry.captureRenderer(r, handleNode))))
+		gzipHandler(requestContextDecorator(captureReporter(r, handleNode))))
 	get.HandleFunc("/api/report",
 		gzipHandler(requestContextDecorator(makeRawReportHandler(r))))
 	get.HandleFunc("/api/probes",

--- a/app/router.go
+++ b/app/router.go
@@ -89,11 +89,11 @@ func RegisterTopologyRoutes(router *mux.Router, r Reporter) {
 	get.HandleFunc("/api/topology",
 		gzipHandler(requestContextDecorator(topologyRegistry.makeTopologyList(r))))
 	get.HandleFunc("/api/topology/{topology}",
-		gzipHandler(requestContextDecorator(captureReporter(r, handleTopology))))
+		gzipHandler(requestContextDecorator(topologyRegistry.captureRenderer(r, handleTopology))))
 	get.HandleFunc("/api/topology/{topology}/ws",
-		requestContextDecorator(captureReporter(r, handleWs))) // NB not gzip!
+		requestContextDecorator(captureReporter(r, handleWebsocket))) // NB not gzip!
 	get.MatcherFunc(URLMatcher("/api/topology/{topology}/{id}")).HandlerFunc(
-		gzipHandler(requestContextDecorator(captureReporter(r, handleNode))))
+		gzipHandler(requestContextDecorator(topologyRegistry.captureRenderer(r, handleNode))))
 	get.HandleFunc("/api/report",
 		gzipHandler(requestContextDecorator(makeRawReportHandler(r))))
 	get.HandleFunc("/api/probes",

--- a/probe/kubernetes/reporter_test.go
+++ b/probe/kubernetes/reporter_test.go
@@ -174,20 +174,23 @@ func TestReporter(t *testing.T) {
 		id            string
 		parentService string
 		latest        map[string]string
+		sets          map[string]report.StringSet
 	}{
 		{pod1ID, serviceID, map[string]string{
 			kubernetes.PodID:      "ping/pong-a",
 			kubernetes.PodName:    "pong-a",
 			kubernetes.Namespace:  "ping",
 			kubernetes.PodCreated: pod1.Created(),
-			kubernetes.ServiceIDs: "ping/pongservice",
+		}, map[string]report.StringSet{
+			kubernetes.ServiceIDs: report.MakeStringSet("ping/pongservice"),
 		}},
 		{pod2ID, serviceID, map[string]string{
 			kubernetes.PodID:      "ping/pong-b",
 			kubernetes.PodName:    "pong-b",
 			kubernetes.Namespace:  "ping",
 			kubernetes.PodCreated: pod1.Created(),
-			kubernetes.ServiceIDs: "ping/pongservice",
+		}, map[string]report.StringSet{
+			kubernetes.ServiceIDs: report.MakeStringSet("ping/pongservice"),
 		}},
 	} {
 		node, ok := rpt.Pod.Nodes[pod.id]
@@ -202,6 +205,12 @@ func TestReporter(t *testing.T) {
 		for k, want := range pod.latest {
 			if have, ok := node.Latest.Lookup(k); !ok || have != want {
 				t.Errorf("Expected pod %s latest %q: %q, got %q", pod.id, k, want, have)
+			}
+		}
+
+		for k, want := range pod.sets {
+			if have, ok := node.Sets.Lookup(k); !ok || !reflect.DeepEqual(want, have) {
+				t.Errorf("Expected pod %s sets %q: %q, got %q", pod.id, k, want, have)
 			}
 		}
 	}

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -238,8 +238,8 @@ var (
 		render.OutgoingInternetID: theOutgoingInternetNode,
 	}
 
-	unmanagedServerID   = render.MakePseudoNodeID(render.UnmanagedID, fixture.ServerHostID)
-	unmanagedServerNode = pseudo(unmanagedServerID, render.OutgoingInternetID).WithChildren(report.MakeNodeSet(
+	UnmanagedServerID   = render.MakePseudoNodeID(render.UnmanagedID, fixture.ServerHostID)
+	unmanagedServerNode = pseudo(UnmanagedServerID, render.OutgoingInternetID).WithChildren(report.MakeNodeSet(
 		uncontainedServerNode,
 		RenderedEndpoints[fixture.NonContainerNodeID],
 		RenderedProcesses[fixture.NonContainerProcessNodeID],
@@ -262,7 +262,7 @@ var (
 				RenderedContainers[fixture.ServerContainerNodeID],
 			)),
 
-		unmanagedServerID:         unmanagedServerNode,
+		UnmanagedServerID:         unmanagedServerNode,
 		render.IncomingInternetID: theIncomingInternetNode(fixture.ServerPodNodeID),
 		render.OutgoingInternetID: theOutgoingInternetNode,
 	}
@@ -282,7 +282,7 @@ var (
 				RenderedPods[fixture.ServerPodNodeID],
 			)),
 
-		unmanagedServerID:         unmanagedServerNode,
+		UnmanagedServerID:         unmanagedServerNode,
 		render.IncomingInternetID: theIncomingInternetNode(fixture.ServiceNodeID),
 		render.OutgoingInternetID: theOutgoingInternetNode,
 	}

--- a/render/filters.go
+++ b/render/filters.go
@@ -275,6 +275,14 @@ func HasChildren(topology string) FilterFunc {
 	}
 }
 
+// IsNamespace checks if the node is a pod/service in the specified namespace
+func IsNamespace(namespace string) FilterFunc {
+	return func(n report.Node) bool {
+		gotNamespace, ok := n.Latest.Lookup(kubernetes.Namespace)
+		return !ok || namespace == gotNamespace
+	}
+}
+
 var systemContainerNames = map[string]struct{}{
 	"weavescope": {},
 	"weavedns":   {},

--- a/render/pod.go
+++ b/render/pod.go
@@ -19,9 +19,8 @@ const (
 var PodRenderer = ApplyDecorators(
 	MakeFilter(
 		func(n report.Node) bool {
-			// Drop deleted or empty pods
 			state, ok := n.Latest.Lookup(kubernetes.PodState)
-			return HasChildren(report.Container)(n) && (!ok || state != kubernetes.StateDeleted)
+			return (!ok || state != kubernetes.StateDeleted)
 		},
 		MakeReduce(
 			MakeFilter(

--- a/render/pod.go
+++ b/render/pod.go
@@ -16,37 +16,41 @@ const (
 
 // PodRenderer is a Renderer which produces a renderable kubernetes
 // graph by merging the container graph and the pods topology.
-var PodRenderer = MakeFilter(
-	func(n report.Node) bool {
-		// Drop deleted or empty pods
-		state, ok := n.Latest.Lookup(kubernetes.PodState)
-		return HasChildren(report.Container)(n) && (!ok || state != kubernetes.StateDeleted)
-	},
-	MakeReduce(
-		MakeFilter(
-			func(n report.Node) bool {
-				// Drop unconnected pseudo nodes (could appear due to filtering)
-				_, isConnected := n.Latest.Lookup(IsConnected)
-				return n.Topology != Pseudo || isConnected
-			},
-			ColorConnected(MakeMap(
-				MapContainer2Pod,
-				ContainerWithImageNameRenderer,
-			)),
+var PodRenderer = ApplyDecorators(
+	MakeFilter(
+		func(n report.Node) bool {
+			// Drop deleted or empty pods
+			state, ok := n.Latest.Lookup(kubernetes.PodState)
+			return HasChildren(report.Container)(n) && (!ok || state != kubernetes.StateDeleted)
+		},
+		MakeReduce(
+			MakeFilter(
+				func(n report.Node) bool {
+					// Drop unconnected pseudo nodes (could appear due to filtering)
+					_, isConnected := n.Latest.Lookup(IsConnected)
+					return n.Topology != Pseudo || isConnected
+				},
+				ColorConnected(MakeMap(
+					MapContainer2Pod,
+					ContainerWithImageNameRenderer,
+				)),
+			),
+			SelectPod,
 		),
-		SelectPod,
 	),
 )
 
 // PodServiceRenderer is a Renderer which produces a renderable kubernetes services
 // graph by merging the pods graph and the services topology.
-var PodServiceRenderer = FilterEmpty(report.Pod,
-	MakeReduce(
-		MakeMap(
-			MapPod2Service,
-			PodRenderer,
+var PodServiceRenderer = ApplyDecorators(
+	FilterEmpty(report.Pod,
+		MakeReduce(
+			MakeMap(
+				MapPod2Service,
+				PodRenderer,
+			),
+			SelectService,
 		),
-		SelectService,
 	),
 )
 
@@ -117,13 +121,13 @@ func MapPod2Service(pod report.Node, _ report.Networks) report.Nodes {
 	if !ok {
 		return report.Nodes{}
 	}
-	ids, ok := pod.Latest.Lookup(kubernetes.ServiceIDs)
+	serviceIDs, ok := pod.Sets.Lookup(kubernetes.ServiceIDs)
 	if !ok {
 		return report.Nodes{}
 	}
 
 	result := report.Nodes{}
-	for _, serviceID := range strings.Fields(ids) {
+	for _, serviceID := range serviceIDs {
 		serviceName := strings.TrimPrefix(serviceID, namespace+"/")
 		id := report.MakeServiceNodeID(namespace, serviceName)
 		node := NewDerivedNode(id, pod).WithTopology(report.Service)

--- a/render/pod_test.go
+++ b/render/pod_test.go
@@ -7,14 +7,13 @@ import (
 	"github.com/weaveworks/scope/probe/kubernetes"
 	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/scope/render/expected"
-	"github.com/weaveworks/scope/report"
 	"github.com/weaveworks/scope/test"
 	"github.com/weaveworks/scope/test/fixture"
 	"github.com/weaveworks/scope/test/reflect"
 )
 
 func TestPodRenderer(t *testing.T) {
-	have := Prune(render.PodRenderer.Render(fixture.Report, render.FilterNoop))
+	have := Prune(render.PodRenderer.Render(fixture.Report, nil))
 	want := Prune(expected.RenderedPods)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -26,7 +25,7 @@ func TestPodFilterRenderer(t *testing.T) {
 	// it is filtered out correctly.
 	input := fixture.Report.Copy()
 	input.Pod.Nodes[fixture.ClientPodNodeID] = input.Pod.Nodes[fixture.ClientPodNodeID].WithLatests(map[string]string{
-		kubernetes.PodID:     "pod:kube-system/foo",
+		kubernetes.PodID:     "kube-system/foo",
 		kubernetes.Namespace: "kube-system",
 		kubernetes.PodName:   "foo",
 	})
@@ -43,7 +42,7 @@ func TestPodFilterRenderer(t *testing.T) {
 }
 
 func TestPodServiceRenderer(t *testing.T) {
-	have := Prune(render.PodServiceRenderer.Render(fixture.Report, render.FilterNoop))
+	have := Prune(render.PodServiceRenderer.Render(fixture.Report, nil))
 	want := Prune(expected.RenderedPodServices)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -54,25 +53,12 @@ func TestPodServiceFilterRenderer(t *testing.T) {
 	// tag on containers or pod namespace in the topology and ensure
 	// it is filtered out correctly.
 	input := fixture.Report.Copy()
-	input.Pod.Nodes[fixture.ClientPodNodeID] = input.Pod.Nodes[fixture.ClientPodNodeID].WithLatests(map[string]string{
-		kubernetes.PodID:     "pod:kube-system/foo",
-		kubernetes.Namespace: "kube-system",
-		kubernetes.PodName:   "foo",
-	})
-	input.Container.Nodes[fixture.ClientContainerNodeID] = input.Container.Nodes[fixture.ClientContainerNodeID].WithLatests(map[string]string{
-		docker.LabelPrefix + "io.kubernetes.pod.name": "kube-system/foo",
-	})
-	have := Prune(render.PodServiceRenderer.Render(input, render.FilterApplication))
+	have := Prune(render.PodServiceRenderer.Render(input, render.FilterSystem))
 	want := Prune(expected.RenderedPodServices.Copy())
-	wantNode := want[fixture.ServiceNodeID]
-	wantNode.Adjacency = nil
-	wantNode.Children = report.MakeNodeSet(
-		expected.RenderedEndpoints[fixture.Server80NodeID],
-		expected.RenderedProcesses[fixture.ServerProcessNodeID],
-		expected.RenderedContainers[fixture.ServerContainerNodeID],
-		expected.RenderedPods[fixture.ServerPodNodeID],
-	)
-	want[fixture.ServiceNodeID] = wantNode
+	delete(want, fixture.ServiceNodeID)
+	delete(want, expected.UnmanagedServerID)
+	delete(want, render.IncomingInternetID)
+	delete(want, render.OutgoingInternetID)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}

--- a/test/fixture/report_fixture.go
+++ b/test/fixture/report_fixture.go
@@ -367,25 +367,27 @@ var (
 			Nodes: report.Nodes{
 				ClientPodNodeID: report.MakeNodeWith(
 					ClientPodNodeID, map[string]string{
-						kubernetes.PodID:      ClientPodID,
-						kubernetes.PodName:    "pong-a",
-						kubernetes.Namespace:  KubernetesNamespace,
-						kubernetes.ServiceIDs: ServiceID,
-						report.HostNodeID:     ClientHostNodeID,
+						kubernetes.PodID:     ClientPodID,
+						kubernetes.PodName:   "pong-a",
+						kubernetes.Namespace: KubernetesNamespace,
+						report.HostNodeID:    ClientHostNodeID,
 					}).
+					WithSets(report.EmptySets.
+						Add(kubernetes.ServiceIDs, report.MakeStringSet(ServiceID))).
 					WithTopology(report.Pod).WithParents(report.EmptySets.
 					Add("host", report.MakeStringSet(ClientHostNodeID)).
 					Add("service", report.MakeStringSet(ServiceID)),
 				),
 				ServerPodNodeID: report.MakeNodeWith(
 					ServerPodNodeID, map[string]string{
-						kubernetes.PodID:      ServerPodID,
-						kubernetes.PodName:    "pong-b",
-						kubernetes.Namespace:  KubernetesNamespace,
-						kubernetes.PodState:   "running",
-						kubernetes.ServiceIDs: ServiceID,
-						report.HostNodeID:     ServerHostNodeID,
+						kubernetes.PodID:     ServerPodID,
+						kubernetes.PodName:   "pong-b",
+						kubernetes.Namespace: KubernetesNamespace,
+						kubernetes.PodState:  "running",
+						report.HostNodeID:    ServerHostNodeID,
 					}).
+					WithSets(report.EmptySets.
+						Add(kubernetes.ServiceIDs, report.MakeStringSet(ServiceID))).
 					WithTopology(report.Pod).WithParents(report.EmptySets.
 					Add("host", report.MakeStringSet(ServerHostNodeID)).
 					Add("service", report.MakeStringSet(ServiceID)),


### PR DESCRIPTION
Fixes #1340

Won't really work in multitenant, as the topologyRegistry shouldn't
change. We need to apply it transiently on each call, on a per-report
basis.

Options are:

a) replace topologyRegistry.walk() with topologyRegistry.Topologies(),
and then modify them, in renderTopologies.

b) make APITopologyDesc.Options a func(report.Report)
[]APITopologyOptionGroup, and call that from renderTopologies.

@tomwilkie, any thoughts? preferences?