### PR TITLE
Simplify k8s instructions

### DIFF
--- a/site/installing.md
+++ b/site/installing.md
@@ -179,7 +179,7 @@ After Scope has been launched, open your web browser to [https://cloud.weave.wor
 
 ### With Weave Cloud (recommended)
 
-Weave Cloud runs the Scope UI for you, so you don't have to configure exposing and securing it for your team.
+Weave Cloud runs the Scope UI for you, and provides secure access control for your team.
 
 Register for a [Weave Cloud account](https://cloud.weave.works/) to get a service token and then replace `<token>` with your token below, running this either on the master or on a machine where `kubectl` is configured to authenticate to your Kubernetes cluster:
 

--- a/site/installing.md
+++ b/site/installing.md
@@ -177,27 +177,21 @@ After Scope has been launched, open your web browser to [https://cloud.weave.wor
 
 ##<a name="k8s"></a>Installing Scope on Kubernetes
 
-To install Scope onto a Kubernetes cluster in Standalone Mode, follow these instructions.
+### With Weave Cloud (recommended)
 
-**Before You Begin**
+Weave Cloud runs the Scope UI for you, so you don't have to configure exposing and securing it for your team.
 
-* Ensure that the cluster allows privileged pods - this is required by the Scope probes. By default, privileged pods are allowed from Kubernetes 1.1 and up. If you are running an earlier version or a non-default configuration, ensure that your API Server and all of your Kubelets are launched with the flag `--allow_privileged`.
+* Register for a [Weave Cloud account](https://cloud.weave.works/) to get a service token and then replace `<token>` with your token below, running this either on the master or on a machine where `kubectl` is configured to authenticate to your Kubernetes cluster:
 
-* The version of [kubectl](http://kubernetes.io/docs/user-guide/kubectl-overview/) must match the cluster version that you are using.
+      $ kubectl apply -f 'https://cloud.weave.works/launch/k8s/weavescope.yaml?service-token=<token>'
 
-* The cluster must support [DaemonSets](https://github.com/kubernetes/kubernetes/blob/master/docs/design/daemon.md).  DaemonSets are necessary to ensure that each Kubernetes node can run a Scope Probe.
+  **SECURITY NOTE: This allows control of your Kubernetes cluster from Weave Cloud, which is a hosted service.**
 
-To enable DaemonSets in an existing cluster, add the `--runtime-config=extensions/v1beta1/daemonsets=true` argument to the [apiserver](https://github.com/kubernetes/kubernetes/blob/master/docs/admin/kube-apiserver.md)'s configuration. This is normally found in the `/etc/kubernetes/manifest/kube-apiserver.manifest`file after a restart of [the apiserver and controller manager](https://github.com/kubernetes/kubernetes/issues/18656) has occurred.  If you are creating a new cluster, set `KUBE_ENABLE_DAEMONSETS=true` in your cluster configuration.
-
-> **Note:** Prior to Kubernetes version 1.2 DaemonSets would fail to schedule pods on unschedulable nodes (typically the master).  This will result in the probe not running on that node.  See [#1030](https://github.com/weaveworks/scope/issues/1030) for more information.  It is advised that you use Kubernetes version 1.2 or higher.
-
-**Install Scope on Your Cluster**
-
-You can run Scope natively in your Kubernetes cluster using `kubectl` with a launch URL as show below.
+### Without Weave Cloud (run the Scope UI yourself)
 
 The simplest way to get the latest release of Scope deployed onto a Kubernetes cluster is by running the following:
 
-    kubectl create -f 'https://cloud.weave.works/launch/k8s/weavescope.yaml' --validate=false
+    $ kubectl apply -f 'https://cloud.weave.works/launch/k8s/weavescope.yaml'
 
 This runs a recent Scope image from the Docker Hub and launches a probe onto every node as well as a single app. Once launched, Scope doesn’t require any other configuration and it also doesn’t depend on Weave Net.
 
@@ -207,7 +201,7 @@ Allowable parameters for the launcher URL:
 - `k8s-service-type` - Kubernetes service type (for running Scope in Standalone mode), can be either
 `LoadBalancer` or `NodePort`, by default this is unspecified (only internal access)
 
-> **Note:**The `--validate=false` flag is currently required due to a bug in Kubernetes (see
+> **Note:** The `--validate=false` flag is currently required due to a bug in Kubernetes (see
 [kubernetes/kubernetes#24089](https://github.com/kubernetes/kubernetes/issues/24089) for more details
 
 To download and read the Scope manifest run:
@@ -219,33 +213,6 @@ To download and read the Scope manifest run:
     kubectl port-forward $(kubectl get pod --selector=weavescope-component=weavescope-app -o jsonpath='{.items..metadata.name}') 4040
 
 Open http://localhost:4040 in your browser. This allows you to access the Scope UI securely, without opening it to the Internet.
-
-###<a name="k8s-weave-cloud"></a>Using Weave Cloud
-
-**Before You Begin**
-
-* All the prerequisites from above apply.
-
-* Obtain a service-token from Weave Cloud by signing up at [https://cloud.weave.works](https://cloud.weave.works/).
-
-**Install Scope on Your Cluster**
-
-To get the latest release of Scope deployed onto a Kubernetes cluster, run the following:
-
-    kubectl create -f 'https://cloud.weave.works/launch/k8s/weavescope.yaml?servie-token=<token>' --validate=false
-
-Where,
-
-* `service-token=<token>` is the token you obtained after you signed up for Weave Cloud.
-
-> **Note:**The `--validate=false` flag is currently required due to a bug in Kubernetes (see
-[kubernetes/kubernetes#24089](https://github.com/kubernetes/kubernetes/issues/24089) for details.
-
-This runs a recent Scope image from the Docker Hub and launches a probe onto every node, pointing them at Weave Cloud. Once launched, Scope doesn’t require any other configuration and it also doesn’t depend on Weave Net.
-
-**Open Scope in Your Browser**
-
-After Scope has been launched, open your web browser to [https://cloud.weave.works](https://cloud.weave.works) and login.  Click 'View Instance' in the top right-hand corner to see the Scope user interface.
 
 ##<a name="ecs"></a>Installing Scope on Amazon ECS
 

--- a/site/installing.md
+++ b/site/installing.md
@@ -201,9 +201,6 @@ Allowable parameters for the launcher URL:
 - `k8s-service-type` - Kubernetes service type (for running Scope in Standalone mode), can be either
 `LoadBalancer` or `NodePort`, by default this is unspecified (only internal access)
 
-> **Note:** The `--validate=false` flag is currently required due to a bug in Kubernetes (see
-[kubernetes/kubernetes#24089](https://github.com/kubernetes/kubernetes/issues/24089) for more details
-
 To download and read the Scope manifest run:
 
     curl --silent --remote-name https://cloud.weave.works/launch/k8s/weavescope.yaml

--- a/site/installing.md
+++ b/site/installing.md
@@ -181,11 +181,11 @@ After Scope has been launched, open your web browser to [https://cloud.weave.wor
 
 Weave Cloud runs the Scope UI for you, so you don't have to configure exposing and securing it for your team.
 
-* Register for a [Weave Cloud account](https://cloud.weave.works/) to get a service token and then replace `<token>` with your token below, running this either on the master or on a machine where `kubectl` is configured to authenticate to your Kubernetes cluster:
+Register for a [Weave Cloud account](https://cloud.weave.works/) to get a service token and then replace `<token>` with your token below, running this either on the master or on a machine where `kubectl` is configured to authenticate to your Kubernetes cluster:
 
     $ kubectl apply -f 'https://cloud.weave.works/launch/k8s/weavescope.yaml?service-token=<token>'
 
-  **SECURITY NOTE: This allows control of your Kubernetes cluster from Weave Cloud, which is a hosted service.**
+**SECURITY NOTE: This allows control of your Kubernetes cluster from Weave Cloud, which is a hosted service.**
 
 ### Without Weave Cloud (run the Scope UI yourself)
 

--- a/site/installing.md
+++ b/site/installing.md
@@ -183,7 +183,7 @@ Weave Cloud runs the Scope UI for you, so you don't have to configure exposing a
 
 * Register for a [Weave Cloud account](https://cloud.weave.works/) to get a service token and then replace `<token>` with your token below, running this either on the master or on a machine where `kubectl` is configured to authenticate to your Kubernetes cluster:
 
-      $ kubectl apply -f 'https://cloud.weave.works/launch/k8s/weavescope.yaml?service-token=<token>'
+    $ kubectl apply -f 'https://cloud.weave.works/launch/k8s/weavescope.yaml?service-token=<token>'
 
   **SECURITY NOTE: This allows control of your Kubernetes cluster from Weave Cloud, which is a hosted service.**
 


### PR DESCRIPTION
Removing workarounds no longer needed in modern clusters, streamline/simplify the instructions, and recommend Weave Cloud usage.

PTAL @paulbellamy. Thanks!