### PR TITLE
Remove ContainerImage.imageID in the details panel

### DIFF
--- a/probe/docker/reporter.go
+++ b/probe/docker/reporter.go
@@ -41,7 +41,6 @@ var (
 	}
 
 	ContainerImageMetadataTemplates = report.MetadataTemplates{
-		ImageID:          {ID: ImageID, Label: "Image ID", From: report.FromSets, Truncate: 12, Priority: 1},
 		report.Container: {ID: report.Container, Label: "# Containers", From: report.FromCounters, Datatype: "number", Priority: 2},
 	}
 


### PR DESCRIPTION
It will be re-introduced later as imageIDs

Fixes #1835 