### PR TITLE
Make sure we generate a proper docker tag

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -83,8 +83,8 @@ deployment:
       - >
         test -z "${DEPLOY_BRANCH}" || test -z "${DOCKER_USER}" || (
           docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS &&
-          docker tag weaveworks/scope:latest ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope:${CIRCLE_BRANCH//\//-} &&
-          docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope:${CIRCLE_BRANCH//\//-}
+          docker tag weaveworks/scope:latest ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope:$(./image-tag "${CIRCLE_BRANCH}") &&
+          docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope:$(./image-tag "${CIRCLE_BRANCH}")
         )
 #  release:
 #    branch: /release-[0-9]+\.[0-9]+/

--- a/image-tag
+++ b/image-tag
@@ -4,9 +4,21 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-WORKING_SUFFIX=$(if ! git diff --exit-code --quiet HEAD >&2; \
-                 then echo "-WIP"; \
-                 else echo ""; \
-                 fi)
-BRANCH_PREFIX=$(git rev-parse --abbrev-ref HEAD)
-echo "${BRANCH_PREFIX//\//-}-$(git rev-parse --short HEAD)$WORKING_SUFFIX"
+if [[ $# -gt 0 ]]; then
+    BRANCH_SUFFIX=""
+    BRANCH_PREFIX="${1}"
+else
+    WORKING_SUFFIX=$(if ! git diff --exit-code --quiet HEAD >&2; \
+                     then echo "-WIP"; \
+                     else echo ""; \
+                     fi)
+    BRANCH_SUFFIX="-$(git rev-parse --short HEAD)$WORKING_SUFFIX"
+    BRANCH_PREFIX=$(git rev-parse --abbrev-ref HEAD)
+fi
+
+PREFIX_LEN=$((127-$(echo -n $BRANCH_SUFFIX | wc -c)))
+BRANCH_PREFIX=$(echo "${BRANCH_PREFIX}" | \
+                sed -e 's/[^a-zA-Z0-9_.]\+/-/g' \
+                    -e 's/^[^a-zA-Z0-9_]*//g' | \
+                cut -c-${PREFIX_LEN})
+echo "$BRANCH_PREFIX$BRANCH_SUFFIX"


### PR DESCRIPTION
I have a branch named like <user>/<feature>, which becomes a part of
the tag name. Docker complains about it, because / is not a valid
character in the tag.

This commit replaces all sequences of invalid chars with a single dash
and makes sure that the tag name never exceeds the 127 chars limit.
