### PR TITLE
Remove kubernetes_id column from the grid view.

### DIFF
--- a/probe/kubernetes/meta.go
+++ b/probe/kubernetes/meta.go
@@ -10,7 +10,6 @@ import (
 
 // These constants are keys used in node metadata
 const (
-	ID          = "kubernetes_id"
 	Name        = "kubernetes_name"
 	Namespace   = "kubernetes_namespace"
 	Created     = "kubernetes_created"
@@ -20,7 +19,6 @@ const (
 // Meta represents a metadata information about a Kubernetes object
 type Meta interface {
 	UID() string
-	ID() string
 	Name() string
 	Namespace() string
 	Created() string
@@ -34,10 +32,6 @@ type meta struct {
 
 func (m meta) UID() string {
 	return string(m.ObjectMeta.UID)
-}
-
-func (m meta) ID() string {
-	return m.ObjectMeta.Namespace + "/" + m.ObjectMeta.Name
 }
 
 func (m meta) Name() string {
@@ -59,7 +53,6 @@ func (m meta) Labels() map[string]string {
 // MetaNode gets the node metadata
 func (m meta) MetaNode(id string) report.Node {
 	return report.MakeNodeWith(id, map[string]string{
-		ID:        m.ID(),
 		Name:      m.Name(),
 		Namespace: m.Namespace(),
 		Created:   m.Created(),

--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -27,7 +27,6 @@ const (
 // Exposed for testing
 var (
 	PodMetadataTemplates = report.MetadataTemplates{
-		ID:               {ID: ID, Label: "ID", From: report.FromLatest, Priority: 1},
 		State:            {ID: State, Label: "State", From: report.FromLatest, Priority: 2},
 		IP:               {ID: IP, Label: "IP", From: report.FromLatest, Priority: 3},
 		report.Container: {ID: report.Container, Label: "# Containers", From: report.FromCounters, Datatype: "number", Priority: 4},
@@ -38,7 +37,6 @@ var (
 	PodMetricTemplates = docker.ContainerMetricTemplates
 
 	ServiceMetadataTemplates = report.MetadataTemplates{
-		ID:         {ID: ID, Label: "ID", From: report.FromLatest, Priority: 1},
 		Namespace:  {ID: Namespace, Label: "Namespace", From: report.FromLatest, Priority: 2},
 		Created:    {ID: Created, Label: "Created", From: report.FromLatest, Priority: 3},
 		PublicIP:   {ID: PublicIP, Label: "Public IP", From: report.FromLatest, Priority: 4},
@@ -49,7 +47,6 @@ var (
 	ServiceMetricTemplates = PodMetricTemplates
 
 	DeploymentMetadataTemplates = report.MetadataTemplates{
-		ID:                 {ID: ID, Label: "ID", From: report.FromLatest, Priority: 1},
 		Namespace:          {ID: Namespace, Label: "Namespace", From: report.FromLatest, Priority: 2},
 		Created:            {ID: Created, Label: "Created", From: report.FromLatest, Priority: 3},
 		ObservedGeneration: {ID: ObservedGeneration, Label: "Observed Gen.", From: report.FromLatest, Priority: 4},
@@ -61,7 +58,6 @@ var (
 	DeploymentMetricTemplates = ReplicaSetMetricTemplates
 
 	ReplicaSetMetadataTemplates = report.MetadataTemplates{
-		ID:                 {ID: ID, Label: "ID", From: report.FromLatest, Priority: 1},
 		Namespace:          {ID: Namespace, Label: "Namespace", From: report.FromLatest, Priority: 2},
 		Created:            {ID: Created, Label: "Created", From: report.FromLatest, Priority: 3},
 		ObservedGeneration: {ID: ObservedGeneration, Label: "Observed Gen.", From: report.FromLatest, Priority: 4},

--- a/probe/kubernetes/reporter_test.go
+++ b/probe/kubernetes/reporter_test.go
@@ -193,13 +193,11 @@ func TestReporter(t *testing.T) {
 		latest        map[string]string
 	}{
 		{pod1ID, serviceID, map[string]string{
-			kubernetes.ID:        "ping/pong-a",
 			kubernetes.Name:      "pong-a",
 			kubernetes.Namespace: "ping",
 			kubernetes.Created:   pod1.Created(),
 		}},
 		{pod2ID, serviceID, map[string]string{
-			kubernetes.ID:        "ping/pong-b",
 			kubernetes.Name:      "pong-b",
 			kubernetes.Namespace: "ping",
 			kubernetes.Created:   pod1.Created(),
@@ -229,7 +227,6 @@ func TestReporter(t *testing.T) {
 		}
 
 		for k, want := range map[string]string{
-			kubernetes.ID:        "ping/pongservice",
 			kubernetes.Name:      "pongservice",
 			kubernetes.Namespace: "ping",
 			kubernetes.Created:   pod1.Created(),

--- a/render/detailed/node_test.go
+++ b/render/detailed/node_test.go
@@ -330,7 +330,6 @@ func TestMakeDetailedPodNode(t *testing.T) {
 			Linkable:   true,
 			Pseudo:     false,
 			Metadata: []report.MetadataRow{
-				{ID: "kubernetes_id", Label: "ID", Value: "ping/pong-b", Priority: 1},
 				{ID: "kubernetes_state", Label: "State", Value: "running", Priority: 2},
 				{ID: "container", Label: "# Containers", Value: "1", Priority: 4, Datatype: "number"},
 				{ID: "kubernetes_namespace", Label: "Namespace", Value: "ping", Priority: 5},

--- a/render/detailed/summary.go
+++ b/render/detailed/summary.go
@@ -241,10 +241,15 @@ func containerImageNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bo
 	return base, true
 }
 
-func podNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
+func addKubernetesLabelAndRank(base NodeSummary, n report.Node) NodeSummary {
 	base.Label, _ = n.Latest.Lookup(kubernetes.Name)
 	namespace, _ := n.Latest.Lookup(kubernetes.Namespace)
 	base.Rank = namespace + "/" + base.Label
+	return base
+}
+
+func podNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
+	base = addKubernetesLabelAndRank(base, n)
 	if c, ok := n.Counters.Lookup(report.Container); ok {
 		if c == 1 {
 			base.LabelMinor = fmt.Sprintf("%d container", c)
@@ -257,9 +262,7 @@ func podNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
 }
 
 func serviceNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
-	base.Label, _ = n.Latest.Lookup(kubernetes.Name)
-	namespace, _ := n.Latest.Lookup(kubernetes.Namespace)
-	base.Rank = namespace + "/" + base.Label
+	base = addKubernetesLabelAndRank(base, n)
 	base.Stack = true
 
 	// Services are always just a group of pods, so there's no counting multiple
@@ -276,9 +279,7 @@ func serviceNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
 }
 
 func deploymentNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
-	base.Label, _ = n.Latest.Lookup(kubernetes.Name)
-	namespace, _ := n.Latest.Lookup(kubernetes.Namespace)
-	base.Rank = namespace + "/" + base.Label
+	base = addKubernetesLabelAndRank(base, n)
 	base.Stack = true
 
 	if p, ok := n.Counters.Lookup(report.Pod); ok {
@@ -293,9 +294,7 @@ func deploymentNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) 
 }
 
 func replicaSetNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
-	base.Label, _ = n.Latest.Lookup(kubernetes.Name)
-	namespace, _ := n.Latest.Lookup(kubernetes.Namespace)
-	base.Rank = namespace + "/" + base.Label
+	base = addKubernetesLabelAndRank(base, n)
 	base.Stack = true
 
 	if p, ok := n.Counters.Lookup(report.Pod); ok {

--- a/render/detailed/summary.go
+++ b/render/detailed/summary.go
@@ -243,8 +243,8 @@ func containerImageNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bo
 
 func podNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
 	base.Label, _ = n.Latest.Lookup(kubernetes.Name)
-	base.Rank, _ = n.Latest.Lookup(kubernetes.ID)
-
+	namespace, _ := n.Latest.Lookup(kubernetes.Namespace)
+	base.Rank = namespace + "/" + base.Label
 	if c, ok := n.Counters.Lookup(report.Container); ok {
 		if c == 1 {
 			base.LabelMinor = fmt.Sprintf("%d container", c)
@@ -258,7 +258,8 @@ func podNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
 
 func serviceNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
 	base.Label, _ = n.Latest.Lookup(kubernetes.Name)
-	base.Rank, _ = n.Latest.Lookup(kubernetes.ID)
+	namespace, _ := n.Latest.Lookup(kubernetes.Namespace)
+	base.Rank = namespace + "/" + base.Label
 	base.Stack = true
 
 	// Services are always just a group of pods, so there's no counting multiple
@@ -276,7 +277,8 @@ func serviceNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
 
 func deploymentNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
 	base.Label, _ = n.Latest.Lookup(kubernetes.Name)
-	base.Rank, _ = n.Latest.Lookup(kubernetes.ID)
+	namespace, _ := n.Latest.Lookup(kubernetes.Namespace)
+	base.Rank = namespace + "/" + base.Label
 	base.Stack = true
 
 	if p, ok := n.Counters.Lookup(report.Pod); ok {
@@ -292,7 +294,8 @@ func deploymentNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) 
 
 func replicaSetNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
 	base.Label, _ = n.Latest.Lookup(kubernetes.Name)
-	base.Rank, _ = n.Latest.Lookup(kubernetes.ID)
+	namespace, _ := n.Latest.Lookup(kubernetes.Namespace)
+	base.Rank = namespace + "/" + base.Label
 	base.Stack = true
 
 	if p, ok := n.Counters.Lookup(report.Pod); ok {

--- a/test/fixture/report_fixture.go
+++ b/test/fixture/report_fixture.go
@@ -90,14 +90,11 @@ var (
 	ServerContainerImageName   = "image/server"
 
 	KubernetesNamespace = "ping"
-	ClientPodID         = "ping/pong-a"
-	ServerPodID         = "ping/pong-b"
 	ClientPodUID        = "5d4c3b2a1"
 	ServerPodUID        = "i9h8g7f6e"
 	ClientPodNodeID     = report.MakePodNodeID(ClientPodUID)
 	ServerPodNodeID     = report.MakePodNodeID(ServerPodUID)
 	ServiceName         = "pongservice"
-	ServiceID           = "ping/pongservice"
 	ServiceUID          = "service1234"
 	ServiceNodeID       = report.MakeServiceNodeID(ServiceUID)
 
@@ -366,7 +363,6 @@ var (
 			Nodes: report.Nodes{
 				ClientPodNodeID: report.MakeNodeWith(
 					ClientPodNodeID, map[string]string{
-						kubernetes.ID:        ClientPodID,
 						kubernetes.Name:      "pong-a",
 						kubernetes.Namespace: KubernetesNamespace,
 						report.HostNodeID:    ClientHostNodeID,
@@ -377,7 +373,6 @@ var (
 				),
 				ServerPodNodeID: report.MakeNodeWith(
 					ServerPodNodeID, map[string]string{
-						kubernetes.ID:        ServerPodID,
 						kubernetes.Name:      "pong-b",
 						kubernetes.Namespace: KubernetesNamespace,
 						kubernetes.State:     "running",
@@ -395,7 +390,6 @@ var (
 				ServiceNodeID: report.MakeNodeWith(
 
 					ServiceNodeID, map[string]string{
-						kubernetes.ID:        ServiceID,
 						kubernetes.Name:      "pongservice",
 						kubernetes.Namespace: "ping",
 					}).


### PR DESCRIPTION
Redundant info

Fixes #1759 