### PR TITLE
probe: process: optionally use the proc connector

### DIFF
--- a/integration/313_short_lived_process.sh
+++ b/integration/313_short_lived_process.sh
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+# shellcheck disable=SC1091
+. ./config.sh
+
+start_suite "Test short lived connections in short lived processes between containers, with ebpf connection tracking enabled, require proc connector"
+
+weave_on "$HOST1" launch
+scope_on "$HOST1" launch --probe.ebpf.connections=true
+weave_on "$HOST1" run -d --name server alpine /bin/sh -c "sleep 2 ; nc -l -p 8080 ; sleep 2"
+weave_on "$HOST1" run -d --name client alpine /bin/sh -c "sleep 5 ; echo Hello | nc server.weave.local 8080 ; sleep 2"
+
+wait_for_containers "$HOST1" 60 server client
+
+has_container "$HOST1" server
+has_container "$HOST1" client
+has_connection containers "$HOST1" client server
+
+endpoints_have_ebpf "$HOST1"
+
+scope_end_suite

--- a/probe/process/proc_connector/proc_connector.go
+++ b/probe/process/proc_connector/proc_connector.go
@@ -1,0 +1,339 @@
+package procconnector
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/weaveworks/common/fs"
+)
+
+const (
+	// <linux/connector.h>
+	cnIdxProc = 0x1
+	cnValProc = 0x1
+
+	// <linux/cn_proc.h>
+	procCnMcastListen = 1
+
+	procEventFork = 0x00000001 // fork() events
+	procEventExec = 0x00000002 // exec() events
+	procEventExit = 0x80000000 // exit() events
+)
+
+var (
+	byteOrder binary.ByteOrder
+)
+
+func init() {
+	var i int32 = 0x01020304
+	u := unsafe.Pointer(&i)
+	pb := (*byte)(u)
+	b := *pb
+	if b == 0x04 {
+		byteOrder = binary.LittleEndian
+	} else {
+		byteOrder = binary.BigEndian
+	}
+}
+
+// ProcConnector receives events from the proc connector and maintain the set
+// of processes.
+type ProcConnector struct {
+	sockfd       int
+	seq          uint32
+	lock         sync.RWMutex
+	activePids   map[int]Process
+	bufferedPids []Process
+	running      bool
+}
+
+// Process represents a single process. Only include the constant details here.
+type Process struct {
+	Pid     int
+	Name    string
+	Cmdline string
+}
+
+// linux/connector.h: struct cb_id
+type cbID struct {
+	Idx uint32
+	Val uint32
+}
+
+// linux/connector.h: struct cb_msg
+type cnMsg struct {
+	ID    cbID
+	Seq   uint32
+	Ack   uint32
+	Len   uint16
+	Flags uint16
+}
+
+// linux/cn_proc.h: struct proc_event.{what,cpu,timestamp_ns}
+type procEventHeader struct {
+	What      uint32
+	CPU       uint32
+	Timestamp uint64
+}
+
+// linux/cn_proc.h: struct proc_event.fork
+type forkProcEvent struct {
+	ParentPid  uint32
+	ParentTgid uint32
+	ChildPid   uint32
+	ChildTgid  uint32
+}
+
+// linux/cn_proc.h: struct proc_event.exec
+type execProcEvent struct {
+	ProcessPid  uint32
+	ProcessTgid uint32
+}
+
+// linux/cn_proc.h: struct proc_event.exit
+type exitProcEvent struct {
+	ProcessPid  uint32
+	ProcessTgid uint32
+	ExitCode    uint32
+	ExitSignal  uint32
+}
+
+// standard netlink header + connector header
+type netlinkProcMessage struct {
+	Header syscall.NlMsghdr
+	Data   cnMsg
+}
+
+// NewProcConnector creates a new process Walker.
+func NewProcConnector() (pc *ProcConnector, err error) {
+	pc = &ProcConnector{
+		running:    false,
+		activePids: map[int]Process{},
+	}
+
+	pc.sockfd, err = syscall.Socket(
+		syscall.AF_NETLINK,
+		syscall.SOCK_DGRAM,
+		syscall.NETLINK_CONNECTOR)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Netlink socket: %s", err)
+	}
+
+	addr := &syscall.SockaddrNetlink{
+		Family: syscall.AF_NETLINK,
+		Groups: cnIdxProc,
+	}
+
+	err = syscall.Bind(pc.sockfd, addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to bind Netlink socket: %s", err)
+	}
+
+	err = pc.subscribe(addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to subscribe to the proc connector: %s", err)
+	}
+
+	// get the initial set of pids before receiving the updates
+	dirEntries, err := fs.ReadDirNames("/proc")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get initial list of processes: %s", err)
+	}
+
+	for _, filename := range dirEntries {
+		pid, err := strconv.Atoi(filename)
+		if err != nil {
+			/* this is not an error: some files in /proc are not
+			 * about processes (e.g. /proc/mounts) */
+			continue
+		}
+
+		name, cmdline := GetCmdline(pid)
+
+		pc.activePids[pid] = Process{
+			Pid:     pid,
+			Name:    name,
+			Cmdline: cmdline,
+		}
+	}
+
+	log.Infof("Proc connector successfully initialized (%d processes)", len(pc.activePids))
+
+	go pc.receive()
+
+	pc.running = true
+
+	return pc, nil
+}
+
+// GetCmdline is getting the name and command line of a process based on
+// /proc/$pid/cmdline
+func GetCmdline(pid int) (name, cmdline string) {
+	name = ""
+
+	cmdlineBuf, err := fs.ReadFile(path.Join("/proc", strconv.Itoa(pid), "cmdline"))
+	if err == nil {
+		i := bytes.IndexByte(cmdlineBuf, '\000')
+		if i == -1 {
+			i = len(cmdlineBuf)
+		}
+		name = string(cmdlineBuf[:i])
+		cmdlineBuf = bytes.Replace(cmdlineBuf, []byte{'\000'}, []byte{' '}, -1)
+		cmdline = string(cmdlineBuf)
+	}
+	if name == "" {
+		if commBuf, err := fs.ReadFile(path.Join("/proc", strconv.Itoa(pid), "comm")); err != nil {
+			name = "[" + strings.TrimSpace(string(commBuf)) + "]"
+		} else {
+			name = "(unknown)"
+		}
+	}
+	return
+}
+
+func (pc *ProcConnector) subscribe(addr *syscall.SockaddrNetlink) error {
+	var op uint32
+	op = procCnMcastListen
+	pc.seq++
+
+	pr := &netlinkProcMessage{}
+	plen := binary.Size(pr.Data) + binary.Size(op)
+	pr.Header.Len = syscall.NLMSG_HDRLEN + uint32(plen)
+	pr.Header.Type = uint16(syscall.NLMSG_DONE)
+	pr.Header.Flags = 0
+	pr.Header.Seq = pc.seq
+	pr.Header.Pid = uint32(os.Getpid())
+
+	pr.Data.ID.Idx = cnIdxProc
+	pr.Data.ID.Val = cnValProc
+
+	pr.Data.Len = uint16(binary.Size(op))
+
+	buf := bytes.NewBuffer(make([]byte, 0, pr.Header.Len))
+	binary.Write(buf, byteOrder, pr)
+	binary.Write(buf, byteOrder, op)
+
+	err := syscall.Sendto(pc.sockfd, buf.Bytes(), 0, addr)
+	return err
+}
+
+func (pc *ProcConnector) receive() {
+	buf := make([]byte, syscall.Getpagesize())
+
+	for {
+		nr, _, err := syscall.Recvfrom(pc.sockfd, buf, 0)
+		if err != nil {
+			log.Errorf("Proc connector failed to receive a message")
+			pc.running = false
+			return
+		}
+		if nr < syscall.NLMSG_HDRLEN {
+			continue
+		}
+
+		msgs, _ := syscall.ParseNetlinkMessage(buf[:nr])
+		for _, m := range msgs {
+			if m.Header.Type == syscall.NLMSG_DONE {
+				pc.handleEvent(m.Data)
+			}
+		}
+	}
+}
+
+func (pc *ProcConnector) handleEvent(data []byte) {
+	buf := bytes.NewBuffer(data)
+	msg := &cnMsg{}
+	hdr := &procEventHeader{}
+
+	binary.Read(buf, byteOrder, msg)
+	binary.Read(buf, byteOrder, hdr)
+
+	switch hdr.What {
+	case procEventFork:
+		event := &forkProcEvent{}
+		binary.Read(buf, byteOrder, event)
+		pid := int(event.ChildTgid)
+		tid := int(event.ChildPid)
+		if pid != tid {
+			return
+		}
+
+		name, cmdline := GetCmdline(pid)
+
+		pc.lock.Lock()
+		pc.activePids[pid] = Process{
+			Pid:     pid,
+			Name:    name,
+			Cmdline: cmdline,
+		}
+		pc.lock.Unlock()
+
+	case procEventExec:
+		event := &execProcEvent{}
+		binary.Read(buf, byteOrder, event)
+		pid := int(event.ProcessTgid)
+
+		name, cmdline := GetCmdline(pid)
+
+		pc.lock.Lock()
+		pc.activePids[pid] = Process{
+			Pid:     pid,
+			Name:    name,
+			Cmdline: cmdline,
+		}
+		pc.lock.Unlock()
+
+	case procEventExit:
+		event := &exitProcEvent{}
+		binary.Read(buf, byteOrder, event)
+		pid := int(event.ProcessTgid)
+		tid := int(event.ProcessPid)
+		if pid != tid {
+			return
+		}
+
+		pc.lock.Lock()
+		defer pc.lock.Unlock()
+
+		if pr, ok := pc.activePids[pid]; ok {
+			pc.bufferedPids = append(pc.bufferedPids, pr)
+			delete(pc.activePids, pid)
+		}
+
+	}
+}
+
+// Walk calls f with all active processes and processes that have come and gone
+// since the last call to Walk
+func (pc *ProcConnector) Walk(f func(pid Process)) {
+	pc.lock.RLock()
+	defer pc.lock.RUnlock()
+
+	for _, pid := range pc.activePids {
+		f(pid)
+	}
+	for _, pid := range pc.bufferedPids {
+		f(pid)
+	}
+	pc.bufferedPids = pc.bufferedPids[:0]
+}
+
+// IsRunning tells whether the proc connector is really working. If the kernel
+// does not have CONFIG_PROC_EVENTS=y or if the socket returns some errors,
+// Scope should gracefully fall back to the previous method.
+func (pc *ProcConnector) IsRunning() bool {
+	if pc == nil {
+		return false
+	}
+	return pc.running
+}


