### PR TITLE
Check existence of SHA1 before running `git diff` 

### DIFF
--- a/tools/rebuild-image
+++ b/tools/rebuild-image
@@ -40,11 +40,25 @@ commit_timestamp() {
 	git show -s --format=%ct "$rev"
 }
 
+# is the SHA1 actually present in the repo?
+# it could be it isn't, e.g. after a force push
+commit_invalid() {
+	local rev=$1
+	git rev-parse --quiet --verify "$rev^{commit}"
+	[ $? -ne 0 ]
+}
+
 cached_revision=$(cached_image_rev)
 if [ -z "$cached_revision" ]; then
 	echo ">>> No cached image found; rebuilding"
 	rebuild
 	exit 0
+fi
+
+if commit_invalid "$cached_revision"; then
+  echo ">>> cached commit invalid, rebuilding"
+  rebuild
+  exit 0
 fi
 
 echo ">>> Found cached image rev $cached_revision"

--- a/tools/rebuild-image
+++ b/tools/rebuild-image
@@ -42,10 +42,10 @@ commit_timestamp() {
 
 # is the SHA1 actually present in the repo?
 # it could be it isn't, e.g. after a force push
-commit_invalid() {
+commit_valid() {
 	local rev=$1
 	git rev-parse --quiet --verify "$rev^{commit}"
-	[ $? -ne 0 ]
+	[ $? -eq 0 ]
 }
 
 cached_revision=$(cached_image_rev)
@@ -55,8 +55,8 @@ if [ -z "$cached_revision" ]; then
 	exit 0
 fi
 
-if commit_invalid "$cached_revision"; then
-  echo ">>> cached commit invalid, rebuilding"
+if ! commit_valid "$cached_revision"; then
+  echo ">>> cached SHA1 not found in repo, rebuilding"
   rebuild
   exit 0
 fi


### PR DESCRIPTION
This fixes a bug whereby a cached Docker image would always end up being used, if the git commit it was built from was not reachable anymore.