### PR TITLE
Fast start the DNS resolution ticker to improve first report latency.

### DIFF
--- a/experimental/example/Makefile
+++ b/experimental/example/Makefile
@@ -37,4 +37,4 @@ endif
 	touch $@
 
 clean:
-	rm -f qotd/*.o qotd/qotd searchapp/searchapp shout/shout *.marker
+	rm -f qotd/*.o qotd/qotd searchapp/searchapp shout/shout .*.marker

--- a/experimental/example/README.md
+++ b/experimental/example/README.md
@@ -7,7 +7,6 @@ $ docker-machine create -d virtualbox --virtualbox-memory=4096 scope-tastic
 $ eval $(docker-machine env scope-tastic)
 $ sudo curl -L git.io/weave -o /usr/local/bin/weave
 $ sudo chmod +x /usr/local/bin/weave
-$ weave launch
 $ curl -o run.sh https://raw.githubusercontent.com/weaveworks/scope/master/experimental/example/run.sh
 $ ./run.sh
 $ sudo wget -O /usr/local/bin/scope https://github.com/weaveworks/scope/releases/download/latest_release/scope
@@ -18,9 +17,15 @@ $ scope launch
 # "architecture"
 
 ```
-curl -> frontend --> app --> searchapp -> elasticsearch
-         (nginx) |
-                 --> qotd -> internet
-                 |
-                 --> redis
+client -> frontend --> app --> searchapp -> elasticsearch
+           (nginx)         |
+                           --> qotd -> internet
+                           |
+                           --> redis
+```
+
+# To push new images
+
+```
+for img in $(docker images | grep tomwilkie | cut -d' ' -f1); do docker push $img:latest; done
 ```

--- a/experimental/example/echo/echo.py
+++ b/experimental/example/echo/echo.py
@@ -6,7 +6,6 @@ import time
 import threading
 import logging
 
-
 from flask import Flask
 from flask import request
 from werkzeug.serving import WSGIRequestHandler
@@ -14,11 +13,7 @@ from werkzeug.serving import WSGIRequestHandler
 app = Flask(__name__)
 
 @app.route('/')
-def hello():
-  if random.random() > 0.6:
-    time.sleep(2)
-  else:
-    time.sleep(0.5)
+def echo():
   return request.data
 
 if __name__ == "__main__":

--- a/experimental/example/k8s/client-deployment.yaml
+++ b/experimental/example/k8s/client-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: client
 spec:
-  replicas: 2
+  replicas: 1
   template:
     metadata:
       labels:

--- a/probe/appclient/app_client.go
+++ b/probe/appclient/app_client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/rpc"
 	"sync"
@@ -20,6 +21,7 @@ import (
 const (
 	initialBackoff = 1 * time.Second
 	maxBackoff     = 60 * time.Second
+	dialTimeout    = 5 * time.Second
 )
 
 // AppClient is a client to an app for dealing with controls.
@@ -62,6 +64,10 @@ func NewAppClient(pc ProbeConfig, hostname, target string, control xfer.ControlH
 	httpTransport, err := pc.getHTTPTransport(hostname)
 	if err != nil {
 		return nil, err
+	}
+
+	httpTransport.Dial = func(network, addr string) (net.Conn, error) {
+		return net.DialTimeout(network, addr, dialTimeout)
 	}
 
 	return &appClient{

--- a/probe/appclient/resolver.go
+++ b/probe/appclient/resolver.go
@@ -17,8 +17,29 @@ const (
 )
 
 var (
-	tick = time.Tick
+	tick = fastStartTicker
 )
+
+// fastStartTicker is a ticker that 'ramps up' from 1 sec to duration.
+func fastStartTicker(duration time.Duration) <-chan time.Time {
+	c := make(chan time.Time, 1)
+	go func() {
+		d := 1 * time.Second
+		for {
+			time.Sleep(d)
+			d = d * 2
+			if d > duration {
+				d = duration
+			}
+
+			select {
+			case c <- time.Now():
+			default:
+			}
+		}
+	}()
+	return c
+}
 
 type setter func(string, []string)
 

--- a/site/installing.md
+++ b/site/installing.md
@@ -193,7 +193,7 @@ This runs a recent Scope image from the Docker Hub and will launch a probe onto 
 
 **Open Scope in Your Browser**
 
-    kubectl port-forward $(kubectl get pod --selector=name=weave-scope-app -o jsonpath={.items..metadata.name}) 4040
+    kubectl port-forward $(kubectl get pod --selector=weavescope-component=weavescope-app -o jsonpath={.items..metadata.name}) 4040
 
 Open http://localhost:4040 in your browser. This allows you to access the Scope UI securely, without opening it to the Internet.
 


### PR DESCRIPTION
Fixes #1400 

First report can take 10s some times, which is suspiciously close to the dns resolution period.  Turns out if the first resolution fails, we wait 10s to try again.  This was we try after 1s, 2s, 4s, 8s then every 10s.