### PR TITLE
Use slices instead of linked lists for Metric

### DIFF
--- a/app/server_helpers.go
+++ b/app/server_helpers.go
@@ -21,6 +21,6 @@ func respondWith(w http.ResponseWriter, code int, response interface{}) {
 	w.WriteHeader(code)
 	encoder := codec.NewEncoder(w, &codec.JsonHandle{})
 	if err := encoder.Encode(response); err != nil {
-		log.Errorf("Error encdoing response: %v", err)
+		log.Errorf("Error encoding response: %v", err)
 	}
 }

--- a/probe/docker/container_test.go
+++ b/probe/docker/container_test.go
@@ -92,8 +92,8 @@ func TestContainer(t *testing.T) {
 				docker.RestartContainer, docker.StopContainer, docker.PauseContainer,
 				docker.AttachContainer, docker.ExecContainer,
 			).WithMetrics(report.Metrics{
-			"docker_cpu_total_usage": report.MakeMetric(),
-			"docker_memory_usage":    report.MakeMetric().Add(now, 12345).WithMax(45678),
+			"docker_cpu_total_usage": report.MakeMetric(nil),
+			"docker_memory_usage":    report.MakeSingletonMetric(now, 12345).WithMax(45678),
 		}).WithParents(report.EmptySets.
 			Add(report.ContainerImage, report.MakeStringSet(report.MakeContainerImageNodeID("baz"))),
 		)

