### PR TITLE
circle.yml: another fix for deploy master with non-upstream hub accounts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -73,7 +73,7 @@ deployment:
           )) &&
           docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope &&
           docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope:$(./image-tag) &&
-          (test "${DOCKER_ORGANIZATION:-$DOCKER_USER}" == "weaveworks" && (
+          (test "${DOCKER_ORGANIZATION:-$DOCKER_USER}" != "weaveworks" || (
             wcloud deploy weaveworks/scope:$(./image-tag)
           ))
         )


### PR DESCRIPTION
After https://github.com/weaveworks/scope/commit/e2441623 "wcloud deploy" is run in the main deploy unit guarded by the environment variable. But the test makes it fail when it is not run under "weaveworks".

/cc @tomwilkie @krnowak 
