### PR TITLE
Filter out docker containers for pods in the kube-system namespace

### DIFF
--- a/render/container.go
+++ b/render/container.go
@@ -31,16 +31,9 @@ var ContainerRenderer = MakeFilter(
 		return !ok || state != docker.StateDeleted
 	},
 	MakeReduce(
-		MakeFilter(
-			func(n report.Node) bool {
-				// Drop unconnected pseudo nodes (could appear due to filtering)
-				_, isConnected := n.Latest.Lookup(IsConnected)
-				return n.Topology != Pseudo || isConnected
-			},
-			MakeMap(
-				MapProcess2Container,
-				ProcessRenderer,
-			),
+		MakeMap(
+			MapProcess2Container,
+			ProcessRenderer,
 		),
 
 		// This mapper brings in short lived connections by joining with container IPs.

--- a/render/filters.go
+++ b/render/filters.go
@@ -228,7 +228,7 @@ func IsApplication(n report.Node) bool {
 	if roleLabel == "system" {
 		return false
 	}
-	namespace, _ := n.Latest.Lookup(kubernetes.Namespace)
+	namespace, _ := n.Latest.Lookup(docker.LabelPrefix + "io.kubernetes.pod.namespace")
 	if namespace == "kube-system" {
 		return false
 	}
@@ -278,8 +278,8 @@ func HasChildren(topology string) FilterFunc {
 // IsNamespace checks if the node is a pod/service in the specified namespace
 func IsNamespace(namespace string) FilterFunc {
 	return func(n report.Node) bool {
-		gotNamespace, ok := n.Latest.Lookup(kubernetes.Namespace)
-		return !ok || namespace == gotNamespace
+		gotNamespace, _ := n.Latest.Lookup(kubernetes.Namespace)
+		return namespace == gotNamespace
 	}
 }
 

--- a/render/filters.go
+++ b/render/filters.go
@@ -95,7 +95,7 @@ func (f *Filter) render(rpt report.Report, dct Decorator) (report.Nodes, int) {
 	inDegrees := map[string]int{}
 	filtered := 0
 	for id, node := range f.Renderer.Render(rpt, dct) {
-		if f.FilterFunc(node) {
+		if node.Topology == Pseudo || f.FilterFunc(node) {
 			output[id] = node
 			inDegrees[id] = 0
 		} else {
@@ -148,17 +148,6 @@ const IsConnected = "is_connected"
 // effects, if any, and returns the opposite truth value.
 func Complement(f FilterFunc) FilterFunc {
 	return func(node report.Node) bool { return !f(node) }
-}
-
-// FilterPseudo produces a renderer that removes pseudo nodes from the given
-// renderer
-func FilterPseudo(r Renderer) Renderer {
-	return MakeFilter(
-		func(node report.Node) bool {
-			return node.Topology != Pseudo
-		},
-		r,
-	)
 }
 
 // FilterUnconnected produces a renderer that filters unconnected nodes
@@ -262,9 +251,6 @@ func FilterEmpty(topology string, r Renderer) Renderer {
 // topology.
 func HasChildren(topology string) FilterFunc {
 	return func(n report.Node) bool {
-		if n.Topology == Pseudo {
-			return true
-		}
 		count := 0
 		n.Children.ForEach(func(child report.Node) {
 			if child.Topology == topology {

--- a/render/filters_test.go
+++ b/render/filters_test.go
@@ -124,18 +124,3 @@ func TestFilterUnconnectedSelf(t *testing.T) {
 		}
 	}
 }
-
-func TestFilterPseudo(t *testing.T) {
-	// Test pseudonodes are removed
-	{
-		nodes := report.Nodes{
-			"foo": report.MakeNode("foo"),
-			"bar": report.MakeNode("bar").WithTopology(render.Pseudo),
-		}
-		renderer := mockRenderer{Nodes: nodes}
-		have := renderer.Render(report.MakeReport(), render.FilterPseudo)
-		if _, ok := have["bar"]; ok {
-			t.Error("expected pseudonode to be removed")
-		}
-	}
-}

--- a/render/pod.go
+++ b/render/pod.go
@@ -27,16 +27,9 @@ var PodRenderer = ConditionalRenderer(renderKubernetesTopologies,
 			return (!ok || state != kubernetes.StateDeleted)
 		},
 		MakeReduce(
-			MakeFilter(
-				func(n report.Node) bool {
-					// Drop unconnected pseudo nodes (could appear due to filtering)
-					_, isConnected := n.Latest.Lookup(IsConnected)
-					return n.Topology != Pseudo || isConnected
-				},
-				ColorConnected(MakeMap(
-					MapContainer2Pod,
-					ContainerWithImageNameRenderer,
-				)),
+			MakeMap(
+				MapContainer2Pod,
+				ContainerWithImageNameRenderer,
 			),
 			SelectPod,
 		),


### PR DESCRIPTION
Fixes #1430 

Also, make all filters drop unconnected pseudo nodes by default, and don't apply filter funcs to pseudo nodes.

- [x] test this on GKE