--- a/probe/host/reporter.go
+++ b/probe/host/reporter.go
@@ -125,9 +125,9 @@ func (r *Reporter) Report() (report.Report, error) {
 	now := mtime.Now()
 	metrics := GetLoad(now)
 	cpuUsage, max := GetCPUUsagePercent()
-	metrics[CPUUsage] = report.MakeMetric().Add(now, cpuUsage).WithMax(max)
+	metrics[CPUUsage] = report.MakeSingletonMetric(now, cpuUsage).WithMax(max)
 	memoryUsage, max := GetMemoryUsageBytes()
-	metrics[MemoryUsage] = report.MakeMetric().Add(now, memoryUsage).WithMax(max)
+	metrics[MemoryUsage] = report.MakeSingletonMetric(now, memoryUsage).WithMax(max)
 
 	rep.Host.AddNode(
 		report.MakeNodeWith(report.MakeHostNodeID(r.hostID), map[string]string{

--- a/probe/host/reporter_test.go
+++ b/probe/host/reporter_test.go
@@ -88,10 +88,10 @@ func TestReporter(t *testing.T) {
 
 	// Should have metrics
 	for key, want := range metrics {
-		wantSample := want.LastSample()
+		wantSample, _ := want.LastSample()
 		if metric, ok := node.Metrics[key]; !ok {
 			t.Errorf("Expected %s metric, but not found", key)
-		} else if sample := metric.LastSample(); sample == nil {
+		} else if sample, ok := metric.LastSample(); !ok {
 			t.Errorf("Expected %s metric to have a sample, but there were none", key)
 		} else if sample.Value != wantSample.Value {
 			t.Errorf("Expected %s metric sample %f, got %f", key, wantSample, sample.Value)

--- a/probe/host/reporter_test.go
+++ b/probe/host/reporter_test.go
@@ -20,9 +20,9 @@ func TestReporter(t *testing.T) {
 		hostname  = "hostname"
 		timestamp = time.Now()
 		metrics   = report.Metrics{
-			host.Load1:       report.MakeMetric().Add(timestamp, 1.0),
-			host.CPUUsage:    report.MakeMetric().Add(timestamp, 30.0).WithMax(100.0),
-			host.MemoryUsage: report.MakeMetric().Add(timestamp, 60.0).WithMax(100.0),
+			host.Load1:       report.MakeSingletonMetric(timestamp, 1.0),
+			host.CPUUsage:    report.MakeSingletonMetric(timestamp, 30.0).WithMax(100.0),
+			host.MemoryUsage: report.MakeSingletonMetric(timestamp, 60.0).WithMax(100.0),
 		}
 		uptime      = "278h55m43s"
 		kernel      = "release version"

--- a/probe/host/system_darwin.go
+++ b/probe/host/system_darwin.go
@@ -45,7 +45,7 @@ var GetLoad = func(now time.Time) report.Metrics {
 		return nil
 	}
 	return report.Metrics{
-		Load1: report.MakeMetric().Add(now, one),
+		Load1: report.MakeSingletonMetric(now, one),
 	}
 }
 

--- a/probe/host/system_linux.go
+++ b/probe/host/system_linux.go
@@ -45,7 +45,7 @@ var GetLoad = func(now time.Time) report.Metrics {
 		return nil
 	}
 	return report.Metrics{
-		Load1: report.MakeMetric().Add(now, one),
+		Load1: report.MakeSingletonMetric(now, one),
 	}
 }
 

--- a/probe/probe_internal_test.go
+++ b/probe/probe_internal_test.go
@@ -77,10 +77,6 @@ func TestProbe(t *testing.T) {
 	want := report.MakeReport()
 	node := report.MakeNodeWith("a", map[string]string{"b": "c"})
 
-	// DeepEqual doesn't handle the location of timestamps correctly
-	// See https://github.com/golang/go/issues/10089
-	node.Controls.Timestamp = time.Now()
-
 	// marshalling->unmarshaling is not idempotent due to `json:"omitempty"`
 	// tags, transforming empty slices into nils. So, we make DeepEqual
 	// happy by setting empty `json:"omitempty"` entries to nil

--- a/probe/probe_internal_test.go
+++ b/probe/probe_internal_test.go
@@ -69,9 +69,6 @@ func (m mockPublisher) Stop() {
 }
 
 func TestProbe(t *testing.T) {
-	// marshalling->unmarshaling is not idempotent due to `json:"omitempty"`
-	// tags, transforming empty slices into nils. So, we make DeepEqual
-	// happy by setting empty `json:"omitempty"` entries to nil
 	const probeID = "probeid"
 	now := time.Now()
 	mtime.NowForce(now)
@@ -79,8 +76,15 @@ func TestProbe(t *testing.T) {
 
 	want := report.MakeReport()
 	node := report.MakeNodeWith("a", map[string]string{"b": "c"})
-	node.Metrics = nil // omitempty
-	// omitempty
+
+	// DeepEqual doesn't handle the location of timestamps correctly
+	// See https://github.com/golang/go/issues/10089
+	node.Controls.Timestamp = time.Now()
+
+	// marshalling->unmarshaling is not idempotent due to `json:"omitempty"`
+	// tags, transforming empty slices into nils. So, we make DeepEqual
+	// happy by setting empty `json:"omitempty"` entries to nil
+	node.Metrics = nil
 	want.Endpoint.Controls = nil
 	want.Process.Controls = nil
 	want.Container.Controls = nil

--- a/probe/process/reporter.go
+++ b/probe/process/reporter.go
@@ -99,11 +99,11 @@ func (r *Reporter) processTopology() (report.Topology, error) {
 
 		if deltaTotal > 0 {
 			cpuUsage := float64(p.Jiffies-prev.Jiffies) / float64(deltaTotal) * 100.
-			node = node.WithMetric(CPUUsage, report.MakeMetric().Add(now, cpuUsage).WithMax(maxCPU))
+			node = node.WithMetric(CPUUsage, report.MakeSingletonMetric(now, cpuUsage).WithMax(maxCPU))
 		}
 
-		node = node.WithMetric(MemoryUsage, report.MakeMetric().Add(now, float64(p.RSSBytes)).WithMax(float64(p.RSSBytesLimit)))
-		node = node.WithMetric(OpenFilesCount, report.MakeMetric().Add(now, float64(p.OpenFilesCount)).WithMax(float64(p.OpenFilesLimit)))
+		node = node.WithMetric(MemoryUsage, report.MakeSingletonMetric(now, float64(p.RSSBytes)).WithMax(float64(p.RSSBytesLimit)))
+		node = node.WithMetric(OpenFilesCount, report.MakeSingletonMetric(now, float64(p.OpenFilesCount)).WithMax(float64(p.OpenFilesLimit)))
 
 		t.AddNode(node)
 	})

--- a/probe/process/reporter_test.go
+++ b/probe/process/reporter_test.go
@@ -62,7 +62,7 @@ func TestReporter(t *testing.T) {
 	}
 	if memoryUsage, ok := node.Metrics[process.MemoryUsage]; !ok {
 		t.Errorf("Expected memory usage metric, but not found")
-	} else if sample := memoryUsage.LastSample(); sample == nil {
+	} else if sample, ok := memoryUsage.LastSample(); !ok {
 		t.Errorf("Expected memory usage metric to have a sample, but there were none")
 	} else if sample.Value != 0. {
 		t.Errorf("Expected memory usage metric sample %f, got %f", 0., sample.Value)

--- a/render/detailed/metrics_test.go
+++ b/render/detailed/metrics_test.go
@@ -117,7 +117,7 @@ func TestNodeMetrics(t *testing.T) {
 func TestMetricRowSummary(t *testing.T) {
 	var (
 		now    = time.Now()
-		metric = report.MakeMetric().Add(now, 1.234)
+		metric = report.MakeSingletonMetric(now, 1.234)
 		row    = report.MetricRow{
 			ID:       "id",
 			Format:   "format",

--- a/render/detailed/summary_test.go
+++ b/render/detailed/summary_test.go
@@ -47,10 +47,10 @@ func TestSummaries(t *testing.T) {
 	// It should summarize nodes' metrics
 	{
 		t1, t2 := mtime.Now().Add(-1*time.Minute), mtime.Now()
-		metric := report.MakeMetric().Add(t1, 1).Add(t2, 2)
+		metric := report.MakeMetric([]report.Sample{{t1, 1}, {t2, 2}})
 		input := fixture.Report.Copy()
 
-		input.Process.Nodes[fixture.ClientProcess1NodeID] = input.Process.Nodes[fixture.ClientProcess1NodeID].WithMetrics(report.Metrics{process.CPUUsage: metric})
+		input.Process.Nodes[fixture.ClientProcess1NodeID].Metrics[process.CPUUsage] = metric
 		have := detailed.Summaries(input, render.ProcessRenderer.Render(input, nil))
 
 		node, ok := have[fixture.ClientProcess1NodeID]

--- a/render/metrics_test.go
+++ b/render/metrics_test.go
@@ -31,20 +31,20 @@ func TestPropagateSingleMetrics(t *testing.T) {
 					report.MakeNode("child1").
 						WithTopology(report.Container).
 						WithMetrics(report.Metrics{
-							"metric1": report.MakeMetric(),
+							"metric1": report.MakeMetric(nil),
 						}),
 				),
 			),
 			topology: report.Container,
 			output: report.Nodes{
 				"a": report.MakeNode("a").WithMetrics(report.Metrics{
-					"metric1": report.MakeMetric(),
+					"metric1": report.MakeMetric(nil),
 				}).WithChildren(
 					report.MakeNodeSet(
 						report.MakeNode("child1").
 							WithTopology(report.Container).
 							WithMetrics(report.Metrics{
-								"metric1": report.MakeMetric(),
+								"metric1": report.MakeMetric(nil),
 							}),
 					),
 				),
@@ -57,30 +57,30 @@ func TestPropagateSingleMetrics(t *testing.T) {
 					report.MakeNode("child1").
 						WithTopology(report.Container).
 						WithMetrics(report.Metrics{
-							"metric1": report.MakeMetric(),
+							"metric1": report.MakeMetric(nil),
 						}),
 					report.MakeNode("child2").
 						WithTopology("otherTopology").
 						WithMetrics(report.Metrics{
-							"metric2": report.MakeMetric(),
+							"metric2": report.MakeMetric(nil),
 						}),
 				),
 			),
 			topology: report.Container,
 			output: report.Nodes{
 				"a": report.MakeNode("a").WithMetrics(report.Metrics{
-					"metric1": report.MakeMetric(),
+					"metric1": report.MakeMetric(nil),
 				}).WithChildren(
 					report.MakeNodeSet(
 						report.MakeNode("child1").
 							WithTopology(report.Container).
 							WithMetrics(report.Metrics{
-								"metric1": report.MakeMetric(),
+								"metric1": report.MakeMetric(nil),
 							}),
 						report.MakeNode("child2").
 							WithTopology("otherTopology").
 							WithMetrics(report.Metrics{
-								"metric2": report.MakeMetric(),
+								"metric2": report.MakeMetric(nil),
 							}),
 					),
 				),
@@ -93,12 +93,12 @@ func TestPropagateSingleMetrics(t *testing.T) {
 					report.MakeNode("child1").
 						WithTopology(report.Container).
 						WithMetrics(report.Metrics{
-							"metric1": report.MakeMetric(),
+							"metric1": report.MakeMetric(nil),
 						}),
 					report.MakeNode("child2").
 						WithTopology(report.Container).
 						WithMetrics(report.Metrics{
-							"metric2": report.MakeMetric(),
+							"metric2": report.MakeMetric(nil),
 						}),
 				),
 			),
@@ -109,12 +109,12 @@ func TestPropagateSingleMetrics(t *testing.T) {
 						report.MakeNode("child1").
 							WithTopology(report.Container).
 							WithMetrics(report.Metrics{
-								"metric1": report.MakeMetric(),
+								"metric1": report.MakeMetric(nil),
 							}),
 						report.MakeNode("child2").
 							WithTopology(report.Container).
 							WithMetrics(report.Metrics{
-								"metric2": report.MakeMetric(),
+								"metric2": report.MakeMetric(nil),
 							}),
 					),
 				),
@@ -127,32 +127,32 @@ func TestPropagateSingleMetrics(t *testing.T) {
 					report.MakeNode("child1").
 						WithTopology(report.Container).
 						WithMetrics(report.Metrics{
-							"metric1": report.MakeMetric(),
+							"metric1": report.MakeMetric(nil),
 						}),
 					report.MakeNode("child2").
 						WithLatest(report.DoesNotMakeConnections, now, "").
 						WithTopology(report.Container).
 						WithMetrics(report.Metrics{
-							"metric2": report.MakeMetric(),
+							"metric2": report.MakeMetric(nil),
 						}),
 				),
 			),
 			topology: report.Container,
 			output: report.Nodes{
 				"a": report.MakeNode("a").WithMetrics(report.Metrics{
-					"metric1": report.MakeMetric(),
+					"metric1": report.MakeMetric(nil),
 				}).WithChildren(
 					report.MakeNodeSet(
 						report.MakeNode("child1").
 							WithTopology(report.Container).
 							WithMetrics(report.Metrics{
-								"metric1": report.MakeMetric(),
+								"metric1": report.MakeMetric(nil),
 							}),
 						report.MakeNode("child2").
 							WithLatest(report.DoesNotMakeConnections, now, "").
 							WithTopology(report.Container).
 							WithMetrics(report.Metrics{
-								"metric2": report.MakeMetric(),
+								"metric2": report.MakeMetric(nil),
 							}),
 					),
 				),

--- a/report/controls.go
+++ b/report/controls.go
@@ -3,8 +3,6 @@ package report
 import (
 	"time"
 
-	"github.com/ugorji/go/codec"
-
 	"github.com/weaveworks/scope/common/mtime"
 )
 
@@ -50,11 +48,11 @@ func (cs Controls) AddControls(controls []Control) {
 }
 
 // NodeControls represent the individual controls that are valid for a given
-// node at a given point in time.  Its is immutable. A zero-value for Timestamp
+// node at a given point in time.  It's immutable. A zero-value for Timestamp
 // indicated this NodeControls is 'not set'.
 type NodeControls struct {
-	Timestamp time.Time
-	Controls  StringSet
+	Timestamp time.Time `json:"timestamp,omitempty"`
+	Controls  StringSet `json:"controls,omitempty"`
 }
 
 // MakeNodeControls makes a new NodeControls
@@ -84,40 +82,4 @@ func (nc NodeControls) Add(ids ...string) NodeControls {
 		Timestamp: mtime.Now(),
 		Controls:  nc.Controls.Add(ids...),
 	}
-}
-
-// WireNodeControls is the intermediate type for json encoding.
-type WireNodeControls struct {
-	Timestamp string    `json:"timestamp,omitempty"`
-	Controls  StringSet `json:"controls,omitempty"`
-}
-
-// CodecEncodeSelf implements codec.Selfer
-func (nc *NodeControls) CodecEncodeSelf(encoder *codec.Encoder) {
-	encoder.Encode(WireNodeControls{
-		Timestamp: renderTime(nc.Timestamp),
-		Controls:  nc.Controls,
-	})
-}
-
-// CodecDecodeSelf implements codec.Selfer
-func (nc *NodeControls) CodecDecodeSelf(decoder *codec.Decoder) {
-	in := WireNodeControls{}
-	if err := decoder.Decode(&in); err != nil {
-		return
-	}
-	*nc = NodeControls{
-		Timestamp: parseTime(in.Timestamp),
-		Controls:  in.Controls,
-	}
-}
-
-// MarshalJSON shouldn't be used, use CodecEncodeSelf instead
-func (NodeControls) MarshalJSON() ([]byte, error) {
-	panic("MarshalJSON shouldn't be used, use CodecEncodeSelf instead")
-}
-
-// UnmarshalJSON shouldn't be used, use CodecDecodeSelf instead
-func (*NodeControls) UnmarshalJSON(b []byte) error {
-	panic("UnmarshalJSON shouldn't be used, use CodecDecodeSelf instead")
 }

--- a/report/controls.go
+++ b/report/controls.go
@@ -52,8 +52,8 @@ func (cs Controls) AddControls(controls []Control) {
 // node at a given point in time.  It's immutable. A zero-value for Timestamp
 // indicated this NodeControls is 'not set'.
 type NodeControls struct {
-	Timestamp time.Time `json:"timestamp,omitempty"`
-	Controls  StringSet `json:"controls,omitempty"`
+	Timestamp time.Time
+	Controls  StringSet
 }
 
 // MakeNodeControls makes a new NodeControls
@@ -85,15 +85,17 @@ func (nc NodeControls) Add(ids ...string) NodeControls {
 	}
 }
 
-// WireNodeControls is the intermediate type for json encoding.
-type WireNodeControls struct {
+// WireNodeControls is the intermediate type for encoding/decoding.
+// Only needed for backwards compatibility with probes
+// (time.Time is encoded in binary in MsgPack)
+type wireNodeControls struct {
 	Timestamp string    `json:"timestamp,omitempty"`
 	Controls  StringSet `json:"controls,omitempty"`
 }
 
 // CodecEncodeSelf implements codec.Selfer
 func (nc *NodeControls) CodecEncodeSelf(encoder *codec.Encoder) {
-	encoder.Encode(WireNodeControls{
+	encoder.Encode(wireNodeControls{
 		Timestamp: renderTime(nc.Timestamp),
 		Controls:  nc.Controls,
 	})
@@ -101,7 +103,7 @@ func (nc *NodeControls) CodecEncodeSelf(encoder *codec.Encoder) {
 
 // CodecDecodeSelf implements codec.Selfer
 func (nc *NodeControls) CodecDecodeSelf(decoder *codec.Decoder) {
-	in := WireNodeControls{}
+	in := wireNodeControls{}
 	if err := decoder.Decode(&in); err != nil {
 		return
 	}

--- a/report/metric_row.go
+++ b/report/metric_row.go
@@ -1,8 +1,6 @@
 package report
 
 import (
-	"time"
-
 	"github.com/ugorji/go/codec"
 )
 
@@ -57,22 +55,23 @@ func (*MetricRow) UnmarshalJSON(b []byte) error {
 }
 
 type wiredMetricRow struct {
-	ID       string    `json:"id"`
-	Label    string    `json:"label"`
-	Format   string    `json:"format,omitempty"`
-	Group    string    `json:"group,omitempty"`
-	Value    float64   `json:"value"`
-	Priority float64   `json:"priority,omitempty"`
-	Samples  []Sample  `json:"samples"`
-	Min      float64   `json:"min"`
-	Max      float64   `json:"max"`
-	First    time.Time `json:"first,omitempty"`
-	Last     time.Time `json:"last,omitempty"`
+	ID       string   `json:"id"`
+	Label    string   `json:"label"`
+	Format   string   `json:"format,omitempty"`
+	Group    string   `json:"group,omitempty"`
+	Value    float64  `json:"value"`
+	Priority float64  `json:"priority,omitempty"`
+	Samples  []Sample `json:"samples"`
+	Min      float64  `json:"min"`
+	Max      float64  `json:"max"`
+	First    string   `json:"first,omitempty"`
+	Last     string   `json:"last,omitempty"`
 }
 
 // CodecEncodeSelf marshals this MetricRow. It takes the basic Metric
 // rendering, then adds some row-specific fields.
 func (m *MetricRow) CodecEncodeSelf(encoder *codec.Encoder) {
+	in := m.Metric.ToIntermediate()
 	encoder.Encode(wiredMetricRow{
 		ID:       m.ID,
 		Label:    m.Label,
@@ -80,11 +79,11 @@ func (m *MetricRow) CodecEncodeSelf(encoder *codec.Encoder) {
 		Group:    m.Group,
 		Value:    m.Value,
 		Priority: m.Priority,
-		Samples:  m.Metric.Samples,
-		Min:      m.Metric.Min,
-		Max:      m.Metric.Max,
-		First:    m.Metric.First,
-		Last:     m.Metric.Last,
+		Samples:  in.Samples,
+		Min:      in.Min,
+		Max:      in.Max,
+		First:    in.First,
+		Last:     in.Last,
 	})
 }
 
@@ -92,6 +91,14 @@ func (m *MetricRow) CodecEncodeSelf(encoder *codec.Encoder) {
 func (m *MetricRow) CodecDecodeSelf(decoder *codec.Decoder) {
 	var in wiredMetricRow
 	decoder.Decode(&in)
+	w := WireMetrics{
+		Samples: in.Samples,
+		Min:     in.Min,
+		Max:     in.Max,
+		First:   in.First,
+		Last:    in.Last,
+	}
+	metric := w.FromIntermediate()
 	*m = MetricRow{
 		ID:       in.ID,
 		Label:    in.Label,
@@ -99,13 +106,7 @@ func (m *MetricRow) CodecDecodeSelf(decoder *codec.Decoder) {
 		Group:    in.Group,
 		Value:    in.Value,
 		Priority: in.Priority,
-		Metric: &Metric{
-			Samples: in.Samples,
-			Min:     in.Min,
-			Max:     in.Max,
-			First:   in.First,
-			Last:    in.Last,
-		},
+		Metric:   &metric,
 	}
 }
 

--- a/report/metric_row.go
+++ b/report/metric_row.go
@@ -1,6 +1,8 @@
 package report
 
 import (
+	"time"
+
 	"github.com/ugorji/go/codec"
 )
 
@@ -55,23 +57,22 @@ func (*MetricRow) UnmarshalJSON(b []byte) error {
 }
 
 type wiredMetricRow struct {
-	ID       string   `json:"id"`
-	Label    string   `json:"label"`
-	Format   string   `json:"format,omitempty"`
-	Group    string   `json:"group,omitempty"`
-	Value    float64  `json:"value"`
-	Priority float64  `json:"priority,omitempty"`
-	Samples  []Sample `json:"samples"`
-	Min      float64  `json:"min"`
-	Max      float64  `json:"max"`
-	First    string   `json:"first,omitempty"`
-	Last     string   `json:"last,omitempty"`
+	ID       string    `json:"id"`
+	Label    string    `json:"label"`
+	Format   string    `json:"format,omitempty"`
+	Group    string    `json:"group,omitempty"`
+	Value    float64   `json:"value"`
+	Priority float64   `json:"priority,omitempty"`
+	Samples  []Sample  `json:"samples"`
+	Min      float64   `json:"min"`
+	Max      float64   `json:"max"`
+	First    time.Time `json:"first,omitempty"`
+	Last     time.Time `json:"last,omitempty"`
 }
 
 // CodecEncodeSelf marshals this MetricRow. It takes the basic Metric
 // rendering, then adds some row-specific fields.
 func (m *MetricRow) CodecEncodeSelf(encoder *codec.Encoder) {
-	in := m.Metric.ToIntermediate()
 	encoder.Encode(wiredMetricRow{
 		ID:       m.ID,
 		Label:    m.Label,
@@ -79,11 +80,11 @@ func (m *MetricRow) CodecEncodeSelf(encoder *codec.Encoder) {
 		Group:    m.Group,
 		Value:    m.Value,
 		Priority: m.Priority,
-		Samples:  in.Samples,
-		Min:      in.Min,
-		Max:      in.Max,
-		First:    in.First,
-		Last:     in.Last,
+		Samples:  m.Metric.Samples,
+		Min:      m.Metric.Min,
+		Max:      m.Metric.Max,
+		First:    m.Metric.First,
+		Last:     m.Metric.Last,
 	})
 }
 
@@ -91,14 +92,6 @@ func (m *MetricRow) CodecEncodeSelf(encoder *codec.Encoder) {
 func (m *MetricRow) CodecDecodeSelf(decoder *codec.Decoder) {
 	var in wiredMetricRow
 	decoder.Decode(&in)
-	w := WireMetrics{
-		Samples: in.Samples,
-		Min:     in.Min,
-		Max:     in.Max,
-		First:   in.First,
-		Last:    in.Last,
-	}
-	metric := w.FromIntermediate()
 	*m = MetricRow{
 		ID:       in.ID,
 		Label:    in.Label,
@@ -106,7 +99,13 @@ func (m *MetricRow) CodecDecodeSelf(decoder *codec.Decoder) {
 		Group:    in.Group,
 		Value:    in.Value,
 		Priority: in.Priority,
-		Metric:   &metric,
+		Metric: &Metric{
+			Samples: in.Samples,
+			Min:     in.Min,
+			Max:     in.Max,
+			First:   in.First,
+			Last:    in.Last,
+		},
 	}
 }
 

--- a/report/metric_row.go
+++ b/report/metric_row.go
@@ -54,6 +54,8 @@ func (*MetricRow) UnmarshalJSON(b []byte) error {
 	panic("UnmarshalJSON shouldn't be used, use CodecDecodeSelf instead")
 }
 
+// Needed to flatten the fields for backwards compatibility with probes
+// (time.Time is encoded in binary in MsgPack)
 type wiredMetricRow struct {
 	ID       string   `json:"id"`
 	Label    string   `json:"label"`

--- a/report/metric_template.go
+++ b/report/metric_template.go
@@ -28,7 +28,7 @@ func (t MetricTemplate) MetricRows(n Node) []MetricRow {
 		Priority: t.Priority,
 		Metric:   &metric,
 	}
-	if s := metric.LastSample(); s != nil {
+	if s, ok := metric.LastSample(); ok {
 		row.Value = toFixed(s.Value, 2)
 	}
 	return []MetricRow{row}

--- a/report/metrics.go
+++ b/report/metrics.go
@@ -32,7 +32,7 @@ func (m Metrics) Merge(other Metrics) Metrics {
 
 // Copy returns a value copy of the sets map.
 func (m Metrics) Copy() Metrics {
-	result := Metrics{}
+	result := make(Metrics, len(m))
 	for k, v := range m {
 		result[k] = v
 	}

--- a/report/metrics.go
+++ b/report/metrics.go
@@ -104,18 +104,6 @@ func (m Metric) Copy() Metric {
 	return c
 }
 
-// WithFirst returns a fresh copy of m, with first set to t.
-// TODO: This seems to be unused
-func (m Metric) WithFirst(t time.Time) Metric {
-	return Metric{
-		Samples: m.Samples,
-		Max:     m.Max,
-		Min:     m.Min,
-		First:   t,
-		Last:    m.Last,
-	}
-}
-
 // WithMax returns a fresh copy of m, with Max set to max
 func (m Metric) WithMax(max float64) Metric {
 	return Metric{

--- a/report/metrics.go
+++ b/report/metrics.go
@@ -24,7 +24,7 @@ func (m Metrics) Merge(other Metrics) Metrics {
 		if rv, ok := result[k]; ok {
 			result[k] = rv.Merge(v)
 		} else {
-			result[k] = v.Copy()
+			result[k] = v
 		}
 	}
 	return result
@@ -140,9 +140,9 @@ func (m Metric) Merge(other Metric) Metric {
 	// Optimize the empty and non-overlapping case since they are very common
 	switch {
 	case len(m.Samples) == 0:
-		return other.Copy()
+		return other
 	case len(other.Samples) == 0:
-		return m.Copy()
+		return m
 	case other.First.After(m.Last):
 		samplesOut := make([]Sample, len(m.Samples)+len(other.Samples))
 		copy(samplesOut, m.Samples)

--- a/report/metrics_test.go
+++ b/report/metrics_test.go
@@ -19,17 +19,17 @@ func TestMetricsMerge(t *testing.T) {
 	t4 := time.Now().Add(3 * time.Minute)
 
 	metrics1 := report.Metrics{
-		"metric1": report.MakeMetric().Add(t1, 0.1).Add(t2, 0.2),
-		"metric2": report.MakeMetric().Add(t3, 0.3),
+		"metric1": report.MakeMetric([]report.Sample{{t1, 0.1}, {t2, 0.2}}),
+		"metric2": report.MakeSingletonMetric(t3, 0.3),
 	}
 	metrics2 := report.Metrics{
-		"metric2": report.MakeMetric().Add(t4, 0.4),
-		"metric3": report.MakeMetric().Add(t1, 0.1).Add(t2, 0.2),
+		"metric2": report.MakeSingletonMetric(t4, 0.4),
+		"metric3": report.MakeMetric([]report.Sample{{t1, 0.1}, {t2, 0.2}}),
 	}
 	want := report.Metrics{
-		"metric1": report.MakeMetric().Add(t1, 0.1).Add(t2, 0.2),
-		"metric2": report.MakeMetric().Add(t3, 0.3).Add(t4, 0.4),
-		"metric3": report.MakeMetric().Add(t1, 0.1).Add(t2, 0.2),
+		"metric1": report.MakeMetric([]report.Sample{{t1, 0.1}, {t2, 0.2}}),
+		"metric2": report.MakeMetric([]report.Sample{{t3, 0.3}, {t4, 0.4}}),
+		"metric3": report.MakeMetric([]report.Sample{{t1, 0.1}, {t2, 0.2}}),
 	}
 	have := metrics1.Merge(metrics2)
 	if !reflect.DeepEqual(want, have) {
@@ -40,7 +40,7 @@ func TestMetricsMerge(t *testing.T) {
 func TestMetricsCopy(t *testing.T) {
 	t1 := time.Now()
 	want := report.Metrics{
-		"metric1": report.MakeMetric().Add(t1, 0.1),
+		"metric1": report.MakeSingletonMetric(t1, 0.1),
 	}
 	delete(want.Copy(), "metric1") // Modify a copy
 	have := want.Copy()            // Check the original wasn't affected
@@ -65,66 +65,24 @@ func checkMetric(t *testing.T, metric report.Metric, first, last time.Time, min,
 }
 
 func TestMetricFirstLastMinMax(t *testing.T) {
-	metric := report.MakeMetric()
-	var zero time.Time
+
+	checkMetric(t, report.MakeMetric(nil), time.Time{}, time.Time{}, 0.0, 0.0)
+
 	t1 := time.Now()
 	t2 := time.Now().Add(1 * time.Minute)
+
+	metric1 := report.MakeMetric([]report.Sample{{t1, -0.1}, {t2, 0.2}})
+
+	checkMetric(t, metric1, t1, t2, -0.1, 0.2)
+	checkMetric(t, metric1.Merge(metric1), t1, t2, -0.1, 0.2)
+
 	t3 := time.Now().Add(2 * time.Minute)
 	t4 := time.Now().Add(3 * time.Minute)
-	other := report.MakeMetric()
-	other.Max = 5
-	other.Min = -5
-	other.First = t1.Add(-1 * time.Minute)
-	other.Last = t4.Add(1 * time.Minute)
+	metric2 := report.MakeMetric([]report.Sample{{t3, 0.31}, {t4, 0.4}})
 
-	tests := []struct {
-		f           func(report.Metric) report.Metric
-		first, last time.Time
-		min, max    float64
-	}{
-		{nil, zero, zero, 0, 0},
-		{func(m report.Metric) report.Metric { return m.Add(t2, 2) }, t2, t2, 0, 2},
-		{func(m report.Metric) report.Metric { return m.Add(t1, 1) }, t1, t2, 0, 2},
-		{func(m report.Metric) report.Metric { return m.Add(t3, -1) }, t1, t3, -1, 2},
-		{func(m report.Metric) report.Metric { return m.Add(t4, 3) }, t1, t4, -1, 3},
-		{func(m report.Metric) report.Metric { return m.Merge(other) }, t1.Add(-1 * time.Minute), t4.Add(1 * time.Minute), -5, 5},
-	}
-	for _, test := range tests {
-		oldFirst, oldLast, oldMin, oldMax := metric.First, metric.Last, metric.Min, metric.Max
-		oldMetric := metric
-		if test.f != nil {
-			metric = test.f(metric)
-		}
-
-		// Check it didn't modify the old one
-		checkMetric(t, oldMetric, oldFirst, oldLast, oldMin, oldMax)
-
-		// Check the new one is as expected
-		checkMetric(t, metric, test.first, test.last, test.min, test.max)
-	}
-}
-
-func TestMetricAdd(t *testing.T) {
-	s := []report.Sample{
-		{time.Now(), 0.1},
-		{time.Now().Add(1 * time.Minute), 0.2},
-		{time.Now().Add(2 * time.Minute), 0.3},
-	}
-
-	have := report.MakeMetric().
-		Add(s[0].Timestamp, s[0].Value).
-		Add(s[2].Timestamp, s[2].Value). // Keeps sorted
-		Add(s[1].Timestamp, s[1].Value).
-		Add(s[2].Timestamp, 0.5) // Overwrites duplicate timestamps
-
-	want := report.MakeMetric().
-		Add(s[0].Timestamp, s[0].Value).
-		Add(s[1].Timestamp, s[1].Value).
-		Add(s[2].Timestamp, 0.5)
-
-	if !reflect.DeepEqual(want, have) {
-		t.Errorf("diff: %s", test.Diff(want, have))
-	}
+	checkMetric(t, metric2, t3, t4, 0.31, 0.4)
+	checkMetric(t, metric1.Merge(metric2), t1, t4, -0.1, 0.4)
+	checkMetric(t, metric2.Merge(metric1), t1, t4, -0.1, 0.4)
 }
 
 func TestMetricMerge(t *testing.T) {
@@ -133,20 +91,12 @@ func TestMetricMerge(t *testing.T) {
 	t3 := time.Now().Add(2 * time.Minute)
 	t4 := time.Now().Add(3 * time.Minute)
 
-	metric1 := report.MakeMetric().
-		Add(t2, 0.2).
-		Add(t3, 0.31)
+	metric1 := report.MakeMetric([]report.Sample{{t2, 0.2}, {t3, 0.31}})
 
-	metric2 := report.MakeMetric().
-		Add(t1, -0.1).
-		Add(t3, 0.3).
-		Add(t4, 0.4)
+	metric2 := report.MakeMetric([]report.Sample{{t1, -0.1}, {t3, 0.3}, {t4, 0.4}})
 
-	want := report.MakeMetric().
-		Add(t1, -0.1).
-		Add(t2, 0.2).
-		Add(t3, 0.31).
-		Add(t4, 0.4)
+	want := report.MakeMetric([]report.Sample{{t1, -0.1}, {t2, 0.2}, {t3, 0.31}, {t4, 0.4}})
+
 	have := metric1.Merge(metric2)
 	if !reflect.DeepEqual(want, have) {
 		t.Errorf("diff: %s", test.Diff(want, have))
@@ -159,8 +109,8 @@ func TestMetricMerge(t *testing.T) {
 	if !metric1.Last.Equal(t3) {
 		t.Errorf("Expected metric1.Last == %q, but was: %q", t3, metric1.Last)
 	}
-	if metric1.Min != 0.0 {
-		t.Errorf("Expected metric1.Min == %f, but was: %f", 0.0, metric1.Min)
+	if metric1.Min != 0.2 {
+		t.Errorf("Expected metric1.Min == %f, but was: %f", 0.2, metric1.Min)
 	}
 	if metric1.Max != 0.31 {
 		t.Errorf("Expected metric1.Max == %f, but was: %f", 0.31, metric1.Max)
@@ -173,13 +123,13 @@ func TestMetricMerge(t *testing.T) {
 }
 
 func TestMetricCopy(t *testing.T) {
-	want := report.MakeMetric()
+	want := report.MakeMetric(nil)
 	have := want.Copy()
 	if !reflect.DeepEqual(want, have) {
 		t.Errorf("diff: %s", test.Diff(want, have))
 	}
 
-	want = report.MakeMetric().Add(time.Now(), 1)
+	want = report.MakeSingletonMetric(time.Now(), 1)
 	have = want.Copy()
 	if !reflect.DeepEqual(want, have) {
 		t.Errorf("diff: %s", test.Diff(want, have))
@@ -190,12 +140,8 @@ func TestMetricDiv(t *testing.T) {
 	t1 := time.Now()
 	t2 := time.Now().Add(1 * time.Minute)
 
-	want := report.MakeMetric().
-		Add(t1, -2).
-		Add(t2, 2)
-	beforeDiv := report.MakeMetric().
-		Add(t1, -2048).
-		Add(t2, 2048)
+	want := report.MakeMetric([]report.Sample{{t1, -2}, {t2, 2}})
+	beforeDiv := report.MakeMetric([]report.Sample{{t1, -2048}, {t2, 2048}})
 	have := beforeDiv.Div(1024)
 	if !reflect.DeepEqual(want, have) {
 		t.Errorf("diff: %s", test.Diff(want, have))
@@ -218,10 +164,7 @@ func TestMetricMarshalling(t *testing.T) {
 		{Timestamp: t4, Value: 0.4},
 	}
 
-	want := report.MakeMetric()
-	for _, sample := range wantSamples {
-		want = want.Add(sample.Timestamp, sample.Value)
-	}
+	want := report.MakeMetric(wantSamples)
 
 	for _, h := range []codec.Handle{
 		codec.Handle(&codec.MsgpackHandle{}),

--- a/test/fixture/report_fixture.go
+++ b/test/fixture/report_fixture.go
@@ -101,22 +101,22 @@ var (
 	ServiceUID          = "service1234"
 	ServiceNodeID       = report.MakeServiceNodeID(ServiceUID)
 
-	ClientProcess1CPUMetric    = report.MakeSingletonMetric(Now, 0.01).WithFirst(Now.Add(-1 * time.Second))
-	ClientProcess1MemoryMetric = report.MakeSingletonMetric(Now, 0.02).WithFirst(Now.Add(-2 * time.Second))
+	ClientProcess1CPUMetric    = report.MakeSingletonMetric(Now.Add(-1*time.Second), 0.01)
+	ClientProcess1MemoryMetric = report.MakeSingletonMetric(Now.Add(-2*time.Second), 0.02)
 
-	ClientContainerCPUMetric    = report.MakeSingletonMetric(Now, 0.03).WithFirst(Now.Add(-3 * time.Second))
-	ClientContainerMemoryMetric = report.MakeSingletonMetric(Now, 0.04).WithFirst(Now.Add(-4 * time.Second))
+	ClientContainerCPUMetric    = report.MakeSingletonMetric(Now.Add(-3*time.Second), 0.03)
+	ClientContainerMemoryMetric = report.MakeSingletonMetric(Now.Add(-4*time.Second), 0.04)
 
-	ServerContainerCPUMetric    = report.MakeSingletonMetric(Now, 0.05).WithFirst(Now.Add(-5 * time.Second))
-	ServerContainerMemoryMetric = report.MakeSingletonMetric(Now, 0.06).WithFirst(Now.Add(-6 * time.Second))
+	ServerContainerCPUMetric    = report.MakeSingletonMetric(Now.Add(-5*time.Second), 0.05)
+	ServerContainerMemoryMetric = report.MakeSingletonMetric(Now.Add(-6*time.Second), 0.06)
 
-	ClientHostCPUMetric    = report.MakeSingletonMetric(Now, 0.07).WithFirst(Now.Add(-7 * time.Second))
-	ClientHostMemoryMetric = report.MakeSingletonMetric(Now, 0.08).WithFirst(Now.Add(-8 * time.Second))
-	ClientHostLoad1Metric  = report.MakeSingletonMetric(Now, 0.09).WithFirst(Now.Add(-9 * time.Second))
+	ClientHostCPUMetric    = report.MakeSingletonMetric(Now.Add(-7*time.Second), 0.07)
+	ClientHostMemoryMetric = report.MakeSingletonMetric(Now.Add(-8*time.Second), 0.08)
+	ClientHostLoad1Metric  = report.MakeSingletonMetric(Now.Add(-9*time.Second), 0.09)
 
-	ServerHostCPUMetric    = report.MakeSingletonMetric(Now, 0.12).WithFirst(Now.Add(-12 * time.Second))
-	ServerHostMemoryMetric = report.MakeSingletonMetric(Now, 0.13).WithFirst(Now.Add(-13 * time.Second))
-	ServerHostLoad1Metric  = report.MakeSingletonMetric(Now, 0.14).WithFirst(Now.Add(-14 * time.Second))
+	ServerHostCPUMetric    = report.MakeSingletonMetric(Now.Add(-12*time.Second), 0.12)
+	ServerHostMemoryMetric = report.MakeSingletonMetric(Now.Add(-13*time.Second), 0.13)
+	ServerHostLoad1Metric  = report.MakeSingletonMetric(Now.Add(-14*time.Second), 0.14)
 
 	Report = report.Report{
 		ID: "test-report",

--- a/test/fixture/report_fixture.go
+++ b/test/fixture/report_fixture.go
@@ -101,22 +101,22 @@ var (
 	ServiceUID          = "service1234"
 	ServiceNodeID       = report.MakeServiceNodeID(ServiceUID)
 
-	ClientProcess1CPUMetric    = report.MakeMetric().Add(Now, 0.01).WithFirst(Now.Add(-1 * time.Second))
-	ClientProcess1MemoryMetric = report.MakeMetric().Add(Now, 0.02).WithFirst(Now.Add(-2 * time.Second))
+	ClientProcess1CPUMetric    = report.MakeSingletonMetric(Now, 0.01).WithFirst(Now.Add(-1 * time.Second))
+	ClientProcess1MemoryMetric = report.MakeSingletonMetric(Now, 0.02).WithFirst(Now.Add(-2 * time.Second))
 
-	ClientContainerCPUMetric    = report.MakeMetric().Add(Now, 0.03).WithFirst(Now.Add(-3 * time.Second))
-	ClientContainerMemoryMetric = report.MakeMetric().Add(Now, 0.04).WithFirst(Now.Add(-4 * time.Second))
+	ClientContainerCPUMetric    = report.MakeSingletonMetric(Now, 0.03).WithFirst(Now.Add(-3 * time.Second))
+	ClientContainerMemoryMetric = report.MakeSingletonMetric(Now, 0.04).WithFirst(Now.Add(-4 * time.Second))
 
-	ServerContainerCPUMetric    = report.MakeMetric().Add(Now, 0.05).WithFirst(Now.Add(-5 * time.Second))
-	ServerContainerMemoryMetric = report.MakeMetric().Add(Now, 0.06).WithFirst(Now.Add(-6 * time.Second))
+	ServerContainerCPUMetric    = report.MakeSingletonMetric(Now, 0.05).WithFirst(Now.Add(-5 * time.Second))
+	ServerContainerMemoryMetric = report.MakeSingletonMetric(Now, 0.06).WithFirst(Now.Add(-6 * time.Second))
 
-	ClientHostCPUMetric    = report.MakeMetric().Add(Now, 0.07).WithFirst(Now.Add(-7 * time.Second))
-	ClientHostMemoryMetric = report.MakeMetric().Add(Now, 0.08).WithFirst(Now.Add(-8 * time.Second))
-	ClientHostLoad1Metric  = report.MakeMetric().Add(Now, 0.09).WithFirst(Now.Add(-9 * time.Second))
+	ClientHostCPUMetric    = report.MakeSingletonMetric(Now, 0.07).WithFirst(Now.Add(-7 * time.Second))
+	ClientHostMemoryMetric = report.MakeSingletonMetric(Now, 0.08).WithFirst(Now.Add(-8 * time.Second))
+	ClientHostLoad1Metric  = report.MakeSingletonMetric(Now, 0.09).WithFirst(Now.Add(-9 * time.Second))
 
-	ServerHostCPUMetric    = report.MakeMetric().Add(Now, 0.12).WithFirst(Now.Add(-12 * time.Second))
-	ServerHostMemoryMetric = report.MakeMetric().Add(Now, 0.13).WithFirst(Now.Add(-13 * time.Second))
-	ServerHostLoad1Metric  = report.MakeMetric().Add(Now, 0.14).WithFirst(Now.Add(-14 * time.Second))
+	ServerHostCPUMetric    = report.MakeSingletonMetric(Now, 0.12).WithFirst(Now.Add(-12 * time.Second))
+	ServerHostMemoryMetric = report.MakeSingletonMetric(Now, 0.13).WithFirst(Now.Add(-13 * time.Second))
+	ServerHostLoad1Metric  = report.MakeSingletonMetric(Now, 0.14).WithFirst(Now.Add(-14 * time.Second))
 
 	Report = report.Report{
 		ID: "test-report",


### PR DESCRIPTION
Also:

* Remove Gob encoder/decoder
* ~~Stop using custom encoders/decoders for Timestamps (both ugorji and the Golang JSON codecs use nanosecond precision).~~ Unfortunately we can't due to backwards compatibility with older probes (otherwise msgpack would encode time.Time in binary)
* Use idiomatic way to check for existence in metric.LastSample()
* Remove Add() method, pass slice to MakeMetric() instead (helps reduce garbage and fixes bug computing Min/Max)
* Remove WithFirst() method.
* Optimize Merge()
* Preallocate map when copying Metrics


TODO:

- [x] Fix `Time.UnmarshalBinary: unsupported version` errors when using former versions of the probe.

Improves #1010 and #1457 . It also makes the code easier to read.