### PR TITLE
[WIP] controls: plugins can add generic controls to start a container

### DIFF
--- a/client/app/scripts/utils/web-api-utils.js
+++ b/client/app/scripts/utils/web-api-utils.js
@@ -223,7 +223,7 @@ export function getApiDetails(dispatch) {
 export function doControlRequest(nodeId, control, dispatch) {
   clearTimeout(controlErrorTimer);
   const url = `api/control/${encodeURIComponent(control.probeId)}/`
-    + `${encodeURIComponent(control.nodeId)}/${control.id}`;
+    + `${encodeURIComponent(control.nodeId)}/${encodeURIComponent(control.id)}`;
   reqwest({
     method: 'POST',
     url,

--- a/probe/controls/tagger.go
+++ b/probe/controls/tagger.go
@@ -1,0 +1,42 @@
+package controls
+
+import (
+	"time"
+
+	"github.com/weaveworks/scope/report"
+)
+
+// Tagger adds controls to nodes
+type Tagger struct {
+}
+
+// NewTagger tags each node with generic controls
+func NewTagger() Tagger {
+	return Tagger{}
+}
+
+// Name of this tagger, for metrics gathering
+func (Tagger) Name() string { return "Controls" }
+
+// Tag implements Tagger.
+func (t Tagger) Tag(r report.Report) (report.Report, error) {
+	for _, topology := range []report.Topology{r.Process, r.Container, r.ContainerImage, r.Host, r.Pod} {
+		// Each topology has most likely not many controls that need
+		// to be propagated. Gather the list in propagatingControls.
+		var propagatingControls []report.Control
+		for _, control := range topology.Controls {
+			if control.AlwaysPropagated {
+				propagatingControls = append(propagatingControls, control)
+			}
+		}
+
+		for _, node := range topology.Nodes {
+			for _, control := range propagatingControls {
+				metadata := map[string]string{"thisisatest": control.ID}
+				topology.AddNode(node.WithLatests(metadata))
+				topology.AddNode(node.WithLatestControl(control.ID, time.Now(), report.NodeControlData{Dead: false}))
+			}
+		}
+	}
+	return r, nil
+}

--- a/probe/docker/registry.go
+++ b/probe/docker/registry.go
@@ -10,6 +10,7 @@ import (
 	"github.com/armon/go-radix"
 	docker_client "github.com/fsouza/go-dockerclient"
 
+	"github.com/weaveworks/scope/common/xfer"
 	"github.com/weaveworks/scope/probe/controls"
 	"github.com/weaveworks/scope/report"
 )
@@ -44,6 +45,7 @@ type Registry interface {
 	GetContainer(string) (Container, bool)
 	GetContainerByPrefix(string) (Container, bool)
 	GetContainerImage(string) (docker_client.APIImages, bool)
+	StartImage(string, string, string, xfer.Request) xfer.Response
 }
 
 // ContainerUpdateWatcher is the type of functions that get called when containers are updated.
@@ -76,6 +78,7 @@ type Client interface {
 	AddEventListener(chan<- *docker_client.APIEvents) error
 	RemoveEventListener(chan *docker_client.APIEvents) error
 
+	CreateContainer(docker_client.CreateContainerOptions) (*docker_client.Container, error)
 	StopContainer(string, uint) error
 	StartContainer(string, *docker_client.HostConfig) error
 	RestartContainer(string, uint) error

--- a/probe/docker/registry_test.go
+++ b/probe/docker/registry_test.go
@@ -139,6 +139,10 @@ func (m *mockDockerClient) RemoveEventListener(events chan *client.APIEvents) er
 	return nil
 }
 
+func (m *mockDockerClient) CreateContainer(_ client.CreateContainerOptions) (*client.Container, error) {
+	return nil, fmt.Errorf("created")
+}
+
 func (m *mockDockerClient) StartContainer(_ string, _ *client.HostConfig) error {
 	return fmt.Errorf("started")
 }

--- a/probe/docker/reporter_test.go
+++ b/probe/docker/reporter_test.go
@@ -5,6 +5,7 @@ import (
 
 	client "github.com/fsouza/go-dockerclient"
 
+	"github.com/weaveworks/scope/common/xfer"
 	"github.com/weaveworks/scope/probe/docker"
 	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/report"
@@ -51,6 +52,10 @@ func (r *mockRegistry) GetContainerByPrefix(_ string) (docker.Container, bool) {
 func (r *mockRegistry) GetContainerImage(id string) (client.APIImages, bool) {
 	image, ok := r.images[id]
 	return image, ok
+}
+
+func (r *mockRegistry) StartImage(_, _, _ string, _ xfer.Request) xfer.Response {
+	return xfer.Response{}
 }
 
 var (

--- a/probe/plugins/registry.go
+++ b/probe/plugins/registry.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaveworks/scope/common/fs"
 	"github.com/weaveworks/scope/common/xfer"
 	"github.com/weaveworks/scope/probe/controls"
+	"github.com/weaveworks/scope/probe/docker"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -53,15 +54,16 @@ type Registry struct {
 	lock              sync.RWMutex
 	context           context.Context
 	cancel            context.CancelFunc
-	controlsByPlugin  map[string]report.StringSet
+	controlsByPlugin  map[string]report.StringSet // set of strings like "controlID~imageName"
 	pluginsByID       map[string]*Plugin
 	handlerRegistry   *controls.HandlerRegistry
 	publisher         ReportPublisher
+	dockerRegistry    docker.Registry
 }
 
 // NewRegistry creates a new registry which watches the given dir root for new
 // plugins, and adds them.
-func NewRegistry(rootPath, apiVersion string, handshakeMetadata map[string]string, handlerRegistry *controls.HandlerRegistry, publisher ReportPublisher) (*Registry, error) {
+func NewRegistry(rootPath, apiVersion string, handshakeMetadata map[string]string, handlerRegistry *controls.HandlerRegistry, publisher ReportPublisher, dockerRegistry docker.Registry) (*Registry, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	r := &Registry{
 		rootPath:          rootPath,
@@ -74,6 +76,7 @@ func NewRegistry(rootPath, apiVersion string, handshakeMetadata map[string]strin
 		pluginsByID:       map[string]*Plugin{},
 		handlerRegistry:   handlerRegistry,
 		publisher:         publisher,
+		dockerRegistry:    dockerRegistry,
 	}
 	if err := r.scan(); err != nil {
 		r.Close()
@@ -261,10 +264,13 @@ func (r *Registry) updateAndGetControlsInTopology(pluginID string, topology *rep
 	var pluginControls []string
 	newControls := report.Controls{}
 	for controlID, control := range topology.Controls {
-		fakeID := fakeControlID(pluginID, controlID)
+		fakeID := fakeControlID(pluginID, controlID, control.StartImage)
 		log.Debugf("plugins: replacing control %s with %s", controlID, fakeID)
 		control.ID = fakeID
 		newControls.AddControl(control)
+		if control.StartImage != "" {
+			controlID = controlID + "~" + url.QueryEscape(control.StartImage)
+		}
 		pluginControls = append(pluginControls, controlID)
 	}
 	newNodes := report.Nodes{}
@@ -275,11 +281,11 @@ func (r *Registry) updateAndGetControlsInTopology(pluginID string, topology *rep
 		node.LatestControls.ForEach(func(controlID string, ts time.Time, data report.NodeControlData) {
 			log.Debugf("plugins: got node control %s", controlID)
 			newControlID := ""
-			if _, found := topology.Controls[controlID]; !found {
+			if control, found := topology.Controls[controlID]; !found {
 				log.Debugf("plugins: node control %s does not exist in topology controls", controlID)
 				newControlID = controlID
 			} else {
-				newControlID = fakeControlID(pluginID, controlID)
+				newControlID = fakeControlID(pluginID, controlID, control.StartImage)
 				log.Debugf("plugins: will replace node control %s with %s", controlID, newControlID)
 			}
 			newLatestControls = newLatestControls.Set(newControlID, ts, data)
@@ -295,8 +301,9 @@ func (r *Registry) updateAndGetControlsInTopology(pluginID string, topology *rep
 func (r *Registry) updatePluginControls(pluginID string, newPluginControls report.StringSet) {
 	oldFakePluginControls := r.fakePluginControls(pluginID)
 	newFakePluginControls := map[string]xfer.ControlHandlerFunc{}
-	for _, controlID := range newPluginControls {
-		newFakePluginControls[fakeControlID(pluginID, controlID)] = r.pluginControlHandler
+	for _, controlAndImage := range newPluginControls {
+		controlID, image := parseControlIDAndImage(controlAndImage)
+		newFakePluginControls[fakeControlID(pluginID, controlID, image)] = r.pluginControlHandler
 	}
 	r.handlerRegistry.Batch(oldFakePluginControls, newFakePluginControls)
 	r.controlsByPlugin[pluginID] = newPluginControls
@@ -310,7 +317,15 @@ type PluginResponse struct {
 }
 
 func (r *Registry) pluginControlHandler(req xfer.Request) xfer.Response {
-	pluginID, controlID := realPluginAndControlID(req.Control)
+	pluginID, controlID, image := realPluginAndControlIDAndImage(req.Control)
+
+	if image != "" {
+		if r.dockerRegistry == nil {
+			return xfer.ResponseErrorf("plugin %s cannot get docker registry", pluginID)
+		}
+		return r.dockerRegistry.StartImage(pluginID, controlID, image, req)
+	}
+
 	req.Control = controlID
 	r.lock.RLock()
 	defer r.lock.RUnlock()
@@ -326,12 +341,24 @@ func (r *Registry) pluginControlHandler(req xfer.Request) xfer.Response {
 	return xfer.ResponseErrorf("plugin %s not found", pluginID)
 }
 
-func realPluginAndControlID(fakeID string) (string, string) {
-	parts := strings.SplitN(fakeID, "~", 2)
-	if len(parts) != 2 {
-		return "", fakeID
+func realPluginAndControlIDAndImage(fakeID string) (string, string, string) {
+	parts := strings.SplitN(fakeID, "~", 3)
+	if len(parts) == 3 {
+		image, _ := url.QueryUnescape(parts[2])
+		return parts[0], parts[1], image
+	} else if len(parts) == 2 {
+		return parts[0], parts[1], ""
 	}
-	return parts[0], parts[1]
+	return "", fakeID, ""
+}
+
+func parseControlIDAndImage(controlAndImage string) (string, string) {
+	parts := strings.SplitN(controlAndImage, "~", 2)
+	if len(parts) == 2 {
+		image, _ := url.QueryUnescape(parts[1])
+		return parts[0], image
+	}
+	return controlAndImage, ""
 }
 
 // Close shuts down the registry. It can still be used after this, but will be
@@ -356,14 +383,18 @@ func (r *Registry) closePlugins(plugins map[string]*Plugin) {
 func (r *Registry) fakePluginControls(pluginID string) []string {
 	oldPluginControls := r.controlsByPlugin[pluginID]
 	var oldFakePluginControls []string
-	for _, controlID := range oldPluginControls {
-		oldFakePluginControls = append(oldFakePluginControls, fakeControlID(pluginID, controlID))
+	for _, controlAndImage := range oldPluginControls {
+		controlID, image := parseControlIDAndImage(controlAndImage)
+		oldFakePluginControls = append(oldFakePluginControls, fakeControlID(pluginID, controlID, image))
 	}
 	return oldFakePluginControls
 }
 
-func fakeControlID(pluginID, controlID string) string {
-	return fmt.Sprintf("%s~%s", pluginID, controlID)
+func fakeControlID(pluginID, controlID, image string) string {
+	if image == "" {
+		return fmt.Sprintf("%s~%s", pluginID, controlID)
+	}
+	return fmt.Sprintf("%s~%s~%s", pluginID, controlID, url.QueryEscape(image))
 }
 
 // Plugin is the implementation of a plugin. It is responsible for doing the

--- a/probe/plugins/registry_internal_test.go
+++ b/probe/plugins/registry_internal_test.go
@@ -30,7 +30,7 @@ import (
 func testRegistry(t *testing.T, apiVersion string) *Registry {
 	handlerRegistry := controls.NewDefaultHandlerRegistry()
 	root := "/plugins"
-	r, err := NewRegistry(root, apiVersion, nil, handlerRegistry, nil)
+	r, err := NewRegistry(root, apiVersion, nil, handlerRegistry, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -747,8 +747,8 @@ func TestRegistryRewritesControlReports(t *testing.T) {
 		t.Fatal(err)
 	}
 	// in a Pod topology, ctrl1 should be faked, ctrl2 should be left intact
-	expectedPodControls := []string{fakeControlID("testPlugin", controlID(1))}
-	expectedPodNodeControls := []string{fakeControlID("testPlugin", controlID(1)), controlID(2)}
+	expectedPodControls := []string{fakeControlID("testPlugin", controlID(1), "")}
+	expectedPodNodeControls := []string{fakeControlID("testPlugin", controlID(1), ""), controlID(2)}
 	checkControls(t, rpt.Pod, expectedPodControls, expectedPodNodeControls, "node1")
 	// in a Host topology, controls should be kept untouched
 	expectedHostControls := []string{controlID(1)}
@@ -781,7 +781,7 @@ func TestRegistryRegistersHandlers(t *testing.T) {
 	testBackend := newTestHandlerRegistryBackend(t)
 	handlerRegistry := controls.NewHandlerRegistry(testBackend)
 	root := "/plugins"
-	r, err := NewRegistry(root, "1", nil, handlerRegistry, nil)
+	r, err := NewRegistry(root, "1", nil, handlerRegistry, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -793,9 +793,9 @@ func TestRegistryRegistersHandlers(t *testing.T) {
 		t.Fatalf("Expected %d registered handler, got %d", expectedLen, len(testBackend.handlers))
 	}
 	fakeIDs := []string{
-		fakeControlID("testPlugin", controlID(1)),
-		fakeControlID("testPlugin2", controlID(1)),
-		fakeControlID("testPlugin2", controlID(2)),
+		fakeControlID("testPlugin", controlID(1), ""),
+		fakeControlID("testPlugin2", controlID(1), ""),
+		fakeControlID("testPlugin2", controlID(2), ""),
 	}
 	for _, fakeID := range fakeIDs {
 		if _, found := testBackend.Handler(fakeID); !found {
@@ -831,14 +831,14 @@ func TestRegistryHandlersCallPlugins(t *testing.T) {
 
 	handlerRegistry := controls.NewDefaultHandlerRegistry()
 	root := "/plugins"
-	r, err := NewRegistry(root, "1", nil, handlerRegistry, nil)
+	r, err := NewRegistry(root, "1", nil, handlerRegistry, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer r.Close()
 
 	r.Report()
-	fakeID := fakeControlID("testPlugin", controlID(1))
+	fakeID := fakeControlID("testPlugin", controlID(1), "")
 	req := xfer.Request{NodeID: "node1", Control: fakeID}
 	res := handlerRegistry.HandleControlRequest(req)
 	if res.Value != fmt.Sprintf("node1,%s", controlID(1)) {

--- a/report/controls.go
+++ b/report/controls.go
@@ -16,6 +16,18 @@ type Control struct {
 	Human string `json:"human"`
 	Icon  string `json:"icon"` // from https://fortawesome.github.io/Font-Awesome/cheatsheet/ please
 	Rank  int    `json:"rank"`
+
+	// AlwaysPropagated will propagate the control to all nodes of its
+	// topology. It is especially useful for plugins, so they can define
+	// controls on containers without having to know the list of
+	// containers. The propagation is done by the control tagger.
+	AlwaysPropagated bool `json:"always_propagated,omitempty"`
+
+	// RunContainerImage is the container image that will be executed by
+	// this control, if non-empty. It provides a way to define what the
+	// control does without a callback. It is especially useful for plugins
+	// to define simple controls without implementing the callbacks.
+	StartImage string `json:"start_image,omitempty"`
 }
 
 // Merge merges other with cs, returning a fresh Controls.


### PR DESCRIPTION
This patch adds a way for plugins to add controls to start a new
container such as GDB for debugging. This does not require the plugin to
know the list of Docker containers, nor does it require to communicate
with the Docker daemon at all. The plumbing is done in the probe itself.
The plugin merely advertises the name of the GDB-like container to use.

This is achieved through two new fields in the report that the plugin
sends to the probe.

```
    "controls": {
      "ctrl-one": {
        "id": "ctrl-one",
        "human": "Ctrl One",
        "icon": "fa-futbol-o",
        "rank": 1,
        "always_propagated": true,
        "start_image": "albanc/toolbox"
      },
    }
```

Notice the two new optional fields:

- AlwaysPropagated (default: false): this asks the new control tagger
(probe/controls/tagger.go) to add the control on all nodes of the topology. In
this way, the plugin does not need to know the list of nodes and it does not
need to duplicate the work from the probe.

- StartImage (default: empty): if not empty, the probe will not forward the
command to the plugin but do the job itself instead. It creates a new Docker
container from the specified image and starts it. A window in the Scope UI is
immediately created and attached to the container.

The plugin developer can simply create an image that will start a
debugger such as GDB or strace. The container will be created with the
following environment variables: $SCOPE_PLUGIN_ID, $SCOPE_CONTROL_ID,
$SCOPE_IMAGE, $SCOPE_APP_ID, $SCOPE_NODE_ID. From $SCOPE_NODE_ID, the
image can determine which process to gdb or strace.

Previously, the controlID given by the plugin was converted before being
added in the report in the following form: `pluginID~controlID`. Now, if
the StartImage field is not empty, the controlID added in the report
will now have this form: `pluginID~controlID~encodedImage`. encodedImage
uses url.QueryEscape() to make sure that slashes in image names don't
bother Scope App.

-----

TODO & questions:

- [ ] This patch was partially tested with https://github.com/kinvolk/scope-debugger but at the moment, "start_image" does not point to an image that uses $SCOPE_NODE_ID, so the full chain has not been tested.
- [ ] I am not so happy with the way I patched the struct controlsByPlugin (probe/plugins/registry.go). I think it will need to be clarified.
- [ ] This does not compile anymore after a rebase on master
- [ ] The report data structure (report/controls.go) is changed by this patch and this is visible by Scope App. Even though the go json parser ignore unknown fields, I am not sure about the compatibility with an older Scope App. I am pondering about using a different data structure for the communication between the plugin and the Probe.

