### PR TITLE
Remove recursive children in MapX2Host

### DIFF
--- a/render/host.go
+++ b/render/host.go
@@ -52,6 +52,7 @@ func MapX2Host(n report.Node, _ report.Networks) report.Nodes {
 	result := NewDerivedNode(id, n).WithTopology(report.Host)
 	result.Latest = result.Latest.Set(report.HostNodeID, timestamp, hostNodeID)
 	result.Counters = result.Counters.Add(n.Topology, 1)
+	result.Children = report.MakeNodeSet(n)
 	return report.Nodes{id: result}
 }
 


### PR DESCRIPTION
Fixes #1472
So container images don't also provide containers to a random host.