### PR TITLE
Name our routes, so /metrics gives more sensible aggregations

### DIFF
--- a/app/controls.go
+++ b/app/controls.go
@@ -14,9 +14,14 @@ import (
 
 // RegisterControlRoutes registers the various control routes with a http mux.
 func RegisterControlRoutes(router *mux.Router, cr ControlRouter) {
-	router.Methods("GET").Path("/api/control/ws").
+	router.
+		Methods("GET").
+		Path("/api/control/ws").
 		HandlerFunc(requestContextDecorator(handleProbeWS(cr)))
-	router.Methods("POST").MatcherFunc(URLMatcher("/api/control/{probeID}/{nodeID}/{control}")).
+	router.
+		Methods("POST").
+		Name("api_control_probeid_nodeid_control").
+		MatcherFunc(URLMatcher("/api/control/{probeID}/{nodeID}/{control}")).
 		HandlerFunc(requestContextDecorator(handleControl(cr)))
 }
 

--- a/app/pipes.go
+++ b/app/pipes.go
@@ -13,18 +13,22 @@ import (
 // RegisterPipeRoutes registers the pipe routes
 func RegisterPipeRoutes(router *mux.Router, pr PipeRouter) {
 	router.Methods("GET").
+		Name("api_pipe_pipeid_check").
 		Path("/api/pipe/{pipeID}/check").
 		HandlerFunc(requestContextDecorator(checkPipe(pr, UIEnd)))
 
 	router.Methods("GET").
+		Name("api_pipe_pipeid").
 		Path("/api/pipe/{pipeID}").
 		HandlerFunc(requestContextDecorator(handlePipeWs(pr, UIEnd)))
 
 	router.Methods("GET").
+		Name("api_pipe_pipeid_probe").
 		Path("/api/pipe/{pipeID}/probe").
 		HandlerFunc(requestContextDecorator(handlePipeWs(pr, ProbeEnd)))
 
 	router.Methods("DELETE", "POST").
+		Name("api_pipe_pipeid").
 		Path("/api/pipe/{pipeID}").
 		HandlerFunc(requestContextDecorator(deletePipe(pr)))
 }

--- a/app/router.go
+++ b/app/router.go
@@ -88,12 +88,18 @@ func RegisterTopologyRoutes(router *mux.Router, r Reporter) {
 		gzipHandler(requestContextDecorator(apiHandler(r))))
 	get.HandleFunc("/api/topology",
 		gzipHandler(requestContextDecorator(topologyRegistry.makeTopologyList(r))))
-	get.HandleFunc("/api/topology/{topology}",
-		gzipHandler(requestContextDecorator(topologyRegistry.captureRenderer(r, handleTopology))))
-	get.HandleFunc("/api/topology/{topology}/ws",
-		requestContextDecorator(captureReporter(r, handleWebsocket))) // NB not gzip!
-	get.MatcherFunc(URLMatcher("/api/topology/{topology}/{id}")).HandlerFunc(
-		gzipHandler(requestContextDecorator(topologyRegistry.captureRenderer(r, handleNode))))
+	get.
+		HandleFunc("/api/topology/{topology}",
+			gzipHandler(requestContextDecorator(topologyRegistry.captureRenderer(r, handleTopology)))).
+		Name("api_topology_topology")
+	get.
+		HandleFunc("/api/topology/{topology}/ws",
+			requestContextDecorator(captureReporter(r, handleWebsocket))). // NB not gzip!
+		Name("api_topology_topology_ws")
+	get.
+		MatcherFunc(URLMatcher("/api/topology/{topology}/{id}")).HandlerFunc(
+		gzipHandler(requestContextDecorator(topologyRegistry.captureRenderer(r, handleNode)))).
+		Name("api_topology_topology_id")
 	get.HandleFunc("/api/report",
 		gzipHandler(requestContextDecorator(makeRawReportHandler(r))))
 	get.HandleFunc("/api/probes",


### PR DESCRIPTION
Previously was showing stuff like:
```
{route="api_pipe_pipe_8999861204239855606_probe"}   2
{route="api_pipe_pipe_2001043336351237495_check"}   1
{route="api_pipe_pipe_5613831799035630055"}
```