### PR TITLE
restore compatibility of old probes with new m/t app

### DIFF
--- a/app/multitenant/aws_collector.go
+++ b/app/multitenant/aws_collector.go
@@ -335,7 +335,7 @@ func (c *awsCollector) Report(ctx context.Context) (report.Report, error) {
 		return report.MakeReport(), err
 	}
 
-	return c.merger.Merge(reports), nil
+	return c.merger.Merge(reports).Upgrade(), nil
 }
 
 // calculateDynamoKeys generates the row & column keys for Dynamo.


### PR DESCRIPTION
This got broken in #1682.

Fixes #1806.