### PR TITLE
Update website plugins documentation

### DIFF
--- a/site/plugins.md
+++ b/site/plugins.md
@@ -200,7 +200,54 @@ A short note about the "icon" field of the topology control - the
 value for it can be taken from [Font Awesome
 Cheatsheet](http://fontawesome.io/cheatsheet/)
 
+#### Node naming
 
+Very often the controller plugin wants to add some controls to already
+existing nodes (like controls for network traffic management to nodes
+representing the running Docker container). To achieve that, it is
+important to make sure that the node ID in the plugin's report matches
+the ID of the node created by the probe. The ID is a
+semicolon-separated list of strings.
+
+For containers, images, hosts and others the ID is usually formatted
+as `${name};<${tag}>`. The `${name}` variable is usually a name of a
+thing the node represents, like an ID of the Docker container or the
+hostname. The `${tag}` denotes the type of the node. There is a fixed
+set of tags used by the probe:
+
+- host
+- container
+- container_image
+- pod
+- service
+- deployment
+- replica_set
+
+The examples of "tagged" node names:
+
+- The Docker container with full ID
+  2299a2ca59dfd821f367e689d5869c4e568272c2305701761888e1d79d7a6f51:
+  `2299a2ca59dfd821f367e689d5869c4e568272c2305701761888e1d79d7a6f51;<container>`
+- The Docker image with name `docker.io/alpine`:
+  `docker.io/alpine;<container_image>`
+- The host with name `example.com`: `example.com;<host>`
+
+The fixed set of tags listed above is not a complete set of names a
+node can have though. For example, nodes representing processes
+have ID formatted as `${host};${pid}`. Probably the easiest ways to
+discover how the nodes are named are:
+
+- Read the code in
+  [report/id.go](https://github.com/weaveworks/scope/blob/master/report/id.go).
+- Browse the Weave Scope GUI, select some node and search for an `id`
+  key in the `nodeDetails` array in the address bar.
+  - For example in the
+    `http://localhost:4040/#!/state/{"controlPipe":null,"nodeDetails":[{"id":"example.com;<host>","label":"example.com","topologyId":"hosts"}],…`
+    URL, you can find the `example.com;<host>` which is an ID of the node
+    representing the host.
+  - Mentally substitute the `<SLASH>` with `/`. This can appear in
+    Docker image names, so `docker.io/alpine` in the address bar will
+    be `docker.io<SLASH>alpine`.
 
  **See Also**
 

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -5,6 +5,7 @@ menu_order: 80
 
 The following topics are discussed:
 
+ * [Official Plugins](#official-plugins)
  * [Listening Protocol](#listening-protocol)
  * [Reporting](#reporting)
  * [Interfaces](#interfaces)
@@ -13,17 +14,21 @@ With a Scope probe plugin, you can insert custom metrics into Scope and have the
 
 ![Custom Metrics With Plugins](images/plugin-features.png)
 
-You can find some examples in [the example plugins](https://github.com/weaveworks/scope/tree/master/examples/plugins) directory.
+## <a id="official-plugins"></a>Official Plugins
 
-There are currently two different examples:
+You can find all the official plugins at [Weaveworks Plugins](https://github.com/weaveworks-plugins).
 
-* A [Python plugin](https://github.com/weaveworks/scope/tree/master/examples/plugins/http-requests) using [bcc](http://iovisor.github.io/bcc/) to extract incoming HTTP request rates per process, without any application-level instrumentation requirements and negligible performance toll (metrics are obtained in-kernel without any packet copying to userspace).
+* [IOWait](https://github.com/weaveworks-plugins/scope-iowait): a Go plugin using [iostat](https://en.wikipedia.org/wiki/Iostat) to provide host-level CPU IO wait or idle metrics.
 
->**Note:** This plugin needs a [recent kernel version with ebpf support](https://github.com/iovisor/bcc/blob/master/INSTALL.md#kernel-configuration). It will not compile on current [dlite](https://github.com/nlf/dlite) and boot2docker hosts.
+* [HTTP Statistics](https://github.com/weaveworks-plugins/scope-http-statistics): A Python plugin using [bcc](http://iovisor.github.io/bcc/) to track multiple metrics about HTTP per process, without any application-level instrumentation requirements and negligible performance toll. This plugin is a work in progress, as of now it implements two metrics (for more information read the [plugin documentation](https://github.com/weaveworks-plugins/scope-http-statistics)):
+	* Number of HTTP requests per seconds.
+	* Number of HTTP responses code per second (per code).
 
- * A [Go plugin](https://github.com/weaveworks/scope/tree/master/examples/plugins/iovisor), using [iostat](https://en.wikipedia.org/wiki/Iostat) to provide host-level CPU IO wait metrics.
+> **Note:** This plugin needs a [recent kernel version with ebpf support](https://github.com/iovisor/bcc/blob/master/INSTALL.md#kernel-configuration). It will not compile on current [dlite](https://github.com/nlf/dlite) and boot2docker hosts.
 
-The example plugins are run by calling `make` in their directory. This builds the plugin, and immediately runs it in the foreground. To run the plugin in the background, see the `Makefile` for examples of the `docker run ...` command.
+* [Traffic Control](https://github.com/weaveworks-plugins/scope-traffic-control): This plugin allows the user to modify latency and packet loss for a specific container via buttons in the UI's container detailed view.
+
+* [Volume Count](https://github.com/weaveworks-plugins/scope-volume-count): This plugin is a Python application that asks docker for the the number of mounted volumes for each container, providing container-level count.
 
 If the running plugin was picked up by Scope, you will see it in the list of `PLUGINS` in the bottom right of the UI.
 

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -221,13 +221,13 @@ hostname. The `${tag}` denotes the type of the node.
 
 There is a fixed set of tags used by the probe:
 
-- host
-- container
-- container_image
-- pod
-- service
-- deployment
-- replica_set
+- `host`
+- `container`
+- `container_image`
+- `pod`
+- `service`
+- `deployment`
+- `replica_set`
 
 These are examples of "tagged" node names:
 

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -13,7 +13,7 @@ The following topics are discussed:
   * [Controller Interface](#controller-interface)
      * [Control](#control)
      * [How to Expose Controls](#expose-controls)
-     * [Naming Nodes](#naming-nodes)     
+     * [Naming Nodes](#naming-nodes)
  * [A Guide to Developing Plugins](#plugins-developing-guide)
   * [Setting up the Structure](#structure)
   * [Defining the Reporter Interface](#reporter-interface)
@@ -55,7 +55,7 @@ separated by a dash.
 
 ### <a id="plugin-registration"></a>Registering Plugins
 
-All plugins listen for HTTP connections on a UNIX socket in the `/var/run/scope/plugins` directory. The Scope probe recursively scans that directory every 5 seconds and looks for any added or removed sockets. 
+All plugins listen for HTTP connections on a UNIX socket in the `/var/run/scope/plugins` directory. The Scope probe recursively scans that directory every 5 seconds and looks for any added or removed sockets.
 
 If you want to run permissions or store any other information with the socket, you can also put the plugin UNIX socket into a sub-directory.
 
@@ -217,7 +217,7 @@ semicolon-separated list of strings.
 For containers, images, hosts and others, the ID is usually formatted
 as `${name};<${tag}>`. The `${name}` variable is usually a name of a
 thing the node represents, like an ID of the Docker container or the
-hostname. The `${tag}` denotes the type of the node. 
+hostname. The `${tag}` denotes the type of the node.
 
 There is a fixed set of tags used by the probe:
 
@@ -337,7 +337,7 @@ func main() {
 ### <a id="reporter-interface"></a>Defining the Reporter Interface
 
 As stated in the [How Plugins Communicate with Scope](#plugins-internals) section, the reporter interface is mandatory.
-Implementing the reporter interface means handling `GET /report` requests.  
+Implementing the reporter interface means handling `GET /report` requests.
 
 The following code snippet is sufficient to implement it:
 


### PR DESCRIPTION
This PR adds information about plugins useful to developers who want create their own plugins, explaining the basic structure of a plugin, report and control interfaces.
Also, it adds a section about the currently implemented plugins with brief descriptions and links to the Weaveworks Plugins organization and the plugins repositories.

/cc @abuehrle can you give me some feedbacks on this first iteration about plugins documentation? I will add more information in later PRs.

/cc @2opremio 