### PR TITLE
Add custom label-based filters in container view

### DIFF
--- a/app/api_topologies_test.go
+++ b/app/api_topologies_test.go
@@ -3,6 +3,7 @@ package app_test
 import (
 	"bytes"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -12,8 +13,15 @@ import (
 
 	"github.com/weaveworks/scope/app"
 	"github.com/weaveworks/scope/probe/kubernetes"
+	"github.com/weaveworks/scope/render"
+	"github.com/weaveworks/scope/render/detailed"
 	"github.com/weaveworks/scope/report"
 	"github.com/weaveworks/scope/test/fixture"
+)
+
+const (
+	containerLabelFiltersGroupID    = "container_label_filters_group"
+	customAPITopologyOptionFilterID = "containerLabelFilter0"
 )
 
 func TestAPITopology(t *testing.T) {
@@ -48,6 +56,56 @@ func TestAPITopology(t *testing.T) {
 			t.Errorf("NonpseudoNodeCount isn't positive for %s: %d", topology.Name, have)
 		}
 	}
+}
+
+func TestContainerLabelFilter(t *testing.T) {
+	topologySummaries, err := getTestContainerLabelFilterTopologySummary(t, false)
+	if err != nil {
+		t.Fatalf("Topology Registry Report error: %s", err)
+	}
+
+	// only the filtered container with fixture.TestLabelKey1 should be present
+	equals(t, 1, len(topologySummaries))
+	for key := range topologySummaries {
+		equals(t, fixture.ClientContainerID+";<container>", key)
+	}
+}
+
+func TestContainerLabelFilterExclude(t *testing.T) {
+	topologySummaries, err := getTestContainerLabelFilterTopologySummary(t, true)
+	if err != nil {
+		t.Fatalf("Topology Registry Report error: %s", err)
+	}
+
+	// all containers but the excluded container should be present
+	for key := range topologySummaries {
+		if fixture.ServerContainerNodeID+";<container>" == key {
+			t.Errorf("TestAPITopologyNegativeContainerLabelFilter Failed. Expected to not find " + fixture.ServerContainerNodeID + ";<container> in report")
+		}
+	}
+}
+
+func getTestContainerLabelFilterTopologySummary(t *testing.T, exclude bool) (detailed.NodeSummaries, error) {
+	ts := topologyServer()
+	defer ts.Close()
+
+	topologyRegistry := app.MakeRegistry()
+	app.AddInitialTopologiesToRegistry(topologyRegistry)
+
+	if exclude == true {
+		topologyRegistry.AddContainerFilters(app.MakeAPITopologyOption(customAPITopologyOptionFilterID, "title", render.DoesNotHaveLabel(fixture.TestLabelKey2, fixture.ApplicationLabelValue2), false))
+	} else {
+		topologyRegistry.AddContainerFilters(app.MakeAPITopologyOption(customAPITopologyOptionFilterID, "title", render.HasLabel(fixture.TestLabelKey1, fixture.ApplicationLabelValue1), false))
+	}
+
+	urlvalues := url.Values{}
+	urlvalues.Set(containerLabelFiltersGroupID, customAPITopologyOptionFilterID)
+	renderer, decorator, err := topologyRegistry.RendererForTopology("containers", urlvalues, fixture.Report)
+	if err != nil {
+		return nil, err
+	}
+
+	return detailed.Summaries(fixture.Report, renderer.Render(fixture.Report, decorator)), nil
 }
 
 func TestAPITopologyAddsKubernetes(t *testing.T) {

--- a/app/api_topologies_test.go
+++ b/app/api_topologies_test.go
@@ -67,7 +67,7 @@ func TestContainerLabelFilter(t *testing.T) {
 	// only the filtered container with fixture.TestLabelKey1 should be present
 	equals(t, 1, len(topologySummaries))
 	for key := range topologySummaries {
-		equals(t, fixture.ClientContainerID+";<container>", key)
+		equals(t, report.MakeContainerNodeID(fixture.ClientContainerID), key)
 	}
 }
 
@@ -79,8 +79,8 @@ func TestContainerLabelFilterExclude(t *testing.T) {
 
 	// all containers but the excluded container should be present
 	for key := range topologySummaries {
-		if fixture.ServerContainerNodeID+";<container>" == key {
-			t.Errorf("TestAPITopologyNegativeContainerLabelFilter Failed. Expected to not find " + fixture.ServerContainerNodeID + ";<container> in report")
+		if report.MakeContainerNodeID(fixture.ServerContainerNodeID) == key {
+			t.Errorf("TestAPITopologyNegativeContainerLabelFilter Failed. Expected to not find " + report.MakeContainerNodeID(fixture.ServerContainerNodeID) + " in report")
 		}
 	}
 }

--- a/app/api_topology.go
+++ b/app/api_topology.go
@@ -107,7 +107,7 @@ func handleWebsocket(
 			log.Errorf("Error generating report: %v", err)
 			return
 		}
-		renderer, decorator, err := topologyRegistry.rendererForTopology(topologyID, r.Form, report)
+		renderer, decorator, err := topologyRegistry.RendererForTopology(topologyID, r.Form, report)
 		if err != nil {
 			log.Errorf("Error generating report: %v", err)
 			return

--- a/prog/main.go
+++ b/prog/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/weaveworks/scope/common/xfer"
 	"github.com/weaveworks/scope/probe/appclient"
 	"github.com/weaveworks/scope/probe/kubernetes"
+	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/weave/common"
 )
 
@@ -33,6 +35,8 @@ var (
 		kubernetesPasswordFlag,
 		kubernetesTokenFlag,
 	}
+	colonFinder         = regexp.MustCompile(`[^\\](:)`)
+	unescapeBackslashes = regexp.MustCompile(`\\(.)`)
 )
 
 type prefixFormatter struct {
@@ -138,6 +142,54 @@ type appFlags struct {
 	consulInf       string
 }
 
+type containerLabelFiltersFlag struct {
+	apiTopologyOptions []app.APITopologyOption
+	filterNumber       int
+	filterIDPrefix     string
+	exclude            bool
+}
+
+func (c *containerLabelFiltersFlag) String() string {
+	return fmt.Sprint(c.apiTopologyOptions)
+}
+
+func (c *containerLabelFiltersFlag) Set(flagValue string) error {
+	filterID := fmt.Sprintf(c.filterIDPrefix+"%d", c.filterNumber)
+	newAPITopologyOption, err := c.toAPITopologyOption(flagValue, filterID)
+	if err != nil {
+		return err
+	}
+	c.filterNumber++
+
+	c.apiTopologyOptions = append(c.apiTopologyOptions, newAPITopologyOption)
+	return nil
+}
+
+func (c *containerLabelFiltersFlag) toAPITopologyOption(flagValue string, filterID string) (app.APITopologyOption, error) {
+	indexRanges := colonFinder.FindAllStringIndex(flagValue, -1)
+	if len(indexRanges) != 1 {
+		if len(indexRanges) == 0 {
+			return app.APITopologyOption{}, fmt.Errorf("No unescaped colon found. This is needed to separate the title from the label")
+		}
+		return app.APITopologyOption{}, fmt.Errorf("Multiple unescaped colons. Escape colons that are part of the title and label")
+	}
+	splitIndices := indexRanges[0]
+	titleStringEscaped := flagValue[:splitIndices[0]+1]
+	labelStringEscaped := flagValue[splitIndices[1]:]
+	containerFilterTitle := unescapeBackslashes.ReplaceAllString(titleStringEscaped, `$1`)
+	containerFilterLabel := unescapeBackslashes.ReplaceAllString(labelStringEscaped, `$1`)
+	labelKeyValuePair := strings.Split(containerFilterLabel, "=")
+	if len(labelKeyValuePair) != 2 {
+		return app.APITopologyOption{}, fmt.Errorf("Docker label in the app.container-label-filter(-exclude) flag isn't in the correct key=value format")
+	}
+
+	filterFunction := render.HasLabel
+	if c.exclude {
+		filterFunction = render.DoesNotHaveLabel
+	}
+	return app.MakeAPITopologyOption(filterID, containerFilterTitle, filterFunction(labelKeyValuePair[0], labelKeyValuePair[1]), false), nil
+}
+
 func logCensoredArgs() {
 	var prettyPrintedArgs string
 	// We show the flags followed by the args. This may change the original
@@ -162,12 +214,14 @@ func logCensoredArgs() {
 
 func main() {
 	var (
-		flags         = flags{}
-		mode          string
-		debug         bool
-		weaveEnabled  bool
-		weaveHostname string
-		dryRun        bool
+		flags                            = flags{}
+		mode                             string
+		debug                            bool
+		weaveEnabled                     bool
+		weaveHostname                    string
+		dryRun                           bool
+		containerLabelFilterFlags        = containerLabelFiltersFlag{exclude: false, filterIDPrefix: "containerLabelFilterExclude"}
+		containerLabelFilterFlagsExclude = containerLabelFiltersFlag{exclude: true, filterIDPrefix: "containerLabelFilter"}
 	)
 
 	// Flags that apply to both probe and app
@@ -244,6 +298,8 @@ func main() {
 	flag.StringVar(&flags.app.weaveHostname, "app.weave.hostname", app.DefaultHostname, "Hostname to advertise in WeaveDNS")
 	flag.StringVar(&flags.app.containerName, "app.container.name", app.DefaultContainerName, "Name of this container (to lookup container ID)")
 	flag.StringVar(&flags.app.dockerEndpoint, "app.docker", app.DefaultDockerEndpoint, "Location of docker endpoint (to lookup container ID)")
+	flag.Var(&containerLabelFilterFlags, "app.container-label-filter", "Add container label-based view filter, specified as title:label. Multiple flags are accepted. Example: --app.container-label-filter='Database Containers:role=db'")
+	flag.Var(&containerLabelFilterFlagsExclude, "app.container-label-filter-exclude", "Add container label-based view filter that excludes containers with the given label, specified as title:label. Multiple flags are accepted. Example: --app.container-label-filter-exclude='Database Containers:role=db'")
 
 	flag.StringVar(&flags.app.collectorURL, "app.collector", "local", "Collector to use (local, dynamodb, or file)")
 	flag.StringVar(&flags.app.s3URL, "app.collector.s3", "local", "S3 URL to use (when collector is dynamodb)")
@@ -264,6 +320,8 @@ func main() {
 	flag.StringVar(&flags.app.consulInf, "app.consul.inf", "", "The interface who's address I should advertise myself under in consul")
 
 	flag.Parse()
+
+	app.AddContainerFilters(append(containerLabelFilterFlags.apiTopologyOptions, containerLabelFilterFlagsExclude.apiTopologyOptions...)...)
 
 	// Deal with common args
 	if debug {

--- a/prog/main.go
+++ b/prog/main.go
@@ -180,7 +180,7 @@ func (c *containerLabelFiltersFlag) toAPITopologyOption(flagValue string, filter
 	containerFilterLabel := unescapeBackslashes.ReplaceAllString(labelStringEscaped, `$1`)
 	labelKeyValuePair := strings.Split(containerFilterLabel, "=")
 	if len(labelKeyValuePair) != 2 {
-		return app.APITopologyOption{}, fmt.Errorf("Docker label in the app.container-label-filter(-exclude) flag isn't in the correct key=value format")
+		return app.APITopologyOption{}, fmt.Errorf("Docker label isn't in the correct key=value format")
 	}
 
 	filterFunction := render.HasLabel

--- a/prog/main_test.go
+++ b/prog/main_test.go
@@ -1,0 +1,26 @@
+package main_test
+
+import (
+	"fmt"
+	"github.com/weaveworks/scope/app"
+	"testing"
+)
+
+func TestMakeContainerFiltersFromFlags(t *testing.T) {
+	containerLabelFlags := containerLabelFiltersFlag{exclude: false}
+	containerLabelFlags.Set(`title1:label=1`)
+	containerLabelFlags.Set(`ti\:tle2:lab\:el=2`)
+	containerLabelFlags.Set(`ti tile3:label=3`)
+	err := containerLabelFlags.Set(`just a string`)
+	if err == nil {
+		t.Fatalf("Invalid container label flag not detected")
+	}
+	apiTopologyOptions := containerLabelFlags.apiTopologyOptions
+	equals(t, 3, len(apiTopologyOptions))
+	equals(t, `title1`, apiTopologyOptions[0].Value)
+	equals(t, `label=1`, apiTopologyOptions[0].Label)
+	equals(t, `ti:tle2`, apiTopologyOptions[1].Value)
+	equals(t, `lab:el=2`, apiTopologyOptions[1].Label)
+	equals(t, `ti tle3`, apiTopologyOptions[2].Value)
+	equals(t, `label=3`, apiTopologyOptions[2].Label)
+}

--- a/render/filters.go
+++ b/render/filters.go
@@ -268,6 +268,22 @@ func IsApplication(n report.Node) bool {
 // IsSystem checks if the node is a "system" node
 var IsSystem = Complement(IsApplication)
 
+// HasLabel checks if the node has the desired docker label
+func HasLabel(labelKey string, labelValue string) FilterFunc {
+	return func(n report.Node) bool {
+		value, _ := n.Latest.Lookup(docker.LabelPrefix + labelKey)
+		if value == labelValue {
+			return true
+		}
+		return false
+	}
+}
+
+// DoesNotHaveLabel checks if the node does NOT have the specified docker label
+func DoesNotHaveLabel(labelKey string, labelValue string) FilterFunc {
+	return Complement(HasLabel(labelKey, labelValue))
+}
+
 // IsNotPseudo returns true if the node is not a pseudo node
 // or internet/service nodes.
 func IsNotPseudo(n report.Node) bool {

--- a/test/fixture/report_fixture.go
+++ b/test/fixture/report_fixture.go
@@ -79,6 +79,11 @@ var (
 	ClientContainerNodeID = report.MakeContainerNodeID(ClientContainerID)
 	ServerContainerNodeID = report.MakeContainerNodeID(ServerContainerID)
 
+	TestLabelKey1          = "myrole"
+	ApplicationLabelValue1 = "customapplication1"
+	TestLabelKey2          = "myrole2"
+	ApplicationLabelValue2 = "customapplication2"
+
 	ClientContainerHostname = ClientContainerName + ".hostname.com"
 	ServerContainerHostname = ServerContainerName + ".hostname.com"
 
@@ -262,6 +267,7 @@ var (
 						docker.ImageID:                               ClientContainerImageID,
 						report.HostNodeID:                            ClientHostNodeID,
 						docker.LabelPrefix + "io.kubernetes.pod.uid": ClientPodUID,
+						docker.LabelPrefix + TestLabelKey1:           ApplicationLabelValue1,
 						kubernetes.Namespace:                         KubernetesNamespace,
 						docker.ContainerState:                        docker.StateRunning,
 						docker.ContainerStateHuman:                   docker.StateRunning,
@@ -288,6 +294,7 @@ var (
 						docker.LabelPrefix + "foo1":                               "bar1",
 						docker.LabelPrefix + "foo2":                               "bar2",
 						docker.LabelPrefix + "io.kubernetes.pod.uid":              ServerPodUID,
+						docker.LabelPrefix + TestLabelKey2:                        ApplicationLabelValue2,
 						kubernetes.Namespace:                                      KubernetesNamespace,
 					}).
 					WithTopology(report.Container).WithParents(report.EmptySets.


### PR DESCRIPTION
Added the ability to add container filters by editing an environment variable, and kept the ability to filter out weavescope system containers
