### PR TITLE
Change webpack local config to use source maps

### DIFF
--- a/client/webpack.external.config.js
+++ b/client/webpack.external.config.js
@@ -1,12 +1,12 @@
-var webpack = require('webpack');
-var autoprefixer = require('autoprefixer');
-var path = require('path');
+const webpack = require('webpack');
+const autoprefixer = require('autoprefixer');
+const path = require('path');
 
-var CleanWebpackPlugin = require('clean-webpack-plugin');
-var ExtractTextPlugin = require("extract-text-webpack-plugin");
-var HtmlWebpackPlugin = require('html-webpack-plugin');
+const CleanWebpackPlugin = require('clean-webpack-plugin');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
-var GLOBALS = {
+const GLOBALS = {
   'process.env': {NODE_ENV: '"production"'}
 };
 
@@ -35,8 +35,8 @@ module.exports = {
   output: {
     path: path.join(__dirname, 'build-external/'),
     filename: '[name]-[chunkhash].js',
-	// Change this line to point to resources on an external host.
-	publicPath: 'https://s3.amazonaws.com/static.weave.works/scope-ui/'
+    // Change this line to point to resources on an external host.
+    publicPath: 'https://s3.amazonaws.com/static.weave.works/scope-ui/'
   },
 
   module: {

--- a/client/webpack.local.config.js
+++ b/client/webpack.local.config.js
@@ -1,7 +1,7 @@
-var webpack = require('webpack');
-var autoprefixer = require('autoprefixer');
-var path = require('path');
-var HtmlWebpackPlugin = require('html-webpack-plugin');
+const webpack = require('webpack');
+const autoprefixer = require('autoprefixer');
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 /**
  * This is the Webpack configuration file for local development. It contains
@@ -15,33 +15,34 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
  */
 
  // Inject websocket url to dev backend
- var WEBPACK_SERVER_HOST = process.env.WEBPACK_SERVER_HOST || 'localhost';
+const WEBPACK_SERVER_HOST = process.env.WEBPACK_SERVER_HOST || 'localhost';
+const DEV_SERVER_URL = `webpack-dev-server/client?http://${WEBPACK_SERVER_HOST}:4041`;
 
 module.exports = {
 
   // Efficiently evaluate modules with source maps
-  devtool: 'cheap-module-source-map',
+  devtool: 'source-map',
 
   // Set entry point include necessary files for hot load
   entry: {
-    'app': [
+    app: [
       './app/scripts/main',
-      'webpack-dev-server/client?http://' + WEBPACK_SERVER_HOST + ':4041',
+      DEV_SERVER_URL,
       'webpack/hot/only-dev-server'
     ],
     'dev-app': [
       './app/scripts/main.dev',
-      'webpack-dev-server/client?http://' + WEBPACK_SERVER_HOST + ':4041',
+      DEV_SERVER_URL,
       'webpack/hot/only-dev-server'
     ],
     'contrast-app': [
       './app/scripts/contrast-main',
-      'webpack-dev-server/client?http://' + WEBPACK_SERVER_HOST + ':4041',
+      DEV_SERVER_URL,
       'webpack/hot/only-dev-server'
     ],
     'terminal-app': [
       './app/scripts/terminal-main',
-      'webpack-dev-server/client?http://' + WEBPACK_SERVER_HOST + ':4041',
+      DEV_SERVER_URL,
       'webpack/hot/only-dev-server'
     ],
     vendors: ['babel-polyfill', 'classnames', 'd3', 'dagre', 'filesize', 'immutable', 'lodash',

--- a/client/webpack.production.config.js
+++ b/client/webpack.production.config.js
@@ -1,12 +1,12 @@
-var webpack = require('webpack');
-var autoprefixer = require('autoprefixer');
-var path = require('path');
+const webpack = require('webpack');
+const autoprefixer = require('autoprefixer');
+const path = require('path');
 
-var CleanWebpackPlugin = require('clean-webpack-plugin');
-var ExtractTextPlugin = require("extract-text-webpack-plugin");
-var HtmlWebpackPlugin = require('html-webpack-plugin');
+const CleanWebpackPlugin = require('clean-webpack-plugin');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
-var GLOBALS = {
+const GLOBALS = {
   'process.env': {NODE_ENV: '"production"'}
 };
 


### PR DESCRIPTION
Fix for #1999.

Updated local webpack config to use source maps, according to this doc:
http://webpack.github.io/docs/configuration.html#devtool

Re-builds might be slightly slower, but breakpoints should work properly now. Also fixed webpack config file linting errors, which caused in-editor linters to freak out.

@foot Could you take a look at this? 