### PR TITLE
Add pod status to summary table

### DIFF
--- a/render/detailed/node.go
+++ b/render/detailed/node.go
@@ -169,7 +169,8 @@ var (
 				Label:      "Pods",
 
 				Columns: []Column{
-					{ID: report.Container, Label: "# Containers"},
+					{ID: kubernetes.State, Label: "State"},
+					{ID: report.Container, Label: "Containers"},
 					{ID: kubernetes.IP, Label: "IP"},
 				},
 			},

--- a/render/detailed/node_test.go
+++ b/render/detailed/node_test.go
@@ -99,7 +99,8 @@ func TestMakeDetailedHostNode(t *testing.T) {
 				Label:      "Pods",
 				TopologyID: "pods",
 				Columns: []detailed.Column{
-					{ID: report.Container, Label: "# Containers"},
+					{ID: kubernetes.State, Label: "State"},
+					{ID: report.Container, Label: "Containers"},
 					{ID: kubernetes.IP, Label: "IP"},
 				},
 				Nodes: []detailed.NodeSummary{podNodeSummary},


### PR DESCRIPTION
Had to shorten the title of # Containers, as it was being truncated.

Fixes #1512

<img width="440" alt="screen shot 2016-05-18 at 14 24 39" src="https://cloud.githubusercontent.com/assets/250199/15360141/51cafcf6-1d04-11e6-9ffd-56481b1dd495.png">
