### PR TITLE
Handle loopback addresses correctly when tracking connections

### DIFF
--- a/probe/endpoint/nat.go
+++ b/probe/endpoint/nat.go
@@ -52,9 +52,9 @@ func (n natMapper) applyNAT(rpt report.Report, scope string) {
 	n.flowWalker.walkFlows(func(f flow) {
 		var (
 			mapping          = toMapping(f)
-			realEndpointID   = report.MakeEndpointNodeID(scope, mapping.originalIP, strconv.Itoa(mapping.originalPort))
+			realEndpointID   = report.MakeEndpointNodeID(scope, "", mapping.originalIP, strconv.Itoa(mapping.originalPort))
 			copyEndpointPort = strconv.Itoa(mapping.rewrittenPort)
-			copyEndpointID   = report.MakeEndpointNodeID(scope, mapping.rewrittenIP, copyEndpointPort)
+			copyEndpointID   = report.MakeEndpointNodeID(scope, "", mapping.rewrittenIP, copyEndpointPort)
 			node, ok         = rpt.Endpoint.Nodes[realEndpointID]
 		)
 		if !ok {

--- a/probe/endpoint/nat_internal_test.go
+++ b/probe/endpoint/nat_internal_test.go
@@ -43,7 +43,7 @@ func TestNat(t *testing.T) {
 		}
 
 		have := report.MakeReport()
-		originalID := report.MakeEndpointNodeID("host1", "10.0.47.1", "80")
+		originalID := report.MakeEndpointNodeID("host1", "", "10.0.47.1", "80")
 		have.Endpoint.AddNode(report.MakeNodeWith(originalID, map[string]string{
 			Addr:      "10.0.47.1",
 			Port:      "80",
@@ -52,7 +52,7 @@ func TestNat(t *testing.T) {
 		}))
 
 		want := have.Copy()
-		wantID := report.MakeEndpointNodeID("host1", "1.2.3.4", "80")
+		wantID := report.MakeEndpointNodeID("host1", "", "1.2.3.4", "80")
 		want.Endpoint.AddNode(report.MakeNodeWith(wantID, map[string]string{
 			Addr:      "1.2.3.4",
 			Port:      "80",
@@ -78,7 +78,7 @@ func TestNat(t *testing.T) {
 		}
 
 		have := report.MakeReport()
-		originalID := report.MakeEndpointNodeID("host2", "10.0.47.2", "22222")
+		originalID := report.MakeEndpointNodeID("host2", "", "10.0.47.2", "22222")
 		have.Endpoint.AddNode(report.MakeNodeWith(originalID, map[string]string{
 			Addr:      "10.0.47.2",
 			Port:      "22222",
@@ -87,7 +87,7 @@ func TestNat(t *testing.T) {
 		}))
 
 		want := have.Copy()
-		want.Endpoint.AddNode(report.MakeNodeWith(report.MakeEndpointNodeID("host2", "2.3.4.5", "22223"), map[string]string{
+		want.Endpoint.AddNode(report.MakeNodeWith(report.MakeEndpointNodeID("host2", "", "2.3.4.5", "22223"), map[string]string{
 			Addr:      "2.3.4.5",
 			Port:      "22223",
 			"copy_of": originalID,

--- a/probe/endpoint/procspy/spy.go
+++ b/probe/endpoint/procspy/spy.go
@@ -24,8 +24,9 @@ type Connection struct {
 
 // Proc is a single process with PID and process name.
 type Proc struct {
-	PID  uint
-	Name string
+	PID            uint
+	Name           string
+	NetNamespaceID uint64
 }
 
 // ConnIter is returned by Connections().

--- a/probe/endpoint/reporter_test.go
+++ b/probe/endpoint/reporter_test.go
@@ -91,8 +91,8 @@ func TestSpyWithProcesses(t *testing.T) {
 	// buf, _ := json.MarshalIndent(r, "", "    ") ; t.Logf("\n%s\n", buf)
 
 	var (
-		scopedLocal  = report.MakeEndpointNodeID(nodeID, fixLocalAddress.String(), strconv.Itoa(int(fixLocalPort)))
-		scopedRemote = report.MakeEndpointNodeID(nodeID, fixRemoteAddress.String(), strconv.Itoa(int(fixRemotePort)))
+		scopedLocal  = report.MakeEndpointNodeID(nodeID, "", fixLocalAddress.String(), strconv.Itoa(int(fixLocalPort)))
+		scopedRemote = report.MakeEndpointNodeID(nodeID, "", fixRemoteAddress.String(), strconv.Itoa(int(fixRemotePort)))
 	)
 
 	if want, have := 1, len(r.Endpoint.Nodes[scopedRemote].Adjacency); want != have {

--- a/probe/host/tagger_test.go
+++ b/probe/host/tagger_test.go
@@ -10,7 +10,7 @@ import (
 func TestTagger(t *testing.T) {
 	var (
 		hostID         = "foo"
-		endpointNodeID = report.MakeEndpointNodeID(hostID, "1.2.3.4", "56789") // hostID ignored
+		endpointNodeID = report.MakeEndpointNodeID(hostID, "", "1.2.3.4", "56789") // hostID ignored
 		node           = report.MakeNodeWith(endpointNodeID, map[string]string{"foo": "bar"})
 	)
 

--- a/render/container.go
+++ b/render/container.go
@@ -264,6 +264,11 @@ func MapContainer2IP(m report.Node) []string {
 			if !ok {
 				continue
 			}
+			// loopback addresses are shared among all namespaces
+			// so we can't use them to attribute connections to a container
+			if report.IsLoopback(addr) {
+				continue
+			}
 			id := report.MakeScopedEndpointNodeID(scope, addr, "")
 			result = append(result, id)
 		}

--- a/render/short_lived_connections_test.go
+++ b/render/short_lived_connections_test.go
@@ -19,11 +19,11 @@ var (
 
 	randomIP             = "3.4.5.6"
 	randomPort           = "56789"
-	randomEndpointNodeID = report.MakeEndpointNodeID(serverHostID, randomIP, randomPort)
+	randomEndpointNodeID = report.MakeEndpointNodeID(serverHostID, "", randomIP, randomPort)
 
 	serverIP             = "192.168.1.1"
 	serverPort           = "80"
-	serverEndpointNodeID = report.MakeEndpointNodeID(serverHostID, serverIP, serverPort)
+	serverEndpointNodeID = report.MakeEndpointNodeID(serverHostID, "", serverIP, serverPort)
 
 	container1ID     = "11b2c3d4e5"
 	container1IP     = "192.168.0.1"
@@ -31,11 +31,11 @@ var (
 	container1NodeID = report.MakeContainerNodeID(container1ID)
 
 	container1Port           = "16782"
-	container1EndpointNodeID = report.MakeEndpointNodeID(serverHostID, container1IP, container1Port)
+	container1EndpointNodeID = report.MakeEndpointNodeID(serverHostID, "", container1IP, container1Port)
 
 	duplicatedIP             = "192.168.0.2"
 	duplicatedPort           = "80"
-	duplicatedEndpointNodeID = report.MakeEndpointNodeID(serverHostID, duplicatedIP, duplicatedPort)
+	duplicatedEndpointNodeID = report.MakeEndpointNodeID(serverHostID, "", duplicatedIP, duplicatedPort)
 
 	container2ID     = "21b2c3d4e5"
 	container2IP     = duplicatedIP

--- a/report/id.go
+++ b/report/id.go
@@ -44,7 +44,7 @@ func makeAddressID(hostID, namespaceID, address string) string {
 	addressIP := net.ParseIP(address)
 	if addressIP != nil && LocalNetworks.Contains(addressIP) {
 		scope = hostID
-	} else if isLoopback(address) {
+	} else if IsLoopback(address) {
 		scope = hostID
 		if namespaceID != "" {
 			scope += "-" + namespaceID
@@ -176,7 +176,8 @@ func ExtractHostID(m Node) string {
 	return hostID
 }
 
-func isLoopback(address string) bool {
+// IsLoopback ascertains if an address comes from a loopback interface.
+func IsLoopback(address string) bool {
 	ip := net.ParseIP(address)
 	return ip != nil && ip.IsLoopback()
 }

--- a/report/id.go
+++ b/report/id.go
@@ -1,13 +1,8 @@
 package report
 
 import (
-	"hash"
-	"hash/fnv"
 	"net"
 	"strings"
-	"sync"
-
-	"github.com/bluele/gcache"
 )
 
 // TheInternet is used as a node ID to indicate a remote IP.
@@ -29,38 +24,9 @@ const (
 	DoesNotMakeConnections = "does_not_make_connections"
 )
 
-var (
-	idCache = gcache.New(1024).LRU().Build()
-	hashers = sync.Pool{
-		New: func() interface{} {
-			return fnv.New64a()
-		},
-	}
-)
-
-func lookupID(part1, part2, part3 string, f func() string) string {
-	h := hashers.Get().(hash.Hash64)
-	h.Write([]byte(part1))
-	h.Write([]byte(part2))
-	h.Write([]byte(part3))
-	sum := h.Sum64()
-	var result string
-	if id, err := idCache.Get(sum); id != nil && err != nil {
-		result = id.(string)
-	} else {
-		result = f()
-		idCache.Set(sum, result)
-	}
-	h.Reset()
-	hashers.Put(h)
-	return result
-}
-
 // MakeEndpointNodeID produces an endpoint node ID from its composite parts.
 func MakeEndpointNodeID(hostID, address, port string) string {
-	return lookupID(hostID, address, port, func() string {
-		return MakeAddressNodeID(hostID, address) + ScopeDelim + port
-	})
+	return MakeAddressNodeID(hostID, address) + ScopeDelim + port
 }
 
 // MakeAddressNodeID produces an address node ID from its composite parts.

--- a/report/id_test.go
+++ b/report/id_test.go
@@ -18,12 +18,12 @@ var (
 	unknownHostID    = ""              // by definition, we don't know it
 	unknownAddress   = "172.16.93.112" // will be a pseudonode, no corresponding host
 
-	client54001EndpointNodeID = report.MakeEndpointNodeID(clientHostID, clientAddress, "54001") // i.e. curl
-	client54002EndpointNodeID = report.MakeEndpointNodeID(clientHostID, clientAddress, "54002") // also curl
-	server80EndpointNodeID    = report.MakeEndpointNodeID(serverHostID, serverAddress, "80")    // i.e. apache
-	unknown1EndpointNodeID    = report.MakeEndpointNodeID(unknownHostID, unknownAddress, "10001")
-	unknown2EndpointNodeID    = report.MakeEndpointNodeID(unknownHostID, unknownAddress, "10002")
-	unknown3EndpointNodeID    = report.MakeEndpointNodeID(unknownHostID, unknownAddress, "10003")
+	client54001EndpointNodeID = report.MakeEndpointNodeID(clientHostID, "", clientAddress, "54001") // i.e. curl
+	client54002EndpointNodeID = report.MakeEndpointNodeID(clientHostID, "", clientAddress, "54002") // also curl
+	server80EndpointNodeID    = report.MakeEndpointNodeID(serverHostID, "", serverAddress, "80")    // i.e. apache
+	unknown1EndpointNodeID    = report.MakeEndpointNodeID(unknownHostID, "", unknownAddress, "10001")
+	unknown2EndpointNodeID    = report.MakeEndpointNodeID(unknownHostID, "", unknownAddress, "10002")
+	unknown3EndpointNodeID    = report.MakeEndpointNodeID(unknownHostID, "", unknownAddress, "10003")
 
 	clientAddressNodeID  = report.MakeAddressNodeID(clientHostID, clientAddress)
 	serverAddressNodeID  = report.MakeAddressNodeID(serverHostID, serverAddress)
@@ -50,7 +50,8 @@ func TestEndpointNodeID(t *testing.T) {
 	}
 
 	for input, want := range map[string]struct{ name, address, port string }{
-		report.MakeEndpointNodeID("host.com", "1.2.3.4", "c"): {"", "1.2.3.4", "c"},
+		report.MakeEndpointNodeID("host.com", "namespaceid", "127.0.0.1", "c"): {"host.com-namespaceid", "127.0.0.1", "c"},
+		report.MakeEndpointNodeID("host.com", "", "1.2.3.4", "c"):              {"", "1.2.3.4", "c"},
 		"a;b;c": {"a", "b", "c"},
 	} {
 		haveName, haveAddress, havePort, ok := report.ParseEndpointNodeID(input)

--- a/test/fixture/report_fixture.go
+++ b/test/fixture/report_fixture.go
@@ -57,15 +57,15 @@ var (
 	ClientHostNodeID = report.MakeHostNodeID(ClientHostID)
 	ServerHostNodeID = report.MakeHostNodeID(ServerHostID)
 
-	Client54001NodeID    = report.MakeEndpointNodeID(ClientHostID, ClientIP, ClientPort54001)            // curl (1)
-	Client54002NodeID    = report.MakeEndpointNodeID(ClientHostID, ClientIP, ClientPort54002)            // curl (2)
-	Server80NodeID       = report.MakeEndpointNodeID(ServerHostID, ServerIP, ServerPort)                 // apache
-	UnknownClient1NodeID = report.MakeEndpointNodeID(ServerHostID, UnknownClient1IP, UnknownClient1Port) // we want to ensure two unknown clients, connnected
-	UnknownClient2NodeID = report.MakeEndpointNodeID(ServerHostID, UnknownClient2IP, UnknownClient2Port) // to the same server, are deduped.
-	UnknownClient3NodeID = report.MakeEndpointNodeID(ServerHostID, UnknownClient3IP, UnknownClient3Port) // Check this one isn't deduped
-	RandomClientNodeID   = report.MakeEndpointNodeID(ServerHostID, RandomClientIP, RandomClientPort)     // this should become an internet node
-	NonContainerNodeID   = report.MakeEndpointNodeID(ServerHostID, ServerIP, NonContainerClientPort)
-	GoogleEndpointNodeID = report.MakeEndpointNodeID(ServerHostID, GoogleIP, GooglePort)
+	Client54001NodeID    = report.MakeEndpointNodeID(ClientHostID, "", ClientIP, ClientPort54001)            // curl (1)
+	Client54002NodeID    = report.MakeEndpointNodeID(ClientHostID, "", ClientIP, ClientPort54002)            // curl (2)
+	Server80NodeID       = report.MakeEndpointNodeID(ServerHostID, "", ServerIP, ServerPort)                 // apache
+	UnknownClient1NodeID = report.MakeEndpointNodeID(ServerHostID, "", UnknownClient1IP, UnknownClient1Port) // we want to ensure two unknown clients, connnected
+	UnknownClient2NodeID = report.MakeEndpointNodeID(ServerHostID, "", UnknownClient2IP, UnknownClient2Port) // to the same server, are deduped.
+	UnknownClient3NodeID = report.MakeEndpointNodeID(ServerHostID, "", UnknownClient3IP, UnknownClient3Port) // Check this one isn't deduped
+	RandomClientNodeID   = report.MakeEndpointNodeID(ServerHostID, "", RandomClientIP, RandomClientPort)     // this should become an internet node
+	NonContainerNodeID   = report.MakeEndpointNodeID(ServerHostID, "", ServerIP, NonContainerClientPort)
+	GoogleEndpointNodeID = report.MakeEndpointNodeID(ServerHostID, "", GoogleIP, GooglePort)
 
 	ClientProcess1NodeID      = report.MakeProcessNodeID(ClientHostID, Client1PID)
 	ClientProcess2NodeID      = report.MakeProcessNodeID(ClientHostID, Client2PID)


### PR DESCRIPTION
Fixes #1733 

Also: revert Endpoint node id cache, since it wasn't doing anything (the code was buggy and it was complicating things)