### PR TITLE
Make it easier to disable weave integrations

### DIFF
--- a/common/backoff/backoff.go
+++ b/common/backoff/backoff.go
@@ -75,7 +75,7 @@ func (b *backoff) Start() {
 
 		if shouldLog {
 			if err != nil {
-				log.Errorf("Error %s, backing off %s: %s",
+				log.Warnf("Error %s, backing off %s: %s",
 					b.msg, backoff, err)
 			} else {
 				log.Infof("Success %s", b.msg)

--- a/common/weave/client.go
+++ b/common/weave/client.go
@@ -171,7 +171,7 @@ func (c *client) Expose() error {
 		// Alread exposed!
 		return nil
 	}
-	if err := exec.Command("weave", "expose").Run(); err != nil {
+	if err := exec.Command("weave", "--local", "expose").Run(); err != nil {
 		return fmt.Errorf("Error running weave expose: %v", err)
 	}
 	return nil

--- a/common/weave/client.go
+++ b/common/weave/client.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"strconv"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/ugorji/go/codec"
 
 	"github.com/weaveworks/scope/common/exec"
@@ -132,11 +131,6 @@ func (c *client) PS() (map[string]PSEntry, error) {
 	if err := cmd.Start(); err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := cmd.Wait(); err != nil {
-			log.Errorf("'weave ps' cmd failed: %v", err)
-		}
-	}()
 
 	psEntriesByPrefix := map[string]PSEntry{}
 	scanner := bufio.NewScanner(out)
@@ -156,10 +150,14 @@ func (c *client) PS() (map[string]PSEntry, error) {
 			IPs:               ips,
 		}
 	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
+	scannerErr := scanner.Err()
+	cmdErr := cmd.Wait()
+	if cmdErr != nil {
+		return nil, cmdErr
 	}
-
+	if scannerErr != nil {
+		return nil, scannerErr
+	}
 	return psEntriesByPrefix, nil
 }
 

--- a/common/weave/client_test.go
+++ b/common/weave/client_test.go
@@ -177,7 +177,7 @@ func TestExpose(t *testing.T) {
 
 	psCalled, exposeCalled := false, false
 	exec.Command = func(name string, args ...string) exec.Cmd {
-		if args[0] == "expose" {
+		if len(args) >= 2 && args[1] == "expose" {
 			exposeCalled = true
 			return testExec.NewMockCmdString("")
 		}

--- a/prog/app.go
+++ b/prog/app.go
@@ -218,9 +218,8 @@ func appMain(flags appFlags) {
 		}
 	})
 
-	// If user supplied a weave router address, periodically try and register
-	// out IP address in WeaveDNS.
-	if flags.weaveAddr != "" {
+	// Periodically try and register out IP address in WeaveDNS.
+	if flags.weaveEnabled {
 		weave, err := newWeavePublisher(
 			flags.dockerEndpoint, flags.weaveAddr,
 			flags.weaveHostname, flags.containerName)

--- a/prog/main.go
+++ b/prog/main.go
@@ -81,6 +81,7 @@ type probeFlags struct {
 	kubernetesAPI      string
 	kubernetesInterval time.Duration
 
+	weaveEnabled  bool
 	weaveAddr     string
 	weaveHostname string
 }
@@ -92,6 +93,7 @@ type appFlags struct {
 	logPrefix string
 	logHTTP   bool
 
+	weaveEnabled   bool
 	weaveAddr      string
 	weaveHostname  string
 	containerName  string
@@ -116,6 +118,7 @@ func main() {
 		flags         = flags{}
 		mode          string
 		debug         bool
+		weaveEnabled  bool
 		weaveHostname string
 		dryRun        bool
 	)
@@ -124,6 +127,7 @@ func main() {
 	flag.StringVar(&mode, "mode", "help", "For internal use.")
 	flag.BoolVar(&debug, "debug", false, "Force debug logging.")
 	flag.BoolVar(&dryRun, "dry-run", false, "Don't start scope, just parse the arguments.  For internal use only.")
+	flag.BoolVar(&weaveEnabled, "weave", true, "Enable Weave Net integrations.")
 	flag.StringVar(&weaveHostname, "weave.hostname", "", "Hostname to advertise/lookup in WeaveDNS")
 
 	// We need to know how to parse them, but they are mainly interpreted by the entrypoint script.
@@ -203,6 +207,8 @@ func main() {
 		flags.probe.weaveHostname = weaveHostname
 		flags.app.weaveHostname = weaveHostname
 	}
+	flags.probe.weaveEnabled = weaveEnabled
+	flags.app.weaveEnabled = weaveEnabled
 	flags.probe.noApp = *noApp || *probeOnly
 
 	// Special case for #1191, check listen address is well formed

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -180,7 +180,7 @@ func probeMain(flags probeFlags) {
 		}
 	}
 
-	if flags.weaveAddr != "" {
+	if flags.weaveEnabled {
 		client := weave.NewClient(sanitize.URL("http://", 6784, "")(flags.weaveAddr))
 		weave := overlay.NewWeave(hostID, client)
 		defer weave.Stop()


### PR DESCRIPTION
Also:
- Treat `weave ps` exit code like any other error (so we silence it if its failing all the time) (fixes #1599)
- Don't run weave ps so aggressively (fixes #1078)
- Log backoff-able errors at WARN (fixes #1008)