### PR TITLE
Quote jsonpath so shell doesn't try to expand

### DIFF
--- a/site/installing.md
+++ b/site/installing.md
@@ -212,7 +212,7 @@ To download and read the Scope manifest run:
 
 **Open Scope in Your Browser**
 
-    kubectl port-forward $(kubectl get pod --selector=weavescope-component=weavescope-app -o jsonpath={.items..metadata.name}) 4040
+    kubectl port-forward $(kubectl get pod --selector=weavescope-component=weavescope-app -o jsonpath='{.items..metadata.name}') 4040
 
 Open http://localhost:4040 in your browser. This allows you to access the Scope UI securely, without opening it to the Internet.
 


### PR DESCRIPTION
This fixes #1526 I realized it was a problem with zsh trying to expand `items..metadata`. Single quotes fixes it for zsh and also works in bash

example in zsh
```
$ echo {items..metadata}
. a d e i m s t
$ echo '{items..metadata}'
{items..metadata}
```