### PR TITLE
middleware/errorhandler: Implement Hijacker so it works with ws proxy

### DIFF
--- a/common/middleware/errorhandler.go
+++ b/common/middleware/errorhandler.go
@@ -83,7 +83,7 @@ func (i *errorInterceptor) Write(data []byte) (int, error) {
 }
 
 // errorInterceptor also implements net.Hijacker, to let the downstream Handler
-// hijack the connection. This is needed by the app-mapper's proxy.
+// hijack the connection. This is needed, for example, for working with websockets.
 func (i *errorInterceptor) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	hj, ok := i.originalWriter.(http.Hijacker)
 	if !ok {

--- a/common/middleware/errorhandler.go
+++ b/common/middleware/errorhandler.go
@@ -1,6 +1,9 @@
 package middleware
 
 import (
+	"bufio"
+	"fmt"
+	"net"
 	"net/http"
 )
 
@@ -77,4 +80,15 @@ func (i *errorInterceptor) Write(data []byte) (int, error) {
 		return i.originalWriter.Write(data)
 	}
 	return len(data), nil
+}
+
+// errorInterceptor also implements net.Hijacker, to let the downstream Handler
+// hijack the connection. This is needed by the app-mapper's proxy.
+func (i *errorInterceptor) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hj, ok := i.originalWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("error interceptor: can't cast original ResponseWriter to Hijacker")
+	}
+	i.gotCode = true
+	return hj.Hijack()
 }

--- a/common/middleware/logging.go
+++ b/common/middleware/logging.go
@@ -45,7 +45,7 @@ var LogFailed = Log{
 // want to report on success, i.e. http.StatusOK.
 //
 // interceptor also implements net.Hijacker, to let the downstream Handler
-// hijack the connection. This is needed by the app-mapper's proxy.
+// hijack the connection. This is needed, for example, for working with websockets.
 type interceptor struct {
 	http.ResponseWriter
 	statusCode int


### PR DESCRIPTION
The lack of this was causing 500s when errorhandler-wrapped requests were hijacked, such as for websocket proxying