### PR TITLE
[WIP] New ConstMap field

### DIFF
--- a/probe/docker/container_test.go
+++ b/probe/docker/container_test.go
@@ -82,16 +82,16 @@ func TestContainer(t *testing.T) {
 			"docker_container_id":          "ping",
 			"docker_container_name":        "pong",
 			"docker_image_id":              "baz",
-			"docker_label_foo1":            "bar1",
-			"docker_label_foo2":            "bar2",
 			"docker_container_state":       "running",
 			"docker_container_state_human": "Up 6 years",
 			"docker_container_uptime":      uptime.String(),
-		}).
-			WithControls(
-				docker.RestartContainer, docker.StopContainer, docker.PauseContainer,
-				docker.AttachContainer, docker.ExecContainer,
-			).WithMetrics(report.Metrics{
+		}).WithConsts(map[string]string{
+			"docker_label_foo1": "bar1",
+			"docker_label_foo2": "bar2",
+		}).WithControls(
+			docker.RestartContainer, docker.StopContainer, docker.PauseContainer,
+			docker.AttachContainer, docker.ExecContainer,
+		).WithMetrics(report.Metrics{
 			"docker_cpu_total_usage": report.MakeMetric(nil),
 			"docker_memory_usage":    report.MakeSingletonMetric(now, 12345).WithMax(45678),
 		}).WithParents(report.EmptySets.

--- a/probe/docker/reporter_test.go
+++ b/probe/docker/reporter_test.go
@@ -116,13 +116,20 @@ func TestReporter(t *testing.T) {
 		}
 
 		for k, want := range map[string]string{
-			docker.ImageID:                      imageID,
-			docker.ImageName:                    "bang",
-			docker.ImageLabelPrefix + "imgfoo1": "bar1",
-			docker.ImageLabelPrefix + "imgfoo2": "bar2",
+			docker.ImageID:   imageID,
+			docker.ImageName: "bang",
 		} {
 			if have, ok := node.Latest.Lookup(k); !ok || have != want {
 				t.Errorf("Expected container image %s latest %q: %q, got %q", containerImageNodeID, k, want, have)
+			}
+		}
+
+		for k, want := range map[string]string{
+			docker.ImageLabelPrefix + "imgfoo1": "bar1",
+			docker.ImageLabelPrefix + "imgfoo2": "bar2",
+		} {
+			if have, ok := node.Const.Lookup(k); !ok || have != want {
+				t.Errorf("Expected container image %s const %q: %q, got %q", containerImageNodeID, k, want, have)
 			}
 		}
 

--- a/probe/endpoint/nat.go
+++ b/probe/endpoint/nat.go
@@ -61,7 +61,7 @@ func (n natMapper) applyNAT(rpt report.Report, scope string) {
 			return
 		}
 
-		rpt.Endpoint.AddNode(node.WithID(copyEndpointID).WithLatests(map[string]string{
+		rpt.Endpoint.AddNode(node.WithID(copyEndpointID).WithConsts(map[string]string{
 			Addr:      mapping.rewrittenIP,
 			Port:      copyEndpointPort,
 			"copy_of": realEndpointID,

--- a/probe/endpoint/nat_internal_test.go
+++ b/probe/endpoint/nat_internal_test.go
@@ -44,7 +44,7 @@ func TestNat(t *testing.T) {
 
 		have := report.MakeReport()
 		originalID := report.MakeEndpointNodeID("host1", "", "10.0.47.1", "80")
-		have.Endpoint.AddNode(report.MakeNodeWith(originalID, map[string]string{
+		have.Endpoint.AddNode(report.MakeNodeWithConsts(originalID, map[string]string{
 			Addr:      "10.0.47.1",
 			Port:      "80",
 			"foo":     "bar",
@@ -53,7 +53,7 @@ func TestNat(t *testing.T) {
 
 		want := have.Copy()
 		wantID := report.MakeEndpointNodeID("host1", "", "1.2.3.4", "80")
-		want.Endpoint.AddNode(report.MakeNodeWith(wantID, map[string]string{
+		want.Endpoint.AddNode(report.MakeNodeWithConsts(wantID, map[string]string{
 			Addr:      "1.2.3.4",
 			Port:      "80",
 			"copy_of": originalID,
@@ -79,7 +79,7 @@ func TestNat(t *testing.T) {
 
 		have := report.MakeReport()
 		originalID := report.MakeEndpointNodeID("host2", "", "10.0.47.2", "22222")
-		have.Endpoint.AddNode(report.MakeNodeWith(originalID, map[string]string{
+		have.Endpoint.AddNode(report.MakeNodeWithConsts(originalID, map[string]string{
 			Addr:      "10.0.47.2",
 			Port:      "22222",
 			"foo":     "baz",
@@ -87,7 +87,7 @@ func TestNat(t *testing.T) {
 		}))
 
 		want := have.Copy()
-		want.Endpoint.AddNode(report.MakeNodeWith(report.MakeEndpointNodeID("host2", "", "2.3.4.5", "22223"), map[string]string{
+		want.Endpoint.AddNode(report.MakeNodeWithConsts(report.MakeEndpointNodeID("host2", "", "2.3.4.5", "22223"), map[string]string{
 			Addr:      "2.3.4.5",
 			Port:      "22223",
 			"copy_of": originalID,

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -184,11 +184,11 @@ func (r *Reporter) addConnection(rpt *report.Report, t fourTuple, namespaceID st
 		fromEndpointNodeID = report.MakeEndpointNodeID(r.hostID, namespaceID, t.fromAddr, strconv.Itoa(int(t.fromPort)))
 		toEndpointNodeID   = report.MakeEndpointNodeID(r.hostID, namespaceID, t.toAddr, strconv.Itoa(int(t.toPort)))
 
-		fromNode = report.MakeNodeWith(fromEndpointNodeID, map[string]string{
+		fromNode = report.MakeNodeWithConsts(fromEndpointNodeID, map[string]string{
 			Addr: t.fromAddr,
 			Port: strconv.Itoa(int(t.fromPort)),
 		}).WithEdge(toEndpointNodeID, report.EdgeMetadata{})
-		toNode = report.MakeNodeWith(toEndpointNodeID, map[string]string{
+		toNode = report.MakeNodeWithConsts(toEndpointNodeID, map[string]string{
 			Addr: t.toAddr,
 			Port: strconv.Itoa(int(t.toPort)),
 		})
@@ -201,10 +201,10 @@ func (r *Reporter) addConnection(rpt *report.Report, t fourTuple, namespaceID st
 	}
 
 	if extraFromNode != nil {
-		fromNode = fromNode.WithLatests(extraFromNode)
+		fromNode = fromNode.WithConsts(extraFromNode)
 	}
 	if extraToNode != nil {
-		toNode = toNode.WithLatests(extraToNode)
+		toNode = toNode.WithConsts(extraToNode)
 	}
 	rpt.Endpoint = rpt.Endpoint.AddNode(fromNode)
 	rpt.Endpoint = rpt.Endpoint.AddNode(toNode)

--- a/probe/endpoint/reporter_test.go
+++ b/probe/endpoint/reporter_test.go
@@ -106,7 +106,7 @@ func TestSpyWithProcesses(t *testing.T) {
 	for key, want := range map[string]string{
 		"pid": strconv.FormatUint(uint64(fixProcessPID), 10),
 	} {
-		have, _ := r.Endpoint.Nodes[scopedLocal].Latest.Lookup(key)
+		have, _ := r.Endpoint.Nodes[scopedLocal].Const.Lookup(key)
 		if want != have {
 			t.Errorf("Process.Nodes[%q][%q]: want %q, have %q", scopedLocal, key, want, have)
 		}

--- a/render/container.go
+++ b/render/container.go
@@ -58,7 +58,7 @@ func ShortLivedConnectionJoin(r Renderer, toIPs func(report.Node) []string) Rend
 		for _, ip := range toIPs(n) {
 			result[ip] = NewDerivedNode(ip, n).
 				WithTopology(IP).
-				WithLatests(map[string]string{
+				WithConsts(map[string]string{
 					originalNodeID:       n.ID,
 					originalNodeTopology: n.Topology,
 				}).
@@ -82,11 +82,11 @@ func ShortLivedConnectionJoin(r Renderer, toIPs func(report.Node) []string) Rend
 		// If this node is not of the original type, exclude it.
 		// This excludes all the nodes we've dragged in from endpoint
 		// that we failed to join to a node.
-		id, ok := n.Latest.Lookup(originalNodeID)
+		id, ok := n.Const.Lookup(originalNodeID)
 		if !ok {
 			return report.Nodes{}
 		}
-		topology, ok := n.Latest.Lookup(originalNodeTopology)
+		topology, ok := n.Const.Lookup(originalNodeTopology)
 		if !ok {
 			return report.Nodes{}
 		}
@@ -103,7 +103,7 @@ func ShortLivedConnectionJoin(r Renderer, toIPs func(report.Node) []string) Rend
 	// don't want to double count edges.
 	endpoint2IP := func(m report.Node, local report.Networks) report.Nodes {
 		// Don't include procspied connections, to prevent double counting
-		_, ok := m.Latest.Lookup(endpoint.Procspied)
+		_, ok := m.Const.Lookup(endpoint.Procspied)
 		if ok {
 			return report.Nodes{}
 		}

--- a/render/detailed/tables_test.go
+++ b/render/detailed/tables_test.go
@@ -25,9 +25,10 @@ func TestNodeTables(t *testing.T) {
 					WithTableTemplates(docker.ContainerTableTemplates),
 			},
 			node: report.MakeNodeWith(fixture.ClientContainerNodeID, map[string]string{
-				docker.ContainerID:            fixture.ClientContainerID,
+				docker.ContainerID:    fixture.ClientContainerID,
+				docker.ContainerState: docker.StateRunning,
+			}).WithConsts(map[string]string{
 				docker.LabelPrefix + "label1": "label1value",
-				docker.ContainerState:         docker.StateRunning,
 			}).WithTopology(report.Container).WithSets(report.EmptySets.
 				Add(docker.ContainerIPs, report.MakeStringSet("10.10.10.0/24", "10.10.10.1/24")),
 			),

--- a/render/filters.go
+++ b/render/filters.go
@@ -204,7 +204,7 @@ var IsStopped = Complement(IsRunning)
 func FilterNonProcspied(r Renderer) Renderer {
 	return MakeFilter(
 		func(node report.Node) bool {
-			_, ok := node.Latest.Lookup(endpoint.Procspied)
+			_, ok := node.Const.Lookup(endpoint.Procspied)
 			return ok
 		},
 		r,

--- a/render/host.go
+++ b/render/host.go
@@ -60,14 +60,14 @@ func MapX2Host(n report.Node, _ report.Networks) report.Nodes {
 // host nodes or pseudo nodes.
 func MapEndpoint2Host(n report.Node, local report.Networks) report.Nodes {
 	// Nodes without a hostid are treated as pseudo nodes
-	hostNodeID, timestamp, ok := n.Latest.LookupEntry(report.HostNodeID)
+	hostNodeID, ok := n.Const.Lookup(report.HostNodeID)
 	if !ok {
 		return MapEndpoint2Pseudo(n, local)
 	}
 
-	id := report.MakeHostNodeID(report.ExtractHostID(n))
+	id := report.MakeHostNodeID(report.ExtractHostIDFromConst(n))
 	result := NewDerivedNode(id, n).WithTopology(report.Host)
-	result.Latest = result.Latest.Set(report.HostNodeID, timestamp, hostNodeID)
+	result.Latest = result.Latest.Set(report.HostNodeID, n.Const.Timestamp, hostNodeID)
 	result.Counters = result.Counters.Add(n.Topology, 1)
 	return report.Nodes{id: result}
 }

--- a/render/process.go
+++ b/render/process.go
@@ -89,7 +89,7 @@ var ProcessNameRenderer = ConditionalRenderer(renderProcesses,
 func MapEndpoint2Pseudo(n report.Node, local report.Networks) report.Nodes {
 	var node report.Node
 
-	addr, ok := n.Latest.Lookup(endpoint.Addr)
+	addr, ok := n.Const.Lookup(endpoint.Addr)
 	if !ok {
 		return report.Nodes{}
 	}
@@ -120,18 +120,18 @@ func MapEndpoint2Pseudo(n report.Node, local report.Networks) report.Nodes {
 // must be merged with a process graph to get that info.
 func MapEndpoint2Process(n report.Node, local report.Networks) report.Nodes {
 	// Nodes without a hostid are treated as pseudo nodes
-	if _, ok := n.Latest.Lookup(report.HostNodeID); !ok {
+	if _, ok := n.Const.Lookup(report.HostNodeID); !ok {
 		return MapEndpoint2Pseudo(n, local)
 	}
 
-	pid, timestamp, ok := n.Latest.LookupEntry(process.PID)
+	pid, ok := n.Const.Lookup(process.PID)
 	if !ok {
 		return report.Nodes{}
 	}
 
-	id := report.MakeProcessNodeID(report.ExtractHostID(n), pid)
+	id := report.MakeProcessNodeID(report.ExtractHostIDFromConst(n), pid)
 	node := NewDerivedNode(id, n).WithTopology(report.Process)
-	node.Latest = node.Latest.Set(process.PID, timestamp, pid)
+	node.Latest = node.Latest.Set(process.PID, n.Const.Timestamp, pid)
 	node.Counters = node.Counters.Add(n.Topology, 1)
 	return report.Nodes{id: node}
 }

--- a/render/process_test.go
+++ b/render/process_test.go
@@ -1,13 +1,12 @@
 package render_test
 
 import (
-	"testing"
-
 	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/scope/render/expected"
 	"github.com/weaveworks/scope/test"
 	"github.com/weaveworks/scope/test/fixture"
 	"github.com/weaveworks/scope/test/reflect"
+	"testing"
 )
 
 func TestEndpointRenderer(t *testing.T) {

--- a/render/short_lived_connections_test.go
+++ b/render/short_lived_connections_test.go
@@ -50,28 +50,28 @@ var (
 	rpt = report.Report{
 		Endpoint: report.Topology{
 			Nodes: report.Nodes{
-				randomEndpointNodeID: report.MakeNodeWith(randomEndpointNodeID, map[string]string{
+				randomEndpointNodeID: report.MakeNodeWithConsts(randomEndpointNodeID, map[string]string{
 					endpoint.Addr:        randomIP,
 					endpoint.Port:        randomPort,
 					endpoint.Conntracked: "true",
 				}).
 					WithAdjacent(serverEndpointNodeID).WithTopology(report.Endpoint),
 
-				serverEndpointNodeID: report.MakeNodeWith(serverEndpointNodeID, map[string]string{
+				serverEndpointNodeID: report.MakeNodeWithConsts(serverEndpointNodeID, map[string]string{
 					endpoint.Addr:        serverIP,
 					endpoint.Port:        serverPort,
 					endpoint.Conntracked: "true",
 				}).
 					WithTopology(report.Endpoint),
 
-				container1EndpointNodeID: report.MakeNodeWith(container1EndpointNodeID, map[string]string{
+				container1EndpointNodeID: report.MakeNodeWithConsts(container1EndpointNodeID, map[string]string{
 					endpoint.Addr:        container1IP,
 					endpoint.Port:        container1Port,
 					endpoint.Conntracked: "true",
 				}).
 					WithAdjacent(duplicatedEndpointNodeID).WithTopology(report.Endpoint),
 
-				duplicatedEndpointNodeID: report.MakeNodeWith(duplicatedEndpointNodeID, map[string]string{
+				duplicatedEndpointNodeID: report.MakeNodeWithConsts(duplicatedEndpointNodeID, map[string]string{
 					endpoint.Addr:        duplicatedIP,
 					endpoint.Port:        duplicatedPort,
 					endpoint.Conntracked: "true",

--- a/report/const_map.go
+++ b/report/const_map.go
@@ -138,14 +138,14 @@ func (m ConstMap) DeepEqual(n ConstMap) bool {
 }
 
 type intermediateConstMap struct {
-	Map       map[string]string `json:"map"`
-	Timestamp time.Time         `json:"timestamp"`
+	Map       map[string]string `json:"map,omitempty"`
+	Timestamp int64             `json:"timestamp,omitempty"`
 }
 
 func (m ConstMap) toIntermediate() intermediateConstMap {
 	intermediate := intermediateConstMap{
-		Map:       map[string]string{},
-		Timestamp: m.Timestamp,
+		Map:       make(map[string]string, m.Map.Size()),
+		Timestamp: m.Timestamp.UnixNano(),
 	}
 	if m.Map != nil {
 		m.Map.ForEach(func(key string, val interface{}) {
@@ -157,9 +157,9 @@ func (m ConstMap) toIntermediate() intermediateConstMap {
 
 func (m *ConstMap) fromIntermediate(in intermediateConstMap) {
 	m.Map = ps.NewMap()
-	m.Timestamp = in.Timestamp
+	m.Timestamp = time.Unix(int64(0), in.Timestamp)
 	for k, v := range in.Map {
-		m.Map = m.Map.Set(k, v)
+		m.Map = m.Map.UnsafeMutableSet(k, v)
 	}
 }
 

--- a/report/const_map.go
+++ b/report/const_map.go
@@ -186,6 +186,7 @@ func (m *intermediateMap) CodecDecodeSelf(decoder *codec.Decoder) {
 
 		out = out.UnsafeMutableSet(key, value)
 	}
+	z.DecSendContainerState(containerMapEnd)
 	m.Map = out
 }
 

--- a/report/const_map.go
+++ b/report/const_map.go
@@ -1,0 +1,192 @@
+package report
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/ugorji/go/codec"
+	"github.com/weaveworks/ps"
+)
+
+// ConstMap is a persistent map which supports latest-win merges. Unlike
+// LatestMap it doesn't support per-key timing granularity, it keeps a single
+// timestamp to save space. We have to embed ps.Map as its an interface.
+// ConstMaps are immutable.
+type ConstMap struct {
+	ps.Map
+	Timestamp time.Time
+}
+
+// EmptyConstMap is an empty ConstMap.  Start with this.
+var EmptyConstMap = ConstMap{ps.NewMap(), time.Time{}}
+
+// MakeConstMap makes an empty ConstMap
+func MakeConstMap() ConstMap {
+	return EmptyConstMap
+}
+
+// Copy is a noop, as ConstMaps are immutable.
+func (m ConstMap) Copy() ConstMap {
+	return m
+}
+
+// Size returns the number of elements
+func (m ConstMap) Size() int {
+	if m.Map == nil {
+		return 0
+	}
+	return m.Map.Size()
+}
+
+// Merge produces a fresh ConstMap, container the kers from both inputs. When
+// both inputs container the same key, the latter value is used.
+func (m ConstMap) Merge(other ConstMap) ConstMap {
+	// Use the map with the latest timestamp as output
+	// to minimize garbage
+	latestTS, output, iter := m.Timestamp, m.Map, other.Map
+	if other.Timestamp.After(latestTS) {
+		latestTS, output, iter = other.Timestamp, other.Map, m.Map
+	}
+
+	iter.ForEach(func(key string, iterVal interface{}) {
+		if _, ok := output.Lookup(key); !ok {
+			output = output.Set(key, iterVal)
+		}
+	})
+
+	return ConstMap{output, latestTS}
+}
+
+// Lookup the value for the given key.
+func (m ConstMap) Lookup(key string) (string, bool) {
+	if m.Map == nil {
+		return "", false
+	}
+	value, ok := m.Map.Lookup(key)
+	if !ok {
+		return "", false
+	}
+	return value.(string), ok
+}
+
+// Set the value for the given key.
+func (m ConstMap) Set(key string, timestamp time.Time, value string) ConstMap {
+	if m.Map == nil {
+		m = EmptyConstMap
+	}
+	return ConstMap{m.Map.Set(key, value), timestamp}
+}
+
+// Delete the value for the given key.
+func (m ConstMap) Delete(key string) ConstMap {
+	if m.Map == nil {
+		m = EmptyConstMap
+	}
+	return ConstMap{m.Map.Delete(key), m.Timestamp}
+}
+
+// ForEach executes f on each key value pair in the map
+func (m ConstMap) ForEach(fn func(k, v string)) {
+	if m.Map == nil {
+		return
+	}
+	m.Map.ForEach(func(key string, value interface{}) {
+		fn(key, value.(string))
+	})
+}
+
+func (m ConstMap) String() string {
+	keys := []string{}
+	if m.Map == nil {
+		m = EmptyConstMap
+	}
+	for _, k := range m.Map.Keys() {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	buf := bytes.NewBufferString("")
+	fmt.Fprintf(buf, "{ %s, {\n", m.Timestamp)
+	for _, key := range keys {
+		val, _ := m.Map.Lookup(key)
+		fmt.Fprintf(buf, "%s: %s,\n", key, val)
+	}
+	fmt.Fprintf(buf, "}\n}")
+	return buf.String()
+}
+
+// DeepEqual tests equality with other ConstMap
+func (m ConstMap) DeepEqual(n ConstMap) bool {
+	if m.Size() != n.Size() {
+		return false
+	}
+	if m.Size() == 0 {
+		return true
+	}
+
+	equal := true
+	m.Map.ForEach(func(k string, val interface{}) {
+		if otherValue, ok := n.Map.Lookup(k); !ok {
+			equal = false
+		} else {
+			equal = equal && val.(string) == otherValue.(string)
+		}
+	})
+	return equal
+}
+
+type intermediateConstMap struct {
+	Map       map[string]string `json:"map"`
+	Timestamp time.Time         `json:"timestamp"`
+}
+
+func (m ConstMap) toIntermediate() intermediateConstMap {
+	intermediate := intermediateConstMap{
+		Map:       map[string]string{},
+		Timestamp: m.Timestamp,
+	}
+	if m.Map != nil {
+		m.Map.ForEach(func(key string, val interface{}) {
+			intermediate.Map[key] = val.(string)
+		})
+	}
+	return intermediate
+}
+
+func (m *ConstMap) fromIntermediate(in intermediateConstMap) {
+	m.Map = ps.NewMap()
+	m.Timestamp = in.Timestamp
+	for k, v := range in.Map {
+		m.Map = m.Map.Set(k, v)
+	}
+}
+
+// CodecEncodeSelf implements codec.Selfer
+func (m *ConstMap) CodecEncodeSelf(encoder *codec.Encoder) {
+	if m.Map != nil {
+		encoder.Encode(m.toIntermediate())
+	} else {
+		encoder.Encode(nil)
+	}
+}
+
+// CodecDecodeSelf implements codec.Selfer
+func (m *ConstMap) CodecDecodeSelf(decoder *codec.Decoder) {
+	var in intermediateConstMap
+	if err := decoder.Decode(&in); err != nil {
+		return
+	}
+	m.fromIntermediate(in)
+}
+
+// MarshalJSON shouldn't be used, use CodecEncodeSelf instead
+func (ConstMap) MarshalJSON() ([]byte, error) {
+	panic("MarshalJSON shouldn't be used, use CodecEncodeSelf instead")
+}
+
+// UnmarshalJSON shouldn't be used, use CodecDecodeSelf instead
+func (*ConstMap) UnmarshalJSON(b []byte) error {
+	panic("UnmarshalJSON shouldn't be used, use CodecDecodeSelf instead")
+}

--- a/report/const_map.go
+++ b/report/const_map.go
@@ -43,6 +43,14 @@ func (m ConstMap) Size() int {
 // Merge produces a fresh ConstMap, container the kers from both inputs. When
 // both inputs container the same key, the latter value is used.
 func (m ConstMap) Merge(other ConstMap) ConstMap {
+	// Handle nil/empty maps
+	switch {
+	case m.Size() == 0:
+		return other
+	case other.Size() == 0:
+		return m
+	}
+
 	// Use the map with the latest timestamp as output
 	// to minimize garbage
 	latestTS, output, iter := m.Timestamp, m.Map, other.Map

--- a/report/const_map.go
+++ b/report/const_map.go
@@ -173,10 +173,10 @@ func (m *ConstMap) fromIntermediate(in intermediateConstMap) {
 
 // CodecEncodeSelf implements codec.Selfer
 func (m *ConstMap) CodecEncodeSelf(encoder *codec.Encoder) {
-	if m.Map != nil {
+	if m.Size() > 0 {
 		encoder.Encode(m.toIntermediate())
 	} else {
-		encoder.Encode(nil)
+		encoder.Encode(intermediateConstMap{})
 	}
 }
 

--- a/report/const_map_internal_test.go
+++ b/report/const_map_internal_test.go
@@ -1,0 +1,55 @@
+package report
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/ugorji/go/codec"
+
+	"github.com/weaveworks/scope/test"
+	"github.com/weaveworks/scope/test/reflect"
+)
+
+func TestConstMapEncoding(t *testing.T) {
+	now := time.Now()
+	want := EmptyConstMap.
+		Set("foo", now, "bar").
+		Set("bar", now, "baz")
+
+	for _, h := range []codec.Handle{
+		codec.Handle(&codec.MsgpackHandle{}),
+		codec.Handle(&codec.JsonHandle{}),
+	} {
+		buf := &bytes.Buffer{}
+		encoder := codec.NewEncoder(buf, h)
+		want.CodecEncodeSelf(encoder)
+		decoder := codec.NewDecoder(buf, h)
+		have := EmptyConstMap
+		have.CodecDecodeSelf(decoder)
+		if !reflect.DeepEqual(want, have) {
+			t.Error(test.Diff(want, have))
+		}
+	}
+
+}
+
+func TestConstMapEncodingNil(t *testing.T) {
+	want := ConstMap{}
+
+	for _, h := range []codec.Handle{
+		codec.Handle(&codec.MsgpackHandle{}),
+		codec.Handle(&codec.JsonHandle{}),
+	} {
+		buf := &bytes.Buffer{}
+		encoder := codec.NewEncoder(buf, h)
+		want.CodecEncodeSelf(encoder)
+		decoder := codec.NewDecoder(buf, h)
+		have := EmptyConstMap
+		have.CodecDecodeSelf(decoder)
+		if !reflect.DeepEqual(want, have) {
+			t.Error(test.Diff(want, have))
+		}
+	}
+
+}

--- a/report/const_map_internal_test.go
+++ b/report/const_map_internal_test.go
@@ -37,13 +37,19 @@ func TestConstMapEncoding(t *testing.T) {
 func TestConstMapEncodingNil(t *testing.T) {
 	want := ConstMap{}
 
+	jsonHandle := codec.Handle(&codec.JsonHandle{})
 	for _, h := range []codec.Handle{
+		jsonHandle,
 		codec.Handle(&codec.MsgpackHandle{}),
-		codec.Handle(&codec.JsonHandle{}),
 	} {
 		buf := &bytes.Buffer{}
 		encoder := codec.NewEncoder(buf, h)
 		want.CodecEncodeSelf(encoder)
+
+		if h == jsonHandle && buf.String() != "{}" {
+			t.Error("Non-empty map when encoding empty ConstMap:", buf.String())
+		}
+
 		decoder := codec.NewDecoder(buf, h)
 		have := EmptyConstMap
 		have.CodecDecodeSelf(decoder)

--- a/report/id.go
+++ b/report/id.go
@@ -181,3 +181,10 @@ func IsLoopback(address string) bool {
 	ip := net.ParseIP(address)
 	return ip != nil && ip.IsLoopback()
 }
+
+// ExtractHostIDFromConst extracts the host id from ConstMap in Node
+func ExtractHostIDFromConst(m Node) string {
+	hostNodeID, _ := m.Const.Lookup(HostNodeID)
+	hostID, _, _ := ParseNodeID(hostNodeID)
+	return hostID
+}

--- a/report/latest_map.go
+++ b/report/latest_map.go
@@ -188,6 +188,9 @@ func (m *LatestMap) CodecEncodeSelf(encoder *codec.Encoder) {
 
 // constants from https://github.com/ugorji/go/blob/master/codec/helper.go#L207
 const (
+	// ----- content types ----
+	cUTF83326 = 1
+	// ----- containerStateValues ----
 	containerMapKey   = 2
 	containerMapValue = 3
 	containerMapEnd   = 4

--- a/report/latest_map.go
+++ b/report/latest_map.go
@@ -10,7 +10,7 @@ import (
 	"github.com/weaveworks/ps"
 )
 
-// LatestMap is a persitent map which support latest-win merges. We have to
+// LatestMap is a persistent map which supports latest-win merges. We have to
 // embed ps.Map as its an interface.  LatestMaps are immutable.
 type LatestMap struct {
 	ps.Map

--- a/report/node.go
+++ b/report/node.go
@@ -94,19 +94,17 @@ func (n Node) WithLatest(k string, ts time.Time, v string) Node {
 
 // WithConsts returns a fresh copy of n, with Metadata m merged in.
 func (n Node) WithConsts(m map[string]string) Node {
-	result := n.Copy()
 	ts := mtime.Now()
 	for k, v := range m {
-		result.Const = result.Const.Set(k, ts, v)
+		n.Const = n.Const.Set(k, ts, v)
 	}
-	return result
+	return n
 }
 
 // WithConst produces a new Node with k mapped to v in the Const metadata.
 func (n Node) WithConst(k string, ts time.Time, v string) Node {
-	result := n.Copy()
-	result.Const = result.Const.Set(k, ts, v)
-	return result
+	n.Const = n.Const.Set(k, ts, v)
+	return n
 }
 
 // WithCounters returns a fresh copy of n, with Counters c merged in.

--- a/report/node.go
+++ b/report/node.go
@@ -18,6 +18,7 @@ type Node struct {
 	Edges     EdgeMetadatas `json:"edges,omitempty"`
 	Controls  NodeControls  `json:"controls,omitempty"`
 	Latest    LatestMap     `json:"latest,omitempty"`
+	Const     ConstMap      `json:"const,omitempty"`
 	Metrics   Metrics       `json:"metrics,omitempty"`
 	Parents   Sets          `json:"parents,omitempty"`
 	Children  NodeSet       `json:"children,omitempty"`
@@ -32,6 +33,7 @@ func MakeNode(id string) Node {
 		Adjacency: EmptyIDList,
 		Edges:     EmptyEdgeMetadatas,
 		Controls:  MakeNodeControls(),
+		Const:     EmptyConstMap,
 		Latest:    EmptyLatestMap,
 		Metrics:   Metrics{},
 		Parents:   EmptySets,
@@ -83,6 +85,23 @@ func (n Node) WithLatests(m map[string]string) Node {
 func (n Node) WithLatest(k string, ts time.Time, v string) Node {
 	n.Latest = n.Latest.Set(k, ts, v)
 	return n
+}
+
+// WithLatests returns a fresh copy of n, with Metadata m merged in.
+func (n Node) WithConsts(m map[string]string) Node {
+	result := n.Copy()
+	ts := mtime.Now()
+	for k, v := range m {
+		result.Const = result.Const.Set(k, ts, v)
+	}
+	return result
+}
+
+// WithLatest produces a new Node with k mapped to v in the Const metadata.
+func (n Node) WithConst(k string, ts time.Time, v string) Node {
+	result := n.Copy()
+	result.Const = result.Const.Set(k, ts, v)
+	return result
 }
 
 // WithCounters returns a fresh copy of n, with Counters c merged in.
@@ -182,6 +201,7 @@ func (n Node) Merge(other Node) Node {
 		Edges:     n.Edges.Merge(other.Edges),
 		Controls:  n.Controls.Merge(other.Controls),
 		Latest:    n.Latest.Merge(other.Latest),
+		Const:     n.Const.Merge(other.Const),
 		Metrics:   n.Metrics.Merge(other.Metrics),
 		Parents:   n.Parents.Merge(other.Parents),
 		Children:  n.Children.Merge(other.Children),

--- a/report/node.go
+++ b/report/node.go
@@ -40,9 +40,14 @@ func MakeNode(id string) Node {
 	}
 }
 
-// MakeNodeWith creates a new Node with the supplied map.
+// MakeNodeWith creates a new Node with the supplied latest map.
 func MakeNodeWith(id string, m map[string]string) Node {
 	return MakeNode(id).WithLatests(m)
+}
+
+// MakeNodeWith creates a new Node with the supplied const map.
+func MakeNodeWithConsts(id string, m map[string]string) Node {
+	return MakeNode(id).WithConsts(m)
 }
 
 // WithID returns a fresh copy of n, with ID changed.

--- a/report/node.go
+++ b/report/node.go
@@ -45,7 +45,7 @@ func MakeNodeWith(id string, m map[string]string) Node {
 	return MakeNode(id).WithLatests(m)
 }
 
-// MakeNodeWith creates a new Node with the supplied const map.
+// MakeNodeWithConsts creates a new Node with the supplied const map.
 func MakeNodeWithConsts(id string, m map[string]string) Node {
 	return MakeNode(id).WithConsts(m)
 }
@@ -92,7 +92,7 @@ func (n Node) WithLatest(k string, ts time.Time, v string) Node {
 	return n
 }
 
-// WithLatests returns a fresh copy of n, with Metadata m merged in.
+// WithConsts returns a fresh copy of n, with Metadata m merged in.
 func (n Node) WithConsts(m map[string]string) Node {
 	result := n.Copy()
 	ts := mtime.Now()
@@ -102,7 +102,7 @@ func (n Node) WithConsts(m map[string]string) Node {
 	return result
 }
 
-// WithLatest produces a new Node with k mapped to v in the Const metadata.
+// WithConst produces a new Node with k mapped to v in the Const metadata.
 func (n Node) WithConst(k string, ts time.Time, v string) Node {
 	result := n.Copy()
 	result.Const = result.Const.Set(k, ts, v)

--- a/report/table.go
+++ b/report/table.go
@@ -23,12 +23,12 @@ func (node Node) AddTable(prefix string, labels map[string]string) Node {
 		if count >= MaxTableRows {
 			break
 		}
-		node = node.WithLatest(prefix+key, mtime.Now(), value)
+		node = node.WithConst(prefix+key, mtime.Now(), value)
 		count++
 	}
 	if len(labels) > MaxTableRows {
 		truncationCount := fmt.Sprintf("%d", len(labels)-MaxTableRows)
-		node = node.WithLatest(TruncationCountPrefix+prefix, mtime.Now(), truncationCount)
+		node = node.WithConst(TruncationCountPrefix+prefix, mtime.Now(), truncationCount)
 	}
 	return node
 }
@@ -37,13 +37,13 @@ func (node Node) AddTable(prefix string, labels map[string]string) Node {
 func (node Node) ExtractTable(prefix string) (rows map[string]string, truncationCount int) {
 	rows = map[string]string{}
 	truncationCount = 0
-	node.Latest.ForEach(func(key, value string) {
+	node.Const.ForEach(func(key, value string) {
 		if strings.HasPrefix(key, prefix) {
 			label := key[len(prefix):]
 			rows[label] = value
 		}
 	})
-	if str, ok := node.Latest.Lookup(TruncationCountPrefix + prefix); ok {
+	if str, ok := node.Const.Lookup(TruncationCountPrefix + prefix); ok {
 		if n, err := fmt.Sscanf(str, "%d", &truncationCount); n != 1 || err != nil {
 			log.Warn("Unexpected truncation count format %q", str)
 		}

--- a/test/fixture/report_fixture.go
+++ b/test/fixture/report_fixture.go
@@ -122,7 +122,7 @@ var (
 				// Node is arbitrary. We're free to put only precisely what we
 				// care to test into the fixture. Just be sure to include the bits
 				// that the mapping funcs extract :)
-				Client54001NodeID: report.MakeNode(Client54001NodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
+				Client54001NodeID: report.MakeNode(Client54001NodeID).WithTopology(report.Endpoint).WithConsts(map[string]string{
 					endpoint.Addr:      ClientIP,
 					endpoint.Port:      ClientPort54001,
 					process.PID:        Client1PID,
@@ -133,7 +133,7 @@ var (
 					EgressByteCount:   newu64(100),
 				}),
 
-				Client54002NodeID: report.MakeNode(Client54002NodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
+				Client54002NodeID: report.MakeNode(Client54002NodeID).WithTopology(report.Endpoint).WithConsts(map[string]string{
 					endpoint.Addr:      ClientIP,
 					endpoint.Port:      ClientPort54002,
 					process.PID:        Client2PID,
@@ -144,7 +144,7 @@ var (
 					EgressByteCount:   newu64(200),
 				}),
 
-				Server80NodeID: report.MakeNode(Server80NodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
+				Server80NodeID: report.MakeNode(Server80NodeID).WithTopology(report.Endpoint).WithConsts(map[string]string{
 					endpoint.Addr:      ServerIP,
 					endpoint.Port:      ServerPort,
 					process.PID:        ServerPID,
@@ -152,7 +152,7 @@ var (
 					endpoint.Procspied: True,
 				}),
 
-				NonContainerNodeID: report.MakeNode(NonContainerNodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
+				NonContainerNodeID: report.MakeNode(NonContainerNodeID).WithTopology(report.Endpoint).WithConsts(map[string]string{
 					endpoint.Addr:      ServerIP,
 					endpoint.Port:      NonContainerClientPort,
 					process.PID:        NonContainerPID,
@@ -161,7 +161,7 @@ var (
 				}).WithAdjacent(GoogleEndpointNodeID),
 
 				// Probe pseudo nodes
-				UnknownClient1NodeID: report.MakeNode(UnknownClient1NodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
+				UnknownClient1NodeID: report.MakeNode(UnknownClient1NodeID).WithTopology(report.Endpoint).WithConsts(map[string]string{
 					endpoint.Addr:      UnknownClient1IP,
 					endpoint.Port:      UnknownClient1Port,
 					endpoint.Procspied: True,
@@ -170,7 +170,7 @@ var (
 					EgressByteCount:   newu64(300),
 				}),
 
-				UnknownClient2NodeID: report.MakeNode(UnknownClient2NodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
+				UnknownClient2NodeID: report.MakeNode(UnknownClient2NodeID).WithTopology(report.Endpoint).WithConsts(map[string]string{
 					endpoint.Addr:      UnknownClient2IP,
 					endpoint.Port:      UnknownClient2Port,
 					endpoint.Procspied: True,
@@ -179,7 +179,7 @@ var (
 					EgressByteCount:   newu64(400),
 				}),
 
-				UnknownClient3NodeID: report.MakeNode(UnknownClient3NodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
+				UnknownClient3NodeID: report.MakeNode(UnknownClient3NodeID).WithTopology(report.Endpoint).WithConsts(map[string]string{
 					endpoint.Addr:      UnknownClient3IP,
 					endpoint.Port:      UnknownClient3Port,
 					endpoint.Procspied: True,
@@ -188,7 +188,7 @@ var (
 					EgressByteCount:   newu64(500),
 				}),
 
-				RandomClientNodeID: report.MakeNode(RandomClientNodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
+				RandomClientNodeID: report.MakeNode(RandomClientNodeID).WithTopology(report.Endpoint).WithConsts(map[string]string{
 					endpoint.Addr:      RandomClientIP,
 					endpoint.Port:      RandomClientPort,
 					endpoint.Procspied: True,
@@ -197,7 +197,7 @@ var (
 					EgressByteCount:   newu64(600),
 				}),
 
-				GoogleEndpointNodeID: report.MakeNode(GoogleEndpointNodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
+				GoogleEndpointNodeID: report.MakeNode(GoogleEndpointNodeID).WithTopology(report.Endpoint).WithConsts(map[string]string{
 					endpoint.Addr:      GoogleIP,
 					endpoint.Port:      GooglePort,
 					endpoint.Procspied: True,


### PR DESCRIPTION
ConstMap is similar to LatestMap, but instead of including a timestamp per key in only has a global timestamp (motivated from discussion on #1201 ). 

This PR only migrates the LatestMap field to ConstMap in the Endpoint topology. If experiments are successful we might extend it to other topologies.

TODO:
- [ ] Add ConstMap tests
- [x] Include custom encoder/decoder (investigating whether using since-epoch would provide considerably better performance than textual dates).
- [ ] Backwards compatibility with old probes not producing ConstMap fields.
