### PR TITLE
Fixes plugin renderer in status line

### DIFF
--- a/client/app/scripts/components/plugins.js
+++ b/client/app/scripts/components/plugins.js
@@ -27,7 +27,7 @@ class Plugins extends React.Component {
           Plugins:
         </span>
         {hasPlugins && this.props.plugins.toIndexedSeq()
-          .map((plugin, index) => this.renderPlugin(plugin, index))}
+          .map(plugin => this.renderPlugin(plugin.toJS()))}
         {!hasPlugins && <span className="plugins-empty">n/a</span>}
       </div>
     );


### PR DESCRIPTION
The code assumed a plugin object was JS, but it's actually an immutable.
Calling `toJS` to fix.

Fixes #1825