### PR TITLE
use go-dockerclient's Client.Stats

### DIFF
--- a/probe/docker/registry.go
+++ b/probe/docker/registry.go
@@ -85,6 +85,7 @@ type Client interface {
 	AttachToContainerNonBlocking(docker_client.AttachToContainerOptions) (docker_client.CloseWaiter, error)
 	CreateExec(docker_client.CreateExecOptions) (*docker_client.Exec, error)
 	StartExecNonBlocking(string, docker_client.StartExecOptions) (docker_client.CloseWaiter, error)
+	Stats(docker_client.StatsOptions) error
 }
 
 func newDockerClient(endpoint string) (Client, error) {
@@ -361,7 +362,7 @@ func (r *registry) updateContainerState(containerID string, intendedState *strin
 	// And finally, ensure we gather stats for it
 	if r.collectStats {
 		if dockerContainer.State.Running {
-			if err := c.StartGatheringStats(); err != nil {
+			if err := c.StartGatheringStats(r.client); err != nil {
 				log.Errorf("Error gathering stats for container %s: %s", containerID, err)
 				return
 			}

--- a/probe/docker/registry_test.go
+++ b/probe/docker/registry_test.go
@@ -55,7 +55,7 @@ func (c *mockContainer) StateString() string {
 	return docker.StateRunning
 }
 
-func (c *mockContainer) StartGatheringStats() error {
+func (c *mockContainer) StartGatheringStats(docker.StatsGatherer) error {
 	return nil
 }
 
@@ -161,6 +161,10 @@ func (m *mockDockerClient) UnpauseContainer(_ string) error {
 
 func (m *mockDockerClient) RemoveContainer(_ client.RemoveContainerOptions) error {
 	return fmt.Errorf("remove")
+}
+
+func (m *mockDockerClient) Stats(_ client.StatsOptions) error {
+	return fmt.Errorf("stats")
 }
 
 type mockCloseWaiter struct{}


### PR DESCRIPTION
...instead of rolling our own.

This also fixes #1799 - a race condition that could result in multiple stats gatherers for a container.