### PR TITLE
Update tools subtree

### DIFF
--- a/tools/cmd/wcloud/cli.go
+++ b/tools/cmd/wcloud/cli.go
@@ -81,7 +81,7 @@ func deploy(c Client, args []string) {
 		username = flags.String("u", "", "Username to report to deploy service (default with be current user)")
 		services ArrayFlags
 	)
-	flag.Var(&services, "service", "Service to update (can be repeated)")
+	flags.Var(&services, "service", "Service to update (can be repeated)")
 	if err := flags.Parse(args); err != nil {
 		usage()
 		return

--- a/tools/cmd/wcloud/types.go
+++ b/tools/cmd/wcloud/types.go
@@ -20,10 +20,12 @@ type Deployment struct {
 // Config for the deployment system for a user.
 type Config struct {
 	RepoURL        string `json:"repo_url" yaml:"repo_url"`
+	RepoBranch     string `json:"repo_branch" yaml:"repo_branch"`
 	RepoPath       string `json:"repo_path" yaml:"repo_path"`
 	RepoBranch     string `json:"repo_branch" yaml:"repo_branch"`
 	RepoKey        string `json:"repo_key" yaml:"repo_key"`
 	KubeconfigPath string `json:"kubeconfig_path" yaml:"kubeconfig_path"`
+	AutoApply      bool   `json:"auto_apply" yaml:"auto_apply"`
 
 	Notifications []NotificationConfig `json:"notifications" yaml:"notifications"`
 
@@ -35,7 +37,8 @@ type Config struct {
 
 // NotificationConfig describes how to send notifications
 type NotificationConfig struct {
-	SlackWebhookURL string `json:"slack_webhook_url" yaml:"slack_webhook_url"`
-	SlackUsername   string `json:"slack_username" yaml:"slack_username"`
-	MessageTemplate string `json:"message_template" yaml:"message_template"`
+	SlackWebhookURL      string `json:"slack_webhook_url" yaml:"slack_webhook_url"`
+	SlackUsername        string `json:"slack_username" yaml:"slack_username"`
+	MessageTemplate      string `json:"message_template" yaml:"message_template"`
+	ApplyMessageTemplate string `json:"apply_message_template" yaml:"apply_message_template"`
 }

--- a/tools/rebuild-image
+++ b/tools/rebuild-image
@@ -40,9 +40,22 @@ commit_timestamp() {
 	git show -s --format=%ct "$rev"
 }
 
+# Is the SHA1 actually present in the repo?
+# It could be it isn't, e.g. after a force push
+is_valid_commit() {
+	local rev=$1
+	git rev-parse --quiet --verify "$rev^{commit}" > /dev/null
+}
+
 cached_revision=$(cached_image_rev)
 if [ -z "$cached_revision" ]; then
 	echo ">>> No cached image found; rebuilding"
+	rebuild
+	exit 0
+fi
+
+if ! is_valid_commit "$cached_revision"; then
+	echo ">>> Git commit of cached image not found in repo; rebuilding"
 	rebuild
 	exit 0
 fi

--- a/tools/shell-lint
+++ b/tools/shell-lint
@@ -11,4 +11,3 @@
 # - file >= 5.22
 
 "$(dirname "${BASH_SOURCE[0]}")/files-with-type" text/x-shellscript "$@" | xargs --no-run-if-empty shellcheck
-


### PR DESCRIPTION
Updates the `/tools` subtee, including fixes to the `rebuild-image` script.

Did a `git subtree pull --prefix tools https://github.com/weaveworks/build-tools.git master --squash`.

/cc @alepuccetti @alban 