### PR TITLE
Helper for reading & writing from binary

### DIFF
--- a/app/router.go
+++ b/app/router.go
@@ -1,8 +1,6 @@
 package app
 
 import (
-	"compress/gzip"
-	"encoding/gob"
 	"io"
 	"net/http"
 	"net/url"
@@ -122,43 +120,22 @@ func RegisterReportPostHandler(a Adder, router *mux.Router) {
 	post := router.Methods("POST").Subrouter()
 	post.HandleFunc("/api/report", requestContextDecorator(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 		var (
-			rpt                              report.Report
-			reader                           = r.Body
-			err                              error
-			compressedSize, uncompressedSize uint64
+			rpt    report.Report
+			reader = r.Body
 		)
 
-		if log.GetLevel() == log.DebugLevel {
-			reader = byteCounter{next: reader, count: &compressedSize}
-		}
-		if strings.Contains(r.Header.Get("Content-Encoding"), "gzip") {
-			reader, err = gzip.NewReader(reader)
-			if err != nil {
-				respondWith(w, http.StatusBadRequest, err)
-				return
-			}
-		}
-
-		if log.GetLevel() == log.DebugLevel {
-			reader = byteCounter{next: reader, count: &uncompressedSize}
-		}
-		decoder := gob.NewDecoder(reader).Decode
+		gzipped := strings.Contains(r.Header.Get("Content-Encoding"), "gzip")
+		var handle codec.Handle
 		if strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
-			decoder = codec.NewDecoder(reader, &codec.JsonHandle{}).Decode
+			handle = &codec.JsonHandle{}
 		} else if strings.HasPrefix(r.Header.Get("Content-Type"), "application/msgpack") {
-			decoder = codec.NewDecoder(reader, &codec.MsgpackHandle{}).Decode
+			handle = &codec.MsgpackHandle{}
 		}
 
-		if err := decoder(&rpt); err != nil {
+		if err := rpt.ReadBinary(reader, gzipped, handle); err != nil {
 			respondWith(w, http.StatusBadRequest, err)
 			return
 		}
-		log.Debugf(
-			"Received report sizes: compressed %d bytes, uncompressed %d bytes (%.2f%%)",
-			compressedSize,
-			uncompressedSize,
-			float32(compressedSize)/float32(uncompressedSize)*100,
-		)
 
 		if err := a.Add(ctx, rpt); err != nil {
 			log.Errorf("Error Adding report: %v", err)

--- a/app/router.go
+++ b/app/router.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"io"
 	"net/http"
 	"net/url"
 	"strings"

--- a/app/router.go
+++ b/app/router.go
@@ -100,21 +100,6 @@ func RegisterTopologyRoutes(router *mux.Router, r Reporter) {
 		gzipHandler(requestContextDecorator(makeProbeHandler(r))))
 }
 
-type byteCounter struct {
-	next  io.ReadCloser
-	count *uint64
-}
-
-func (c byteCounter) Read(p []byte) (n int, err error) {
-	n, err = c.next.Read(p)
-	*c.count += uint64(n)
-	return n, err
-}
-
-func (c byteCounter) Close() error {
-	return c.next.Close()
-}
-
 // RegisterReportPostHandler registers the handler for report submission
 func RegisterReportPostHandler(a Adder, router *mux.Router) {
 	post := router.Methods("POST").Subrouter()

--- a/app/router_test.go
+++ b/app/router_test.go
@@ -2,7 +2,6 @@ package app_test
 
 import (
 	"bytes"
-	"encoding/gob"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -84,11 +83,6 @@ func TestReportPostHandler(t *testing.T) {
 		}
 	}
 
-	test("", func(v interface{}) ([]byte, error) {
-		buf := &bytes.Buffer{}
-		err := gob.NewEncoder(buf).Encode(v)
-		return buf.Bytes(), err
-	})
 	test("application/json", func(v interface{}) ([]byte, error) {
 		buf := &bytes.Buffer{}
 		err := codec.NewEncoder(buf, &codec.JsonHandle{}).Encode(v)

--- a/probe/appclient/report_publisher.go
+++ b/probe/appclient/report_publisher.go
@@ -2,9 +2,6 @@ package appclient
 
 import (
 	"bytes"
-	"compress/gzip"
-	"github.com/ugorji/go/codec"
-
 	"github.com/weaveworks/scope/report"
 )
 
@@ -24,11 +21,6 @@ func NewReportPublisher(publisher Publisher) *ReportPublisher {
 // Publish serialises and compresses a report, then passes it to a publisher
 func (p *ReportPublisher) Publish(r report.Report) error {
 	buf := &bytes.Buffer{}
-	gzwriter := gzip.NewWriter(buf)
-	if err := codec.NewEncoder(gzwriter, &codec.MsgpackHandle{}).Encode(r); err != nil {
-		return err
-	}
-	gzwriter.Close() // otherwise the content won't get flushed to the output stream
-
+	r.WriteBinary(buf)
 	return p.publisher.Publish(buf)
 }

--- a/report/marshal.go
+++ b/report/marshal.go
@@ -21,7 +21,7 @@ func (rep Report) WriteBinary(w io.Writer) error {
 	return nil
 }
 
-// ReadBinary reads into a Report from a gzipped msgpack.
+// ReadBinary reads bytes into a Report.
 //
 // Will decompress the binary if gzipped is true, and will use the given
 // codecHandle to decode it. If codecHandle is nil, will decode as a gob.
@@ -33,9 +33,11 @@ func (rep *Report) ReadBinary(r io.Reader, gzipped bool, codecHandle codec.Handl
 			return err
 		}
 	}
-	decoder := gob.NewDecoder(r).Decode
+	var decoder func(interface{}) error
 	if codecHandle != nil {
 		decoder = codec.NewDecoder(r, codecHandle).Decode
+	} else {
+		decoder = gob.NewDecoder(r).Decode
 	}
 	if err := decoder(&rep); err != nil {
 		return err

--- a/report/marshal.go
+++ b/report/marshal.go
@@ -2,7 +2,6 @@ package report
 
 import (
 	"compress/gzip"
-	"encoding/gob"
 	"io"
 
 	log "github.com/Sirupsen/logrus"
@@ -36,7 +35,7 @@ func (c byteCounter) Read(p []byte) (n int, err error) {
 // ReadBinary reads bytes into a Report.
 //
 // Will decompress the binary if gzipped is true, and will use the given
-// codecHandle to decode it. If codecHandle is nil, will decode as a gob.
+// codecHandle to decode it.
 func (rep *Report) ReadBinary(r io.Reader, gzipped bool, codecHandle codec.Handle) error {
 	var err error
 	var compressedSize, uncompressedSize uint64
@@ -56,13 +55,7 @@ func (rep *Report) ReadBinary(r io.Reader, gzipped bool, codecHandle codec.Handl
 	if log.GetLevel() == log.DebugLevel {
 		r = byteCounter{next: r, count: &uncompressedSize}
 	}
-	var decoder func(interface{}) error
-	if codecHandle != nil {
-		decoder = codec.NewDecoder(r, codecHandle).Decode
-	} else {
-		decoder = gob.NewDecoder(r).Decode
-	}
-	if err := decoder(&rep); err != nil {
+	if err := codec.NewDecoder(r, codecHandle).Decode(&rep); err != nil {
 		return err
 	}
 	log.Debugf(

--- a/report/marshal.go
+++ b/report/marshal.go
@@ -1,0 +1,42 @@
+package report
+
+import (
+	"compress/gzip"
+	"io"
+
+	"github.com/ugorji/go/codec"
+)
+
+// WriteBinary writes a Report as a gzipped msgpack.
+func (rep Report) WriteBinary(w io.Writer) error {
+	gzwriter, err := gzip.NewWriterLevel(w, gzip.BestCompression)
+	if err != nil {
+		return err
+	}
+	if err = codec.NewEncoder(gzwriter, &codec.MsgpackHandle{}).Encode(&rep); err != nil {
+		return err
+	}
+	gzwriter.Close() // otherwise the content won't get flushed to the output stream
+	return nil
+}
+
+// ReadBinary reads into a Report from a gzipped msgpack.
+func (rep *Report) ReadBinary(r io.Reader) error {
+	reader, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	if err := codec.NewDecoder(reader, &codec.MsgpackHandle{}).Decode(&rep); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MakeFromBinary constructs a Report from a gzipped msgpack.
+func MakeFromBinary(r io.Reader) (*Report, error) {
+	rep := MakeReport()
+	if err := rep.ReadBinary(r); err != nil {
+		return nil, err
+	}
+	return &rep, nil
+}


### PR DESCRIPTION
I found a couple of places where we had said in code that reports are serialized as compress msgpacks. This patch formalizes that convention by providing an API.

I'm working on another PR where I re-use this API in a different place.

There are a bunch of places in tests that could probably also be changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/scope/1600)
<!-- Reviewable:end -->
