### PR TITLE
Close help dialog when the canvas is clicked

### DIFF
--- a/client/app/scripts/reducers/__tests__/root-test.js
+++ b/client/app/scripts/reducers/__tests__/root-test.js
@@ -471,4 +471,9 @@ describe('RootReducer', () => {
     expect(nextState.get('nodeDetails').size).toEqual(1);
     expect(nextState.get('currentTopology').get('name')).toBe('Topo2');
   });
+  it('closes the help dialog if the canvas is clicked', () => {
+    let nextState = initialState.set('showingHelp', true);
+    nextState = reducer(nextState, { type: ActionTypes.CLICK_BACKGROUND });
+    expect(nextState.get('showingHelp')).toBe(false);
+  });
 });

--- a/client/app/scripts/reducers/root.js
+++ b/client/app/scripts/reducers/root.js
@@ -186,6 +186,9 @@ export function rootReducer(state = initialState, action) {
     }
 
     case ActionTypes.CLICK_BACKGROUND: {
+      if (state.get('showingHelp')) {
+        state = state.set('showingHelp', false);
+      }
       return closeAllNodeDetails(state);
     }
 


### PR DESCRIPTION
@davkal , @bowenli From #1325. Closes the 'Help' dialog when it is open and the background is clicked. I looked for other related dialog windows to see if there needed to be a dedicated action for this, but this was the only one I could find that didn't have this behavior already. 