### PR TITLE
Add anti-dance heuristics (and feature flags)

### DIFF
--- a/client/app/scripts/charts/__tests__/node-layout-test.js
+++ b/client/app/scripts/charts/__tests__/node-layout-test.js
@@ -35,6 +35,21 @@ describe('NodesLayout', () => {
         'n2-n4': {id: 'n2-n4', source: 'n2', target: 'n4'}
       })
     },
+    addNode15: {
+      nodes: fromJS({
+        n1: {id: 'n1'},
+        n2: {id: 'n2'},
+        n3: {id: 'n3'},
+        n4: {id: 'n4'},
+        n5: {id: 'n5'}
+      }),
+      edges: fromJS({
+        'n1-n3': {id: 'n1-n3', source: 'n1', target: 'n3'},
+        'n1-n4': {id: 'n1-n4', source: 'n1', target: 'n4'},
+        'n1-n5': {id: 'n1-n5', source: 'n1', target: 'n5'},
+        'n2-n4': {id: 'n2-n4', source: 'n2', target: 'n4'}
+      })
+    },
     removeEdge24: {
       nodes: fromJS({
         n1: {id: 'n1'},
@@ -82,6 +97,19 @@ describe('NodesLayout', () => {
         n3: {id: 'n3'},
         n4: {id: 'n4'},
         n5: {id: 'n5'}
+      }),
+      edges: fromJS({
+        'n1-n4': {id: 'n1-n4', source: 'n1', target: 'n4'}
+      })
+    },
+    singlePortrait6: {
+      nodes: fromJS({
+        n1: {id: 'n1'},
+        n2: {id: 'n2'},
+        n3: {id: 'n3'},
+        n4: {id: 'n4'},
+        n5: {id: 'n5'},
+        n6: {id: 'n6'}
       }),
       edges: fromJS({
         'n1-n4': {id: 'n1-n4', source: 'n1', target: 'n4'}
@@ -281,5 +309,66 @@ describe('NodesLayout', () => {
     expect(nodes.n1.x).toBeLessThan(nodes.n3.x);
     expect(nodes.n1.x).toBeLessThan(nodes.n5.x);
     expect(nodes.n2.x).toEqual(nodes.n5.x);
+  });
+
+  it('renders an additional single node in single nodes group', () => {
+    let result = NodesLayout.doLayout(
+      nodeSets.singlePortrait.nodes,
+      nodeSets.singlePortrait.edges);
+
+    nodes = result.nodes.toJS();
+
+    // first square row on same level as top-most other node
+    expect(nodes.n1.y).toEqual(nodes.n2.y);
+    expect(nodes.n1.y).toEqual(nodes.n3.y);
+    expect(nodes.n4.y).toEqual(nodes.n5.y);
+
+    // all singles right to other nodes
+    expect(nodes.n1.x).toEqual(nodes.n4.x);
+    expect(nodes.n1.x).toBeLessThan(nodes.n2.x);
+    expect(nodes.n1.x).toBeLessThan(nodes.n3.x);
+    expect(nodes.n1.x).toBeLessThan(nodes.n5.x);
+    expect(nodes.n2.x).toEqual(nodes.n5.x);
+
+    options.cachedLayout = result;
+    options.nodeCache = options.nodeCache.merge(result.nodes);
+    options.edgeCache = options.edgeCache.merge(result.edge);
+
+    result = NodesLayout.doLayout(
+      nodeSets.singlePortrait6.nodes,
+      nodeSets.singlePortrait6.edges,
+      options
+    );
+
+    nodes = result.nodes.toJS();
+
+    expect(nodes.n1.x).toBeLessThan(nodes.n2.x);
+    expect(nodes.n1.x).toBeLessThan(nodes.n3.x);
+    expect(nodes.n1.x).toBeLessThan(nodes.n5.x);
+    expect(nodes.n1.x).toBeLessThan(nodes.n6.x);
+  });
+
+  it('adds a new node to existing layout in a line', () => {
+    let result = NodesLayout.doLayout(
+      nodeSets.initial4.nodes,
+      nodeSets.initial4.edges);
+
+    nodes = result.nodes.toJS();
+
+    coords = getNodeCoordinates(result.nodes);
+    options.cachedLayout = result;
+    options.nodeCache = options.nodeCache.merge(result.nodes);
+    options.edgeCache = options.edgeCache.merge(result.edge);
+
+    result = NodesLayout.doLayout(
+      nodeSets.addNode15.nodes,
+      nodeSets.addNode15.edges,
+      options
+    );
+
+    nodes = result.nodes.toJS();
+
+    expect(nodes.n1.x).toBeGreaterThan(nodes.n5.x);
+    expect(nodes.n1.y).toEqual(nodes.n5.y);
   });
 });

--- a/client/app/scripts/charts/__tests__/node-layout-test.js
+++ b/client/app/scripts/charts/__tests__/node-layout-test.js
@@ -133,6 +133,9 @@ describe('NodesLayout', () => {
   };
 
   beforeEach(() => {
+    // clear feature flags
+    window.localStorage.clear();
+
     options = {
       nodeCache: makeMap(),
       edgeCache: makeMap()
@@ -416,6 +419,9 @@ describe('NodesLayout', () => {
   });
 
   it('adds a new node to existing layout in a line', () => {
+    // feature flag
+    window.localStorage.setItem('scope-experimental:layout-dance', true);
+
     let result = NodesLayout.doLayout(
       nodeSets.rank4.nodes,
       nodeSets.rank4.edges,

--- a/client/app/scripts/charts/__tests__/node-layout-test.js
+++ b/client/app/scripts/charts/__tests__/node-layout-test.js
@@ -294,7 +294,9 @@ describe('NodesLayout', () => {
   it('renders single nodes next to portrait graph', () => {
     const result = NodesLayout.doLayout(
       nodeSets.singlePortrait.nodes,
-      nodeSets.singlePortrait.edges);
+      nodeSets.singlePortrait.edges,
+      { noCache: true }
+    );
 
     nodes = result.nodes.toJS();
 
@@ -314,7 +316,9 @@ describe('NodesLayout', () => {
   it('renders an additional single node in single nodes group', () => {
     let result = NodesLayout.doLayout(
       nodeSets.singlePortrait.nodes,
-      nodeSets.singlePortrait.edges);
+      nodeSets.singlePortrait.edges,
+      { noCache: true }
+    );
 
     nodes = result.nodes.toJS();
 
@@ -347,28 +351,28 @@ describe('NodesLayout', () => {
     expect(nodes.n1.x).toBeLessThan(nodes.n5.x);
     expect(nodes.n1.x).toBeLessThan(nodes.n6.x);
   });
-
-  it('adds a new node to existing layout in a line', () => {
-    let result = NodesLayout.doLayout(
-      nodeSets.initial4.nodes,
-      nodeSets.initial4.edges);
-
-    nodes = result.nodes.toJS();
-
-    coords = getNodeCoordinates(result.nodes);
-    options.cachedLayout = result;
-    options.nodeCache = options.nodeCache.merge(result.nodes);
-    options.edgeCache = options.edgeCache.merge(result.edge);
-
-    result = NodesLayout.doLayout(
-      nodeSets.addNode15.nodes,
-      nodeSets.addNode15.edges,
-      options
-    );
-
-    nodes = result.nodes.toJS();
-
-    expect(nodes.n1.x).toBeGreaterThan(nodes.n5.x);
-    expect(nodes.n1.y).toEqual(nodes.n5.y);
-  });
+  //
+  // it('adds a new node to existing layout in a line', () => {
+  //   let result = NodesLayout.doLayout(
+  //     nodeSets.initial4.nodes,
+  //     nodeSets.initial4.edges);
+  //
+  //   nodes = result.nodes.toJS();
+  //
+  //   coords = getNodeCoordinates(result.nodes);
+  //   options.cachedLayout = result;
+  //   options.nodeCache = options.nodeCache.merge(result.nodes);
+  //   options.edgeCache = options.edgeCache.merge(result.edge);
+  //
+  //   result = NodesLayout.doLayout(
+  //     nodeSets.addNode15.nodes,
+  //     nodeSets.addNode15.edges,
+  //     options
+  //   );
+  //
+  //   nodes = result.nodes.toJS();
+  //
+  //   expect(nodes.n1.x).toBeGreaterThan(nodes.n5.x);
+  //   expect(nodes.n1.y).toEqual(nodes.n5.y);
+  // });
 });

--- a/client/app/scripts/charts/nodes-layout.js
+++ b/client/app/scripts/charts/nodes-layout.js
@@ -3,6 +3,7 @@ import debug from 'debug';
 import { fromJS, Map as makeMap, Set as ImmSet } from 'immutable';
 
 import { EDGE_ID_SEPARATOR } from '../constants/naming';
+import { featureIsEnabledAny } from '../utils/feature-utils';
 import { buildTopologyCacheId, updateNodeDegrees } from '../utils/topology-utils';
 
 const log = debug('scope:nodes-layout');
@@ -460,13 +461,17 @@ export function doLayout(immNodes, immEdges, opts) {
     layout = copyLayoutProperties(layout, nodeCache, edgeCache);
   } else {
     const nodesWithDegrees = updateNodeDegrees(immNodes, immEdges);
-    if (useCache && hasNewSingleNode(nodesWithDegrees, nodeCache)) {
+    if (useCache
+      && featureIsEnabledAny('layout-dance', 'layout-dance-single')
+      && hasNewSingleNode(nodesWithDegrees, nodeCache)) {
       // special case: new nodes are 0-degree nodes, no need for layout run,
       // they will be layed out further below
       log('skip layout, only 0-degree node(s) added');
       layout = cloneLayout(cachedLayout, nodesWithDegrees, immEdges);
       layout = copyLayoutProperties(layout, nodeCache, edgeCache);
-    } else if (useCache && hasNewNodesOfExistingRank(nodesWithDegrees, immEdges, nodeCache)) {
+    } else if (useCache
+      && featureIsEnabledAny('layout-dance', 'layout-dance-rank')
+      && hasNewNodesOfExistingRank(nodesWithDegrees, immEdges, nodeCache)) {
       // special case: few new nodes were added, no need for layout run,
       // they will inserted according to ranks
       log('skip layout, used rank-based insertion');

--- a/client/app/scripts/charts/nodes-layout.js
+++ b/client/app/scripts/charts/nodes-layout.js
@@ -465,7 +465,7 @@ export function doLayout(immNodes, immEdges, opts) {
       && featureIsEnabledAny('layout-dance', 'layout-dance-single')
       && hasNewSingleNode(nodesWithDegrees, nodeCache)) {
       // special case: new nodes are 0-degree nodes, no need for layout run,
-      // they will be layed out further below
+      // they will be laid out further below
       log('skip layout, only 0-degree node(s) added');
       layout = cloneLayout(cachedLayout, nodesWithDegrees, immEdges);
       layout = copyLayoutProperties(layout, nodeCache, edgeCache);

--- a/client/app/scripts/charts/nodes-layout.js
+++ b/client/app/scripts/charts/nodes-layout.js
@@ -8,8 +8,9 @@ import { buildTopologyCacheId, updateNodeDegrees } from '../utils/topology-utils
 const log = debug('scope:nodes-layout');
 
 const topologyCaches = {};
-const DEFAULT_WIDTH = 800;
-const DEFAULT_MARGINS = {top: 0, left: 0};
+export const DEFAULT_WIDTH = 800;
+export const DEFAULT_HEIGHT = DEFAULT_WIDTH / 2;
+export const DEFAULT_MARGINS = {top: 0, left: 0};
 const DEFAULT_SCALE = val => val * 2;
 const NODE_SIZE_FACTOR = 1;
 const NODE_SEPARATION_FACTOR = 2.0;
@@ -127,11 +128,63 @@ function runLayoutEngine(graph, imNodes, imEdges, opts) {
   };
 }
 
-export function doLayoutNewNodesOfExistingRank(layout, immNodes, immEdges, opts) {
-  console.log(opts);
+/**
+ * Adds `points` array to edge based on location of source and target
+ * @param {Map} edge           new edge
+ * @param {Map} nodeCache      all nodes
+ * @returns {Map}              modified edge
+ */
+function setSimpleEdgePoints(edge, nodeCache) {
+  const source = nodeCache.get(edge.get('source'));
+  const target = nodeCache.get(edge.get('target'));
+  return edge.set('points', fromJS([
+    {x: source.get('x'), y: source.get('y')},
+    {x: target.get('x'), y: target.get('y')}
+  ]));
+}
+
+/**
+ * Layout nodes that have rank that already exists.
+ * Relies on only nodes being added that have a connection to an existing node
+ * while having a rank of an existing node. They will be laid out in the same
+ * line as the latter, with a direct connection between the existing and the new node.
+ * @param  {object} layout    Layout with nodes and edges
+ * @param  {Map} nodeCache    previous nodes
+ * @param  {object} opts      Options
+ * @return {object}           new layout object
+ */
+export function doLayoutNewNodesOfExistingRank(layout, nodeCache, opts) {
+  const result = Object.assign({}, layout);
+  const options = opts || {};
+  const scale = options.scale || DEFAULT_SCALE;
+  const nodesep = scale(NODE_SEPARATION_FACTOR);
+  const nodeWidth = scale(NODE_SIZE_FACTOR);
+
   // determine new nodes
-  // layout new nodes
-  // return layout
+  const oldNodes = ImmSet.fromKeys(nodeCache);
+  const newNodes = ImmSet.fromKeys(layout.nodes.filter(n => n.get('degree') > 0))
+    .subtract(oldNodes);
+  result.nodes = layout.nodes.map(n => {
+    if (newNodes.contains(n.get('id'))) {
+      const nodesSameRank = nodeCache.filter(nn => nn.get('rank') === n.get('rank'));
+      if (nodesSameRank.size > 0) {
+        const y = nodesSameRank.first().get('y');
+        const x = nodesSameRank.maxBy(nn => nn.get('x')).get('x') + nodesep + nodeWidth;
+        return n.merge({ x, y });
+      }
+      return n;
+    }
+    return n;
+  });
+
+  result.edges = layout.edges.map(edge => {
+    if (!edge.has('points')) {
+      return setSimpleEdgePoints(edge, layout.nodes);
+    }
+    return edge;
+  });
+
+  return result;
 }
 
 /**
@@ -223,51 +276,42 @@ function layoutSingleNodes(layout, opts) {
  * @param  {Object} opts   Options with width and margins
  * @return {Object}        modified layout
  */
-function shiftLayoutToCenter(layout, opts) {
+export function shiftLayoutToCenter(layout, opts) {
   const result = Object.assign({}, layout);
   const options = opts || {};
   const margins = options.margins || DEFAULT_MARGINS;
   const width = options.width || DEFAULT_WIDTH;
-  const height = options.height || width / 2;
+  const height = options.height || DEFAULT_HEIGHT;
 
   let offsetX = 0 + margins.left;
   let offsetY = 0 + margins.top;
 
   if (layout.width < width) {
-    offsetX = (width - layout.width) / 2 + margins.left;
+    const xMin = layout.nodes.minBy(n => n.get('x'));
+    const xMax = layout.nodes.maxBy(n => n.get('x'));
+    offsetX = (width - (xMin.get('x') + xMax.get('x'))) / 2 + margins.left;
   }
   if (layout.height < height) {
-    offsetY = (height - layout.height) / 2 + margins.top;
+    const yMin = layout.nodes.minBy(n => n.get('y'));
+    const yMax = layout.nodes.maxBy(n => n.get('y'));
+    offsetY = (height - (yMin.get('y') + yMax.get('y'))) / 2 + margins.top;
   }
 
-  result.nodes = layout.nodes.map(node => node.merge({
-    x: node.get('x') + offsetX,
-    y: node.get('y') + offsetY
-  }));
+  if (offsetX || offsetY) {
+    result.nodes = layout.nodes.map(node => node.merge({
+      x: node.get('x') + offsetX,
+      y: node.get('y') + offsetY
+    }));
 
-  result.edges = layout.edges.map(edge => edge.update('points',
-    points => points.map(point => point.merge({
-      x: point.get('x') + offsetX,
-      y: point.get('y') + offsetY
-    }))
-  ));
+    result.edges = layout.edges.map(edge => edge.update('points',
+      points => points.map(point => point.merge({
+        x: point.get('x') + offsetX,
+        y: point.get('y') + offsetY
+      }))
+    ));
+  }
 
   return result;
-}
-
-/**
- * Adds `points` array to edge based on location of source and target
- * @param {Map} edge           new edge
- * @param {Map} nodeCache      all nodes
- * @returns {Map}              modified edge
- */
-function setSimpleEdgePoints(edge, nodeCache) {
-  const source = nodeCache.get(edge.get('source'));
-  const target = nodeCache.get(edge.get('target'));
-  return edge.set('points', fromJS([
-    {x: source.get('x'), y: source.get('y')},
-    {x: target.get('x'), y: target.get('y')}
-  ]));
 }
 
 /**
@@ -303,11 +347,25 @@ function hasNewSingleNode(nodes, cache) {
  * Determine if all new nodes are of existing ranks
  * Requires cached nodes (implies a previous layout run).
  * @param  {Map} nodes     new Map of nodes
+ * @param  {Map} edges     new Map of edges
  * @param  {Map} cache     old Map of nodes
  * @return {Boolean} True if all new nodes have a rank that already exists
  */
-function hasNewNodesOfExistingRank(nodes, cache) {
-  return false && nodes && cache;
+export function hasNewNodesOfExistingRank(nodes, edges, cache) {
+  const oldNodes = ImmSet.fromKeys(cache);
+  const newNodes = ImmSet.fromKeys(nodes).subtract(oldNodes);
+
+  // if new there are edges that connect 2 new nodes, need a full layout
+  const bothNodesNew = edges.find(edge => newNodes.contains(edge.get('source'))
+    && newNodes.contains(edge.get('target')));
+  if (bothNodesNew) {
+    return false;
+  }
+
+  const oldRanks = cache.filter(n => n.get('rank')).map(n => n.get('rank')).toSet();
+  const hasNewNodesOfExistingRankOrSingle = newNodes.every(key => nodes.getIn([key, 'degree']) === 0
+    || oldRanks.contains(nodes.getIn([key, 'rank'])));
+  return oldNodes.size > 0 && hasNewNodesOfExistingRankOrSingle;
 }
 
 /**
@@ -357,8 +415,10 @@ function copyLayoutProperties(layout, nodeCache, edgeCache) {
     if (edgeCache.has(edge.get('id'))
       && hasSameEndpoints(edgeCache.get(edge.get('id')), result.nodes)) {
       return edge.merge(edgeCache.get(edge.get('id')));
+    } else if (nodeCache.get(edge.get('source')) && nodeCache.get(edge.get('target'))) {
+      return setSimpleEdgePoints(edge, nodeCache);
     }
-    return setSimpleEdgePoints(edge, nodeCache);
+    return edge;
   });
   return result;
 }
@@ -406,13 +466,13 @@ export function doLayout(immNodes, immEdges, opts) {
       log('skip layout, only 0-degree node(s) added');
       layout = cloneLayout(cachedLayout, nodesWithDegrees, immEdges);
       layout = copyLayoutProperties(layout, nodeCache, edgeCache);
-    } else if (useCache && hasNewNodesOfExistingRank(nodesWithDegrees, nodeCache)) {
+    } else if (useCache && hasNewNodesOfExistingRank(nodesWithDegrees, immEdges, nodeCache)) {
       // special case: few new nodes were added, no need for layout run,
       // they will inserted according to ranks
       log('skip layout, used rank-based insertion');
       layout = cloneLayout(cachedLayout, nodesWithDegrees, immEdges);
       layout = copyLayoutProperties(layout, nodeCache, edgeCache);
-      layout = doLayoutNewNodesOfExistingRank(layout, nodesWithDegrees, immEdges);
+      layout = doLayoutNewNodesOfExistingRank(layout, nodeCache, opts);
     } else {
       const graph = cache.graph;
       layout = runLayoutEngine(graph, nodesWithDegrees, immEdges, opts);
@@ -420,6 +480,7 @@ export function doLayout(immNodes, immEdges, opts) {
         return layout;
       }
     }
+
     layout = layoutSingleNodes(layout, opts);
     layout = shiftLayoutToCenter(layout, opts);
   }

--- a/client/app/scripts/components/debug-toolbar.js
+++ b/client/app/scripts/components/debug-toolbar.js
@@ -160,8 +160,8 @@ class DebugToolbar extends React.Component {
     this.onChange = this.onChange.bind(this);
     this.toggleColors = this.toggleColors.bind(this);
     this.addNodes = this.addNodes.bind(this);
-    this.intermittendTimer = null;
-    this.intermittendNodes = makeSet();
+    this.intermittentTimer = null;
+    this.intermittentNodes = makeSet();
     this.shortLivedTimer = null;
     this.shortLivedNodes = makeSet();
     this.state = {
@@ -188,26 +188,13 @@ class DebugToolbar extends React.Component {
     this.asyncDispatch(setAppState(state => state.set('topologiesLoaded', !loading)));
   }
 
-  updateAdjacencies() {
-    const ns = this.props.nodes;
-    const nodeNames = ns.keySeq().toJS();
-    this.asyncDispatch(receiveNodesDelta({
-      add: this._addNodes(7),
-      update: sample(nodeNames).map(n => ({
-        id: n,
-        adjacency: sample(nodeNames),
-      }), nodeNames.length),
-      remove: this._removeNode(),
-    }));
-  }
-
-  setIntermittend() {
+  setIntermittent() {
     // simulate epheremal nodes
-    if (this.intermittendTimer) {
-      clearInterval(this.intermittendTimer);
-      this.intermittendTimer = null;
+    if (this.intermittentTimer) {
+      clearInterval(this.intermittentTimer);
+      this.intermittentTimer = null;
     } else {
-      this.intermittendTimer = setInterval(() => {
+      this.intermittentTimer = setInterval(() => {
         // add new node
         this.addNodes(1);
 
@@ -370,7 +357,7 @@ class DebugToolbar extends React.Component {
         <div>
           <label>Short-lived nodes</label>
           <button onClick={() => this.setShortLived()}>Toggle short-lived nodes</button>
-          <button onClick={() => this.setIntermittend()}>Toggle intermittend nodes</button>
+          <button onClick={() => this.setIntermittent()}>Toggle intermittent nodes</button>
         </div>
 
         <div>

--- a/client/app/scripts/utils/__tests__/feature-utils-test.js
+++ b/client/app/scripts/utils/__tests__/feature-utils-test.js
@@ -1,0 +1,30 @@
+
+const FU = require('../feature-utils');
+
+describe('FeatureUtils', () => {
+  const FEATURE_X_KEY = 'my feature 1';
+  const FEATURE_Y_KEY = 'my feature 2';
+
+  beforeEach(() => {
+    FU.clearFeatures();
+  });
+
+  describe('Setting of features', () => {
+    it('should not have any features by default', () => {
+      expect(FU.featureIsEnabled(FEATURE_X_KEY)).toBeFalsy();
+      expect(FU.featureIsEnabled(FEATURE_Y_KEY)).toBeFalsy();
+    });
+
+    it('should work with enabling one feature', () => {
+      let success;
+      expect(FU.featureIsEnabled(FEATURE_X_KEY)).toBeFalsy();
+      success = FU.setFeature(FEATURE_X_KEY, true);
+      expect(success).toBeTruthy();
+      expect(FU.featureIsEnabled(FEATURE_X_KEY)).toBeTruthy();
+      expect(FU.featureIsEnabled(FEATURE_Y_KEY)).toBeFalsy();
+      success = FU.setFeature(FEATURE_X_KEY, false);
+      expect(success).toBeTruthy();
+      expect(FU.featureIsEnabled(FEATURE_X_KEY)).toBeFalsy();
+    });
+  });
+});

--- a/client/app/scripts/utils/__tests__/feature-utils-test.js
+++ b/client/app/scripts/utils/__tests__/feature-utils-test.js
@@ -6,7 +6,8 @@ describe('FeatureUtils', () => {
   const FEATURE_Y_KEY = 'my feature 2';
 
   beforeEach(() => {
-    FU.clearFeatures();
+    FU.setFeature(FEATURE_X_KEY, false);
+    FU.setFeature(FEATURE_Y_KEY, false);
   });
 
   describe('Setting of features', () => {
@@ -25,6 +26,18 @@ describe('FeatureUtils', () => {
       success = FU.setFeature(FEATURE_X_KEY, false);
       expect(success).toBeTruthy();
       expect(FU.featureIsEnabled(FEATURE_X_KEY)).toBeFalsy();
+    });
+
+    it('should allow for either feature', () => {
+      let success;
+      expect(FU.featureIsEnabledAny(FEATURE_X_KEY, FEATURE_Y_KEY)).toBeFalsy();
+      success = FU.setFeature(FEATURE_X_KEY, true);
+      expect(success).toBeTruthy();
+      expect(FU.featureIsEnabledAny(FEATURE_X_KEY, FEATURE_Y_KEY)).toBeTruthy();
+      success = FU.setFeature(FEATURE_X_KEY, false);
+      success = FU.setFeature(FEATURE_Y_KEY, true);
+      expect(success).toBeTruthy();
+      expect(FU.featureIsEnabledAny(FEATURE_X_KEY, FEATURE_Y_KEY)).toBeTruthy();
     });
   });
 });

--- a/client/app/scripts/utils/feature-utils.js
+++ b/client/app/scripts/utils/feature-utils.js
@@ -1,7 +1,7 @@
 import { storageGet, storageSet } from './storage-utils';
 
 // prefix for all feature flags
-const STORAGE_KEY_PREFIX = 'scope-experimental-';
+const STORAGE_KEY_PREFIX = 'scope-experimental:';
 
 const getKey = key => `${STORAGE_KEY_PREFIX}${key}`;
 
@@ -9,7 +9,7 @@ const getKey = key => `${STORAGE_KEY_PREFIX}${key}`;
  * Returns true if `feature` is enabled
  *
  * Features can be enabled either via calling `setFeature()` or by setting
- * `localStorage.scope-experimental-featureName = true` in the console.
+ * `localStorage.scope-experimental:featureName = true` in the console.
  * @param  {String} feature Feature name, ideally one word or hyphenated
  * @return {Boolean}         True if feature is enabled
  */

--- a/client/app/scripts/utils/feature-utils.js
+++ b/client/app/scripts/utils/feature-utils.js
@@ -1,0 +1,18 @@
+import { storageGetObject, storageSetObject } from './storage-utils';
+
+const STORAGE_FEATURE_KEY = 'scopeFeatureFlags';
+
+export function featureIsEnabled(feature) {
+  const features = storageGetObject(STORAGE_FEATURE_KEY, {});
+  return features[feature];
+}
+
+export function setFeature(feature, isEnabled) {
+  const features = storageGetObject(STORAGE_FEATURE_KEY, {});
+  features[feature] = isEnabled;
+  return storageSetObject(STORAGE_FEATURE_KEY, features);
+}
+
+export function clearFeatures() {
+  return storageSetObject(STORAGE_FEATURE_KEY, {});
+}

--- a/client/app/scripts/utils/feature-utils.js
+++ b/client/app/scripts/utils/feature-utils.js
@@ -1,18 +1,39 @@
-import { storageGetObject, storageSetObject } from './storage-utils';
+import { storageGet, storageSet } from './storage-utils';
 
-const STORAGE_FEATURE_KEY = 'scopeFeatureFlags';
+// prefix for all feature flags
+const STORAGE_KEY_PREFIX = 'scope-experimental-';
 
+const getKey = key => `${STORAGE_KEY_PREFIX}${key}`;
+
+/**
+ * Returns true if `feature` is enabled
+ *
+ * Features can be enabled either via calling `setFeature()` or by setting
+ * `localStorage.scope-experimental-featureName = true` in the console.
+ * @param  {String} feature Feature name, ideally one word or hyphenated
+ * @return {Boolean}         True if feature is enabled
+ */
 export function featureIsEnabled(feature) {
-  const features = storageGetObject(STORAGE_FEATURE_KEY, {});
-  return features[feature];
+  return storageGet(getKey(feature));
 }
 
+/**
+ * Returns true if any of the features given as arguments are enabled.
+ *
+ * Useful if features are hierarchical, e.g.:
+ * `featureIsEnabledAny('superFeature', 'subFeature')`
+ * @param  {String} args Feature names
+ * @return {Boolean}      True if any of the features are enabled
+ */
+export function featureIsEnabledAny(...args) {
+  return Array.prototype.some.call(args, feature => featureIsEnabled(feature));
+}
+
+/**
+ * Set true/false if a feature is enabled.
+ * @param {String}  feature   Feature name
+ * @param {Boolean} isEnabled true/false
+ */
 export function setFeature(feature, isEnabled) {
-  const features = storageGetObject(STORAGE_FEATURE_KEY, {});
-  features[feature] = isEnabled;
-  return storageSetObject(STORAGE_FEATURE_KEY, features);
-}
-
-export function clearFeatures() {
-  return storageSetObject(STORAGE_FEATURE_KEY, {});
+  return storageSet(getKey(feature), isEnabled);
 }

--- a/client/app/scripts/utils/storage-utils.js
+++ b/client/app/scripts/utils/storage-utils.js
@@ -6,7 +6,7 @@ const log = debug('scope:storage-utils');
 const storage = typeof(Storage) !== 'undefined' ? window.localStorage : null;
 
 export function storageGet(key, defaultValue) {
-  if (storage && storage[key] !== undefined) {
+  if (storage && storage.getItem(key) !== undefined) {
     return storage.getItem(key);
   }
   return defaultValue;
@@ -16,8 +16,31 @@ export function storageSet(key, value) {
   if (storage) {
     try {
       storage.setItem(key, value);
+      return true;
     } catch (e) {
       log('Error storing value in storage. Maybe full? Could not store key.', key);
     }
   }
+  return false;
+}
+
+export function storageGetObject(key, defaultValue) {
+  const value = storageGet(key);
+  if (value) {
+    try {
+      return JSON.parse(value);
+    } catch (e) {
+      log('Error getting object for key.', key);
+    }
+  }
+  return defaultValue;
+}
+
+export function storageSetObject(key, obj) {
+  try {
+    return storageSet(key, JSON.stringify(obj));
+  } catch (e) {
+    log('Error encoding object for key', key);
+  }
+  return false;
 }

--- a/client/package.json
+++ b/client/package.json
@@ -90,6 +90,10 @@
   },
   "jest": {
     "transform": {".*": "<rootDir>/node_modules/babel-jest"},
+    "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
+    "setupFiles": [
+      "<rootDir>/test/support/localStorage.js"
+    ],
     "testPathDirs": [
       "<rootDir>/app/scripts"
     ],

--- a/client/package.json
+++ b/client/package.json
@@ -90,7 +90,6 @@
   },
   "jest": {
     "transform": {".*": "<rootDir>/node_modules/babel-jest"},
-    "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
     "setupFiles": [
       "<rootDir>/test/support/localStorage.js"
     ],

--- a/client/test/support/localStorage.js
+++ b/client/test/support/localStorage.js
@@ -1,0 +1,17 @@
+const localStorageMock = (function() {
+  let store = {};
+  return {
+    store,
+    getItem: function(key) {
+      return store[key];
+    },
+    setItem: function(key, value) {
+      store[key] = value.toString();
+    },
+    clear: function() {
+      store = {};
+    }
+  };
+})();
+Object.defineProperty(window, 'Storage', { value: localStorageMock });
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });

--- a/client/test/support/localStorage.js
+++ b/client/test/support/localStorage.js
@@ -6,7 +6,7 @@ const localStorageMock = (function() {
       return store[key];
     },
     setItem: function(key, value) {
-      store[key] = value.toString();
+      store[key] = value;
     },
     clear: function() {
       store = {};


### PR DESCRIPTION
This PR introduces new special cases that will not trigger a full re-layout:

- new 0-degree nodes
- new nodes that are connected to previous nodes while sharing a rank of other existing nodes

Both heuristics are disabled by default and can be enabled via feature flags, which are introduced here as well (see `utils/feature-utils`):

In the console you can set `localStorage['scope-experimental:layout-dance'] = true` to try them out.

Related to #1033 