### PR TITLE
update text and background color for contrast. add fill and border to…

### DIFF
--- a/client/app/scripts/charts/node-shape-circle.js
+++ b/client/app/scripts/charts/node-shape-circle.js
@@ -4,7 +4,9 @@ import {getMetricValue, getMetricColor, getClipPathDefinition} from '../utils/me
 import {CANVAS_METRIC_FONT_SIZE} from '../constants/styles.js';
 
 
-export default function NodeShapeCircle({id, highlighted, size, color, metric}) {
+export default function NodeShapeCircle({
+  id, highlighted, size, metric, color, lightColor, darkColor
+}) {
   const clipId = `mask-${id}`;
   const {height, hasMetric, formattedValue} = getMetricValue(metric, size);
   const metricStyle = { fill: getMetricColor(metric) };
@@ -15,13 +17,13 @@ export default function NodeShapeCircle({id, highlighted, size, color, metric}) 
     <g className={className}>
       {hasMetric && getClipPathDefinition(clipId, size, height)}
       {highlighted && <circle r={size * 0.7} className="highlighted" />}
-      <circle r={size * 0.5} className="border" stroke={color} />
-      <circle r={size * 0.45} className="shadow" />
+      <circle r={size * 0.535} className="outline" fill="none" stroke={darkColor} />
+      <circle r={size * 0.5} className="border" fill={lightColor} stroke={color} />
       {hasMetric && <circle r={size * 0.45} className="metric-fill" style={metricStyle}
         clipPath={`url(#${clipId})`} />}
       {highlighted && hasMetric ?
         <text style={{fontSize}}>{formattedValue}</text> :
-        <circle className="node" r={Math.max(2, (size * 0.125))} />}
+        <circle className="node" r={Math.max(1.33333, (size * 0.08333))} fill={darkColor} />}
     </g>
   );
 }

--- a/client/app/scripts/charts/node-shape-cloud.js
+++ b/client/app/scripts/charts/node-shape-cloud.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import d3 from 'd3';
 
-import { isContrastMode } from '../utils/contrast-utils';
-
 const CLOUD_PATH = 'M 1920,384 Q 1920,225 1807.5,112.5 1695,0 1536,0 H 448 '
   + 'Q 263,0 131.5,131.5 0,263 0,448 0,580 71,689.5 142,799 258,853 '
   + 'q -2,28 -2,43 0,212 150,362 150,150 362,150 158,0 286.5,-88 128.5,-88 '
@@ -18,7 +16,7 @@ function getExtents(svgPath) {
   return [d3.extent(points, p => p[0]), d3.extent(points, p => p[1])];
 }
 
