### PR TITLE
Custom encoder for latest maps

### DIFF
--- a/report/latest_map.go
+++ b/report/latest_map.go
@@ -237,7 +237,7 @@ func (m *LatestMap) CodecDecodeSelf(decoder *codec.Decoder) {
 		var value LatestEntry
 		z.DecSendContainerState(containerMapValue)
 		if !r.TryDecodeAsNil() {
-			value.CodecDecodeSelf(decoder)
+			decoder.Decode(&value)
 		}
 
 		out = out.Set(key, value)

--- a/report/latest_map.go
+++ b/report/latest_map.go
@@ -193,20 +193,9 @@ func (m *LatestMap) CodecEncodeSelf(encoder *codec.Encoder) {
 	} else {
 		encoder.Encode(nil)
 	}
-
-	//_, r := codec.GenHelperEncoder(encoder)
-	//if m.Map == nil {
-	//	r.EncodeNil()
-	//	return
-	//}
-	//
-	//r.EncodeMapStart(m.Map.Size())
-	//m.Map.ForEach(func(key string, value interface{}) {
-	//	r.EncodeString(1, key)
-	//	encoder.Encode(value.(LatestEntry))
-	//})
 }
 
+// constants from https://github.com/ugorji/go/blob/master/codec/helper.go#L207
 const (
 	containerMapKey   = 2
 	containerMapValue = 3
@@ -214,6 +203,10 @@ const (
 )
 
 // CodecDecodeSelf implements codec.Selfer
+// This implementation does not use the intermediate form as that was a
+// performance issue; skipping it saved almost 10% CPU.  Note this means
+// we are using undocumented, internal APIs, which could break in the future.
+// See https://github.com/weaveworks/scope/pull/1709 for more information.
 func (m *LatestMap) CodecDecodeSelf(decoder *codec.Decoder) {
 	z, r := codec.GenHelperDecoder(decoder)
 	if r.TryDecodeAsNil() {


### PR DESCRIPTION
Implement a custom encoder for latest maps, instead of round tripping through a temporary map.

<s>In a very unscientific test, LatestMap decoding went from about 5% CPU to nothing (it was unmeasurable).</s>  See below for better numbers

<s>As it stands, this change won't be backward compatible.  But if we like this approach, it can be made so with a little work.</s> Is now backwards compatible.  Have not implemented optimised encode - which prove this.