### PR TITLE
Use image name without version as id.

### DIFF
--- a/probe/docker/registry.go
+++ b/probe/docker/registry.go
@@ -43,6 +43,7 @@ type Registry interface {
 	WatchContainerUpdates(ContainerUpdateWatcher)
 	GetContainer(string) (Container, bool)
 	GetContainerByPrefix(string) (Container, bool)
+	GetContainerImage(string) (*docker_client.APIImages, bool)
 }
 
 // ContainerUpdateWatcher is the type of functions that get called when containers are updated.
@@ -388,6 +389,13 @@ func (r *registry) GetContainerByPrefix(prefix string) (Container, bool) {
 		return out[0].(Container), true
 	}
 	return nil, false
+}
+
+func (r *registry) GetContainerImage(id string) (*docker_client.APIImages, bool) {
+	r.RLock()
+	defer r.RUnlock()
+	image, ok := r.images[id]
+	return image, ok
 }
 
 // WalkImages runs f on every image of running containers the registry

--- a/probe/docker/reporter.go
+++ b/probe/docker/reporter.go
@@ -38,7 +38,7 @@ var (
 	}
 
 	ContainerImageMetadataTemplates = report.MetadataTemplates{
-		ImageID:          {ID: ImageID, Label: "Image ID", From: report.FromLatest, Truncate: 12, Priority: 1},
+		ImageID:          {ID: ImageID, Label: "Image ID", From: report.FromSets, Truncate: 12, Priority: 1},
 		report.Container: {ID: report.Container, Label: "# Containers", From: report.FromCounters, Datatype: "number", Priority: 2},
 	}
 