-export default function NodeShapeCloud({highlighted, size, color}) {
+export default function NodeShapeCloud({highlighted, size, color, darkColor}) {
   const [[minx, maxx], [miny, maxy]] = getExtents(CLOUD_PATH);
   const width = (maxx - minx);
   const height = (maxy - miny);
@@ -26,11 +24,11 @@ export default function NodeShapeCloud({highlighted, size, color}) {
   const cy = height / 2;
   const pathSize = (width + height) / 2;
   const baseScale = (size * 2) / pathSize;
-  const strokeWidth = isContrastMode() ? 6 / baseScale : 4 / baseScale;
+  const strokeWidth = 5 / baseScale;
+  const shadowColor = '#FFF';
 
   const pathProps = v => ({
     d: CLOUD_PATH,
-    fill: 'none',
     transform: `scale(-${v * baseScale}) translate(-${cx},-${cy})`,
     strokeWidth
   });
@@ -39,9 +37,9 @@ export default function NodeShapeCloud({highlighted, size, color}) {
     <g className="shape shape-cloud">
       {highlighted &&
           <path className="highlighted" {...pathProps(0.7)} />}
-      <path className="border" stroke={color} {...pathProps(0.5)} />
-      <path className="shadow" {...pathProps(0.45)} />
-      <circle className="node" r={Math.max(2, (size * 0.125))} />
+      <path className="outline" stroke={darkColor} fill="none" {...pathProps(0.53)} />
+      <path className="border" stroke={color} {...pathProps(0.5)} fill={shadowColor} />
+      <circle className="node" r={Math.max(1.33333, (size * 0.08333))} fill={darkColor} />
     </g>
   );
 }

--- a/client/app/scripts/charts/node-shape-heptagon.js
+++ b/client/app/scripts/charts/node-shape-heptagon.js
@@ -20,7 +20,9 @@ function polygon(r, sides) {
 }
 
 
-export default function NodeShapeHeptagon({id, highlighted, size, color, metric}) {
+export default function NodeShapeHeptagon({
+  id, highlighted, size, metric, color, lightColor, darkColor
+}) {
   const scaledSize = size * 1.0;
   const pathProps = v => ({
     d: line(polygon(scaledSize * v, 7)),
@@ -37,13 +39,13 @@ export default function NodeShapeHeptagon({id, highlighted, size, color, metric}
     <g className={className}>
       {hasMetric && getClipPathDefinition(clipId, size, height, size * 0.5 - height, -size * 0.5)}
       {highlighted && <path className="highlighted" {...pathProps(0.7)} />}
-      <path className="border" stroke={color} {...pathProps(0.5)} />
-      <path className="shadow" {...pathProps(0.45)} />
+      <path className="outline" stroke={darkColor} fill="none" {...pathProps(0.535)} />
+      <path className="border" stroke={color} fill={lightColor} {...pathProps(0.5)} />
       {hasMetric && <path className="metric-fill" clipPath={`url(#${clipId})`}
         style={metricStyle} {...pathProps(0.45)} />}
       {highlighted && hasMetric ?
         <text style={{fontSize}}>{formattedValue}</text> :
-        <circle className="node" r={Math.max(2, (size * 0.125))} />}
+        <circle className="node" r={Math.max(1.33333, (size * 0.08333))} fill={darkColor} />}
     </g>
   );
 }

--- a/client/app/scripts/charts/node-shape-hex.js
+++ b/client/app/scripts/charts/node-shape-hex.js
@@ -30,13 +30,15 @@ function getPoints(h) {
 }
 
 
-export default function NodeShapeHex({id, highlighted, size, color, metric}) {
+export default function NodeShapeHex({
+  id, highlighted, size, metric, color, lightColor, darkColor
+}) {
   const pathProps = v => ({
     d: getPoints(size * v * 2),
     transform: `rotate(90) translate(-${size * getWidth(v)}, -${size * v})`
   });
 
-  const shadowSize = 0.45;
+  const shadowSize = 0.47;
   const upperHexBitHeight = -0.25 * size * shadowSize;
 
   const clipId = `mask-${id}`;
@@ -50,15 +52,17 @@ export default function NodeShapeHex({id, highlighted, size, color, metric}) {
       {hasMetric && getClipPathDefinition(clipId, size, height, size - height +
                                           upperHexBitHeight, 0)}
       {highlighted && <path className="highlighted" {...pathProps(0.7)} />}
-      <path className="border" stroke={color} {...pathProps(0.5)} />
-      <path className="shadow" {...pathProps(shadowSize)} />
+
+      <path className="outline" stroke={darkColor} fill="none" {...pathProps(0.55)} />
+      <path className="border" stroke={color} fill={lightColor} {...pathProps(0.5)} />
+
       {hasMetric && <path className="metric-fill" style={metricStyle}
         clipPath={`url(#${clipId})`} {...pathProps(shadowSize)} />}
       {highlighted && hasMetric ?
         <text style={{fontSize}}>
           {formattedValue}
         </text> :
-        <circle className="node" r={Math.max(2, (size * 0.125))} />}
+        <circle className="node" r={Math.max(1.33333, (size * 0.08333))} fill={darkColor} />}
     </g>
   );
 }

--- a/client/app/scripts/charts/node-shape-square.js
+++ b/client/app/scripts/charts/node-shape-square.js
@@ -5,7 +5,7 @@ import {CANVAS_METRIC_FONT_SIZE} from '../constants/styles.js';
 
 
 export default function NodeShapeSquare({
-  id, highlighted, size, color, rx = 0, ry = 0, metric
+  id, highlighted, size, rx = 0, ry = 0, metric, color, lightColor, darkColor
 }) {
   const rectProps = (scale, radiusScale) => ({
     width: scale * size * 2,
@@ -26,15 +26,15 @@ export default function NodeShapeSquare({
     <g className={className}>
       {hasMetric && getClipPathDefinition(clipId, size, height)}
       {highlighted && <rect className="highlighted" {...rectProps(0.7)} />}
-      <rect className="border" stroke={color} {...rectProps(0.5, 0.5)} />
-      <rect className="shadow" {...rectProps(0.45, 0.39)} />
+      <rect className="outline" stroke={darkColor} fill="none" {...rectProps(0.55, 0.55)} />
+      <rect className="border" stroke={color} fill={lightColor} {...rectProps(0.5, 0.5)} />
       {hasMetric && <rect className="metric-fill" style={metricStyle}
         clipPath={`url(#${clipId})`} {...rectProps(0.45, 0.39)} />}
       {highlighted && hasMetric ?
         <text style={{fontSize}}>
           {formattedValue}
         </text> :
-        <circle className="node" r={Math.max(2, (size * 0.125))} />}
+        <circle className="node" r={Math.max(1.33333, (size * 0.08333))} fill={darkColor} />}
     </g>
   );
 }

--- a/client/app/scripts/charts/node.js
+++ b/client/app/scripts/charts/node.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import { Map as makeMap, List as makeList } from 'immutable';
 
 import { clickNode, enterNode, leaveNode } from '../actions/app-actions';
-import { getNodeColor } from '../utils/color-utils';
+import { getNodeColor, getNodeColorLight, getNodeColorDark } from '../utils/color-utils';
 import MatchedText from '../components/matched-text';
 import MatchedResults from '../components/matched-results';
 
@@ -90,6 +90,8 @@ class Node extends React.Component {
     const nodeScale = focused ? this.props.selectedNodeScale : this.props.nodeScale;
 
     const color = getNodeColor(rank, label, pseudo);
+    const lightColor = getNodeColorLight(rank, label, pseudo);
+    const darkColor = getNodeColorDark(rank, label, pseudo);
     const truncate = !focused && !hovered;
     const labelWidth = nodeScale(scaleFactor * 3);
     const labelOffsetX = -labelWidth / 2;
@@ -146,6 +148,8 @@ class Node extends React.Component {
           <NodeShapeType
             size={size}
             color={color}
+            lightColor={lightColor}
+            darkColor={darkColor}
             {...this.props} />
         </g>
 

--- a/client/app/scripts/utils/color-utils.js
+++ b/client/app/scripts/utils/color-utils.js
@@ -40,23 +40,18 @@ export function colors(text, secondText) {
   return color;
 }
 
-export function getNeutralColor() {
-  return PSEUDO_COLOR;
+export function brightenColor(color) {
+  let hsl = d3.rgb(color).hsl();
+  if (hsl.l > 0.5) {
+    hsl = hsl.brighter(0.5);
+  } else {
+    hsl = hsl.brighter(0.8);
+  }
+  return hsl.toString();
 }
 
-export function getNodeColor(text = '', secondText = '', isPseudo = false) {
-  if (isPseudo) {
-    return PSEUDO_COLOR;
-  }
-  return colors(text, secondText).toString();
-}
-
-export function getNodeColorDark(text = '', secondText = '', isPseudo = false) {
-  if (isPseudo) {
-    return PSEUDO_COLOR;
-  }
-  const color = d3.rgb(colors(text, secondText));
-  let hsl = color.hsl();
+export function darkenColor(color) {
+  let hsl = d3.rgb(color).hsl();
 
   // ensure darkness
   if (hsl.h > 20 && hsl.h < 120) {
@@ -70,16 +65,35 @@ export function getNodeColorDark(text = '', secondText = '', isPseudo = false) {
   return hsl.toString();
 }
 
-export function getNetworkColor(text) {
-  return networkColorScale(text);
+export function getNeutralColor() {
+  return PSEUDO_COLOR;
 }
 
-export function brightenColor(color) {
-  let hsl = d3.rgb(color).hsl();
-  if (hsl.l > 0.5) {
-    hsl = hsl.brighter(0.5);
-  } else {
-    hsl = hsl.brighter(0.8);
+export function getNodeColor(text = '', secondText = '', isPseudo = false) {
+  if (isPseudo) {
+    return PSEUDO_COLOR;
   }
-  return hsl.toString();
+  return colors(text, secondText).toString();
+}
+
+export function getNodeColorDark(text = '', secondText = '', isPseudo = false) {
+  if (isPseudo) {
+    return darkenColor(PSEUDO_COLOR);
+  }
+
+  const color = d3.rgb(colors(text, secondText));
+  return darkenColor(color);
+}
+
+export function getNodeColorLight(text = '', secondText = '', isPseudo = false) {
+  if (isPseudo) {
+    return brightenColor(PSEUDO_COLOR);
+  }
+
+  const color = d3.rgb(colors(text, secondText));
+  return brightenColor(color);
+}
+
+export function getNetworkColor(text) {
+  return networkColorScale(text);
 }

--- a/client/app/styles/contrast.less
+++ b/client/app/styles/contrast.less
@@ -5,18 +5,16 @@
 @background-darker-color: darken(@background-color, 20%);
 @background-darker-secondary-color: darken(@background-color, 15%);
 @background-dark-color: @primary-color;
-@text-color: darken(@primary-color, 20%);
+@text-color: black;
 @text-secondary-color: lighten(@text-color, 10%);
 @text-tertiary-color: lighten(@text-color, 20%);
 @border-light-color: lighten(@text-color, 50%);
 @text-darker-color: darken(@text-color, 20%);
-@white: @background-lighter-color;
+@white: white;
 
 @node-opacity-blurred: 0.6;
 @node-highlight-fill-opacity: 0.3;
 @node-highlight-stroke-opacity: 0.5;
-@node-highlight-stroke-width: 3px;
-@node-border-stroke-width: 5px;
 @node-pseudo-opacity: 1;
 @edge-highlight-opacity: 0.3;
 @edge-opacity-blurred: 0;
@@ -31,3 +29,7 @@
 
 @search-border-color: @background-darker-color;
 @search-border-width: 2px;
+
+/* specific elements */
+@body-background-color: #FFF;
+@label-background-color: #FFF;

--- a/client/app/styles/main.less
+++ b/client/app/styles/main.less
@@ -46,9 +46,9 @@
 @node-opacity-blurred: 0.25;
 @node-highlight-fill-opacity: 0.1;
 @node-highlight-stroke-opacity: 0.4;
-@node-highlight-stroke-width: 1px;
-@node-border-stroke-width: 2.5px;
-@node-pseudo-opacity: 0.8;
+@node-highlight-stroke-width: 2px;
+@node-border-stroke-width: 3px;
+@node-pseudo-opacity: 1;
 @edge-highlight-opacity: 0.1;
 @edge-opacity-blurred: 0.2;
 @edge-opacity: 0.5;
@@ -62,6 +62,10 @@
 
 @search-border-color: transparent;
 @search-border-width: 1px;
+
+/* specific elements */
+@body-background-color: linear-gradient(30deg, @background-color 0%, @background-lighter-color 100%);
+@label-background-color: fade(@background-average-color, 70%);
 
 /* add this class to truncate text with ellipsis, container needs width */
 .truncate {
@@ -130,7 +134,7 @@ body {
 
 /* Space out content a bit */
 body {
-  background: linear-gradient(30deg, @background-color 0%, @background-lighter-color 100%);
+  background: @body-background-color;
   color: @text-color;
   line-height: 150%;
   font-family: @base-font;
@@ -403,14 +407,14 @@ h2 {
       }
       span:not(.match) {
         padding: 0 0.25em;
-        background-color: fade(@background-average-color, 70%);
+        background-color: @label-background-color;
       }
       span:empty {
         padding: 0;
       }
     }
     .matched-results {
-      background-color: fade(@background-average-color, 70%);
+      background-color: @label-background-color;
     }
 
     &.pseudo {
@@ -430,7 +434,6 @@ h2 {
 
       .border {
         opacity: @node-pseudo-opacity;
-        stroke: @text-tertiary-color;
       }
     }
 
@@ -504,9 +507,12 @@ h2 {
     /* cloud paths have stroke-width set dynamically */
     &:not(.shape-cloud) .border {
       stroke-width: @node-border-stroke-width;
-      fill: @background-color;
       transition: stroke-opacity 0.333s @base-ease, fill 0.333s @base-ease;
       stroke-opacity: 1;
+    }
+
+    &:not(.shape-cloud) .outline {
+      stroke-width: 2px;
     }
 
     &.metrics .border {
@@ -522,13 +528,12 @@ h2 {
 
     .shadow {
       stroke: none;
-      fill: @background-lighter-color;
+
     }
 
     .node {
-      fill: @text-color;
-      stroke: @background-lighter-color;
-      stroke-width: 2px;
+
+
     }
 
     text {
@@ -544,10 +549,6 @@ h2 {
       stroke-width: @node-highlight-stroke-width;
       stroke-opacity: @node-highlight-stroke-opacity;
     }
-  }
-
-  .stack .shape .border {
-    stroke-width: @node-border-stroke-width - 0.5;
   }
 
 }


### PR DESCRIPTION
Fixes https://github.com/weaveworks/scope/issues/1943
- On contrast mode, text color set to black, background set to white (no gradient)
- Label background set to white (no transparency)
- Visual update of nodes

![untitled-1](https://cloud.githubusercontent.com/assets/915421/19705220/19c1c7c4-9ac0-11e6-8055-0a2dac43b680.png)
- Note: there is an existing bug where sometimes the node rendering has a gap between the fill and border. This PR does not fix this.
