### PR TITLE
Precompute base of the container nodes

### DIFF
--- a/probe/docker/container.go
+++ b/probe/docker/container.go
@@ -119,14 +119,17 @@ type container struct {
 	pendingStats [20]docker.Stats
 	numPending   int
 	hostID       string
+	baseNode     report.Node
 }
 
 // NewContainer creates a new Container
 func NewContainer(c *docker.Container, hostID string) Container {
-	return &container{
+	result := &container{
 		container: c,
 		hostID:    hostID,
 	}
+	result.baseNode = result.getBaseNode()
+	return result
 }
 
 func (c *container) UpdateState(container *docker.Container) {
@@ -380,46 +383,49 @@ func (c *container) env() map[string]string {
 	return result
 }
 
+func (c *container) getBaseNode() report.Node {
+	result := report.MakeNodeWith(report.MakeContainerNodeID(c.ID()), map[string]string{
+		ContainerID:       c.ID(),
+		ContainerName:     strings.TrimPrefix(c.container.Name, "/"),
+		ContainerCreated:  c.container.Created.Format(time.RFC822),
+		ContainerCommand:  c.container.Path + " " + strings.Join(c.container.Args, " "),
+		ImageID:           c.Image(),
+		ContainerHostname: c.Hostname(),
+	}).WithParents(report.EmptySets.
+		Add(report.ContainerImage, report.MakeStringSet(report.MakeContainerImageNodeID(c.Image()))),
+	)
+	result = result.AddTable(LabelPrefix, c.container.Config.Labels)
+	result = result.AddTable(EnvPrefix, c.env())
+	return result
+}
+
 func (c *container) GetNode() report.Node {
 	c.RLock()
 	defer c.RUnlock()
-	result := report.MakeNodeWith(report.MakeContainerNodeID(c.ID()), map[string]string{
-		ContainerID:         c.ID(),
-		ContainerName:       strings.TrimPrefix(c.container.Name, "/"),
-		ContainerCreated:    c.container.Created.Format(time.RFC822),
-		ContainerCommand:    c.container.Path + " " + strings.Join(c.container.Args, " "),
-		ImageID:             c.Image(),
-		ContainerHostname:   c.Hostname(),
+	latest := map[string]string{
 		ContainerState:      c.StateString(),
 		ContainerStateHuman: c.State(),
-	}).WithMetrics(
-		c.metrics(),
-	).WithParents(report.EmptySets.
-		Add(report.ContainerImage, report.MakeStringSet(report.MakeContainerImageNodeID(c.Image()))),
-	)
+	}
+	controls := []string{}
 
 	if c.container.State.Paused {
-		result = result.WithControls(UnpauseContainer)
+		controls = append(controls, UnpauseContainer)
 	} else if c.container.State.Running {
 		uptime := (mtime.Now().Sub(c.container.State.StartedAt) / time.Second) * time.Second
 		networkMode := ""
 		if c.container.HostConfig != nil {
 			networkMode = c.container.HostConfig.NetworkMode
 		}
-		result = result.WithLatests(map[string]string{
-			ContainerUptime:       uptime.String(),
-			ContainerRestartCount: strconv.Itoa(c.container.RestartCount),
-			ContainerNetworkMode:  networkMode,
-		})
-		result = result.WithControls(
-			RestartContainer, StopContainer, PauseContainer, AttachContainer, ExecContainer,
-		)
+		latest[ContainerUptime] = uptime.String()
+		latest[ContainerRestartCount] = strconv.Itoa(c.container.RestartCount)
+		latest[ContainerNetworkMode] = networkMode
+		controls = append(controls, RestartContainer, StopContainer, PauseContainer, AttachContainer, ExecContainer)
 	} else {
-		result = result.WithControls(StartContainer, RemoveContainer)
+		controls = append(controls, StartContainer, RemoveContainer)
 	}
 
-	result = result.AddTable(LabelPrefix, c.container.Config.Labels)
-	result = result.AddTable(EnvPrefix, c.env())
+	result := c.baseNode.WithLatests(latest)
+	result = result.WithControls(controls...)
 	result = result.WithMetrics(c.metrics())
 	return result
 }

--- a/probe/docker/container.go
+++ b/probe/docker/container.go
@@ -386,7 +386,6 @@ func (c *container) env() map[string]string {
 func (c *container) getBaseNode() report.Node {
 	result := report.MakeNodeWith(report.MakeContainerNodeID(c.ID()), map[string]string{
 		ContainerID:       c.ID(),
-		ContainerName:     strings.TrimPrefix(c.container.Name, "/"),
 		ContainerCreated:  c.container.Created.Format(time.RFC822),
 		ContainerCommand:  c.container.Path + " " + strings.Join(c.container.Args, " "),
 		ImageID:           c.Image(),
@@ -416,6 +415,7 @@ func (c *container) GetNode() report.Node {
 		if c.container.HostConfig != nil {
 			networkMode = c.container.HostConfig.NetworkMode
 		}
+		latest[ContainerName] = strings.TrimPrefix(c.container.Name, "/")
 		latest[ContainerUptime] = uptime.String()
 		latest[ContainerRestartCount] = strconv.Itoa(c.container.RestartCount)
 		latest[ContainerNetworkMode] = networkMode

--- a/probe/docker/container_test.go
+++ b/probe/docker/container_test.go
@@ -51,6 +51,10 @@ func TestContainer(t *testing.T) {
 		return connection
 	}
 
+	now := time.Unix(12345, 67890).UTC()
+	mtime.NowForce(now)
+	defer mtime.NowReset()
+
 	const hostID = "scope"
 	c := docker.NewContainer(container1, hostID)
 	err := c.StartGatheringStats()
@@ -58,10 +62,6 @@ func TestContainer(t *testing.T) {
 		t.Errorf("%v", err)
 	}
 	defer c.StopGatheringStats()
-
-	now := time.Unix(12345, 67890).UTC()
-	mtime.NowForce(now)
-	defer mtime.NowReset()
 
 	// Send some stats to the docker container
 	stats := &client.Stats{}


### PR DESCRIPTION
Improves #1454

The CPU consumption of the probes is now better (maybe even bearable) but not acceptable:
<img width="1488" alt="screen shot 2016-05-10 at 07 05 11" src="https://cloud.githubusercontent.com/assets/2362916/15136995/867ae772-167e-11e6-98ee-3953c3d01bcc.png">

Profile: [pprof.localhost:4041.samples.cpu.002.pb.gz](https://github.com/weaveworks/scope/files/256468/pprof.localhost.4041.samples.cpu.002.pb.gz)
![probe_cpu](https://cloud.githubusercontent.com/assets/2362916/15137022/b4bdcce4-167e-11e6-908e-58d9e80b130f.png)

We really really need #1406 to avoid surprises before releases

