### PR TITLE
Remove cache from SmartMerger.

### DIFF
--- a/app/collector.go
+++ b/app/collector.go
@@ -78,7 +78,7 @@ func NewCollector(window time.Duration) Collector {
 		waitableCondition: waitableCondition{
 			waiters: map[chan struct{}]struct{}{},
 		},
-		merger: NewSmartMerger(window),
+		merger: NewSmartMerger(),
 	}
 }
 

--- a/app/collector.go
+++ b/app/collector.go
@@ -78,7 +78,7 @@ func NewCollector(window time.Duration) Collector {
 		waitableCondition: waitableCondition{
 			waiters: map[chan struct{}]struct{}{},
 		},
-		merger: NewSmartMerger(),
+		merger: NewSmartMerger(window),
 	}
 }
 

--- a/app/merger_test.go
+++ b/app/merger_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/weaveworks/scope/app"
 	"github.com/weaveworks/scope/report"
@@ -28,7 +29,7 @@ func TestMerger(t *testing.T) {
 		AddNode(report.MakeNode("bar")).
 		AddNode(report.MakeNode("baz"))
 
-	for _, merger := range []app.Merger{app.MakeDumbMerger(), app.NewSmartMerger()} {
+	for _, merger := range []app.Merger{app.MakeDumbMerger(), app.NewSmartMerger(10 * time.Second)} {
 		// Test the empty list case
 		if have := merger.Merge([]report.Report{}); !reflect.DeepEqual(have, report.MakeReport()) {
 			t.Errorf("Bad merge: %s", test.Diff(have, want))
@@ -62,18 +63,18 @@ func TestSmartMerger(t *testing.T) {
 	want := report.MakeReport()
 	want.Endpoint.AddNode(report.MakeNode("foo"))
 
-	merger := app.NewSmartMerger()
+	merger := app.NewSmartMerger(10 * time.Second)
 	if have := merger.Merge(reports); !reflect.DeepEqual(have, want) {
 		t.Errorf("Bad merge: %s", test.Diff(have, want))
 	}
 }
 
 func BenchmarkSmartMerger(b *testing.B) {
-	benchmarkMerger(b, app.NewSmartMerger(), false)
+	benchmarkMerger(b, app.NewSmartMerger(10*time.Second), false)
 }
 
 func BenchmarkSmartMergerWithoutCaching(b *testing.B) {
-	benchmarkMerger(b, app.NewSmartMerger(), true)
+	benchmarkMerger(b, app.NewSmartMerger(10*time.Second), true)
 }
 
 func BenchmarkDumbMerger(b *testing.B) {


### PR DESCRIPTION
Fixes #1441 

So by my calculations, with 1 host reporting every 3 seconds, there will be 5 reports involved in every merge. So ~10 intermediate, cached nodes. Every 3 seconds, 5 of these will be invalidated, so it will take 600s for the 1000 node cache up.

I added a timeout on the cache and reduce it to 200 entries, and after 12mins my scope app was using 103.8MB.