### PR TITLE
Refactor caching layers in dynamo collector

### DIFF
--- a/app/multitenant/dynamo_collector.go
+++ b/app/multitenant/dynamo_collector.go
@@ -128,9 +128,10 @@ type watchKey struct {
 // https://github.com/aws/aws-sdk-go/wiki/common-examples
 func NewDynamoDBCollector(
 	userIDer UserIDer,
-	dynamoDBConfig, s3Config *aws.Config,
-	tableName, bucketName, natsHost, memcachedHost string,
-	memcachedTimeout time.Duration, memcachedService string,
+	dynamoDBConfig *aws.Config, tableName string,
+	s3Store *S3Store,
+	natsHost,
+	memcachedHost string, memcachedTimeout time.Duration, memcachedService string,
 ) (DynamoDBCollector, error) {
 	var nc *nats.Conn
 	if natsHost != "" {
@@ -140,8 +141,6 @@ func NewDynamoDBCollector(
 			return nil, err
 		}
 	}
-
-	s3Store := NewS3Client(s3Config, bucketName)
 
 	var memcacheClient *MemcacheClient
 	if memcachedHost != "" {
@@ -161,7 +160,7 @@ func NewDynamoDBCollector(
 
 	return &dynamoDBCollector{
 		db:        dynamodb.New(session.New(dynamoDBConfig)),
-		s3:        &s3Store,
+		s3:        s3Store,
 		userIDer:  userIDer,
 		tableName: tableName,
 		merger:    app.NewSmartMerger(),

--- a/app/multitenant/dynamo_collector.go
+++ b/app/multitenant/dynamo_collector.go
@@ -23,14 +23,12 @@ import (
 )
 
 const (
-	hourField              = "hour"
-	tsField                = "ts"
-	reportField            = "report"
-	reportCacheSize        = (15 / 3) * 10 * 5 // (window size * report rate) * number of hosts per user * number of users
-	reportCacheExpiration  = 15 * time.Second
-	memcacheExpiration     = 15 // seconds
-	memcacheUpdateInterval = 1 * time.Minute
-	natsTimeout            = 10 * time.Second
+	hourField             = "hour"
+	tsField               = "ts"
+	reportField           = "report"
+	reportCacheSize       = (15 / 3) * 10 * 5 // (window size * report rate) * number of hosts per user * number of users
+	reportCacheExpiration = 15 * time.Second
+	natsTimeout           = 10 * time.Second
 )
 
 var (
@@ -130,30 +128,14 @@ func NewDynamoDBCollector(
 	userIDer UserIDer,
 	dynamoDBConfig *aws.Config, tableName string,
 	s3Store *S3Store,
-	natsHost,
-	memcachedHost string, memcachedTimeout time.Duration, memcachedService string,
+	natsHost string,
+	memcacheClient *MemcacheClient,
 ) (DynamoDBCollector, error) {
 	var nc *nats.Conn
 	if natsHost != "" {
 		var err error
 		nc, err = nats.Connect(natsHost)
 		if err != nil {
-			return nil, err
-		}
-	}
-
-	var memcacheClient *MemcacheClient
-	if memcachedHost != "" {
-		var err error
-		memcacheClient, err = NewMemcacheClient(memcachedHost, memcachedTimeout, memcachedService, memcacheUpdateInterval, memcacheExpiration)
-		if err != nil {
-			// TODO(jml): Ideally, we wouldn't abort here, we would instead
-			// log errors when we try to use the memcache & fail to do so, as
-			// aborting here introduces ordering dependencies into our
-			// deployment.
-			//
-			// Note: this error only happens when either the memcachedHost or
-			// any of the SRV records that it points to fail to resolve.
 			return nil, err
 		}
 	}

--- a/app/multitenant/memcache_client.go
+++ b/app/multitenant/memcache_client.go
@@ -134,7 +134,7 @@ func memcacheStatusCode(err error) string {
 }
 
 // FetchReports gets reports from memcache.
-func (c *MemcacheClient) FetchReports(keys []string) ([]report.Report, []string, error) {
+func (c *MemcacheClient) FetchReports(keys []string) (map[string]report.Report, []string, error) {
 	var found map[string]*memcache.Item
 	err := timeRequestStatus("Get", memcacheRequestDuration, memcacheStatusCode, func() error {
 		var err error
@@ -165,17 +165,17 @@ func (c *MemcacheClient) FetchReports(keys []string) ([]report.Report, []string,
 				ch <- result{key: key}
 				return
 			}
-			ch <- result{report: rep}
+			ch <- result{key: key, report: rep}
 		}(key)
 	}
 
-	var reports []report.Report
+	var reports map[string]report.Report
 	for i := 0; i < len(keys)-len(missing); i++ {
 		r := <-ch
 		if r.report == nil {
 			missing = append(missing, r.key)
 		} else {
-			reports = append(reports, *r.report)
+			reports[r.key] = *r.report
 		}
 	}
 

--- a/app/multitenant/s3_client.go
+++ b/app/multitenant/s3_client.go
@@ -38,7 +38,7 @@ func NewS3Client(config *aws.Config, bucketName string) S3Store {
 }
 
 // FetchReports fetches multiple reports in parallel from S3.
-func (store *S3Store) FetchReports(keys []string) ([]report.Report, []string, error) {
+func (store *S3Store) FetchReports(keys []string) (map[string]report.Report, []string, error) {
 	type result struct {
 		key    string
 		report *report.Report
@@ -55,13 +55,13 @@ func (store *S3Store) FetchReports(keys []string) ([]report.Report, []string, er
 		}(key)
 	}
 
-	reports := []report.Report{}
+	reports := map[string]report.Report{}
 	for range keys {
 		r := <-ch
 		if r.err != nil {
 			return nil, []string{}, r.err
 		}
-		reports = append(reports, *r.report)
+		reports[r.key] = *r.report
 	}
 	return reports, []string{}, nil
 }

--- a/app/multitenant/s3_client.go
+++ b/app/multitenant/s3_client.go
@@ -1,0 +1,96 @@
+package multitenant
+
+import (
+	"bytes"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/weaveworks/scope/report"
+)
+
+var (
+	s3RequestDuration = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Namespace: "scope",
+		Name:      "s3_request_duration_seconds",
+		Help:      "Time in seconds spent doing S3 requests.",
+	}, []string{"method", "status_code"})
+)
+
+// S3Store is an S3 client that stores and retrieves Reports.
+type S3Store struct {
+	s3         *s3.S3
+	bucketName string
+}
+
+func init() {
+	prometheus.MustRegister(s3RequestDuration)
+}
+
+// NewS3Client creates a new S3 client.
+func NewS3Client(config *aws.Config, bucketName string) S3Store {
+	return S3Store{
+		s3:         s3.New(session.New(config)),
+		bucketName: bucketName,
+	}
+}
+
+// FetchReports fetches multiple reports in parallel from S3.
+func (store *S3Store) FetchReports(keys []string) ([]report.Report, []string, error) {
+	type result struct {
+		key    string
+		report *report.Report
+		err    error
+	}
+
+	ch := make(chan result, len(keys))
+
+	for _, key := range keys {
+		go func(key string) {
+			r := result{key: key}
+			r.report, r.err = store.fetchReport(key)
+			ch <- r
+		}(key)
+	}
+
+	reports := []report.Report{}
+	for range keys {
+		r := <-ch
+		if r.err != nil {
+			return nil, []string{}, r.err
+		}
+		reports = append(reports, *r.report)
+	}
+	return reports, []string{}, nil
+}
+
+func (store *S3Store) fetchReport(key string) (*report.Report, error) {
+	var resp *s3.GetObjectOutput
+	err := timeRequest("Get", s3RequestDuration, func() error {
+		var err error
+		resp, err = store.s3.GetObject(&s3.GetObjectInput{
+			Bucket: aws.String(store.bucketName),
+			Key:    aws.String(key),
+		})
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return report.MakeFromBinary(resp.Body)
+}
+
+// StoreBytes stores a report in S3, expecting the report to be serialized
+// already.
+func (store *S3Store) StoreBytes(key string, content []byte) error {
+	return timeRequest("Put", s3RequestDuration, func() error {
+		_, err := store.s3.PutObject(&s3.PutObjectInput{
+			Body:   bytes.NewReader(content),
+			Bucket: aws.String(store.bucketName),
+			Key:    aws.String(key),
+		})
+		return err
+	})
+}

--- a/prog/app.go
+++ b/prog/app.go
@@ -99,10 +99,11 @@ func collectorFactory(userIDer multitenant.UserIDer, collectorURL, s3URL, natsHo
 		if err != nil {
 			return nil, err
 		}
-		tableName := strings.TrimPrefix(parsed.Path, "/")
 		bucketName := strings.TrimPrefix(s3.Path, "/")
+		s3Store := multitenant.NewS3Client(s3Config, bucketName)
+		tableName := strings.TrimPrefix(parsed.Path, "/")
 		dynamoCollector, err := multitenant.NewDynamoDBCollector(
-			userIDer, dynamoDBConfig, s3Config, tableName, bucketName, natsHostname,
+			userIDer, dynamoDBConfig, tableName, &s3Store, natsHostname,
 			memcachedHostname, memcachedTimeout, memcachedService,
 		)
 		if err != nil {

--- a/prog/app.go
+++ b/prog/app.go
@@ -126,8 +126,14 @@ func collectorFactory(userIDer multitenant.UserIDer, collectorURL, s3URL, natsHo
 			}
 		}
 		awsCollector, err := multitenant.NewAWSCollector(
-			userIDer, dynamoDBConfig, tableName, &s3Store, natsHostname,
-			memcacheClient,
+			multitenant.AWSCollectorConfig{
+				UserIDer:       userIDer,
+				DynamoDBConfig: dynamoDBConfig,
+				DynamoTable:    tableName,
+				S3Store:        &s3Store,
+				NatsHost:       natsHostname,
+				MemcacheClient: memcacheClient,
+			},
 		)
 		if err != nil {
 			return nil, err

--- a/prog/app.go
+++ b/prog/app.go
@@ -125,7 +125,7 @@ func collectorFactory(userIDer multitenant.UserIDer, collectorURL, s3URL, natsHo
 				return nil, err
 			}
 		}
-		dynamoCollector, err := multitenant.NewDynamoDBCollector(
+		awsCollector, err := multitenant.NewAWSCollector(
 			userIDer, dynamoDBConfig, tableName, &s3Store, natsHostname,
 			memcacheClient,
 		)
@@ -133,11 +133,11 @@ func collectorFactory(userIDer multitenant.UserIDer, collectorURL, s3URL, natsHo
 			return nil, err
 		}
 		if createTables {
-			if err := dynamoCollector.CreateTables(); err != nil {
+			if err := awsCollector.CreateTables(); err != nil {
 				return nil, err
 			}
 		}
-		return dynamoCollector, nil
+		return awsCollector, nil
 	}
 
 	return nil, fmt.Errorf("Invalid collector '%s'", collectorURL)


### PR DESCRIPTION
I wanted to better understand what was going on, so I refactored it.

Highlights:

* S3 client code moved from `dynamo_collector` into a new file, and given same interface as `MemcacheClient`
* `NewDynamoDBCollector` now takes both a memcache client and an s3 client, rather than being responsible for constructing both
* `FetchReports` returns a map of fetched reports, making it easier to write back to the in-process cache

Lowlights:

* We write back to the in-process cache after retrieving from the in-process cache
* memcache constants now in `prog/app.go`
* despite branch name, doesn't actually instrument

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/scope/1616)
<!-- Reviewable:end -->
