### PR TITLE
Add local networks for each k8s service

### DIFF
--- a/probe/kubernetes/reporter_test.go
+++ b/probe/kubernetes/reporter_test.go
@@ -184,7 +184,7 @@ func TestReporter(t *testing.T) {
 	pod1ID := report.MakePodNodeID(pod1UID)
 	pod2ID := report.MakePodNodeID(pod2UID)
 	serviceID := report.MakeServiceNodeID(serviceUID)
-	rpt, _ := kubernetes.NewReporter(newMockClient(), nil, "", nil).Report()
+	rpt, _ := kubernetes.NewReporter(newMockClient(), nil, "", "foo", nil).Report()
 
 	// Reporter should have added the following pods
 	for _, pod := range []struct {
@@ -247,7 +247,7 @@ func TestTagger(t *testing.T) {
 		docker.LabelPrefix + "io.kubernetes.pod.uid": "123456",
 	}))
 
-	rpt, err := kubernetes.NewReporter(newMockClient(), nil, "", nil).Tag(rpt)
+	rpt, err := kubernetes.NewReporter(newMockClient(), nil, "", "", nil).Tag(rpt)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -275,7 +275,7 @@ func TestReporterGetLogs(t *testing.T) {
 
 	client := newMockClient()
 	pipes := mockPipeClient{}
-	reporter := kubernetes.NewReporter(client, pipes, "", nil)
+	reporter := kubernetes.NewReporter(client, pipes, "", "", nil)
 
 	// Should error on invalid IDs
 	{

--- a/probe/kubernetes/service.go
+++ b/probe/kubernetes/service.go
@@ -16,6 +16,7 @@ type Service interface {
 	Meta
 	GetNode() report.Node
 	Selector() labels.Selector
+	ClusterIP() string
 }
 
 type service struct {
@@ -41,4 +42,8 @@ func (s *service) GetNode() report.Node {
 		latest[PublicIP] = s.Spec.LoadBalancerIP
 	}
 	return s.MetaNode(report.MakeServiceNodeID(s.UID())).WithLatests(latest)
+}
+
+func (s *service) ClusterIP() string {
+	return s.Spec.ClusterIP
 }

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -157,7 +157,7 @@ func probeMain(flags probeFlags) {
 	if flags.kubernetesEnabled {
 		if client, err := kubernetes.NewClient(flags.kubernetesAPI, flags.kubernetesInterval); err == nil {
 			defer client.Stop()
-			reporter := kubernetes.NewReporter(client, clients, probeID, p)
+			reporter := kubernetes.NewReporter(client, clients, probeID, hostID, p)
 			defer reporter.Stop()
 			p.AddReporter(reporter)
 			p.AddTagger(reporter)


### PR DESCRIPTION
Fixes #1469 

I openly admit this is a hack more than a robust solution. But I agreed on doing this with @tomwilkie since a robust fix would imply turning nat mapping upside down (it's racy and doesn't allow replacing conenctions easily) which is risky for 0.15.
