### PR TITLE
Elide service-token when logging commandline arguments

### DIFF
--- a/prog/app.go
+++ b/prog/app.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"net/url"
-	"os"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -213,7 +212,7 @@ func appMain(flags appFlags) {
 	app.UniqueID = strconv.FormatInt(rand.Int63(), 16)
 	app.Version = version
 	log.Infof("app starting, version %s, ID %s", app.Version, app.UniqueID)
-	log.Infof("command line: %v", os.Args)
+	logCensoredArgs()
 
 	userIDer := multitenant.NoopUserIDer
 	if flags.userIDHeader != "" {

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -74,7 +74,7 @@ func probeMain(flags probeFlags) {
 	sig := metrics.DefaultInmemSignal(inm)
 	defer sig.Stop()
 	metrics.NewGlobal(metrics.DefaultConfig("scope-probe"), inm)
-
+	logCensoredArgs()
 	defer log.Info("probe exiting")
 
 	if flags.spyProcs && os.Getegid() != 0 {


### PR DESCRIPTION
Fixes #1779 