### PR TITLE
Show detailed debugging information when querying reports

### DIFF
--- a/app/router.go
+++ b/app/router.go
@@ -39,6 +39,15 @@ func requestContextDecorator(f CtxHandlerFunc) http.HandlerFunc {
 	}
 }
 
+// GetRequestURI obtains the request URI from the context
+func GetRequestURI(ctx context.Context) string {
+	request, ok := ctx.Value(RequestCtxKey).(*http.Request)
+	if ok && request != nil {
+		return request.RequestURI
+	}
+	return ""
+}
+
 // URLMatcher uses request.RequestURI (the raw, unparsed request) to attempt
 // to match pattern.  It does this as go's URL.Parse method is broken, and
 // mistakenly unescapes the Path before parsing it.  This breaks %2F (encoded

--- a/report/marshal.go
+++ b/report/marshal.go
@@ -32,39 +32,41 @@ func (c byteCounter) Read(p []byte) (n int, err error) {
 	return n, err
 }
 
-// ReadBinary reads bytes into a Report.
+// ReadStats includes statistics related to unmarshalling a report
+type ReadStats struct {
+	CompressedSize, UncompressedSize uint64
+}
+
+// ReadBinaryWithStats reads bytes into a Report and obtains statistics when running in debug mode.
 //
 // Will decompress the binary if gzipped is true, and will use the given
 // codecHandle to decode it.
-func (rep *Report) ReadBinary(r io.Reader, gzipped bool, codecHandle codec.Handle) error {
+func (rep *Report) ReadBinaryWithStats(r io.Reader, gzipped bool, codecHandle codec.Handle) (ReadStats, error) {
 	var err error
 	var compressedSize, uncompressedSize uint64
 
-	// We have historically had trouble with reports being too large. We are
-	// keeping this instrumentation around to help us implement
-	// weaveworks/scope#985.
 	if log.GetLevel() == log.DebugLevel {
 		r = byteCounter{next: r, count: &compressedSize}
 	}
 	if gzipped {
 		r, err = gzip.NewReader(r)
 		if err != nil {
-			return err
+			return ReadStats{}, err
 		}
 	}
 	if log.GetLevel() == log.DebugLevel {
 		r = byteCounter{next: r, count: &uncompressedSize}
 	}
 	if err := codec.NewDecoder(r, codecHandle).Decode(&rep); err != nil {
-		return err
+		return ReadStats{}, err
 	}
-	log.Debugf(
-		"Received report sizes: compressed %d bytes, uncompressed %d bytes (%.2f%%)",
-		compressedSize,
-		uncompressedSize,
-		float32(compressedSize)/float32(uncompressedSize)*100,
-	)
-	return nil
+	return ReadStats{compressedSize, uncompressedSize}, nil
+}
+
+// ReadBinary is identical to ReadBinaryWithStats without obtaining statistics
+func (rep *Report) ReadBinary(r io.Reader, gzipped bool, codecHandle codec.Handle) error {
+	_, err := rep.ReadBinaryWithStats(r, gzipped, codecHandle)
+	return err
 }
 
 // MakeFromBinary constructs a Report from a gzipped msgpack.
@@ -74,4 +76,15 @@ func MakeFromBinary(r io.Reader) (*Report, error) {
 		return nil, err
 	}
 	return &rep, nil
+}
+
+// MakeFromBinaryWithStats constructs a Report from a gzipped msgpack and provides
+// statistics when running in debug mode.
+func MakeFromBinaryWithStats(r io.Reader) (*Report, ReadStats, error) {
+	rep := MakeReport()
+	stats, err := rep.ReadBinaryWithStats(r, true, &codec.MsgpackHandle{})
+	if err != nil {
+		return nil, stats, err
+	}
+	return &rep, stats, nil
 }


### PR DESCRIPTION
With this change, when running the query service in debug mode, it will print lines like the following:

```
<app> DEBU: 2016/07/15 13:53:05.642154 Report query triggered through "/api/probes" (user "1")
        Took 2.140328158s (530.945042ms key fetch, 1.288712788s report fetch, 320.670328ms report merge)
        Merged 14 reports with stats:
        [{{0 0} in-process-store} {{0 0} in-process-store} {{0 0} in-process-store} {{0 0} in-process-store} {{0 0} in-process-store} {{580 1195} memcached} {{580 1195} memcached} {{586 1195} memcached} {{118255 936467} memcached} {{581 1195} memcached} {{128103 993918} memcached} {{117471 917276} memcached} {{122201 942165} memcached} {{119971 930528} memcached}]
```
