### PR TITLE
Add dry run flag to scope, so when launched we can check the args are valid.

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,11 +2,6 @@
 
 mkdir -p /var/run/weave
 
-if [ "$1" = "version" -o "$1" = "help" ]; then
-    exec -a scope /home/weave/scope --mode $1
-    exit 0
-fi
-
 for arg in $@; do
     case "$arg" in
         --no-app|--probe-only|--service-token*|--probe.token*)

--- a/prog/main.go
+++ b/prog/main.go
@@ -116,11 +116,13 @@ func main() {
 		mode          string
 		debug         bool
 		weaveHostname string
+		dryRun        bool
 	)
 
 	// Flags that apply to both probe and app
 	flag.StringVar(&mode, "mode", "help", "For internal use.")
 	flag.BoolVar(&debug, "debug", false, "Force debug logging.")
+	flag.BoolVar(&dryRun, "dry-run", false, "Don't start scope, just parse the arguments.")
 	flag.StringVar(&weaveHostname, "weave.hostname", "", "Hostname to advertise/lookup in WeaveDNS")
 
 	// We need to know how to parse them, but they are mainly interpreted by the entrypoint script.
@@ -201,6 +203,10 @@ func main() {
 		flags.app.weaveHostname = weaveHostname
 	}
 	flags.probe.noApp = *noApp || *probeOnly
+
+	if dryRun {
+		return
+	}
 
 	switch mode {
 	case "app":

--- a/prog/main.go
+++ b/prog/main.go
@@ -123,7 +123,7 @@ func main() {
 	// Flags that apply to both probe and app
 	flag.StringVar(&mode, "mode", "help", "For internal use.")
 	flag.BoolVar(&debug, "debug", false, "Force debug logging.")
-	flag.BoolVar(&dryRun, "dry-run", false, "Don't start scope, just parse the arguments.")
+	flag.BoolVar(&dryRun, "dry-run", false, "Don't start scope, just parse the arguments.  For internal use only.")
 	flag.StringVar(&weaveHostname, "weave.hostname", "", "Hostname to advertise/lookup in WeaveDNS")
 
 	// We need to know how to parse them, but they are mainly interpreted by the entrypoint script.

--- a/prog/main.go
+++ b/prog/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -203,6 +204,18 @@ func main() {
 		flags.app.weaveHostname = weaveHostname
 	}
 	flags.probe.noApp = *noApp || *probeOnly
+
+	// Special case for #1191, check listen address is well formed
+	_, _, err := net.SplitHostPort(flags.app.listen)
+	if err != nil {
+		log.Errorf("Invalid value for -app.http.address: %v", err)
+	}
+	if flags.probe.httpListen != "" {
+		_, _, err := net.SplitHostPort(flags.probe.httpListen)
+		if err != nil {
+			log.Errorf("Invalid value for -app.http.address: %v", err)
+		}
+	}
 
 	if dryRun {
 		return

--- a/scope
+++ b/scope
@@ -127,7 +127,8 @@ case "$COMMAND" in
         ;;
 
     version)
-        docker run --rm -e CHECKPOINT_DISABLE $SCOPE_IMAGE version
+        docker run --rm -e CHECKPOINT_DISABLE --entrypoint=/home/weave/scope \
+            $WEAVESCOPE_DOCKER_ARGS $SCOPE_IMAGE --mode=version
         ;;
 
     help)
@@ -138,7 +139,8 @@ scope help     - Print this
 
 scope launch   - Launch Scope
 EOF
-        docker run --rm -e CHECKPOINT_DISABLE $SCOPE_IMAGE help
+        docker run --rm -e CHECKPOINT_DISABLE --entrypoint=/home/weave/scope \
+            $WEAVESCOPE_DOCKER_ARGS $SCOPE_IMAGE -h
 
         cat >&2 <<EOF
 
@@ -150,6 +152,11 @@ EOF
         ;;
 
     launch)
+        # Do a dry run of scope in the foreground, so it can parse args etc
+        # avoiding the entrypoint script in the process.
+        docker run --rm -e CHECKPOINT_DISABLE --entrypoint=/home/weave/scope \
+            $WEAVESCOPE_DOCKER_ARGS $SCOPE_IMAGE --dry-run $@
+
         if ! check_docker_for_mac || check_probe_only ; then
             check_not_running $SCOPE_CONTAINER_NAME $SCOPE_IMAGE_NAME
             docker rm -f $SCOPE_CONTAINER_NAME >/dev/null 2>&1 || true


### PR DESCRIPTION
Fixes #1191, fixes #1559, fixes #1548
