### PR TITLE
Bump memcache expiration

### DIFF
--- a/app/multitenant/aws_collector.go
+++ b/app/multitenant/aws_collector.go
@@ -326,6 +326,7 @@ func (c *awsCollector) Report(ctx context.Context) (report.Report, error) {
 		}
 	}
 
+	log.Debugf("Fetching %d reports from %v to %v", len(reportKeys), start, now)
 	reports, err := c.getReports(reportKeys)
 	if err != nil {
 		return report.MakeReport(), err

--- a/app/multitenant/memcache_client.go
+++ b/app/multitenant/memcache_client.go
@@ -56,10 +56,10 @@ type MemcacheClient struct {
 // MemcacheConfig defines how a MemcacheClient should be constructed.
 type MemcacheConfig struct {
 	Host           string
-	Timeout        time.Duration
 	Service        string
+	Timeout        time.Duration
 	UpdateInterval time.Duration
-	Expiration     int32
+	Expiration     time.Duration
 }
 
 // NewMemcacheClient creates a new MemcacheClient that gets its server list
@@ -72,7 +72,7 @@ func NewMemcacheClient(config MemcacheConfig) *MemcacheClient {
 	newClient := &MemcacheClient{
 		client:     client,
 		serverList: &servers,
-		expiration: config.Expiration,
+		expiration: int32(config.Expiration.Seconds()),
 		hostname:   config.Host,
 		service:    config.Service,
 		quit:       make(chan struct{}),

--- a/app/multitenant/memcache_client.go
+++ b/app/multitenant/memcache_client.go
@@ -188,6 +188,11 @@ func (c *MemcacheClient) FetchReports(keys []string) (map[string]report.Report, 
 		}
 	}
 
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		log.Warningf("Missing %d reports from memcache: %v", len(missing), missing)
+	}
+
 	memcacheHits.Add(float64(len(reports)))
 	memcacheRequests.Add(float64(len(keys)))
 	return reports, missing, nil

--- a/prog/app.go
+++ b/prog/app.go
@@ -80,7 +80,7 @@ func awsConfigFromURL(url *url.URL) (*aws.Config, error) {
 	return config, nil
 }
 
-func collectorFactory(userIDer multitenant.UserIDer, collectorURL, s3URL, natsHostname, memcachedHostname string, memcachedTimeout time.Duration, memcachedService string, window time.Duration, createTables bool) (app.Collector, error) {
+func collectorFactory(userIDer multitenant.UserIDer, collectorURL, s3URL, natsHostname, memcachedHostname string, memcachedTimeout time.Duration, memcachedService string, memcachedExpiration, window time.Duration, createTables bool) (app.Collector, error) {
 	if collectorURL == "local" {
 		return app.NewCollector(window), nil
 	}
@@ -112,7 +112,7 @@ func collectorFactory(userIDer multitenant.UserIDer, collectorURL, s3URL, natsHo
 				multitenant.MemcacheConfig{
 					Host:           memcachedHostname,
 					Timeout:        memcachedTimeout,
-					Expiration:     window,
+					Expiration:     memcachedExpiration,
 					UpdateInterval: memcacheUpdateInterval,
 					Service:        memcachedService,
 				},
@@ -210,7 +210,7 @@ func appMain(flags appFlags) {
 
 	collector, err := collectorFactory(
 		userIDer, flags.collectorURL, flags.s3URL, flags.natsHostname, flags.memcachedHostname,
-		flags.memcachedTimeout, flags.memcachedService, flags.window, flags.awsCreateTables)
+		flags.memcachedTimeout, flags.memcachedService, flags.memcachedExpiration, flags.window, flags.awsCreateTables)
 	if err != nil {
 		log.Fatalf("Error creating collector: %v", err)
 		return

--- a/prog/app.go
+++ b/prog/app.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	memcacheExpiration     = 15 // seconds
+	memcacheExpiration     = 15 * time.Second
 	memcacheUpdateInterval = 1 * time.Minute
 )
 

--- a/prog/app.go
+++ b/prog/app.go
@@ -28,7 +28,6 @@ import (
 )
 
 const (
-	memcacheExpiration     = 15 * time.Second
 	memcacheUpdateInterval = 1 * time.Minute
 )
 
@@ -113,7 +112,7 @@ func collectorFactory(userIDer multitenant.UserIDer, collectorURL, s3URL, natsHo
 				multitenant.MemcacheConfig{
 					Host:           memcachedHostname,
 					Timeout:        memcachedTimeout,
-					Expiration:     memcacheExpiration,
+					Expiration:     window,
 					UpdateInterval: memcacheUpdateInterval,
 					Service:        memcachedService,
 				},
@@ -127,6 +126,7 @@ func collectorFactory(userIDer multitenant.UserIDer, collectorURL, s3URL, natsHo
 				S3Store:        &s3Store,
 				NatsHost:       natsHostname,
 				MemcacheClient: memcacheClient,
+				Window:         window,
 			},
 		)
 		if err != nil {

--- a/prog/app.go
+++ b/prog/app.go
@@ -110,8 +110,13 @@ func collectorFactory(userIDer multitenant.UserIDer, collectorURL, s3URL, natsHo
 		var memcacheClient *multitenant.MemcacheClient
 		if memcachedHostname != "" {
 			memcacheClient = multitenant.NewMemcacheClient(
-				memcachedHostname, memcachedTimeout, memcachedService,
-				memcacheUpdateInterval, memcacheExpiration,
+				multitenant.MemcacheConfig{
+					Host:           memcachedHostname,
+					Timeout:        memcachedTimeout,
+					Expiration:     memcacheExpiration,
+					UpdateInterval: memcacheUpdateInterval,
+					Service:        memcachedService,
+				},
 			)
 		}
 		awsCollector, err := multitenant.NewAWSCollector(

--- a/prog/main.go
+++ b/prog/main.go
@@ -99,15 +99,16 @@ type appFlags struct {
 	containerName  string
 	dockerEndpoint string
 
-	collectorURL      string
-	s3URL             string
-	controlRouterURL  string
-	pipeRouterURL     string
-	natsHostname      string
-	memcachedHostname string
-	memcachedTimeout  time.Duration
-	memcachedService  string
-	userIDHeader      string
+	collectorURL        string
+	s3URL               string
+	controlRouterURL    string
+	pipeRouterURL       string
+	natsHostname        string
+	memcachedHostname   string
+	memcachedTimeout    time.Duration
+	memcachedService    string
+	memcachedExpiration time.Duration
+	userIDHeader        string
 
 	awsCreateTables bool
 	consulInf       string
@@ -190,6 +191,7 @@ func main() {
 	flag.StringVar(&flags.app.natsHostname, "app.nats", "", "Hostname for NATS service to use for shortcut reports.  If empty, shortcut reporting will be disabled.")
 	flag.StringVar(&flags.app.memcachedHostname, "app.memcached.hostname", "", "Hostname for memcached service to use when caching reports.  If empty, no memcached will be used.")
 	flag.DurationVar(&flags.app.memcachedTimeout, "app.memcached.timeout", 100*time.Millisecond, "Maximum time to wait before giving up on memcached requests.")
+	flag.DurationVar(&flags.app.memcachedExpiration, "app.memcached.expiration", 15*time.Second, "How long reports stay in the memcache.")
 	flag.StringVar(&flags.app.memcachedService, "app.memcached.service", "memcached", "SRV service used to discover memcache servers.")
 	flag.StringVar(&flags.app.userIDHeader, "app.userid.header", "", "HTTP header to use as userid")
 

--- a/prog/main.go
+++ b/prog/main.go
@@ -191,7 +191,7 @@ func main() {
 	flag.StringVar(&flags.app.natsHostname, "app.nats", "", "Hostname for NATS service to use for shortcut reports.  If empty, shortcut reporting will be disabled.")
 	flag.StringVar(&flags.app.memcachedHostname, "app.memcached.hostname", "", "Hostname for memcached service to use when caching reports.  If empty, no memcached will be used.")
 	flag.DurationVar(&flags.app.memcachedTimeout, "app.memcached.timeout", 100*time.Millisecond, "Maximum time to wait before giving up on memcached requests.")
-	flag.DurationVar(&flags.app.memcachedExpiration, "app.memcached.expiration", 15*time.Second, "How long reports stay in the memcache.")
+	flag.DurationVar(&flags.app.memcachedExpiration, "app.memcached.expiration", 2*15*time.Second, "How long reports stay in the memcache.")
 	flag.StringVar(&flags.app.memcachedService, "app.memcached.service", "memcached", "SRV service used to discover memcache servers.")
 	flag.StringVar(&flags.app.userIDHeader, "app.userid.header", "", "HTTP header to use as userid")
 


### PR DESCRIPTION
We were getting memcache misses and they are probably due to entries expiring between fetching the keys from dynamo and performing the query to memcache.

This PR adds a flag for controlling expiration length and changes the default to be twice the default window.

In addition, it adds a `MemcacheConfig` struct, and passes the `app.window` flag through to the aws_collector, thus removing a lot of duplication of the magic number 15. I've also left some instrumentation in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/scope/1640)
<!-- Reviewable:end -->
