### PR TITLE
Don't merge nodes in the rendering pipeline

### DIFF
--- a/render/container.go
+++ b/render/container.go
@@ -39,7 +39,7 @@ var ContainerRenderer = MakeFilter(
 			},
 			MakeMap(
 				MapProcess2Container,
-				ColorConnected(ProcessRenderer),
+				ProcessRenderer,
 			),
 		),
 
@@ -273,6 +273,8 @@ func MapProcess2Container(n report.Node, _ report.Networks) report.Nodes {
 	} else {
 		id = MakePseudoNodeID(UncontainedID, report.ExtractHostID(n))
 		node = NewDerivedPseudoNode(id, n)
+		node = propagateLatest(report.HostNodeID, n, node)
+		node = propagateLatest(IsConnected, n, node)
 	}
 	return report.Nodes{id: node}
 }

--- a/render/host.go
+++ b/render/host.go
@@ -13,7 +13,7 @@ var HostRenderer = MakeReduce(
 	),
 	MakeMap(
 		MapX2Host,
-		ColorConnected(ProcessRenderer),
+		ProcessRenderer,
 	),
 	MakeMap(
 		MapX2Host,

--- a/render/id.go
+++ b/render/id.go
@@ -18,10 +18,11 @@ func MakeGroupNodeTopology(originalTopology, key string) string {
 
 // NewDerivedNode makes a node based on node, but with a new ID
 func NewDerivedNode(id string, node report.Node) report.Node {
-	return node.WithID(id).WithChildren(report.MakeNodeSet(node)).PruneParents()
+	return report.MakeNode(id).WithChildren(node.Children.Add(node))
 }
 
 // NewDerivedPseudoNode makes a new pseudo node with the node as a child
 func NewDerivedPseudoNode(id string, node report.Node) report.Node {
-	return NewDerivedNode(id, node).WithTopology(Pseudo)
+	output := NewDerivedNode(id, node).WithTopology(Pseudo)
+	return output
 }

--- a/render/process.go
+++ b/render/process.go
@@ -28,13 +28,13 @@ var EndpointRenderer = FilterNonProcspied(SelectEndpoint)
 
 // ProcessRenderer is a Renderer which produces a renderable process
 // graph by merging the endpoint graph and the process topology.
-var ProcessRenderer = MakeReduce(
+var ProcessRenderer = ColorConnected(MakeReduce(
 	MakeMap(
 		MapEndpoint2Process,
 		EndpointRenderer,
 	),
 	SelectProcess,
-)
+))
 
 // processWithContainerNameRenderer is a Renderer which produces a process
 // graph enriched with container names where appropriate

--- a/render/render.go
+++ b/render/render.go
@@ -151,3 +151,10 @@ func (ad applyDecorator) Stats(rpt report.Report, dct Decorator) Stats {
 func ApplyDecorators(renderer Renderer) Renderer {
 	return applyDecorator{renderer}
 }
+
+func propagateLatest(key string, from, to report.Node) report.Node {
+	if value, timestamp, ok := from.Latest.LookupEntry(key); ok {
+		to.Latest = to.Latest.Set(key, timestamp, value)
+	}
+	return to
+}


### PR DESCRIPTION
Fixes #1212 

This make an almost 50% reduction in the cost of the rendering pipeline, reduces memory usage by 20% and makes a big difference to garbage load.

Unfortunately is breaks everything.  So we need to fix that....