### PR TITLE
If k8s objects only have one container, show that container's metrics on them

### DIFF
--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -34,6 +34,8 @@ var (
 		Created:          {ID: Created, Label: "Created", From: report.FromLatest, Priority: 6},
 	}
 
+	PodMetricTemplates = docker.ContainerMetricTemplates
+
 	ServiceMetadataTemplates = report.MetadataTemplates{
 		ID:         {ID: ID, Label: "ID", From: report.FromLatest, Priority: 1},
 		Namespace:  {ID: Namespace, Label: "Namespace", From: report.FromLatest, Priority: 2},
@@ -42,6 +44,8 @@ var (
 		IP:         {ID: IP, Label: "Internal IP", From: report.FromLatest, Priority: 5},
 		report.Pod: {ID: report.Pod, Label: "# Pods", From: report.FromCounters, Datatype: "number", Priority: 6},
 	}
+
+	ServiceMetricTemplates = PodMetricTemplates
 
 	DeploymentMetadataTemplates = report.MetadataTemplates{
 		ID:                 {ID: ID, Label: "ID", From: report.FromLatest, Priority: 1},
@@ -53,6 +57,8 @@ var (
 		Strategy:           {ID: Strategy, Label: "Strategy", From: report.FromLatest, Priority: 7},
 	}
 
+	DeploymentMetricTemplates = ReplicaSetMetricTemplates
+
 	ReplicaSetMetadataTemplates = report.MetadataTemplates{
 		ID:                 {ID: ID, Label: "ID", From: report.FromLatest, Priority: 1},
 		Namespace:          {ID: Namespace, Label: "Namespace", From: report.FromLatest, Priority: 2},
@@ -61,6 +67,8 @@ var (
 		DesiredReplicas:    {ID: DesiredReplicas, Label: "Desired Replicas", From: report.FromLatest, Datatype: "number", Priority: 5},
 		report.Pod:         {ID: report.Pod, Label: "# Pods", From: report.FromCounters, Datatype: "number", Priority: 6},
 	}
+
+	ReplicaSetMetricTemplates = PodMetricTemplates
 
 	TableTemplates = report.TableTemplates{
 		LabelPrefix: {ID: LabelPrefix, Label: "Kubernetes Labels", Prefix: LabelPrefix},
@@ -203,6 +211,7 @@ func (r *Reporter) serviceTopology() (report.Topology, []Service, error) {
 	var (
 		result = report.MakeTopology().
 			WithMetadataTemplates(ServiceMetadataTemplates).
+			WithMetricTemplates(ServiceMetricTemplates).
 			WithTableTemplates(TableTemplates)
 		services = []Service{}
 	)
@@ -218,6 +227,7 @@ func (r *Reporter) deploymentTopology(probeID string) (report.Topology, []Deploy
 	var (
 		result = report.MakeTopology().
 			WithMetadataTemplates(DeploymentMetadataTemplates).
+			WithMetricTemplates(DeploymentMetricTemplates).
 			WithTableTemplates(TableTemplates)
 		deployments = []Deployment{}
 	)
@@ -235,6 +245,7 @@ func (r *Reporter) replicaSetTopology(probeID string, deployments []Deployment) 
 	var (
 		result = report.MakeTopology().
 			WithMetadataTemplates(ReplicaSetMetadataTemplates).
+			WithMetricTemplates(ReplicaSetMetricTemplates).
 			WithTableTemplates(TableTemplates)
 		replicaSets = []ReplicaSet{}
 		selectors   = []func(labelledChild){}
@@ -311,6 +322,7 @@ func (r *Reporter) podTopology(services []Service, replicaSets []ReplicaSet) (re
 	var (
 		pods = report.MakeTopology().
 			WithMetadataTemplates(PodMetadataTemplates).
+			WithMetricTemplates(PodMetricTemplates).
 			WithTableTemplates(TableTemplates)
 		selectors = []func(labelledChild){}
 	)

--- a/render/metrics.go
+++ b/render/metrics.go
@@ -1,0 +1,24 @@
+package render
+
+import (
+	"github.com/weaveworks/scope/report"
+)
+
+// PropagateSingleMetrics puts metrics from one of the children onto the parent
+// iff there is only one child of that type.
+func PropagateSingleMetrics(topology string) MapFunc {
+	return func(n report.Node, _ report.Networks) report.Nodes {
+		var found []report.Node
+		n.Children.ForEach(func(child report.Node) {
+			if child.Topology == topology {
+				if _, ok := child.Latest.Lookup(report.DoesNotMakeConnections); !ok {
+					found = append(found, child)
+				}
+			}
+		})
+		if len(found) == 1 {
+			n = n.WithMetrics(found[0].Metrics)
+		}
+		return report.Nodes{n.ID: n}
+	}
+}

--- a/render/metrics_test.go
+++ b/render/metrics_test.go
@@ -1,0 +1,167 @@
+package render_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/weaveworks/scope/render"
+	"github.com/weaveworks/scope/report"
+	"github.com/weaveworks/scope/test"
+	"github.com/weaveworks/scope/test/reflect"
+)
+
+func TestPropagateSingleMetrics(t *testing.T) {
+	now := time.Now()
+	for _, c := range []struct {
+		name     string
+		input    report.Node
+		topology string
+		output   report.Nodes
+	}{
+		{
+			name:     "empty",
+			input:    report.MakeNode("empty"),
+			topology: "",
+			output:   report.Nodes{"empty": report.MakeNode("empty")},
+		},
+		{
+			name: "one child",
+			input: report.MakeNode("a").WithChildren(
+				report.MakeNodeSet(
+					report.MakeNode("child1").
+						WithTopology(report.Container).
+						WithMetrics(report.Metrics{
+							"metric1": report.MakeMetric(),
+						}),
+				),
+			),
+			topology: report.Container,
+			output: report.Nodes{
+				"a": report.MakeNode("a").WithMetrics(report.Metrics{
+					"metric1": report.MakeMetric(),
+				}).WithChildren(
+					report.MakeNodeSet(
+						report.MakeNode("child1").
+							WithTopology(report.Container).
+							WithMetrics(report.Metrics{
+								"metric1": report.MakeMetric(),
+							}),
+					),
+				),
+			},
+		},
+		{
+			name: "ignores other topologies",
+			input: report.MakeNode("a").WithChildren(
+				report.MakeNodeSet(
+					report.MakeNode("child1").
+						WithTopology(report.Container).
+						WithMetrics(report.Metrics{
+							"metric1": report.MakeMetric(),
+						}),
+					report.MakeNode("child2").
+						WithTopology("otherTopology").
+						WithMetrics(report.Metrics{
+							"metric2": report.MakeMetric(),
+						}),
+				),
+			),
+			topology: report.Container,
+			output: report.Nodes{
+				"a": report.MakeNode("a").WithMetrics(report.Metrics{
+					"metric1": report.MakeMetric(),
+				}).WithChildren(
+					report.MakeNodeSet(
+						report.MakeNode("child1").
+							WithTopology(report.Container).
+							WithMetrics(report.Metrics{
+								"metric1": report.MakeMetric(),
+							}),
+						report.MakeNode("child2").
+							WithTopology("otherTopology").
+							WithMetrics(report.Metrics{
+								"metric2": report.MakeMetric(),
+							}),
+					),
+				),
+			},
+		},
+		{
+			name: "two children",
+			input: report.MakeNode("a").WithChildren(
+				report.MakeNodeSet(
+					report.MakeNode("child1").
+						WithTopology(report.Container).
+						WithMetrics(report.Metrics{
+							"metric1": report.MakeMetric(),
+						}),
+					report.MakeNode("child2").
+						WithTopology(report.Container).
+						WithMetrics(report.Metrics{
+							"metric2": report.MakeMetric(),
+						}),
+				),
+			),
+			topology: report.Container,
+			output: report.Nodes{
+				"a": report.MakeNode("a").WithChildren(
+					report.MakeNodeSet(
+						report.MakeNode("child1").
+							WithTopology(report.Container).
+							WithMetrics(report.Metrics{
+								"metric1": report.MakeMetric(),
+							}),
+						report.MakeNode("child2").
+							WithTopology(report.Container).
+							WithMetrics(report.Metrics{
+								"metric2": report.MakeMetric(),
+							}),
+					),
+				),
+			},
+		},
+		{
+			name: "ignores k8s pause container",
+			input: report.MakeNode("a").WithChildren(
+				report.MakeNodeSet(
+					report.MakeNode("child1").
+						WithTopology(report.Container).
+						WithMetrics(report.Metrics{
+							"metric1": report.MakeMetric(),
+						}),
+					report.MakeNode("child2").
+						WithLatest(report.DoesNotMakeConnections, now, "").
+						WithTopology(report.Container).
+						WithMetrics(report.Metrics{
+							"metric2": report.MakeMetric(),
+						}),
+				),
+			),
+			topology: report.Container,
+			output: report.Nodes{
+				"a": report.MakeNode("a").WithMetrics(report.Metrics{
+					"metric1": report.MakeMetric(),
+				}).WithChildren(
+					report.MakeNodeSet(
+						report.MakeNode("child1").
+							WithTopology(report.Container).
+							WithMetrics(report.Metrics{
+								"metric1": report.MakeMetric(),
+							}),
+						report.MakeNode("child2").
+							WithLatest(report.DoesNotMakeConnections, now, "").
+							WithTopology(report.Container).
+							WithMetrics(report.Metrics{
+								"metric2": report.MakeMetric(),
+							}),
+					),
+				),
+			},
+		},
+	} {
+		got := render.PropagateSingleMetrics(c.topology)(c.input, report.Networks{})
+		if !reflect.DeepEqual(got, c.output) {
+			t.Errorf("[%s] Diff: %s", c.name, test.Diff(c.output, got))
+		}
+	}
+}

--- a/render/pod.go
+++ b/render/pod.go
@@ -26,12 +26,15 @@ var PodRenderer = ConditionalRenderer(renderKubernetesTopologies,
 			state, ok := n.Latest.Lookup(kubernetes.State)
 			return (!ok || state != kubernetes.StateDeleted)
 		},
-		MakeReduce(
-			MakeMap(
-				MapContainer2Pod,
-				ContainerWithImageNameRenderer,
+		MakeMap(
+			PropagateSingleMetrics(report.Container),
+			MakeReduce(
+				MakeMap(
+					MapContainer2Pod,
+					ContainerWithImageNameRenderer,
+				),
+				SelectPod,
 			),
-			SelectPod,
 		),
 	)),
 )
@@ -40,12 +43,15 @@ var PodRenderer = ConditionalRenderer(renderKubernetesTopologies,
 // graph by merging the pods graph and the services topology.
 var PodServiceRenderer = ConditionalRenderer(renderKubernetesTopologies,
 	ApplyDecorators(
-		MakeReduce(
-			MakeMap(
-				Map2Service,
-				PodRenderer,
+		MakeMap(
+			PropagateSingleMetrics(report.Pod),
+			MakeReduce(
+				MakeMap(
+					Map2Service,
+					PodRenderer,
+				),
+				SelectService,
 			),
-			SelectService,
 		),
 	),
 )
@@ -54,12 +60,15 @@ var PodServiceRenderer = ConditionalRenderer(renderKubernetesTopologies,
 // graph by merging the pods graph and the deployments topology.
 var DeploymentRenderer = ConditionalRenderer(renderKubernetesTopologies,
 	ApplyDecorators(
-		MakeReduce(
-			MakeMap(
-				Map2Deployment,
-				ReplicaSetRenderer,
+		MakeMap(
+			PropagateSingleMetrics(report.ReplicaSet),
+			MakeReduce(
+				MakeMap(
+					Map2Deployment,
+					ReplicaSetRenderer,
+				),
+				SelectDeployment,
 			),
-			SelectDeployment,
 		),
 	),
 )
@@ -68,12 +77,15 @@ var DeploymentRenderer = ConditionalRenderer(renderKubernetesTopologies,
 // graph by merging the pods graph and the replica sets topology.
 var ReplicaSetRenderer = ConditionalRenderer(renderKubernetesTopologies,
 	ApplyDecorators(
-		MakeReduce(
-			MakeMap(
-				Map2ReplicaSet,
-				PodRenderer,
+		MakeMap(
+			PropagateSingleMetrics(report.Pod),
+			MakeReduce(
+				MakeMap(
+					Map2ReplicaSet,
+					PodRenderer,
+				),
+				SelectReplicaSet,
 			),
-			SelectReplicaSet,
 		),
 	),
 )


### PR DESCRIPTION
![screen shot 2016-05-11 at 11 47 14](https://cloud.githubusercontent.com/assets/250199/15178847/2aaae85a-1770-11e6-87e5-f6266e70f73e.png)

We ignore the pause container with this, (even though it uses a bit of memory).

Not super-useful when you have pods/etc with > 1 container in them, but is a nice best-effort affordance when we can do it. Bit of a stop-gap until we have metric aggregation.