### PR TITLE
Fixes node label overlap

### DIFF
--- a/client/app/scripts/charts/node.js
+++ b/client/app/scripts/charts/node.js
@@ -93,7 +93,7 @@ class Node extends React.Component {
     const truncate = !focused && !hovered;
     const labelWidth = nodeScale(scaleFactor * 3);
     const labelOffsetX = -labelWidth / 2;
-    const labelDy = (showingNetworks && networks) ? 0.75 : 0.60;
+    const labelDy = (showingNetworks && networks) ? 0.70 : 0.55;
     const labelOffsetY = nodeScale(labelDy * scaleFactor);
     const networkOffset = nodeScale(scaleFactor * 0.67);
 

--- a/client/app/scripts/charts/nodes-chart.js
+++ b/client/app/scripts/charts/nodes-chart.js
@@ -8,7 +8,7 @@ import timely from 'timely';
 
 import { clickBackground } from '../actions/app-actions';
 import { EDGE_ID_SEPARATOR } from '../constants/naming';
-import { DETAILS_PANEL_WIDTH, MAX_NODE_SIZE } from '../constants/styles';
+import { MIN_NODE_SIZE, DETAILS_PANEL_WIDTH, MAX_NODE_SIZE } from '../constants/styles';
 import Logo from '../components/logo';
 import { doLayout } from './nodes-layout';
 import NodesChartElements from './nodes-chart-elements';
@@ -371,7 +371,8 @@ class NodesChart extends React.Component {
     const expanse = Math.min(height, width);
     const nodeSize = expanse / 3; // single node should fill a third of the screen
     const maxNodeSize = Math.min(MAX_NODE_SIZE, expanse / 10);
-    const normalizedNodeSize = Math.min(nodeSize / Math.sqrt(nodes.size), maxNodeSize);
+    const normalizedNodeSize = Math.max(MIN_NODE_SIZE,
+      Math.min(nodeSize / Math.sqrt(nodes.size), maxNodeSize));
     return this.state.nodeScale.copy().range([0, normalizedNodeSize]);
   }
 

--- a/client/app/scripts/constants/styles.js
+++ b/client/app/scripts/constants/styles.js
@@ -22,6 +22,7 @@ export const CANVAS_MARGINS = {
 // The base size the shapes were defined at matches nicely w/ a 14px font.
 //
 export const BASE_NODE_SIZE = 64;
+export const MIN_NODE_SIZE = 24;
 export const MAX_NODE_SIZE = 96;
 export const BASE_NODE_LABEL_SIZE = 14;
-export const MIN_NODE_LABEL_SIZE = BASE_NODE_LABEL_SIZE;
+export const MIN_NODE_LABEL_SIZE = 12;

--- a/client/app/styles/main.less
+++ b/client/app/styles/main.less
@@ -361,7 +361,6 @@ h2 {
       // stroke-width: 4px;
     }
 
-    .node-label,
     .node-sublabel {
       line-height: 125%;
     }
@@ -371,7 +370,6 @@ h2 {
     }
 
     .node-label-wrapper {
-
       //
       // Base line height doesn't hop across foreignObject =/
       //
@@ -400,10 +398,10 @@ h2 {
 
     .node-label, .node-sublabel {
       span {
-        padding: 0 0.25em;
         border-radius: 2px;
       }
       span:not(.match) {
+        padding: 0 0.25em;
         background-color: fade(@background-average-color, 70%);
       }
     }

--- a/client/app/styles/main.less
+++ b/client/app/styles/main.less
@@ -398,15 +398,17 @@ h2 {
       font-size: 0.85em;
     }
 
-    &.hovered {
-      .node-label, .node-sublabel {
-        span:not(.match) {
-          background-color: fade(@background-average-color, 70%);
-        }
+    .node-label, .node-sublabel {
+      span {
+        padding: 0 0.25em;
+        border-radius: 2px;
       }
-      .matched-results {
+      span:not(.match) {
         background-color: fade(@background-average-color, 70%);
       }
+    }
+    .matched-results {
+      background-color: fade(@background-average-color, 70%);
     }
 
     &.pseudo {


### PR DESCRIPTION
- Also permanently enables the label bg (previous was only on hover) to
  aid readibility w/ the (sometimes) smaller labels.

Fixes #1760 