### PR TITLE
Get route name before munging request

### DIFF
--- a/common/middleware/instrument.go
+++ b/common/middleware/instrument.go
@@ -30,9 +30,9 @@ func (i Instrument) Wrap(next http.Handler) http.Handler {
 		begin := time.Now()
 		isWS := strconv.FormatBool(isWSHandshakeRequest(r))
 		interceptor := &interceptor{ResponseWriter: w, statusCode: http.StatusOK}
+		route := i.getRouteName(r)
 		next.ServeHTTP(interceptor, r)
 		var (
-			route  = i.getRouteName(r)
 			status = strconv.Itoa(interceptor.statusCode)
 			took   = time.Since(begin)
 		)


### PR DESCRIPTION
This ought to correct a problem where we incorrectly report route names
for admin routes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/scope/1590)
<!-- Reviewable:end -->
