### PR TITLE
Give time to the overlay test backoff collectors to finish

### DIFF
--- a/probe/overlay/weave_test.go
+++ b/probe/overlay/weave_test.go
@@ -81,6 +81,9 @@ func runTest(t *testing.T, f func(*overlay.Weave)) {
 		return len(have.Overlay.Nodes)
 	})
 
+	// Give some time for the Backoff collectors to finish
+	time.Sleep(time.Second)
+
 	f(w)
 }
 


### PR DESCRIPTION
Not the most elegant/robust solution but it solves the problem without adding
extra methods to the backoff interface (only to check if they are ready from
tests).

Fixes #1984 