### PR TITLE
circleci: push traffic control plugin image to docker hub

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -50,6 +50,8 @@ test:
     - test -z "$SECRET_PASSWORD" || (cd $SRCDIR/integration; eval $(./gce.sh hosts); ./run_all.sh):
         parallel: true
         timeout: 300
+    - cd $SRCDIR/examples/plugins/traffic-control && make .traffic-control.uptodate && docker tag weaveworks/scope-traffic-control-plugin weaveworks/scope-traffic-control-plugin:$(../../../tools/image-tag):
+        parallel: true
   post:
     - test -z "$SECRET_PASSWORD" || (cd $SRCDIR/integration; ./gce.sh destroy):
         parallel: true
@@ -69,10 +71,14 @@ deployment:
           docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS &&
           (test "${DOCKER_ORGANIZATION:-$DOCKER_USER}" == "weaveworks" || (
             docker tag weaveworks/scope:latest ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope:latest &&
-            docker tag weaveworks/scope:$(./tools/image-tag) ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope:$(./tools/image-tag)
+            docker tag weaveworks/scope:$(./tools/image-tag) ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope:$(./tools/image-tag) &&
+            docker tag weaveworks/scope-traffic-control-plugin:latest ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope-traffic-control-plugin:latest &&
+            docker tag weaveworks/scope-traffic-control-plugin:$(./tools/image-tag) ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope-traffic-control-plugin:$(./tools/image-tag)
           )) &&
           docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope &&
           docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope:$(./tools/image-tag) &&
+          docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope-traffic-control-plugin &&
+          docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope-traffic-control-plugin:$(./tools/image-tag) &&
           (test "${DOCKER_ORGANIZATION:-$DOCKER_USER}" != "weaveworks" || (
             wcloud deploy -u circle weaveworks/scope:$(./tools/image-tag)
           ))

--- a/examples/plugins/traffic-control/Makefile
+++ b/examples/plugins/traffic-control/Makefile
@@ -2,7 +2,8 @@
 
 SUDO=$(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 EXE=traffic-control
-IMAGE=weavescope-$(EXE)-plugin
+IMAGE=weaveworks/scope-$(EXE)-plugin
+NAME=weaveworks-scope-${EXE}-plugin
 UPTODATE=.$(EXE).uptodate
 
 run: $(UPTODATE)
@@ -13,7 +14,7 @@ run: $(UPTODATE)
 		--pid=host \
 		--privileged \
 		-v /var/run:/var/run \
-		--name $(IMAGE) $(IMAGE)
+		--name $(NAME) $(IMAGE)
 
 $(UPTODATE): $(EXE) Dockerfile
 	$(SUDO) docker build -t $(IMAGE) .


### PR DESCRIPTION
After this patch, circleci builds the traffic control plugin image and
pushes it on docker hub. Rename traffic control plugin docker image
to "weaveworks/scope-traffic-control-plugin".