### PR TITLE
silence abnormal websocket close

### DIFF
--- a/app/controls.go
+++ b/app/controls.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"io"
 	"net/http"
 	"net/rpc"
 
@@ -84,7 +83,7 @@ func handleProbeWS(cr ControlRouter) CtxHandlerFunc {
 			return
 		}
 		defer cr.Deregister(ctx, probeID, id)
-		if err := codec.WaitForReadError(); err != nil && err != io.EOF && !xfer.IsExpectedWSCloseError(err) {
+		if err := codec.WaitForReadError(); err != nil && !xfer.IsExpectedWSCloseError(err) {
 			log.Errorf("Error on websocket: %v", err)
 		}
 	}

--- a/app/pipe_router.go
+++ b/app/pipe_router.go
@@ -101,7 +101,7 @@ func (pr *localPipeRouter) Get(_ context.Context, id string, e End) (xfer.Pipe, 
 	defer pr.Unlock()
 	p, ok := pr.pipes[id]
 	if !ok {
-		log.Infof("Creating pipe id %s", id)
+		log.Debugf("Creating pipe id %s", id)
 		p = &pipe{
 			ui:    end{lastUsedTime: mtime.Now()},
 			probe: end{lastUsedTime: mtime.Now()},

--- a/app/pipes.go
+++ b/app/pipes.go
@@ -52,7 +52,8 @@ func handlePipeWs(pr PipeRouter, end End) CtxHandlerFunc {
 		id := mux.Vars(r)["pipeID"]
 		pipe, endIO, err := pr.Get(ctx, id, end)
 		if err != nil {
-			log.Errorf("Error getting pipe %s: %v", id, err)
+			// this usually means the pipe has been closed
+			log.Debugf("Error getting pipe %s: %v", id, err)
 			http.NotFound(w, r)
 			return
 		}

--- a/app/pipes.go
+++ b/app/pipes.go
@@ -65,7 +65,6 @@ func handlePipeWs(pr PipeRouter, end End) CtxHandlerFunc {
 		}
 		defer conn.Close()
 
-		log.Infof("Success got pipe %s:%s", id, end)
 		if err := pipe.CopyToWebsocket(endIO, conn); err != nil && !xfer.IsExpectedWSCloseError(err) {
 			log.Printf("Error copying to pipe %s (%d) websocket: %v", id, end, err)
 		}
@@ -75,7 +74,7 @@ func handlePipeWs(pr PipeRouter, end End) CtxHandlerFunc {
 func deletePipe(pr PipeRouter) CtxHandlerFunc {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 		pipeID := mux.Vars(r)["pipeID"]
-		log.Infof("Deleting pipe %s", pipeID)
+		log.Debugf("Deleting pipe %s", pipeID)
 		if err := pr.Delete(ctx, pipeID); err != nil {
 			respondWith(w, http.StatusInternalServerError, err)
 		}

--- a/app/pipes.go
+++ b/app/pipes.go
@@ -66,7 +66,7 @@ func handlePipeWs(pr PipeRouter, end End) CtxHandlerFunc {
 		defer conn.Close()
 
 		if err := pipe.CopyToWebsocket(endIO, conn); err != nil && !xfer.IsExpectedWSCloseError(err) {
-			log.Printf("Error copying to pipe %s (%d) websocket: %v", id, end, err)
+			log.Errorf("Error copying to pipe %s (%d) websocket: %v", id, end, err)
 		}
 	}
 }

--- a/common/xfer/websocket.go
+++ b/common/xfer/websocket.go
@@ -167,8 +167,7 @@ func (p *pingingWebsocket) Close() error {
 // IsExpectedWSCloseError returns boolean indicating whether the error is a
 // clean disconnection.
 func IsExpectedWSCloseError(err error) bool {
-	return websocket.IsCloseError(
-		err,
+	return err == io.EOF || err == io.ErrClosedPipe || websocket.IsCloseError(err,
 		websocket.CloseNormalClosure,
 		websocket.CloseGoingAway,
 		websocket.CloseNoStatusReceived,

--- a/common/xfer/websocket.go
+++ b/common/xfer/websocket.go
@@ -172,5 +172,6 @@ func IsExpectedWSCloseError(err error) bool {
 		websocket.CloseNormalClosure,
 		websocket.CloseGoingAway,
 		websocket.CloseNoStatusReceived,
+		websocket.CloseAbnormalClosure,
 	)
 }

--- a/probe/appclient/app_client.go
+++ b/probe/appclient/app_client.go
@@ -311,7 +311,10 @@ func (c *appClient) pipeConnection(id string, pipe xfer.Pipe) (bool, error) {
 	defer c.closeConn(id)
 
 	_, remote := pipe.Ends()
-	return false, pipe.CopyToWebsocket(remote, conn)
+	if err := pipe.CopyToWebsocket(remote, conn); err != nil && !xfer.IsExpectedWSCloseError(err) {
+		return false, err
+	}
+	return false, nil
 }
 
 func (c *appClient) PipeConnection(id string, pipe xfer.Pipe) {

--- a/probe/docker/controls.go
+++ b/probe/docker/controls.go
@@ -89,13 +89,13 @@ func (r *registry) attachContainer(containerID string, req xfer.Request) xfer.Re
 	}
 	pipe.OnClose(func() {
 		if err := cw.Close(); err != nil {
-			log.Errorf("Error closing attachment: %v", err)
+			log.Errorf("Error closing attachment to container %s: %v", containerID, err)
 			return
 		}
 	})
 	go func() {
 		if err := cw.Wait(); err != nil {
-			log.Errorf("Error waiting on exec: %v", err)
+			log.Errorf("Error waiting on attachment to container %s: %v", containerID, err)
 		}
 		pipe.Close()
 	}()
@@ -135,13 +135,13 @@ func (r *registry) execContainer(containerID string, req xfer.Request) xfer.Resp
 	}
 	pipe.OnClose(func() {
 		if err := cw.Close(); err != nil {
-			log.Errorf("Error closing exec: %v", err)
+			log.Errorf("Error closing exec in container %s: %v", containerID, err)
 			return
 		}
 	})
 	go func() {
 		if err := cw.Wait(); err != nil {
-			log.Errorf("Error waiting on exec: %v", err)
+			log.Errorf("Error waiting on exec in container %s: %v", containerID, err)
 		}
 		pipe.Close()
 	}()

--- a/probe/docker/controls.go
+++ b/probe/docker/controls.go
@@ -92,7 +92,6 @@ func (r *registry) attachContainer(containerID string, req xfer.Request) xfer.Re
 			log.Errorf("Error closing attachment: %v", err)
 			return
 		}
-		log.Infof("Attachment to container %s closed.", containerID)
 	})
 	go func() {
 		if err := cw.Wait(); err != nil {
@@ -139,7 +138,6 @@ func (r *registry) execContainer(containerID string, req xfer.Request) xfer.Resp
 			log.Errorf("Error closing exec: %v", err)
 			return
 		}
-		log.Infof("Exec on container %s closed.", containerID)
 	})
 	go func() {
 		if err := cw.Wait(); err != nil {


### PR DESCRIPTION
- silence `websocket.CloseAbnormalClose` since we get this when attach/exec windows are closed
- reduce pipe log noise
- improve some of the remaining pipe logging

Fixes #1202.