### PR TITLE
procspy: use a Reader to copy the background reader buffer

### DIFF
--- a/probe/endpoint/procspy/background_reader_linux.go
+++ b/probe/endpoint/procspy/background_reader_linux.go
@@ -46,7 +46,10 @@ func (br *backgroundReader) getWalkedProcPid(buf *bytes.Buffer) (map[uint64]*Pro
 	br.mtx.Lock()
 	defer br.mtx.Unlock()
 
-	_, err := io.Copy(buf, br.latestBuf)
+	// Don't access latestBuf directly but create a reader. In this way,
+	// the buffer will not be empty in the next call of getWalkedProcPid
+	// and it can be copied again.
+	_, err := io.Copy(buf, bytes.NewReader(br.latestBuf.Bytes()))
 
 	return br.latestSockets, err
 }


### PR DESCRIPTION
getWalkedProcPid() reads latestBuf every 3 seconds (for each report).
But performWalk() writes latestBuf every 10 seconds or so. So we need to
be able to read the same buffer several times.

/cc @2opremio @iaguis