### PR TITLE
Fix a JS bug where certain query strings would contain a && instead of &

### DIFF
--- a/client/app/scripts/utils/web-api-utils.js
+++ b/client/app/scripts/utils/web-api-utils.js
@@ -27,7 +27,7 @@ let firstMessageOnWebsocketAt = 0;
 
 function buildOptionsQuery(options) {
   if (options) {
-    return options.reduce((query, value, param) => `${query}&${param}=${value}`, '');
+    return Object.keys(options.toJS()).map(key => `${key}=${options.get(key)}`).join('&');
   }
   return '';
 }


### PR DESCRIPTION
This was causing 400s when talking to overly-strict services