### PR TITLE
Fix kubectl port-forward command to access the scope app locally

### DIFF
--- a/site/installing.md
+++ b/site/installing.md
@@ -240,7 +240,7 @@ To download and read the Scope manifest run:
 
 **Open Scope in Your Browser**
 
-    kubectl port-forward $(kubectl get pod --selector=weavescope-component=weavescope-app -o jsonpath='{.items..metadata.name}') 4040
+    kubectl port-forward $(kubectl get pod --selector=weave-scope-component=app -o jsonpath='{.items..metadata.name}') 4040
 
 Open http://localhost:4040 in your browser. This allows you to access the Scope UI securely, without opening it to the Internet.
 


### PR DESCRIPTION
HI there,

I was testing weave scope on kubernetes and discovered that the `kubectl port-forward` command in the doc was not corresponding to current labels.

![weave-scope-labels](https://cloud.githubusercontent.com/assets/1931038/20219293/0bf5bb66-a829-11e6-8b89-ea0503f17002.png)

Signed-off-by Steve Durrheimer <s.durrheimer@gmail.com>