### PR TITLE
Support single/double quote key on us-intl keyboards in terminal

### DIFF
--- a/client/app/scripts/components/app.js
+++ b/client/app/scripts/components/app.js
@@ -56,6 +56,7 @@ class App extends React.Component {
 
   onKeyUp(ev) {
     const { showingTerminal } = this.props;
+    keyPressLog('onKeyUp', 'keyCode', ev.keyCode, ev);
 
     // don't get esc in onKeyPress
     if (ev.keyCode === ESC_KEY_CODE) {

--- a/client/app/scripts/vendor/term.js
+++ b/client/app/scripts/vendor/term.js
@@ -2756,6 +2756,13 @@ Terminal.prototype.keyDown = function(ev) {
     case 123:
       key = '\x1b[24~';
       break;
+    // Special case for US-intl '/"
+    case 222:
+      key = '\'';
+      if (ev.shiftKey) {
+        key = '"';
+      }
+      break;
     default:
       // a-z and space
       if (ev.ctrlKey) {

--- a/client/app/scripts/vendor/term.js
+++ b/client/app/scripts/vendor/term.js
@@ -2756,14 +2756,22 @@ Terminal.prototype.keyDown = function(ev) {
     case 123:
       key = '\x1b[24~';
       break;
-    // Special case for US-intl '/"
-    case 222:
-      key = '\'';
-      if (ev.shiftKey) {
-        key = '"';
-      }
-      break;
     default:
+      // Special case for US-intl
+      // Firefox leaves ev.key empty, Chrome sets it to "Dead"
+      if (!ev.key || ev.key === 'Dead') {
+        if (ev.keyCode === 54) {
+          key = ev.shiftKey ? '^' : '6';
+          break;
+        } else if (ev.keyCode === 192) {
+          key = ev.shiftKey ? '~' : '`';
+          break;
+        } else if (ev.keyCode === 222) {
+          key = ev.shiftKey ? '"' : "'";
+          break;
+        }
+      }
+
       // a-z and space
       if (ev.ctrlKey) {
         if (ev.keyCode >= 65 && ev.keyCode <= 90) {


### PR DESCRIPTION
Doesn't support the accenting capabilities of this key but gives you
single/double quotes back which is a long way. If you need accented keys
for filenames etc you'll have to use other kb tricks.

Fixes #1403 