### PR TITLE
fix MemcacheClient.FetchReports miss & leak on corrupt report

### DIFF
--- a/app/multitenant/memcache_client.go
+++ b/app/multitenant/memcache_client.go
@@ -186,7 +186,8 @@ func (c *MemcacheClient) FetchReports(keys []string) (map[string]report.Report, 
 	}
 
 	reports := map[string]report.Report{}
-	for i := 0; i < len(keys)-len(missing); i++ {
+	lenFound := len(keys) - len(missing)
+	for i := 0; i < lenFound; i++ {
 		r := <-ch
 		if r.report == nil {
 			missing = append(missing, r.key)


### PR DESCRIPTION
Problem: Decoding a corrupt report grows the 'missing' list. Since we are waiting for 'len(keys)-len(missing)' decoder go-routines, this results in waiting for fewer go-routines than we should. The surplus go-routines leak and we ignore their reports. And since the keys of the ignored reports are not included in 'missing', we won't attempt to fetch them from S3 either. Oops.

Fix: calculate the number of go-routines once, at the beginning.