### PR TITLE
Add option to scope to have static content served from S3 instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ extras/fixprobe/*.json
 *sublime-workspace
 *npm-debug.log
 app/static.go
-prog/static.go
 vendor/github.com/ugorji/go/codec/codecgen/bin/*
 *.codecgen.go
+client/build-external/*
+prog/staticui/*
+prog/externalui/*

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ prog/staticui/staticui.go: $(SCOPE_BACKEND_BUILD_UPTODATE)
 
 prog/externalui/externalui.go: $(SCOPE_BACKEND_BUILD_UPTODATE)
 	mkdir -p prog/externalui
-	esc -o $@ -pkg externalui -prefix client/build-external -include '.*\.htm' client/build-external
+	esc -o $@ -pkg externalui -prefix client/build-external -include '\.html$$' client/build-external
 
 endif
 

--- a/circle.yml
+++ b/circle.yml
@@ -30,6 +30,7 @@ dependencies:
     - "cd $SRCDIR/backend; ../tools/rebuild-image weaveworks/scope-backend-build . Dockerfile build.sh && touch $SRCDIR/.scope_backend_build.uptodate"
     - test -z "$SECRET_PASSWORD" || (cd $SRCDIR/integration; ./gce.sh make_template):
         parallel: false
+   - sudo apt-get update && sudo apt-get install python-pip && sudo pip install awscli:
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ dependencies:
     - "cd $SRCDIR/backend; ../tools/rebuild-image weaveworks/scope-backend-build . Dockerfile build.sh && touch $SRCDIR/.scope_backend_build.uptodate"
     - test -z "$SECRET_PASSWORD" || (cd $SRCDIR/integration; ./gce.sh make_template):
         parallel: false
-   - sudo apt-get update && sudo apt-get install python-pip && sudo pip install awscli:
+    - sudo apt-get update && sudo apt-get install python-pip && sudo pip install awscli
 
 test:
   override:
@@ -80,6 +80,9 @@ deployment:
           docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope:$(./tools/image-tag) &&
           docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope-traffic-control-plugin &&
           docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope-traffic-control-plugin:$(./tools/image-tag) &&
+          (test -n "${UI_BUCKET_KEY_ID}" || (
+            make ui-upload
+          )) &&
           (test "${DOCKER_ORGANIZATION:-$DOCKER_USER}" != "weaveworks" || (
             wcloud deploy -u circle weaveworks/scope:$(./tools/image-tag)
           ))

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /home/weave
 COPY package.json /home/weave/
 ENV NPM_CONFIG_LOGLEVEL=warn NPM_CONFIG_PROGRESS=false
 RUN npm install
-COPY webpack.local.config.js webpack.production.config.js server.js .babelrc .eslintrc .eslintignore /home/weave/
+COPY webpack.local.config.js webpack.production.config.js webpack.external.config.js server.js .babelrc .eslintrc .eslintignore /home/weave/

--- a/client/package.json
+++ b/client/package.json
@@ -77,6 +77,7 @@
   },
   "scripts": {
     "build": "webpack --config webpack.production.config.js",
+    "build-external": "webpack --config webpack.external.config.js",
     "start": "node server.js",
     "start-production": "NODE_ENV=production node server.js",
     "test": "jest",

--- a/client/webpack.external.config.js
+++ b/client/webpack.external.config.js
@@ -36,7 +36,7 @@ module.exports = {
     path: path.join(__dirname, 'build-external/'),
     filename: '[name]-[chunkhash].js',
 	// Change this line to point to resources on an external host.
-	publicPath: 'https://s3.amazonaws.com/static.weave.works/service-ui/'
+	publicPath: 'https://s3.amazonaws.com/static.weave.works/scope-ui/'
   },
 
   module: {

--- a/client/webpack.external.config.js
+++ b/client/webpack.external.config.js
@@ -11,7 +11,9 @@ var GLOBALS = {
 };
 
 /**
- * This is the Webpack configuration file for production.
+ * This is the Webpack configuration file for hosting most of the static content
+ * (all but index.htm) on an external host (eg. a CDN).
+ * You should change output.publicPath to point to your external host.
  */
 module.exports = {
 
@@ -31,8 +33,10 @@ module.exports = {
   },
 
   output: {
-    path: path.join(__dirname, 'build/'),
+    path: path.join(__dirname, 'build-external/'),
     filename: '[name]-[chunkhash].js',
+	// Change this line to point to resources on an external host.
+	publicPath: 'https://s3.amazonaws.com/static.weave.works/service-ui/'
   },
 
   module: {

--- a/prog/app.go
+++ b/prog/app.go
@@ -59,7 +59,7 @@ func router(collector app.Collector, controlRouter app.ControlRouter, pipeRouter
 	app.RegisterPipeRoutes(router, pipeRouter)
 	app.RegisterTopologyRoutes(router, collector)
 
-	uiHandler := http.FileServer(FS(false))
+	uiHandler := http.FileServer(GetFS(false))
 	router.PathPrefix("/ui").Name("static").Handler(
 		middleware.PathRewrite(regexp.MustCompile("^/ui"), "").Wrap(
 			uiHandler))

--- a/prog/app.go
+++ b/prog/app.go
@@ -47,7 +47,7 @@ func init() {
 }
 
 // Router creates the mux for all the various app components.
-func router(collector app.Collector, controlRouter app.ControlRouter, pipeRouter app.PipeRouter) http.Handler {
+func router(collector app.Collector, controlRouter app.ControlRouter, pipeRouter app.PipeRouter, externalUI bool) http.Handler {
 	router := mux.NewRouter().SkipClean(true)
 
 	// We pull in the http.DefaultServeMux to get the pprof routes
@@ -59,7 +59,7 @@ func router(collector app.Collector, controlRouter app.ControlRouter, pipeRouter
 	app.RegisterPipeRoutes(router, pipeRouter)
 	app.RegisterTopologyRoutes(router, collector)
 
-	uiHandler := http.FileServer(GetFS(false))
+	uiHandler := http.FileServer(GetFS(externalUI))
 	router.PathPrefix("/ui").Name("static").Handler(
 		middleware.PathRewrite(regexp.MustCompile("^/ui"), "").Wrap(
 			uiHandler))
@@ -267,7 +267,7 @@ func appMain(flags appFlags) {
 		}
 	}
 
-	handler := router(collector, controlRouter, pipeRouter)
+	handler := router(collector, controlRouter, pipeRouter, flags.externalUI)
 	if flags.logHTTP {
 		handler = middleware.Logging.Wrap(handler)
 	}

--- a/prog/main.go
+++ b/prog/main.go
@@ -130,6 +130,7 @@ type appFlags struct {
 	memcachedExpiration       time.Duration
 	memcachedCompressionLevel int
 	userIDHeader              string
+	externalUI                bool
 
 	blockProfileRate int
 
@@ -255,6 +256,7 @@ func main() {
 	flag.StringVar(&flags.app.memcachedService, "app.memcached.service", "memcached", "SRV service used to discover memcache servers.")
 	flag.IntVar(&flags.app.memcachedCompressionLevel, "app.memcached.compression", gzip.DefaultCompression, "How much to compress reports stored in memcached.")
 	flag.StringVar(&flags.app.userIDHeader, "app.userid.header", "", "HTTP header to use as userid")
+	flag.BoolVar(&flags.app.externalUI, "app.externalUI", false, "Point to externally hosted static UI assets")
 
 	flag.IntVar(&flags.app.blockProfileRate, "app.block.profile.rate", 0, "If more than 0, enable block profiling. The profiler aims to sample an average of one blocking event per rate nanoseconds spent blocked.")
 

--- a/prog/static.go
+++ b/prog/static.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/weaveworks/scope/prog/staticui"
+	"github.com/weaveworks/scope/prog/externalui"
+)
+
+func GetFS(use_external bool) http.FileSystem {
+	if use_external {
+		return externalui.FS(false)
+	} else {
+		return staticui.FS(false)
+	}
+}


### PR DESCRIPTION
A second webpack config is added, and both configs are built into the scope binary
under two different generated files.
The second one only includes html assets, pointing to further assets in S3 instead.
The old (local static content) mode is used unless you pass `-app.externalUI`

`make ui-upload` will push the generated content to S3, which is run as a circle-ci
deploy step as long as our various weave-specific env vars are defined.

I've said S3 above but the code is fully repurposable for any other CDN or external hosting,
simply by changing `output.publicPath` in `client/webpack.external.config.js`.

By serving this content from S3, we defeat some race conditions involved with changing live
versions of scope during a rolling upgrade.