### PR DESCRIPTION
Before this patch:
- The process walker (probe/process/walker_linux.go) iterates over /proc
  at every Tick (every second) to get all the processes with their
  details.
- There are two kind of process details: the constant ones (pid, name,
  cmdline) and the dynamic ones (# threads, memory, cpu, # open files).
  The constant details were read only one time (cached via
  cachedReadFile) and the dynamic ones were read every time.
- Short-lived processes were rarely caught.

This patch adds a new package "procconnector" (for proc connector) that
receives notifications for fork, exec and exit events. It maintains the
list of processes in the map "activePids" and update it whenever a proc
connector event is received. Since it is event based, it is unlikely to
miss any process.

ProcConnector has a Walk() function that iterates over both activePids
(running processes) and bufferedPids (processes terminated since the
last iteration). This is exactly the same logic than in
probe/endpoint/conntrack.go with activeFlows and bufferedFlows: this
ensures that all processes are displayed in at least one iteration.

Since the Scope process view only displays processes that have
connections, and short-lived processes have short-lived connections,
this patch is not immediately useful by itself. But with the coming work
to get connections from eBPF, this will allow us to display short-lived
processes and short-lived connections.

When running this patch on top of the eBPF work, I can successfully see
the connection between the two "nc" processes generated by the following
script:

> # !/bin/bash
> 
> PORT=$RANDOM
> let "PORT %= 1000"
> let "PORT += 50000"
> echo "PORT=$PORT"
> nc -l $PORT &
> sleep 0.2
> echo Hello | nc 127.0.0.1 $PORT
> wait

The proc connector requires a kernel compiled with CONFIG_PROC_EVENTS=y.
The feature has been added in v2.6.15 released on 3 January, 2006, see
https://github.com/torvalds/linux/commit/9f46080c41d5f3f7c00b4e169ba4b0b2865258bf

CONFIG_PROC_EVENTS=y is usually enabled in Linux distributions. However,
Scope should gracefully fall back to the previous /proc polling logic.

---

/cc @asymmetric @iaguis
