### PR TITLE
table-mode: handle nodes w/ no value for sorted column gracefully

### DIFF
--- a/client/app/scripts/components/node-details/node-details-table.js
+++ b/client/app/scripts/components/node-details/node-details-table.js
@@ -105,10 +105,10 @@ function getSortedNodes(nodes, columns, sortBy, sortedDesc) {
   const getValue = getValueForSortBy(sortBy || getDefaultSortBy(columns, nodes));
   const withAndWithoutValues = _.groupBy(nodes, (n) => {
     const v = getValue(n);
-    return v !== null && v !== undefined;
+    return v !== null && v !== undefined ? 'withValues' : 'withoutValues';
   });
-  const withValues = sortNodes(withAndWithoutValues.true, columns, sortBy, sortedDesc);
-  const withoutValues = sortNodes(withAndWithoutValues.false, columns, sortBy, sortedDesc);
+  const withValues = sortNodes(withAndWithoutValues.withValues, columns, sortBy, sortedDesc);
+  const withoutValues = sortNodes(withAndWithoutValues.withoutValues, columns, sortBy, sortedDesc);
 
   return _.concat(withValues, withoutValues);
 }

--- a/client/app/scripts/components/node-details/node-details-table.js
+++ b/client/app/scripts/components/node-details/node-details-table.js
@@ -87,7 +87,7 @@ function getMetaDataSorters(nodes) {
 }
 
 
-function getSortedNodes(nodes, columns, sortBy, sortedDesc) {
+function sortNodes(nodes, columns, sortBy, sortedDesc) {
   const sortedNodes = _.sortBy(
     nodes,
     getValueForSortBy(sortBy || getDefaultSortBy(columns, nodes)),
@@ -98,6 +98,19 @@ function getSortedNodes(nodes, columns, sortBy, sortedDesc) {
     sortedNodes.reverse();
   }
   return sortedNodes;
+}
+
+
+function getSortedNodes(nodes, columns, sortBy, sortedDesc) {
+  const getValue = getValueForSortBy(sortBy || getDefaultSortBy(columns, nodes));
+  const withAndWithoutValues = _.groupBy(nodes, (n) => {
+    const v = getValue(n);
+    return v !== null && v !== undefined;
+  });
+  const withValues = sortNodes(withAndWithoutValues.true, columns, sortBy, sortedDesc);
+  const withoutValues = sortNodes(withAndWithoutValues.false, columns, sortBy, sortedDesc);
+
+  return _.concat(withValues, withoutValues);
 }
 
 


### PR DESCRIPTION
- put empty values below those that have a value.

```
+-----+-----+
|3    |5    |
|4    |4    |
|5    |3    |
|null |null |
|null |null |
+-----+-----+
```
Fixes #1744 