### PR TITLE
Add options for storing memcached reports with different compression levels

### DIFF
--- a/app/multitenant/aws_collector.go
+++ b/app/multitenant/aws_collector.go
@@ -2,6 +2,7 @@ package multitenant
 
 import (
 	"bytes"
+	"compress/gzip"
 	"crypto/md5"
 	"fmt"
 	"io"
@@ -346,7 +347,7 @@ func (c *awsCollector) Add(ctx context.Context, rep report.Report) error {
 
 	// first, encode the report into a buffer and record its size
 	var buf bytes.Buffer
-	rep.WriteBinary(&buf)
+	rep.WriteBinary(&buf, gzip.BestCompression)
 	reportSizeHistogram.Observe(float64(buf.Len()))
 
 	// second, put the report on s3

--- a/app/multitenant/memcache_client.go
+++ b/app/multitenant/memcache_client.go
@@ -2,6 +2,7 @@ package multitenant
 
 import (
 	"bytes"
+	"compress/gzip"
 	"fmt"
 	"net"
 	"sort"
@@ -200,6 +201,13 @@ func (c *MemcacheClient) FetchReports(keys []string) (map[string]report.Report, 
 
 	memcacheHits.Add(float64(len(reports)))
 	return reports, missing, nil
+}
+
+// StoreReport serializes and stores a report.
+func (c *MemcacheClient) StoreReport(key string, report *report.Report) error {
+	var buf bytes.Buffer
+	report.WriteBinary(&buf, gzip.BestCompression)
+	return c.StoreBytes(key, buf.Bytes())
 }
 
 // StoreBytes stores a report, expecting the report to be serialized already.

--- a/app/multitenant/memcache_client.go
+++ b/app/multitenant/memcache_client.go
@@ -204,10 +204,11 @@ func (c *MemcacheClient) FetchReports(keys []string) (map[string]report.Report, 
 }
 
 // StoreReport serializes and stores a report.
-func (c *MemcacheClient) StoreReport(key string, report *report.Report) error {
+func (c *MemcacheClient) StoreReport(key string, report *report.Report) (int, error) {
 	var buf bytes.Buffer
 	report.WriteBinary(&buf, gzip.BestCompression)
-	return c.StoreBytes(key, buf.Bytes())
+	err := c.StoreBytes(key, buf.Bytes())
+	return buf.Len(), err
 }
 
 // StoreBytes stores a report, expecting the report to be serialized already.

--- a/app/multitenant/memcache_client.go
+++ b/app/multitenant/memcache_client.go
@@ -208,14 +208,9 @@ func (c *MemcacheClient) FetchReports(keys []string) (map[string]report.Report, 
 func (c *MemcacheClient) StoreReport(key string, report *report.Report) (int, error) {
 	var buf bytes.Buffer
 	report.WriteBinary(&buf, c.compressionLevel)
-	err := c.StoreBytes(key, buf.Bytes())
-	return buf.Len(), err
-}
-
-// StoreBytes stores a report, expecting the report to be serialized already.
-func (c *MemcacheClient) StoreBytes(key string, content []byte) error {
-	return instrument.TimeRequestHistogramStatus("Put", memcacheRequestDuration, memcacheStatusCode, func() error {
-		item := memcache.Item{Key: key, Value: content, Expiration: c.expiration}
+	err := instrument.TimeRequestHistogramStatus("Put", memcacheRequestDuration, memcacheStatusCode, func() error {
+		item := memcache.Item{Key: key, Value: buf.Bytes(), Expiration: c.expiration}
 		return c.client.Set(&item)
 	})
+	return buf.Len(), err
 }

--- a/app/multitenant/memcache_client.go
+++ b/app/multitenant/memcache_client.go
@@ -58,11 +58,12 @@ type MemcacheClient struct {
 
 // MemcacheConfig defines how a MemcacheClient should be constructed.
 type MemcacheConfig struct {
-	Host           string
-	Service        string
-	Timeout        time.Duration
-	UpdateInterval time.Duration
-	Expiration     time.Duration
+	Host             string
+	Service          string
+	Timeout          time.Duration
+	UpdateInterval   time.Duration
+	Expiration       time.Duration
+	CompressionLevel int
 }
 
 // NewMemcacheClient creates a new MemcacheClient that gets its server list

--- a/app/multitenant/s3_client.go
+++ b/app/multitenant/s3_client.go
@@ -2,6 +2,7 @@ package multitenant
 
 import (
 	"bytes"
+	"compress/gzip"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -82,6 +83,13 @@ func (store *S3Store) fetchReport(key string) (*report.Report, error) {
 		return nil, err
 	}
 	return report.MakeFromBinary(resp.Body)
+}
+
+// StoreReport serializes and stores a report.
+func (store *S3Store) StoreReport(key string, report *report.Report) error {
+	var buf bytes.Buffer
+	report.WriteBinary(&buf, gzip.BestCompression)
+	return store.StoreBytes(key, buf.Bytes())
 }
 
 // StoreBytes stores a report in S3, expecting the report to be serialized

--- a/app/multitenant/s3_client.go
+++ b/app/multitenant/s3_client.go
@@ -86,10 +86,13 @@ func (store *S3Store) fetchReport(key string) (*report.Report, error) {
 }
 
 // StoreReport serializes and stores a report.
-func (store *S3Store) StoreReport(key string, report *report.Report) error {
+//
+// Returns the size of the report. This only equals bytes written if err is nil.
+func (store *S3Store) StoreReport(key string, report *report.Report) (int, error) {
 	var buf bytes.Buffer
 	report.WriteBinary(&buf, gzip.BestCompression)
-	return store.StoreBytes(key, buf.Bytes())
+	err := store.StoreBytes(key, buf.Bytes())
+	return buf.Len(), err
 }
 
 // StoreBytes stores a report in S3, expecting the report to be serialized

--- a/probe/appclient/report_publisher.go
+++ b/probe/appclient/report_publisher.go
@@ -2,6 +2,7 @@ package appclient
 
 import (
 	"bytes"
+	"compress/gzip"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -28,6 +29,6 @@ func (p *ReportPublisher) Publish(r report.Report) error {
 		})
 	}
 	buf := &bytes.Buffer{}
-	r.WriteBinary(buf)
+	r.WriteBinary(buf, gzip.BestCompression)
 	return p.publisher.Publish(buf)
 }

--- a/prog/app.go
+++ b/prog/app.go
@@ -81,7 +81,7 @@ func awsConfigFromURL(url *url.URL) (*aws.Config, error) {
 	return config, nil
 }
 
-func collectorFactory(userIDer multitenant.UserIDer, collectorURL, s3URL, natsHostname, memcachedHostname string, memcachedTimeout time.Duration, memcachedService string, memcachedExpiration, window time.Duration, createTables bool) (app.Collector, error) {
+func collectorFactory(userIDer multitenant.UserIDer, collectorURL, s3URL, natsHostname, memcachedHostname string, memcachedTimeout time.Duration, memcachedService string, memcachedExpiration time.Duration, memcachedCompressionLevel int, window time.Duration, createTables bool) (app.Collector, error) {
 	if collectorURL == "local" {
 		return app.NewCollector(window), nil
 	}
@@ -114,11 +114,12 @@ func collectorFactory(userIDer multitenant.UserIDer, collectorURL, s3URL, natsHo
 		if memcachedHostname != "" {
 			memcacheClient = multitenant.NewMemcacheClient(
 				multitenant.MemcacheConfig{
-					Host:           memcachedHostname,
-					Timeout:        memcachedTimeout,
-					Expiration:     memcachedExpiration,
-					UpdateInterval: memcacheUpdateInterval,
-					Service:        memcachedService,
+					Host:             memcachedHostname,
+					Timeout:          memcachedTimeout,
+					Expiration:       memcachedExpiration,
+					UpdateInterval:   memcacheUpdateInterval,
+					Service:          memcachedService,
+					CompressionLevel: memcachedCompressionLevel,
 				},
 			)
 		}
@@ -214,7 +215,8 @@ func appMain(flags appFlags) {
 
 	collector, err := collectorFactory(
 		userIDer, flags.collectorURL, flags.s3URL, flags.natsHostname, flags.memcachedHostname,
-		flags.memcachedTimeout, flags.memcachedService, flags.memcachedExpiration, flags.window, flags.awsCreateTables)
+		flags.memcachedTimeout, flags.memcachedService, flags.memcachedExpiration, flags.memcachedCompressionLevel,
+		flags.window, flags.awsCreateTables)
 	if err != nil {
 		log.Fatalf("Error creating collector: %v", err)
 		return

--- a/prog/main.go
+++ b/prog/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"compress/gzip"
 	"flag"
 	"fmt"
 	"net"
@@ -100,16 +101,17 @@ type appFlags struct {
 	containerName  string
 	dockerEndpoint string
 
-	collectorURL        string
-	s3URL               string
-	controlRouterURL    string
-	pipeRouterURL       string
-	natsHostname        string
-	memcachedHostname   string
-	memcachedTimeout    time.Duration
-	memcachedService    string
-	memcachedExpiration time.Duration
-	userIDHeader        string
+	collectorURL              string
+	s3URL                     string
+	controlRouterURL          string
+	pipeRouterURL             string
+	natsHostname              string
+	memcachedHostname         string
+	memcachedTimeout          time.Duration
+	memcachedService          string
+	memcachedExpiration       time.Duration
+	memcachedCompressionLevel int
+	userIDHeader              string
 
 	awsCreateTables bool
 	consulInf       string
@@ -195,6 +197,7 @@ func main() {
 	flag.DurationVar(&flags.app.memcachedTimeout, "app.memcached.timeout", 100*time.Millisecond, "Maximum time to wait before giving up on memcached requests.")
 	flag.DurationVar(&flags.app.memcachedExpiration, "app.memcached.expiration", 2*15*time.Second, "How long reports stay in the memcache.")
 	flag.StringVar(&flags.app.memcachedService, "app.memcached.service", "memcached", "SRV service used to discover memcache servers.")
+	flag.IntVar(&flags.app.memcachedCompressionLevel, "app.memcached.compression", gzip.DefaultCompression, "How much to compress reports stored in memcached.")
 	flag.StringVar(&flags.app.userIDHeader, "app.userid.header", "", "HTTP header to use as userid")
 
 	flag.BoolVar(&flags.app.awsCreateTables, "app.aws.create.tables", false, "Create the tables in DynamoDB")

--- a/report/marshal.go
+++ b/report/marshal.go
@@ -9,8 +9,8 @@ import (
 )
 
 // WriteBinary writes a Report as a gzipped msgpack.
-func (rep Report) WriteBinary(w io.Writer) error {
-	gzwriter, err := gzip.NewWriterLevel(w, gzip.BestCompression)
+func (rep Report) WriteBinary(w io.Writer, compressionLevel int) error {
+	gzwriter, err := gzip.NewWriterLevel(w, compressionLevel)
 	if err != nil {
 		return err
 	}

--- a/report/marshal_test.go
+++ b/report/marshal_test.go
@@ -2,6 +2,7 @@ package report_test
 
 import (
 	"bytes"
+	"compress/gzip"
 	"reflect"
 	"testing"
 
@@ -11,12 +12,38 @@ import (
 func TestRoundtrip(t *testing.T) {
 	var buf bytes.Buffer
 	r1 := report.MakeReport()
-	r1.WriteBinary(&buf)
+	r1.WriteBinary(&buf, gzip.BestCompression)
 	r2, err := report.MakeFromBinary(&buf)
 	if err != nil {
 		t.Error(err)
 	}
 	if !reflect.DeepEqual(r1, *r2) {
 		t.Errorf("%v != %v", r1, *r2)
+	}
+}
+
+func TestRoundtripNoCompression(t *testing.T) {
+	// Make sure that we can use our standard routines for decompressing
+	// something with '0' level compression.
+	var buf bytes.Buffer
+	r1 := report.MakeReport()
+	r1.WriteBinary(&buf, 0)
+	r2, err := report.MakeFromBinary(&buf)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(r1, *r2) {
+		t.Errorf("%v != %v", r1, *r2)
+	}
+}
+
+func TestMoreCompressionMeansSmaller(t *testing.T) {
+	// Make sure that 0 level compression actually does compress less.
+	var buf1, buf2 bytes.Buffer
+	r := report.MakeReport()
+	r.WriteBinary(&buf1, gzip.BestCompression)
+	r.WriteBinary(&buf2, 0)
+	if buf1.Len() >= buf2.Len() {
+		t.Errorf("Compression doesn't change size: %v >= %v", buf1.Len(), buf2.Len())
 	}
 }

--- a/report/marshal_test.go
+++ b/report/marshal_test.go
@@ -1,0 +1,22 @@
+package report_test
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/weaveworks/scope/report"
+)
+
+func TestRoundtrip(t *testing.T) {
+	var buf bytes.Buffer
+	r1 := report.MakeReport()
+	r1.WriteBinary(&buf)
+	r2, err := report.MakeFromBinary(&buf)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(r1, *r2) {
+		t.Errorf("%v != %v", r1, *r2)
+	}
+}


### PR DESCRIPTION
Also factor out functions for calculating the keys we use for storage. Not intrinsically related to this change, but helped me understand what was going on.

Note that now if we have the same compression level between memcache & s3, we'll duplicate work.

Fixes #1671

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/scope/1684)
<!-- Reviewable:end -->
