### PR TITLE
Scope slow: improve error messages for debugging

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.3
 MAINTAINER Weaveworks Inc <help@weave.works>
 LABEL works.weave.role=system
 WORKDIR /home/weave
-RUN echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >>/etc/apk/repositories && \
+RUN echo "http://dl-3.alpinelinux.org/alpine/edge/testing" >>/etc/apk/repositories && \
 	apk add --update bash runit conntrack-tools iproute2 util-linux curl && \
 	rm -rf /var/cache/apk/*
 ADD ./docker.tgz /

--- a/probe/docker/container.go
+++ b/probe/docker/container.go
@@ -116,7 +116,7 @@ type container struct {
 	container    *docker.Container
 	statsConn    ClientConn
 	latestStats  docker.Stats
-	pendingStats [20]docker.Stats
+	pendingStats [60]docker.Stats
 	numPending   int
 	hostID       string
 	baseNode     report.Node

--- a/probe/probe.go
+++ b/probe/probe.go
@@ -152,7 +152,9 @@ func (p *Probe) report() report.Report {
 			t := time.Now()
 			timer := time.AfterFunc(p.spyInterval, func() { log.Warningf("%v reporter took longer than %v", rep.Name(), p.spyInterval) })
 			newReport, err := rep.Report()
-			timer.Stop()
+			if !timer.Stop() {
+				log.Warningf("%v reporter took %v (longer than %v)", rep.Name(), time.Now().Sub(t), p.spyInterval)
+			}
 			metrics.MeasureSince([]string{rep.Name(), "reporter"}, t)
 			if err != nil {
 				log.Errorf("error generating report: %v", err)
@@ -175,7 +177,9 @@ func (p *Probe) tag(r report.Report) report.Report {
 		t := time.Now()
 		timer := time.AfterFunc(p.spyInterval, func() { log.Warningf("%v tagger took longer than %v", tagger.Name(), p.spyInterval) })
 		r, err = tagger.Tag(r)
-		timer.Stop()
+		if !timer.Stop() {
+			log.Warningf("%v tagger took %v (longer than %v)", tagger.Name(), time.Now().Sub(t), p.spyInterval)
+		}
 		metrics.MeasureSince([]string{tagger.Name(), "tagger"}, t)
 		if err != nil {
 			log.Errorf("error applying tagger: %v", err)

--- a/vendor/runsvinit/example/Dockerfile
+++ b/vendor/runsvinit/example/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-RUN echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >>/etc/apk/repositories && \
+RUN echo "http://dl-3.alpinelinux.org/alpine/edge/testing" >>/etc/apk/repositories && \
     apk add --update runit && \
     rm -rf /var/cache/apk/*
 

--- a/vendor/runsvinit/zombietest/Dockerfile
+++ b/vendor/runsvinit/zombietest/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-RUN echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >>/etc/apk/repositories && \
+RUN echo "http://dl-3.alpinelinux.org/alpine/edge/testing" >>/etc/apk/repositories && \
     apk add --update runit && \
     rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
I often have the following error messages:

```
Host reporter took longer than 1s
Endpoint reporter took longer than 1s
Process reporter took longer than 1s
Docker reporter took longer than 1s
```

With this patch, the messages are more descriptive. Examples:
```
Process reporter took 1.399966061s (longer than 1s)
Endpoint reporter took 4.100178596s (longer than 1s)
Topology tagger took 1.897464894s (longer than 1s)
```

I also repeatedly have the following, sometimes flooding the output:
```
docker container: dropping stats.
docker container: dropping stats.
docker container: dropping stats.
```
I increased the buffer.

Finally, I use another mirror than `dl-4.alpinelinux.org` because the server is down and this breaks my builds on circleci.

/cc @alepuccetti 
