### PR TITLE
circle.yml: deploy non-master branches

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -69,6 +69,15 @@ deployment:
           (test "${DOCKER_ORGANIZATION:-$DOCKER_USER}" == "weaveworks" || docker tag weaveworks/scope:latest ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope:latest) &&
           docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope
         )
+  hub-dev:
+    branch: /^((?!master).)*$/  # not the master branch
+    commands:
+      - >
+        test -z "${DEPLOY_BRANCH}" || test -z "${DOCKER_USER}" || (
+          docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS &&
+          docker tag weaveworks/scope:latest ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope:${CIRCLE_BRANCH//\//-} &&
+          docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope:${CIRCLE_BRANCH//\//-}
+        )
 #  release:
 #    branch: /release-[0-9]+\.[0-9]+/
 #    owner: weaveworks


### PR DESCRIPTION
By default, non-master branches are not deployed on the Docker Hub. With
this patch, you can enable this feature by setting the environment
variable DEPLOY_BRANCH in the circle configuration.

It will not be tagged with the "latest" tag but instead derive the tag
from the branch name. Since "/" are not allowed in Docker tag names, all
"/" are replaced by "-".

When testing code in Scope, I use circle to build the Docker image but I
don't want to always use my "master" branch for development.

/cc @alepuccetti
