### PR TITLE
Fix nil pointer error when memcache not enabled

### DIFF
--- a/app/multitenant/dynamo_collector.go
+++ b/app/multitenant/dynamo_collector.go
@@ -330,8 +330,12 @@ func (c *dynamoDBCollector) getReports(userid string, row int64, start, end time
 		return nil, err
 	}
 
+	stores := []ReportStore{c.inProcess}
+	if c.memcache != nil {
+		stores = append(stores, c.memcache)
+	}
 	var reports []report.Report
-	for _, store := range []ReportStore{c.inProcess, c.memcache} {
+	for _, store := range stores {
 		if store == nil {
 			continue
 		}


### PR DESCRIPTION
When no memcache options were provided, we would get stack traces indicating that we were calling `GetMulti` on a nil memcache client.

This PR fixes that problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/scope/1612)
<!-- Reviewable:end -->
