### PR TITLE
Add graph complexity check on page load

### DIFF
--- a/client/app/scripts/reducers/__tests__/root-test.js
+++ b/client/app/scripts/reducers/__tests__/root-test.js
@@ -1,5 +1,4 @@
-const is = require('immutable').is;
-
+import {is, fromJS} from 'immutable';
 // Root reducer test suite using Jasmine matchers
 
 describe('RootReducer', () => {
@@ -43,6 +42,34 @@ describe('RootReducer', () => {
       stack: undefined
     }
   };
+
+  const topologies = [{
+    hide_if_empty: true,
+    name: 'Processes',
+    rank: 1,
+    sub_topologies: [],
+    url: '/api/topology/processes',
+    fullName: 'Processes',
+    id: 'processes',
+    options: [
+      {
+        defaultValue: 'hide',
+        id: 'unconnected',
+        options: [
+          {
+            label: 'Unconnected nodes hidden',
+            value: 'hide'
+          }
+        ]
+      }
+    ],
+    stats: {
+      edge_count: 319,
+      filtered_nodes: 214,
+      node_count: 320,
+      nonpseudo_node_count: 320
+    }
+  }];
 
   // actions
 
@@ -467,5 +494,10 @@ describe('RootReducer', () => {
     let nextState = initialState.set('showingHelp', true);
     nextState = reducer(nextState, { type: ActionTypes.CLICK_BACKGROUND });
     expect(nextState.get('showingHelp')).toBe(false);
+  });
+  it('switches to grid mode when complexity is high', () => {
+    let nextState = initialState.set('currentTopology', fromJS(topologies[0]));
+    nextState = reducer(nextState, {type: ActionTypes.SET_RECEIVED_NODES_DELTA});
+    expect(nextState.get('gridMode')).toBe(true);
   });
 });

--- a/client/app/scripts/reducers/root.js
+++ b/client/app/scripts/reducers/root.js
@@ -8,7 +8,8 @@ import { EDGE_ID_SEPARATOR } from '../constants/naming';
 import { applyPinnedSearches, updateNodeMatches } from '../utils/search-utils';
 import { getNetworkNodes, getAvailableNetworks } from '../utils/network-view-utils';
 import { findTopologyById, getAdjacentNodes, setTopologyUrlsById, updateTopologyIds,
-  filterHiddenTopologies, addTopologyFullname, getDefaultTopology } from '../utils/topology-utils';
+  filterHiddenTopologies, addTopologyFullname, getDefaultTopology, graphExceedsComplexityThresh
+} from '../utils/topology-utils';
 
 const log = debug('scope:app-store');
 const error = debug('scope:error');
@@ -501,6 +502,13 @@ export function rootReducer(state = initialState, action) {
     }
 
     case ActionTypes.SET_RECEIVED_NODES_DELTA: {
+      // Turn on the table view if the graph is too complex
+      if (!state.get('nodesLoaded')) {
+        const topoStats = state.get('currentTopology').get('stats');
+        state = graphExceedsComplexityThresh(topoStats)
+          ? state.set('gridMode', true)
+          : state;
+      }
       return state.set('nodesLoaded', true);
     }
 

--- a/client/app/scripts/utils/topology-utils.js
+++ b/client/app/scripts/utils/topology-utils.js
@@ -175,3 +175,8 @@ export function getCurrentTopologyUrl(state) {
 export function isNodeMatchingQuery(node, query) {
   return node.get('label').includes(query) || node.get('subLabel').includes(query);
 }
+
+export function graphExceedsComplexityThresh(stats) {
+  // Check to see if complexity is high. Used to trigger table view on page load.
+  return (stats.get('node_count') + (2 * stats.get('edge_count'))) > 500;
+}


### PR DESCRIPTION
Fix for #1721 .

When the page is loaded, the first received topology will trigger a check to see if the graph will be too complex to render. If so, the view will switch to the table view.  The complexity check formula:
`(currentTopology.stats.node_count * (2 * currentTopology.stats.edge_count)) > 500`

The user can switch to the graph view at any time. This logic only applies at page load. To test with a high node count (on linux):
`nc -lk 1122 & for i in $(seq 1 300) ; do nc localhost 1122 & done`

@davkal Let me know what you think.