### PR TITLE
Fast start the dns resolution ticker to improve first report latency.

### DIFF
--- a/probe/appclient/app_client.go
+++ b/probe/appclient/app_client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/rpc"
 	"sync"
@@ -20,6 +21,7 @@ import (
 const (
 	initialBackoff = 1 * time.Second
 	maxBackoff     = 60 * time.Second
+	dialTimeout    = 5 * time.Second
 )
 
 // AppClient is a client to an app for dealing with controls.
@@ -62,6 +64,10 @@ func NewAppClient(pc ProbeConfig, hostname, target string, control xfer.ControlH
 	httpTransport, err := pc.getHTTPTransport(hostname)
 	if err != nil {
 		return nil, err
+	}
+
+	httpTransport.Dial = func(network, addr string) (net.Conn, error) {
+		return net.DialTimeout(network, addr, dialTimeout)
 	}
 
 	return &appClient{

--- a/probe/appclient/resolver.go
+++ b/probe/appclient/resolver.go
@@ -17,8 +17,29 @@ const (
 )
 
 var (
-	tick = time.Tick
+	tick = fastStartTicker
 )
+
+// fastStartTicker is a ticker that 'ramps up' from 1 sec to duration.
+func fastStartTicker(duration time.Duration) <-chan time.Time {
+	c := make(chan time.Time, 1)
+	go func() {
+		d := 1 * time.Second
+		for {
+			time.Sleep(d)
+			d = d * 2
+			if d > duration {
+				d = duration
+			}
+
+			select {
+			case c <- time.Now():
+			default:
+			}
+		}
+	}()
+	return c
+}
 
 type setter func(string, []string)
 


### PR DESCRIPTION
Fixes #1400

First report can take 10s some times, which is suspiciously close to the dns resolution period. Turns out if the first resolution fails, we wait 10s to try again. This was we try after 1s, 2s, 4s, 8s then every 10s.