--- a/probe/docker/reporter_test.go
+++ b/probe/docker/reporter_test.go
@@ -40,6 +40,11 @@ func (r *mockRegistry) GetContainer(_ string) (docker.Container, bool) { return 
 
 func (r *mockRegistry) GetContainerByPrefix(_ string) (docker.Container, bool) { return nil, false }
 
+func (r *mockRegistry) GetContainerImage(id string) (*client.APIImages, bool) {
+	image, ok := r.images[id]
+	return image, ok
+}
+
 var (
 	mockRegistryInstance = &mockRegistry{
 		containersByPID: map[int]docker.Container{

--- a/probe/docker/tagger.go
+++ b/probe/docker/tagger.go
@@ -85,8 +85,7 @@ func (t *Tagger) tag(tree process.Tree, topology *report.Topology) {
 		topology.AddNode(report.MakeNodeWith(nodeID, map[string]string{
 			ContainerID: c.ID(),
 		}).WithParents(report.EmptySets.
-			Add(report.Container, report.MakeStringSet(report.MakeContainerNodeID(c.ID()))).
-			Add(report.ContainerImage, report.MakeStringSet(report.MakeContainerImageNodeID(c.Image()))),
+			Add(report.Container, report.MakeStringSet(report.MakeContainerNodeID(c.ID()))),
 		))
 
 	}

--- a/probe/docker/tagger_test.go
+++ b/probe/docker/tagger_test.go
@@ -68,5 +68,10 @@ func TestTagger(t *testing.T) {
 		if have, ok := node.Parents.Lookup(report.Container); !ok || !have.Contains(report.MakeContainerNodeID("ping")) {
 			t.Errorf("Expected process node %s to have container %q as a parent, got %q", nodeID, "ping", have)
 		}
+
+		// node should have the container image as a parent
+		if have, ok := node.Parents.Lookup(report.ContainerImage); !ok || !have.Contains(report.MakeContainerImageNodeID("bang")) {
+			t.Errorf("Expected process node %s to have container image %q as a parent, got %q", nodeID, "bang", have)
+		}
 	}
 }

--- a/probe/docker/tagger_test.go
+++ b/probe/docker/tagger_test.go
@@ -68,10 +68,5 @@ func TestTagger(t *testing.T) {
 		if have, ok := node.Parents.Lookup(report.Container); !ok || !have.Contains(report.MakeContainerNodeID("ping")) {
 			t.Errorf("Expected process node %s to have container %q as a parent, got %q", nodeID, "ping", have)
 		}
-
-		// node should have the container image as a parent
-		if have, ok := node.Parents.Lookup(report.ContainerImage); !ok || !have.Contains(report.MakeContainerImageNodeID("baz")) {
-			t.Errorf("Expected process node %s to have container image %q as a parent, got %q", nodeID, "baz", have)
-		}
 	}
 }

--- a/render/detailed/node_test.go
+++ b/render/detailed/node_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/weaveworks/scope/probe/process"
 	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/scope/render/detailed"
+	"github.com/weaveworks/scope/render/expected"
 	"github.com/weaveworks/scope/report"
 	"github.com/weaveworks/scope/test"
 	"github.com/weaveworks/scope/test/fixture"
@@ -29,7 +30,7 @@ func TestMakeDetailedHostNode(t *testing.T) {
 	renderableNode := renderableNodes[fixture.ClientHostNodeID]
 	have := detailed.MakeNode("hosts", fixture.Report, renderableNodes, renderableNode)
 
-	containerImageNodeSummary := child(t, render.ContainerImageRenderer, fixture.ClientContainerImageNodeID)
+	containerImageNodeSummary := child(t, render.ContainerImageRenderer, expected.ClientContainerImageNodeID)
 	containerNodeSummary := child(t, render.ContainerRenderer, fixture.ClientContainerNodeID)
 	process1NodeSummary := child(t, render.ProcessRenderer, fixture.ClientProcess1NodeID)
 	process1NodeSummary.Linkable = true
@@ -176,7 +177,7 @@ func TestMakeDetailedHostNode(t *testing.T) {
 
 func TestMakeDetailedContainerNode(t *testing.T) {
 	id := fixture.ServerContainerNodeID
-	renderableNodes := render.ContainerRenderer.Render(fixture.Report, render.FilterNoop)
+	renderableNodes := render.ContainerWithImageNameRenderer.Render(fixture.Report, render.FilterNoop)
 	renderableNode, ok := renderableNodes[id]
 	if !ok {
 		t.Fatalf("Node not found: %s", id)
@@ -190,6 +191,7 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 			ID:         id,
 			Label:      "server",
 			LabelMinor: "server.hostname.com",
+			Rank:       fixture.ServerContainerImageName,
 			Shape:      "hexagon",
 			Linkable:   true,
 			Pseudo:     false,
@@ -232,7 +234,7 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 		},
 		Parents: []detailed.Parent{
 			{
-				ID:         fixture.ServerContainerImageNodeID,
+				ID:         expected.ServerContainerImageNodeID,
 				Label:      fixture.ServerContainerImageName,
 				TopologyID: "containers-by-image",
 			},

--- a/render/detailed/parents_test.go
+++ b/render/detailed/parents_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/scope/render/detailed"
+	"github.com/weaveworks/scope/render/expected"
 	"github.com/weaveworks/scope/report"
 	"github.com/weaveworks/scope/test"
 	"github.com/weaveworks/scope/test/fixture"
@@ -30,15 +31,17 @@ func TestParents(t *testing.T) {
 			want: nil,
 		},
 		{
-			node: render.ContainerImageRenderer.Render(fixture.Report, render.FilterNoop)[fixture.ClientContainerImageNodeID],
+			name: "Container image",
+			node: render.ContainerImageRenderer.Render(fixture.Report, render.FilterNoop)[expected.ClientContainerImageNodeID],
 			want: []detailed.Parent{
 				{ID: fixture.ClientHostNodeID, Label: fixture.ClientHostName, TopologyID: "hosts"},
 			},
 		},
 		{
-			node: render.ContainerRenderer.Render(fixture.Report, render.FilterNoop)[fixture.ClientContainerNodeID],
+			name: "Container",
+			node: render.ContainerWithImageNameRenderer.Render(fixture.Report, render.FilterNoop)[fixture.ClientContainerNodeID],
 			want: []detailed.Parent{
-				{ID: fixture.ClientContainerImageNodeID, Label: fixture.ClientContainerImageName, TopologyID: "containers-by-image"},
+				{ID: expected.ClientContainerImageNodeID, Label: fixture.ClientContainerImageName, TopologyID: "containers-by-image"},
 				{ID: fixture.ClientHostNodeID, Label: fixture.ClientHostName, TopologyID: "hosts"},
 				{ID: fixture.ClientPodNodeID, Label: "pong-a", TopologyID: "pods"},
 			},
@@ -47,7 +50,6 @@ func TestParents(t *testing.T) {
 			node: render.ProcessRenderer.Render(fixture.Report, render.FilterNoop)[fixture.ClientProcess1NodeID],
 			want: []detailed.Parent{
 				{ID: fixture.ClientContainerNodeID, Label: fixture.ClientContainerName, TopologyID: "containers"},
-				{ID: fixture.ClientContainerImageNodeID, Label: fixture.ClientContainerImageName, TopologyID: "containers-by-image"},
 				{ID: fixture.ClientHostNodeID, Label: fixture.ClientHostName, TopologyID: "hosts"},
 			},
 		},

--- a/render/detailed/summary_test.go
+++ b/render/detailed/summary_test.go
@@ -134,10 +134,10 @@ func TestMakeNodeSummary(t *testing.T) {
 		},
 		{
 			name:  "single container image rendering",
-			input: expected.RenderedContainerImages[fixture.ClientContainerImageNodeID],
+			input: expected.RenderedContainerImages[expected.ClientContainerImageNodeID],
 			ok:    true,
 			want: detailed.NodeSummary{
-				ID:         fixture.ClientContainerImageNodeID,
+				ID:         expected.ClientContainerImageNodeID,
 				Label:      fixture.ClientContainerImageName,
 				LabelMinor: "1 container",
 				Rank:       fixture.ClientContainerImageName,
@@ -145,10 +145,9 @@ func TestMakeNodeSummary(t *testing.T) {
 				Linkable:   true,
 				Stack:      true,
 				Metadata: []report.MetadataRow{
-					{ID: docker.ImageID, Label: "Image ID", Value: fixture.ClientContainerImageID, Priority: 1},
 					{ID: report.Container, Label: "# Containers", Value: "1", Priority: 2, Datatype: "number"},
 				},
-				Adjacency: report.MakeIDList(fixture.ServerContainerImageNodeID),
+				Adjacency: report.MakeIDList(expected.ServerContainerImageNodeID),
 			},
 		},
 		{

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -208,8 +208,11 @@ var (
 		render.OutgoingInternetID: theOutgoingInternetNode,
 	}
 
+	ClientContainerImageNodeID = report.MakeContainerImageNodeID(fixture.ClientContainerImageName)
+	ServerContainerImageNodeID = report.MakeContainerImageNodeID(fixture.ServerContainerImageName)
+
 	RenderedContainerImages = report.Nodes{
-		fixture.ClientContainerImageNodeID: containerImage(fixture.ClientContainerImageNodeID, fixture.ServerContainerImageNodeID).
+		ClientContainerImageNodeID: containerImage(ClientContainerImageNodeID, ServerContainerImageNodeID).
 			WithLatests(map[string]string{
 				report.HostNodeID: fixture.ClientHostNodeID,
 				docker.ImageID:    fixture.ClientContainerImageID,
@@ -226,7 +229,7 @@ var (
 				RenderedContainers[fixture.ClientContainerNodeID],
 			)),
 
-		fixture.ServerContainerImageNodeID: containerImage(fixture.ServerContainerImageNodeID).
+		ServerContainerImageNodeID: containerImage(ServerContainerImageNodeID).
 			WithChildren(report.MakeNodeSet(
 				RenderedEndpoints[fixture.Server80NodeID],
 				RenderedProcesses[fixture.ServerProcessNodeID],
@@ -234,7 +237,7 @@ var (
 			)),
 
 		uncontainedServerID:       uncontainedServerNode,
-		render.IncomingInternetID: theIncomingInternetNode(fixture.ServerContainerImageNodeID),
+		render.IncomingInternetID: theIncomingInternetNode(ServerContainerImageNodeID),
 		render.OutgoingInternetID: theOutgoingInternetNode,
 	}
 
@@ -298,7 +301,7 @@ var (
 				RenderedProcesses[fixture.ClientProcess1NodeID],
 				RenderedProcesses[fixture.ClientProcess2NodeID],
 				RenderedContainers[fixture.ClientContainerNodeID],
-				RenderedContainerImages[fixture.ClientContainerImageNodeID],
+				RenderedContainerImages[ClientContainerImageNodeID],
 				RenderedPods[fixture.ClientPodNodeID],
 			)),
 
@@ -309,7 +312,7 @@ var (
 				RenderedProcesses[fixture.ServerProcessNodeID],
 				RenderedProcesses[fixture.NonContainerProcessNodeID],
 				RenderedContainers[fixture.ServerContainerNodeID],
-				RenderedContainerImages[fixture.ServerContainerImageNodeID],
+				RenderedContainerImages[ServerContainerImageNodeID],
 				RenderedPods[fixture.ServerPodNodeID],
 			)),
 

--- a/report/sets.go
+++ b/report/sets.go
@@ -46,6 +46,16 @@ func (s Sets) Add(key string, value StringSet) Sets {
 	}
 }
 
+// Delete the given set from the Sets.
+func (s Sets) Delete(key string) Sets {
+	if s.psMap == nil {
+		return EmptySets
+	}
+	return Sets{
+		psMap: s.psMap.Delete(key),
+	}
+}
+
 // Lookup returns the sets stored under key.
 func (s Sets) Lookup(key string) (StringSet, bool) {
 	if s.psMap == nil {

--- a/test/fixture/report_fixture.go
+++ b/test/fixture/report_fixture.go
@@ -217,8 +217,7 @@ var (
 				}).
 					WithTopology(report.Process).WithParents(report.EmptySets.
 					Add("host", report.MakeStringSet(ClientHostNodeID)).
-					Add("container", report.MakeStringSet(ClientContainerNodeID)).
-					Add("container_image", report.MakeStringSet(ClientContainerImageNodeID)),
+					Add("container", report.MakeStringSet(ClientContainerNodeID)),
 				).WithMetrics(report.Metrics{
 					process.CPUUsage:    ClientProcess1CPUMetric,
 					process.MemoryUsage: ClientProcess1MemoryMetric,
@@ -231,8 +230,7 @@ var (
 				}).
 					WithTopology(report.Process).WithParents(report.EmptySets.
 					Add("host", report.MakeStringSet(ClientHostNodeID)).
-					Add("container", report.MakeStringSet(ClientContainerNodeID)).
-					Add("container_image", report.MakeStringSet(ClientContainerImageNodeID)),
+					Add("container", report.MakeStringSet(ClientContainerNodeID)),
 				),
 				ServerProcessNodeID: report.MakeNodeWith(ServerProcessNodeID, map[string]string{
 					process.PID:        ServerPID,
@@ -242,8 +240,7 @@ var (
 				}).
 					WithTopology(report.Process).WithParents(report.EmptySets.
 					Add("host", report.MakeStringSet(ServerHostNodeID)).
-					Add("container", report.MakeStringSet(ServerContainerNodeID)).
-					Add("container_image", report.MakeStringSet(ServerContainerImageNodeID)),
+					Add("container", report.MakeStringSet(ServerContainerNodeID)),
 				),
 				NonContainerProcessNodeID: report.MakeNodeWith(NonContainerProcessNodeID, map[string]string{
 					process.PID:       NonContainerPID,


### PR DESCRIPTION
Fixes #1521 

As part of this, I made it so parent links don't have to be real nodes; to simplify, I also removed the container image parent for processes.