### PR TITLE
Fix linter error for string in context.WithValue

### DIFF
--- a/app/router.go
+++ b/app/router.go
@@ -29,8 +29,13 @@ var (
 	UniqueID = "0"
 )
 
+// contextKey is a wrapper type for use in context.WithValue() to satisfy golint
+// https://github.com/golang/go/issues/17293
+// https://github.com/golang/lint/pull/245
+type contextKey string
+
 // RequestCtxKey is key used for request entry in context
-const RequestCtxKey = "request"
+const RequestCtxKey contextKey = contextKey("request")
 
 // CtxHandlerFunc is a http.HandlerFunc, with added contexts
 type CtxHandlerFunc func(context.Context, http.ResponseWriter, *http.Request)


### PR DESCRIPTION
https://github.com/golang/lint/pull/245 introduced a new requirement that keys passed to `context.WithValue` may not be basic types, but custom ones.

Cfr. [discussion](https://github.com/golang/go/issues/17293).

Comment for `contextKey` copied from [Docker](https://github.com/docker/notary/pull/988/files#diff-14a3fdf4f432f6add827134b51b38c03R9).