### PR TITLE
Fixes UI hanging if currentTopology no longer exists for some reason

### DIFF
--- a/client/app/scripts/reducers/root.js
+++ b/client/app/scripts/reducers/root.js
@@ -606,7 +606,8 @@ export function rootReducer(state = initialState, action) {
       state = state.set('errorUrl', null);
       state = state.update('topologyUrlsById', topologyUrlsById => topologyUrlsById.clear());
       state = processTopologies(state, action.topologies);
-      if (!state.get('currentTopologyId')) {
+      const currentTopologyId = state.get('currentTopologyId');
+      if (!currentTopologyId || !findTopologyById(state.get('topologies'), currentTopologyId)) {
         state = state.set('currentTopologyId', getDefaultTopology(state.get('topologies')));
         log(`Set currentTopologyId to ${state.get('currentTopologyId')}`);
       }


### PR DESCRIPTION
- Reasons: k8s was currentTopology but was then disabled while the UI
  was looking at that view.

Fallback to our default-topo-selection logic.

Fixes #1880 