### PR TITLE
If we don't get a path name from the router, make one up from the url.

### DIFF
--- a/common/middleware/instrument.go
+++ b/common/middleware/instrument.go
@@ -40,19 +40,29 @@ func (i Instrument) Wrap(next http.Handler) http.Handler {
 	})
 }
 
-var invalidChars = regexp.MustCompile(`[^a-zA-Z0-9]+`)
-
+// Return a name identifier for ths request.  There are three options:
+//   1. The request matches a gorilla mux route, with a name.  Use that.
+//   2. The request matches an unamed gorilla mux router.  Munge the path
+//      template such that templates like '/api/{org}/foo' come out as
+//      'api_org_foo'.
+//   3. The request doesn't match a mux route.  Munge the Path in the same
+//      manner as (2).
+// We do all this as we do not wish to emit high cardinality labels to
+// prometheus.
 func (i Instrument) getRouteName(r *http.Request) string {
 	var routeMatch mux.RouteMatch
-	if !i.RouteMatcher.Match(r, &routeMatch) {
-		return MakeLabelValue(r.URL.Path)
+	if i.RouteMatcher.Match(r, &routeMatch) {
+		if name := routeMatch.Route.GetName(); name != "" {
+			return name
+		}
+		if tmpl, err := routeMatch.Route.GetPathTemplate(); err != nil {
+			return MakeLabelValue(tmpl)
+		}
 	}
-	name := routeMatch.Route.GetName()
-	if name == "" {
-		return MakeLabelValue(r.URL.Path)
-	}
-	return name
+	return MakeLabelValue(r.URL.Path)
 }
+
+var invalidChars = regexp.MustCompile(`[^a-zA-Z0-9]+`)
 
 // MakeLabelValue converts a Gorilla mux path to a string suitable for use in
 // a Prometheus label value.
@@ -62,6 +72,9 @@ func MakeLabelValue(path string) string {
 
 	// Trim leading and trailing underscores.
 	result = strings.Trim(result, "_")
+
+	// Make it all lowercase
+	result = strings.ToLower(result)
 
 	// Special case.
 	if result == "" {

--- a/common/middleware/instrument_test.go
+++ b/common/middleware/instrument_test.go
@@ -1,0 +1,29 @@
+package middleware_test
+
+import (
+	"testing"
+
+	"github.com/weaveworks/scope/common/middleware"
+)
+
+func TestMakeLabelValue(t *testing.T) {
+	for input, want := range map[string]string{
+		"/":                      "root", // special case
+		"//":                     "root", // unintended consequence of special case
+		"a":                      "a",
+		"/foo":                   "foo",
+		"foo/":                   "foo",
+		"/foo/":                  "foo",
+		"/foo/bar":               "foo_bar",
+		"foo/bar/":               "foo_bar",
+		"/foo/bar/":              "foo_bar",
+		"/foo/{orgName}/Bar":     "foo_orgname_bar",
+		"/foo/{org_name}/Bar":    "foo_org_name_bar",
+		"/foo/{org__name}/Bar":   "foo_org_name_bar",
+		"/foo/{org___name}/_Bar": "foo_org_name_bar",
+	} {
+		if have := middleware.MakeLabelValue(input); want != have {
+			t.Errorf("%q: want %q, have %q", input, want, have)
+		}
+	}
+}

--- a/common/middleware/instrument_test.go
+++ b/common/middleware/instrument_test.go
@@ -21,6 +21,7 @@ func TestMakeLabelValue(t *testing.T) {
 		"/foo/{org_name}/Bar":    "foo_org_name_bar",
 		"/foo/{org__name}/Bar":   "foo_org_name_bar",
 		"/foo/{org___name}/_Bar": "foo_org_name_bar",
+		"/foo.bar/baz.qux/":      "foo_bar_baz_qux",
 	} {
 		if have := middleware.MakeLabelValue(input); want != have {
 			t.Errorf("%q: want %q, have %q", input, want, have)

--- a/prog/app.go
+++ b/prog/app.go
@@ -52,7 +52,7 @@ func router(collector app.Collector, controlRouter app.ControlRouter, pipeRouter
 	app.RegisterPipeRoutes(router, pipeRouter)
 	app.RegisterTopologyRoutes(router, collector)
 
-	router.PathPrefix("/").Handler(http.FileServer(FS(false)))
+	router.PathPrefix("/").Name("static").Handler(http.FileServer(FS(false)))
 
 	instrument := middleware.Instrument{
 		RouteMatcher: router,


### PR DESCRIPTION
To stop the monitoring showing "unamed_path" everywhere.