### PR TITLE
Update client deps to use Node v6.9.0

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4.2.2
+FROM node:6.9.0
 WORKDIR /home/weave
 COPY package.json /home/weave/
 ENV NPM_CONFIG_LOGLEVEL=warn NPM_CONFIG_PROGRESS=false

--- a/client/app/scripts/charts/__tests__/node-layout-test.js
+++ b/client/app/scripts/charts/__tests__/node-layout-test.js
@@ -1,7 +1,3 @@
-jest.dontMock('../nodes-layout');
-jest.dontMock('../../utils/topology-utils');
-jest.dontMock('../../constants/naming'); // edge naming: 'source-target'
-
 import { fromJS, Map } from 'immutable';
 
 const makeMap = Map;

--- a/client/app/scripts/components/__tests__/node-details-test.js
+++ b/client/app/scripts/components/__tests__/node-details-test.js
@@ -1,15 +1,8 @@
 import React from 'react';
 import Immutable from 'immutable';
 import TestUtils from 'react/lib/ReactTestUtils';
-
-jest.dontMock('../node-details.js');
-jest.dontMock('../node-details/node-details-controls.js');
-jest.dontMock('../node-details/node-details-relatives.js');
-jest.dontMock('../node-details/node-details-table.js');
-jest.dontMock('../node-details/node-details-health-overflow-item.js');
-jest.dontMock('../../hoc/metric-feeder.js');
-jest.dontMock('../../utils/color-utils');
-jest.dontMock('../../utils/title-utils');
+import { Provider } from 'react-redux';
+import configureStore from '../../stores/configureStore';
 
 // need ES5 require to keep automocking off
 const NodeDetails = require('../node-details.js').NodeDetails;
@@ -26,7 +19,11 @@ describe('NodeDetails', () => {
   });
 
   it('shows n/a when node was not found', () => {
-    const c = TestUtils.renderIntoDocument(<NodeDetails notFound />);
+    const c = TestUtils.renderIntoDocument(
+      <Provider store={configureStore()}>
+        <NodeDetails notFound />
+      </Provider>
+    );
     const notFound = TestUtils.findRenderedDOMComponentWithClass(c,
       'node-details-header-notavailable');
     expect(notFound).toBeDefined();
@@ -35,8 +32,13 @@ describe('NodeDetails', () => {
   it('show label of node with title', () => {
     nodes = nodes.set(nodeId, Immutable.fromJS({id: nodeId}));
     details = {label: 'Node 1'};
-    const c = TestUtils.renderIntoDocument(<NodeDetails nodes={nodes}
-      nodeId={nodeId} details={details} />);
+    const c = TestUtils.renderIntoDocument(
+      <Provider store={configureStore()}>
+        <NodeDetails nodes={nodes}
+          nodeId={nodeId} details={details}
+        />
+      </Provider>
+    );
 
     const title = TestUtils.findRenderedDOMComponentWithClass(c, 'node-details-header-label');
     expect(title.title).toBe('Node 1');

--- a/client/app/scripts/reducers/__tests__/root-test.js
+++ b/client/app/scripts/reducers/__tests__/root-test.js
@@ -1,11 +1,3 @@
-jest.dontMock('../../utils/router-utils');
-jest.dontMock('../../utils/search-utils');
-jest.dontMock('../../utils/string-utils');
-jest.dontMock('../../utils/topology-utils');
-jest.dontMock('../../utils/network-view-utils');
-jest.dontMock('../../constants/action-types');
-jest.dontMock('../root');
-
 const is = require('immutable').is;
 
 // Root reducer test suite using Jasmine matchers

--- a/client/app/scripts/utils/__tests__/search-utils-test.js
+++ b/client/app/scripts/utils/__tests__/search-utils-test.js
@@ -1,7 +1,3 @@
-jest.dontMock('../search-utils');
-jest.dontMock('../string-utils');
-jest.dontMock('../../constants/naming'); // edge naming: 'source-target'
-
 import { fromJS } from 'immutable';
 
 const SearchUtils = require('../search-utils').testable;

--- a/client/app/scripts/utils/__tests__/string-utils-test.js
+++ b/client/app/scripts/utils/__tests__/string-utils-test.js
@@ -1,4 +1,3 @@
-jest.dontMock('../string-utils');
 
 describe('StringUtils', () => {
   const StringUtils = require('../string-utils');

--- a/client/app/scripts/utils/__tests__/topology-utils-test.js
+++ b/client/app/scripts/utils/__tests__/topology-utils-test.js
@@ -1,6 +1,3 @@
-jest.dontMock('../topology-utils');
-jest.dontMock('../../constants/naming'); // edge naming: 'source-target'
-
 import { fromJS } from 'immutable';
 
 describe('TopologyUtils', () => {

--- a/client/app/scripts/utils/__tests__/web-api-utils-test.js
+++ b/client/app/scripts/utils/__tests__/web-api-utils-test.js
@@ -1,4 +1,3 @@
-jest.dontMock('../web-api-utils');
 
 import {OrderedMap as makeOrderedMap} from 'immutable';
 

--- a/client/package.json
+++ b/client/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "autoprefixer": "6.3.3",
-    "babel-core": "6.7.2",
+    "babel-core": "6.10.4",
     "babel-eslint": "5.0.0",
     "babel-jest": "9.0.3",
     "babel-loader": "6.2.4",
@@ -53,7 +53,7 @@
     "html-webpack-plugin": "^2.16.0",
     "http-proxy-rules": "^1.0.1",
     "immutable-devtools": "0.0.6",
-    "jest-cli": "~0.9.2",
+    "jest-cli": "16.0.2",
     "json-loader": "0.5.4",
     "less": "~2.6.1",
     "less-loader": "2.2.2",
@@ -89,22 +89,15 @@
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
-    "testFileExtensions": [
-      "js"
-    ],
     "testPathDirs": [
       "<rootDir>/app/scripts"
     ],
     "moduleFileExtensions": [
       "js",
       "json"
-    ],
-    "unmockedModulePathPatterns": [
-      "/dispatcher/",
-      "/node_modules/"
     ]
   },
   "engines": {
-    "node": ">=4.2.2"
+    "node": "6.9.0"
   }
 }


### PR DESCRIPTION
From issue #1947. 
@davkal, @foot, @bowenli This PR upgrades some dependencies to work with Node 6 LTS. The major change is that `jest` auto-mocking is turned off by default now. Webpack dev server should be more efficient, and builds should be a little faster. I gathered some data on how long docker image builds are taking before/after:
`time docker build -t node4-build .` : `real	16m12.900s`& `real 8m39.124s`
`time docker build -t node6-build .`: `real	4m13.992s` <-- This PR