### PR TITLE
Add localstorage support for saving view state

### DIFF
--- a/client/app/scripts/utils/storage-utils.js
+++ b/client/app/scripts/utils/storage-utils.js
@@ -1,0 +1,23 @@
+import debug from 'debug';
+
+const log = debug('scope:storage-utils');
+
+// localStorage detection
+const storage = typeof(Storage) !== 'undefined' ? window.localStorage : null;
+
+export function storageGet(key, defaultValue) {
+  if (storage && storage[key] !== undefined) {
+    return storage.getItem(key);
+  }
+  return defaultValue;
+}
+
+export function storageSet(key, value) {
+  if (storage) {
+    try {
+      storage.setItem(key, value);
+    } catch (e) {
+      log('Error storing value in storage. Maybe full? Could not store key.', key);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support to remember the view state even after the browser
tab has been closed. This helps someone who is always looking at the
table view of a certain topology to which currently they have to perform
a minimum of 2 clicks.

* app view state is backed up in localStorage
* when visiting Scope with no URL view state, the localStorage state is
 used (i.e. the URL state has priority)