### PR TITLE
allow more accurate reporting of memcache hit ratio

### DIFF
--- a/app/multitenant/memcache_client.go
+++ b/app/multitenant/memcache_client.go
@@ -150,7 +150,7 @@ func memcacheStatusCode(err error) string {
 
 // FetchReports gets reports from memcache.
 func (c *MemcacheClient) FetchReports(keys []string) (map[string]report.Report, []string, error) {
-	memcacheRequests.Add(float64(len(keys)))
+	defer memcacheRequests.Add(float64(len(keys)))
 	var found map[string]*memcache.Item
 	err := instrument.TimeRequestHistogramStatus("Get", memcacheRequestDuration, memcacheStatusCode, func() error {
 		var err error


### PR DESCRIPTION
A lot of time could pass between recording the request count and hit count pertaining to a particular report fetching batch, which skewed calculations cache hit ratios.

Fix that by defering the request count recording to the end, which is when we record the hit count.

Hopefully this will cure the >100% memcache hit ratios we sometimes see in our monitoring.