### PR TITLE
Lint fixes

### DIFF
--- a/app/multitenant/sqs_control_router.go
+++ b/app/multitenant/sqs_control_router.go
@@ -333,7 +333,7 @@ func (pw *probeWorker) loop() {
 			return err
 		})
 		if err != nil {
-			log.Errorf("Error recieving message: %v", err)
+			log.Errorf("Error receiving message: %v", err)
 			continue
 		}
 

--- a/tools/lint
+++ b/tools/lint
@@ -40,11 +40,11 @@ function spell_check {
 	filename="$1"
 	local lint_result=0
 
-	# we don't want to spell check tar balls or binaries
+	# we don't want to spell check tar balls, binaries, Makefile and json files
 	if file "$filename" | grep executable >/dev/null 2>&1; then
 		return $lint_result
 	fi
-	if [[ $filename == *".tar" || $filename == *".gz" ]]; then
+	if [[ $filename == *".tar" || $filename == *".gz" || $filename == *".json" || $(basename "$filename") == "Makefile" ]]; then
 		return $lint_result
 	fi
 


### PR DESCRIPTION
It fixes one typo and tells lint script to avoid running misspell on Makefiles and JSON files.