### PR TITLE
linter: fix punctuation and capitalization

### DIFF
--- a/app/control_router.go
+++ b/app/control_router.go
@@ -41,7 +41,7 @@ func (l *localControlRouter) Handle(_ context.Context, probeID string, req xfer.
 	probe, ok := l.probes[probeID]
 	l.Unlock()
 	if !ok {
-		return xfer.Response{}, fmt.Errorf("Probe %s is not connected right now...", probeID)
+		return xfer.Response{}, fmt.Errorf("probe %s is not connected right now", probeID)
 	}
 	return probe.handler(req), nil
 }

--- a/app/multitenant/consul_pipe_router.go
+++ b/app/multitenant/consul_pipe_router.go
@@ -332,11 +332,11 @@ func (pr *consulPipeRouter) Release(ctx context.Context, id string, e app.End) e
 	// atomically clear my end of the pipe in consul
 	return pr.client.CAS(key, &consulPipe{}, func(in interface{}) (interface{}, bool, error) {
 		if in == nil {
-			return nil, false, fmt.Errorf("Pipe %s not found", id)
+			return nil, false, fmt.Errorf("pipe %s not found", id)
 		}
 		p := in.(*consulPipe)
 		if p.addrFor(e) != pr.advertise {
-			return nil, false, fmt.Errorf("Pipe %s not owned by us!", id)
+			return nil, false, fmt.Errorf("pipe %s not owned by us", id)
 		}
 		refs := p.release(e)
 		if refs == 0 {

--- a/app/multitenant/sqs_control_router.go
+++ b/app/multitenant/sqs_control_router.go
@@ -215,7 +215,7 @@ func (cr *sqsControlRouter) Handle(ctx context.Context, probeID string, req xfer
 	// Get the queue url for the local (control app) queue, and for the probe.
 	responseQueueURL := cr.getResponseQueueURL()
 	if responseQueueURL == nil {
-		return xfer.Response{}, fmt.Errorf("No SQS queue yet!")
+		return xfer.Response{}, fmt.Errorf("no SQS queue yet")
 	}
 
 	var probeQueueURL *sqs.GetQueueUrlOutput
@@ -258,7 +258,7 @@ func (cr *sqsControlRouter) Handle(ctx context.Context, probeID string, req xfer
 	case response := <-waiter:
 		return response, nil
 	case <-time.After(rpcTimeout):
-		return xfer.Response{}, fmt.Errorf("Request timedout.")
+		return xfer.Response{}, fmt.Errorf("request timed out")
 	}
 }
 

--- a/test/fs/fs.go
+++ b/test/fs/fs.go
@@ -114,7 +114,7 @@ func (p dir) ReadDirNames(path string) ([]string, error) {
 
 func (p dir) ReadFile(path string) ([]byte, error) {
 	if path == "/" {
-		return nil, fmt.Errorf("I'm a directory!")
+		return nil, fmt.Errorf("I'm a directory")
 	}
 
 	head, tail := split(path)
@@ -158,7 +158,7 @@ func (p dir) Stat(path string, stat *syscall.Stat_t) error {
 
 func (p dir) Open(path string) (io.ReadWriteCloser, error) {
 	if path == "/" {
-		return nil, fmt.Errorf("I'm a directory!")
+		return nil, fmt.Errorf("I'm a directory")
 	}
 
 	head, tail := split(path)
@@ -208,18 +208,18 @@ func (p File) IsDir() bool { return false }
 
 // ReadDir implements FS
 func (p File) ReadDir(path string) ([]os.FileInfo, error) {
-	return nil, fmt.Errorf("I'm a file!")
+	return nil, fmt.Errorf("I'm a file")
 }
 
 // ReadDirNames implements FS
 func (p File) ReadDirNames(path string) ([]string, error) {
-	return nil, fmt.Errorf("I'm a file!")
+	return nil, fmt.Errorf("I'm a file")
 }
 
 // ReadFile implements FS
 func (p File) ReadFile(path string) ([]byte, error) {
 	if path != "/" {
-		return nil, fmt.Errorf("I'm a file!")
+		return nil, fmt.Errorf("I'm a file")
 	}
 	if p.FReader != nil {
 		return ioutil.ReadAll(p.FReader)
@@ -230,7 +230,7 @@ func (p File) ReadFile(path string) ([]byte, error) {
 // Lstat implements FS
 func (p File) Lstat(path string, stat *syscall.Stat_t) error {
 	if path != "/" {
-		return fmt.Errorf("I'm a file!")
+		return fmt.Errorf("I'm a file")
 	}
 	*stat = p.FStat
 	return nil
@@ -239,7 +239,7 @@ func (p File) Lstat(path string, stat *syscall.Stat_t) error {
 // Stat implements FS
 func (p File) Stat(path string, stat *syscall.Stat_t) error {
 	if path != "/" {
-		return fmt.Errorf("I'm a file!")
+		return fmt.Errorf("I'm a file")
 	}
 	*stat = p.FStat
 	return nil
@@ -248,7 +248,7 @@ func (p File) Stat(path string, stat *syscall.Stat_t) error {
 // Open implements FS
 func (p File) Open(path string) (io.ReadWriteCloser, error) {
 	if path != "/" {
-		return nil, fmt.Errorf("I'm a file!")
+		return nil, fmt.Errorf("I'm a file")
 	}
 	buf := bytes.NewBuffer([]byte(p.FContents))
 	s := struct {
@@ -273,7 +273,7 @@ func (p File) Open(path string) (io.ReadWriteCloser, error) {
 // Add adds a new node to the fs
 func (p File) Add(path string, e Entry) error {
 	if path != "/" {
-		return fmt.Errorf("I'm a file!")
+		return fmt.Errorf("I'm a file")
 	}
 	return nil
 }
@@ -281,7 +281,7 @@ func (p File) Add(path string, e Entry) error {
 // Remove removes a node from the fs
 func (p File) Remove(path string) error {
 	if path != "/" {
-		return fmt.Errorf("I'm a file!")
+		return fmt.Errorf("I'm a file")
 	}
 	return nil
 }

--- a/tools/cmd/wcloud/client.go
+++ b/tools/cmd/wcloud/client.go
@@ -47,7 +47,7 @@ func (c Client) Deploy(deployment Deployment) error {
 		return err
 	}
 	if res.StatusCode != 204 {
-		return fmt.Errorf("Error making request: %s", res.Status)
+		return fmt.Errorf("error making request: %s", res.Status)
 	}
 	return nil
 }
@@ -63,7 +63,7 @@ func (c Client) GetDeployments(from, through int64) ([]Deployment, error) {
 		return nil, err
 	}
 	if res.StatusCode != 200 {
-		return nil, fmt.Errorf("Error making request: %s", res.Status)
+		return nil, fmt.Errorf("error making request: %s", res.Status)
 	}
 	var response struct {
 		Deployments []Deployment `json:"deployments"`
@@ -85,7 +85,7 @@ func (c Client) GetEvents(from, through int64) ([]byte, error) {
 		return nil, err
 	}
 	if res.StatusCode != 200 {
-		return nil, fmt.Errorf("Error making request: %s", res.Status)
+		return nil, fmt.Errorf("error making request: %s", res.Status)
 	}
 	return ioutil.ReadAll(res.Body)
 }
@@ -101,10 +101,10 @@ func (c Client) GetConfig() (*Config, error) {
 		return nil, err
 	}
 	if res.StatusCode == 404 {
-		return nil, fmt.Errorf("No configuration uploaded yet.")
+		return nil, fmt.Errorf("no configuration uploaded yet")
 	}
 	if res.StatusCode != 200 {
-		return nil, fmt.Errorf("Error making request: %s", res.Status)
+		return nil, fmt.Errorf("error making request: %s", res.Status)
 	}
 	var config Config
 	if err := json.NewDecoder(res.Body).Decode(&config); err != nil {
@@ -128,7 +128,7 @@ func (c Client) SetConfig(config *Config) error {
 		return err
 	}
 	if res.StatusCode != 204 {
-		return fmt.Errorf("Error making request: %s", res.Status)
+		return fmt.Errorf("error making request: %s", res.Status)
 	}
 	return nil
 }
@@ -144,7 +144,7 @@ func (c Client) GetLogs(deployID string) ([]byte, error) {
 		return nil, err
 	}
 	if res.StatusCode != 200 {
-		return nil, fmt.Errorf("Error making request: %s", res.Status)
+		return nil, fmt.Errorf("error making request: %s", res.Status)
 	}
 	return ioutil.ReadAll(res.Body)
 }


### PR DESCRIPTION
Symptoms:
> app/control_router.go:44:38: error strings should not be capitalized or end with punctuation or a newline

This is blocking the build on: https://github.com/weaveworks/scope/pull/2020
https://circleci.com/gh/kinvolk/scope/363