### PR TITLE
Move grid selector to top menu

### DIFF
--- a/client/app/scripts/components/app.js
+++ b/client/app/scripts/components/app.js
@@ -124,6 +124,7 @@ class App extends React.Component {
           </div>
           <Search />
           <Topologies />
+          <GridModeSelector />
         </div>
 
         <Nodes />
@@ -131,7 +132,6 @@ class App extends React.Component {
         <Sidebar classNames={gridMode ? 'sidebar-gridmode' : ''}>
           {showingMetricsSelector && !gridMode && <MetricSelector />}
           {showingNetworkSelector && !gridMode && <NetworkSelector />}
-          <GridModeSelector />
           <Status />
           <TopologyOptions />
         </Sidebar>

--- a/client/app/styles/main.less
+++ b/client/app/styles/main.less
@@ -1175,6 +1175,24 @@ h2 {
   }
 }
 
+.grid-mode-selector {
+  margin-top: 8px;
+  margin-left: 8px;
+
+  &-wrapper {
+    border-color: @background-darker-secondary-color;
+  }
+
+  &-action {
+    background-color: transparent;
+    text-transform: uppercase;
+
+    &-selected, &:hover {
+      background-color: @background-darker-secondary-color;
+    }
+  }
+}
+
 .topology-option {
   &-action {
     &-selected {
@@ -1253,7 +1271,7 @@ h2 {
   transition: width 0.3s 0s @base-ease;
 
   &-wrapper {
-    flex: 0 1 25%;
+    flex: 0 1 20%;
     margin: 8px;
     text-align: right;
   }


### PR DESCRIPTION
* move to top right, to bookend topologies
* hierarchically similar to search, so similar positioning

Fixes #1743

![screen shot 2016-08-04 at 14 47 12](https://cloud.githubusercontent.com/assets/859729/17402303/d8f97e24-5a52-11e6-933f-2243eff8ba93.png)
