### PR TITLE
Add eBPF connection tracking with gobpf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GO_HOST=$(NO_CROSS_COMP); $(GO)
 WITH_GO_HOST_ENV=$(NO_CROSS_COMP); $(GO_ENV)
 GO_BUILD_INSTALL_DEPS=-i
 GO_BUILD_TAGS='netgo unsafe'
-GO_BUILD_FLAGS=$(GO_BUILD_INSTALL_DEPS) -ldflags "-extldflags \"-static\" -X main.version=$(SCOPE_VERSION) -s -w" -tags $(GO_BUILD_TAGS)
+GO_BUILD_FLAGS=$(GO_BUILD_INSTALL_DEPS) -ldflags "-X main.version=$(SCOPE_VERSION) -s -w" -tags $(GO_BUILD_TAGS)
 IMAGE_TAG=$(shell ./tools/image-tag)
 
 all: $(SCOPE_EXPORT)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,9 @@
-FROM golang:1.7.1
+FROM ubuntu:yakkety
+ENV GOPATH /go
+ENV PATH /go/bin:/usr/lib/go-1.7/bin:/usr/bin:/bin:/usr/sbin:/sbin
+RUN echo "deb [trusted=yes] http://52.8.15.63/apt/xenial xenial-nightly main" > /etc/apt/sources.list.d/iovisor.list
 RUN apt-get update && \
-	apt-get install -y libpcap-dev python-requests time file shellcheck && \
+	apt-get install -y libpcap-dev python-requests time file shellcheck libelf1 bcc-tools libbcc golang-1.7 git && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN go clean -i net && \
 	go install -tags netgo std && \
@@ -12,5 +15,6 @@ RUN go get -tags netgo \
 		github.com/mjibson/esc \
 		github.com/client9/misspell/cmd/misspell && \
 	rm -rf /go/pkg/ /go/src/
+
 COPY build.sh /
 ENTRYPOINT ["/build.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,38 @@
-FROM zlim/bcc
+FROM ubuntu:xenial
 MAINTAINER Weaveworks Inc <help@weave.works>
 LABEL works.weave.role=system
 WORKDIR /home/weave
-RUN apt-get update -y && apt-get install -y runit bash conntrack iproute2 util-linux libbcc libpcap0.8 localepurge && printf "#NEEDSCONFIGFIRST\nMANDELETE\nSHOWFREEDSPACE\nC\n" > /etc/locale.nopurge && dpkg-reconfigure localepurge && apt-get autoremove -y python curl localepurge && rm -rf /var/lib/dpkg/info/* && rm -rf /var/lib/apt/lists/*
-ADD ./docker.tgz /
-ADD ./demo.json /
+# we could use the xenial-nightly repo to get a more up to date (and smaller) libbcc, but it is not signed
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4052245BD4284CDD \
+    && apt-get update -y \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://repo.iovisor.org/apt/xenial xenial main" > /etc/apt/sources.list.d/iovisor.list \
+    && apt-get update -y \
+    && apt-get install -y \
+        runit \
+        bash \
+        conntrack \
+        iproute2 \
+        util-linux \
+        libbcc \
+        libpcap0.8 \
+    && apt-get remove -y apt-transport-https \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/dpkg/info/* \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /lib/udev/hwdb.* \
+    && rm -rf /usr/share/perl/* \
+    && rm -rf /usr/share/locale/* \
+    && rm -rf /usr/share/man/* \
+    && rm -rf /usr/share/doc/* \
+    && rm -rf /usr/lib/perl \
+    && rm -rf /usr/lib/python3.* \
+    && rm -rf /tmp/* \
+    && rm -rf /var/tmp/* \
+    && rm -rf /var/cache/* \
+    && rm -rf /var/log/*
+ADD ./docker.tgz ./demo.json /
 ADD ./weave /usr/bin/
 COPY ./scope ./runsvinit ./entrypoint.sh /home/weave/
 COPY ./run-app /etc/service/app/run

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,8 @@
-FROM alpine:3.3
+FROM zlim/bcc
 MAINTAINER Weaveworks Inc <help@weave.works>
 LABEL works.weave.role=system
 WORKDIR /home/weave
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >>/etc/apk/repositories && \
-	apk add --update bash runit conntrack-tools iproute2 util-linux curl && \
-	rm -rf /var/cache/apk/*
+RUN apt-get update -y && apt-get install -y runit bash conntrack iproute2 util-linux libbcc libpcap0.8 localepurge && printf "#NEEDSCONFIGFIRST\nMANDELETE\nSHOWFREEDSPACE\nC\n" > /etc/locale.nopurge && dpkg-reconfigure localepurge && apt-get autoremove -y python curl localepurge && rm -rf /var/lib/dpkg/info/* && rm -rf /var/lib/apt/lists/*
 ADD ./docker.tgz /
 ADD ./demo.json /
 ADD ./weave /usr/bin/

--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -1,0 +1,533 @@
+package endpoint
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"strconv"
+	"sync"
+	"unsafe"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/iovisor/gobpf"
+)
+
+/*
+#cgo CFLAGS: -I/usr/include/bcc/compat
+#cgo LDFLAGS: -lbcc
+#include <bcc/bpf_common.h>
+#include <bcc/libbpf.h>
+#include <bcc/perf_reader.h>
+#include <stdio.h>
+
+void *bpf_open_perf_buffer(perf_reader_raw_cb raw_cb, void *cb_cookie, int pid, int cpu);
+
+extern void tcpEventCb();
+
+#define TASK_COMM_LEN 16 // linux/sched.h
+
+struct tcp_event_t {
+        char ev_type[12];
+        uint32_t pid;
+        char comm[TASK_COMM_LEN];
+        uint32_t saddr;
+        uint32_t daddr;
+        uint16_t sport;
+        uint16_t dport;
+        uint32_t netns;
+};
+
+*/
+import "C"
+
+const source string = `
+#include <uapi/linux/ptrace.h>
+#include <net/sock.h>
+#include <net/inet_sock.h>
+#include <net/net_namespace.h>
+#include <bcc/proto.h>
+
+#define TCP_EVENT_TYPE_CONNECT 1
+#define TCP_EVENT_TYPE_ACCEPT  2
+#define TCP_EVENT_TYPE_CLOSE   3
+
+struct tcp_event_t {
+	char ev_type[12];
+	u32 pid;
+	char comm[TASK_COMM_LEN];
+	u32 saddr;
+	u32 daddr;
+	u16 sport;
+	u16 dport;
+	u32 netns;
+};
+
+BPF_PERF_OUTPUT(tcp_event);
+BPF_HASH(connectsock, u64, struct sock *);
+BPF_HASH(closesock, u64, struct sock *);
+
+int kprobe__tcp_v4_connect(struct pt_regs *ctx, struct sock *sk)
+{
+	u64 pid = bpf_get_current_pid_tgid();
+
+	// stash the sock ptr for lookup on return
+	connectsock.update(&pid, &sk);
+
+	return 0;
+};
+
+int kretprobe__tcp_v4_connect(struct pt_regs *ctx)
+{
+	int ret = PT_REGS_RC(ctx);
+	u64 pid = bpf_get_current_pid_tgid();
+
+	struct sock **skpp;
+	skpp = connectsock.lookup(&pid);
+	if (skpp == 0) {
+		return 0;	// missed entry
+	}
+
+	if (ret != 0) {
+		// failed to send SYNC packet, may not have populated
+		// socket __sk_common.{skc_rcv_saddr, ...}
+		connectsock.delete(&pid);
+		return 0;
+	}
+
+
+	// pull in details
+	struct sock *skp = *skpp;
+	struct ns_common *ns;
+	u32 saddr = 0, daddr = 0, net_ns_inum = 0;
+	u16 sport = 0, dport = 0;
+	bpf_probe_read(&sport, sizeof(sport), &((struct inet_sock *)skp)->inet_sport);
+	bpf_probe_read(&saddr, sizeof(saddr), &skp->__sk_common.skc_rcv_saddr);
+	bpf_probe_read(&daddr, sizeof(daddr), &skp->__sk_common.skc_daddr);
+	bpf_probe_read(&dport, sizeof(dport), &skp->__sk_common.skc_dport);
+
+// Get network namespace id, if kernel supports it
+#ifdef CONFIG_NET_NS
+	possible_net_t skc_net;
+	bpf_probe_read(&skc_net, sizeof(skc_net), &skp->__sk_common.skc_net);
+	bpf_probe_read(&net_ns_inum, sizeof(net_ns_inum), &skc_net.net->ns.inum);
+#else
+	net_ns_inum = 0;
+#endif
+
+	// output
+	struct tcp_event_t evt = {
+		.ev_type = "connect",
+		.pid = pid >> 32,
+		.saddr = saddr,
+		.daddr = daddr,
+		.sport = ntohs(sport),
+		.dport = ntohs(dport),
+		.netns = net_ns_inum,
+	};
+
+	bpf_get_current_comm(&evt.comm, sizeof(evt.comm));
+
+	// do not send event if IP address is 0.0.0.0 or port is 0
+	if (evt.saddr != 0 && evt.daddr != 0 && evt.sport != 0 && evt.dport != 0) {
+		tcp_event.perf_submit(ctx, &evt, sizeof(evt));
+	}
+
+	connectsock.delete(&pid);
+
+	return 0;
+}
+
+int kprobe__tcp_close(struct pt_regs *ctx, struct sock *sk)
+{
+	u64 pid = bpf_get_current_pid_tgid();
+
+	// stash the sock ptr for lookup on return
+	closesock.update(&pid, &sk);
+
+	return 0;
+};
+
+int kretprobe__tcp_close(struct pt_regs *ctx)
+{
+	u64 pid = bpf_get_current_pid_tgid();
+
+	struct sock **skpp;
+	skpp = closesock.lookup(&pid);
+	if (skpp == 0) {
+		return 0;	// missed entry
+	}
+
+	closesock.delete(&pid);
+
+	// pull in details
+	struct sock *skp = *skpp;
+	u16 family = 0;
+	bpf_probe_read(&family, sizeof(family), &skp->__sk_common.skc_family);
+	if (family != AF_INET) {
+		return 0;
+	}
+
+	u32 saddr = 0, daddr = 0, net_ns_inum = 0;
+	u16 sport = 0, dport = 0;
+	bpf_probe_read(&saddr, sizeof(saddr), &skp->__sk_common.skc_rcv_saddr);
+	bpf_probe_read(&daddr, sizeof(daddr), &skp->__sk_common.skc_daddr);
+	bpf_probe_read(&sport, sizeof(sport), &((struct inet_sock *)skp)->inet_sport);
+	bpf_probe_read(&dport, sizeof(dport), &skp->__sk_common.skc_dport);
+
+// Get network namespace id, if kernel supports it
+#ifdef CONFIG_NET_NS
+	possible_net_t skc_net;
+	bpf_probe_read(&skc_net, sizeof(skc_net), &skp->__sk_common.skc_net);
+	bpf_probe_read(&net_ns_inum, sizeof(net_ns_inum), &skc_net.net->ns.inum);
+#else
+	net_ns_inum = 0;
+#endif
+
+	// output
+	struct tcp_event_t evt = {
+		.ev_type = "close",
+		.pid = pid >> 32,
+		.saddr = saddr,
+		.daddr = daddr,
+		.sport = ntohs(sport),
+		.dport = ntohs(dport),
+		.netns = net_ns_inum,
+	};
+
+	bpf_get_current_comm(&evt.comm, sizeof(evt.comm));
+
+	// do not send event if IP address is 0.0.0.0 or port is 0
+	if (evt.saddr != 0 && evt.daddr != 0 && evt.sport != 0 && evt.dport != 0) {
+		tcp_event.perf_submit(ctx, &evt, sizeof(evt));
+	}
+
+	return 0;
+}
+
+int kretprobe__inet_csk_accept(struct pt_regs *ctx)
+{
+	struct sock *newsk = (struct sock *)PT_REGS_RC(ctx);
+	u64 pid = bpf_get_current_pid_tgid();
+
+	if (newsk == NULL)
+		return 0;
+
+	// check this is TCP
+	u8 protocol = 0;
+	// workaround for reading the sk_protocol bitfield:
+	bpf_probe_read(&protocol, 1, (void *)((long)&newsk->sk_wmem_queued) - 3);
+	if (protocol != IPPROTO_TCP)
+		return 0;
+
+	// pull in details
+	u16 family = 0, lport = 0, dport = 0;
+	u32 net_ns_inum = 0;
+	bpf_probe_read(&family, sizeof(family), &newsk->__sk_common.skc_family);
+	bpf_probe_read(&lport, sizeof(lport), &newsk->__sk_common.skc_num);
+	bpf_probe_read(&dport, sizeof(dport), &newsk->__sk_common.skc_dport);
+
+// Get network namespace id, if kernel supports it
+#ifdef CONFIG_NET_NS
+	possible_net_t skc_net;
+	bpf_probe_read(&skc_net, sizeof(skc_net), &newsk->__sk_common.skc_net);
+	bpf_probe_read(&net_ns_inum, sizeof(net_ns_inum), &skc_net.net->ns.inum);
+#else
+	net_ns_inum = 0;
+#endif
+
+	if (family == AF_INET) {
+		struct tcp_event_t evt = {.ev_type = "accept", .netns = net_ns_inum};
+		evt.pid = pid >> 32;
+		bpf_probe_read(&evt.saddr, sizeof(u32),
+			&newsk->__sk_common.skc_rcv_saddr);
+		bpf_probe_read(&evt.daddr, sizeof(u32),
+			&newsk->__sk_common.skc_daddr);
+			evt.sport = lport;
+		evt.dport = ntohs(dport);
+		bpf_get_current_comm(&evt.comm, sizeof(evt.comm));
+		tcp_event.perf_submit(ctx, &evt, sizeof(evt));
+	}
+	// else drop
+
+	return 0;
+}
+`
+
+var byteOrder binary.ByteOrder
+
+func init() {
+	var i int32 = 0x01020304
+	u := unsafe.Pointer(&i)
+	pb := (*byte)(u)
+	b := *pb
+	if b == 0x04 {
+		byteOrder = binary.LittleEndian
+	} else {
+		byteOrder = binary.BigEndian
+	}
+}
+
+// An ebpfConnection represents a TCP connection
+type ebpfConnection struct {
+	tuple            fourTuple
+	networkNamespace string
+	incoming         bool
+	pid              int
+}
+
+type eventTracker interface {
+	handleConnection(eventType string, tuple fourTuple, pid int, networkNamespace string)
+	hasDied() bool
+	run()
+	walkConnections(f func(ebpfConnection))
+	initialize()
+	isInitialized() bool
+}
+
+var ebpfTracker *EbpfTracker
+
+// nilTracker is a tracker that does nothing, and it implements the eventTracker interface.
+// It is returned when the useEbpfConn flag is false.
+type nilTracker struct{}
+
+func (n nilTracker) handleConnection(_ string, _ fourTuple, _ int, _ string) {}
+func (n nilTracker) hasDied() bool                                           { return true }
+func (n nilTracker) run()                                                    {}
+func (n nilTracker) walkConnections(f func(ebpfConnection))                  {}
+func (n nilTracker) initialize()                                             {}
+func (n nilTracker) isInitialized() bool                                     { return false }
+
+// EbpfTracker contains the sets of open and closed TCP connections.
+// Closed connections are kept in the `closedConnections` slice for one iteration of `walkConnections`.
+type EbpfTracker struct {
+	sync.Mutex
+	readers     []*C.struct_perf_reader
+	initialized bool
+	dead        bool
+
+	openConnections   map[string]ebpfConnection
+	closedConnections []ebpfConnection
+}
+
+func newEbpfTracker(useEbpfConn bool) eventTracker {
+	if !useEbpfConn {
+		return &nilTracker{}
+	}
+	m := bpf.NewBpfModule(source, []string{})
+
+	connectKprobe, err := m.LoadKprobe("kprobe__tcp_v4_connect")
+	if err != nil {
+		return &nilTracker{}
+	}
+
+	err = m.AttachKprobe("tcp_v4_connect", connectKprobe)
+	if err != nil {
+		return &nilTracker{}
+	}
+
+	connectKretprobe, err := m.LoadKprobe("kretprobe__tcp_v4_connect")
+	if err != nil {
+		return &nilTracker{}
+	}
+
+	err = m.AttachKretprobe("tcp_v4_connect", connectKretprobe)
+	if err != nil {
+		return &nilTracker{}
+	}
+
+	closeKprobe, err := m.LoadKprobe("kprobe__tcp_close")
+	if err != nil {
+		return &nilTracker{}
+	}
+
+	err = m.AttachKprobe("tcp_close", closeKprobe)
+	if err != nil {
+		return &nilTracker{}
+	}
+
+	closeKretprobe, err := m.LoadKprobe("kretprobe__tcp_close")
+	if err != nil {
+		return &nilTracker{}
+	}
+
+	err = m.AttachKretprobe("tcp_close", closeKretprobe)
+	if err != nil {
+		return &nilTracker{}
+	}
+
+	acceptKretprobe, err := m.LoadKprobe("kretprobe__inet_csk_accept")
+	if err != nil {
+		return &nilTracker{}
+	}
+
+	err = m.AttachKretprobe("inet_csk_accept", acceptKretprobe)
+	if err != nil {
+		return &nilTracker{}
+	}
+
+	t := bpf.NewBpfTable(0, m)
+	readers, err := initPerfMap(t)
+	if err != nil {
+		return &nilTracker{}
+	}
+	tracker := &EbpfTracker{
+		openConnections: map[string]ebpfConnection{},
+		readers:         readers,
+	}
+	go tracker.run()
+
+	ebpfTracker = tracker
+	return tracker
+}
+
+func initPerfMap(table *bpf.BpfTable) ([]*C.struct_perf_reader, error) {
+	fd := table.Config()["fd"].(int)
+	keySize := table.Config()["key_size"].(uint64)
+	leafSize := table.Config()["leaf_size"].(uint64)
+
+	if keySize != 4 || leafSize != 4 {
+		return nil, fmt.Errorf("wrong size")
+	}
+
+	key := make([]byte, keySize)
+	leaf := make([]byte, leafSize)
+	keyP := unsafe.Pointer(&key[0])
+	leafP := unsafe.Pointer(&leaf[0])
+
+	readers := []*C.struct_perf_reader{}
+
+	cpu := 0
+	res := 0
+	for res == 0 {
+		reader := C.bpf_open_perf_buffer((*[0]byte)(C.tcpEventCb), nil, -1, C.int(cpu))
+		if reader == nil {
+			return nil, fmt.Errorf("failed to get reader")
+		}
+
+		perfFd := C.perf_reader_fd(reader)
+
+		readers = append(readers, (*C.struct_perf_reader)(reader))
+
+		// copy perfFd into leaf, respecting the host endienness
+		byteOrder.PutUint32(leaf, uint32(perfFd))
+
+		r, err := C.bpf_update_elem(C.int(fd), keyP, leafP, 0)
+		if r != 0 {
+			return nil, fmt.Errorf("unable to initialize perf map: %v", err)
+		}
+
+		res = int(C.bpf_get_next_key(C.int(fd), keyP, keyP))
+		cpu++
+	}
+	return readers, nil
+}
+
+func (t *EbpfTracker) handleConnection(eventType string, tuple fourTuple, pid int, networkNamespace string) {
+	t.Lock()
+	defer t.Unlock()
+
+	switch eventType {
+	case "connect":
+		conn := ebpfConnection{
+			incoming:         false,
+			tuple:            tuple,
+			pid:              pid,
+			networkNamespace: networkNamespace,
+		}
+		t.openConnections[tuple.String()] = conn
+	case "accept":
+		conn := ebpfConnection{
+			incoming:         true,
+			tuple:            tuple,
+			pid:              pid,
+			networkNamespace: networkNamespace,
+		}
+		t.openConnections[tuple.String()] = conn
+	case "close":
+		if deadConn, ok := t.openConnections[tuple.String()]; ok {
+			delete(t.openConnections, tuple.String())
+			t.closedConnections = append(t.closedConnections, deadConn)
+		} else {
+			log.Errorf("EbpfTracker error: unmatched close event: %s pid=%d netns=%s", tuple.String(), pid, networkNamespace)
+		}
+	}
+}
+
+func handleConnection(eventType string, tuple fourTuple, pid int, networkNamespace string) {
+	ebpfTracker.handleConnection(eventType, tuple, pid, networkNamespace)
+}
+
+func (t *EbpfTracker) run() {
+	for {
+		C.perf_reader_poll(C.int(len(t.readers)), &t.readers[0], -1)
+	}
+}
+
+func tcpEventCallback(cpu int, tcpEvent *C.struct_tcp_event_t) {
+	typ := C.GoString(&tcpEvent.ev_type[0])
+	pid := tcpEvent.pid & 0xffffffff
+
+	saddrbuf := make([]byte, 4)
+	daddrbuf := make([]byte, 4)
+
+	binary.LittleEndian.PutUint32(saddrbuf, uint32(tcpEvent.saddr))
+	binary.LittleEndian.PutUint32(daddrbuf, uint32(tcpEvent.daddr))
+
+	sIP := net.IPv4(saddrbuf[0], saddrbuf[1], saddrbuf[2], saddrbuf[3])
+	dIP := net.IPv4(daddrbuf[0], daddrbuf[1], daddrbuf[2], daddrbuf[3])
+
+	sport := tcpEvent.sport
+	dport := tcpEvent.dport
+	netns := tcpEvent.netns
+
+	tuple := fourTuple{sIP.String(), dIP.String(), uint16(sport), uint16(dport)}
+	handleConnection(typ, tuple, int(pid), strconv.Itoa(int(netns)))
+}
+
+//export tcpEventCb
+func tcpEventCb(cbCookie unsafe.Pointer, raw unsafe.Pointer, rawSize C.int) {
+	// See src/cc/perf_reader.c:parse_sw()
+	// struct {
+	//     uint32_t size;
+	//     char data[0];
+	// };
+
+	var tcpEvent C.struct_tcp_event_t
+
+	if int(rawSize) != 4+int(unsafe.Sizeof(tcpEvent)) {
+		fmt.Printf("invalid perf event: rawSize=%d != %d + %d\n", rawSize, 4, unsafe.Sizeof(tcpEvent))
+		return
+	}
+
+	tcpEventCallback(0, (*C.struct_tcp_event_t)(raw))
+}
+
+// walkConnections calls f with all open connections and connections that have come and gone
+// since the last call to walkConnections
+func (t *EbpfTracker) walkConnections(f func(ebpfConnection)) {
+	t.Lock()
+	defer t.Unlock()
+
+	for _, connection := range t.openConnections {
+		f(connection)
+	}
+	for _, connection := range t.closedConnections {
+		f(connection)
+	}
+	t.closedConnections = t.closedConnections[:0]
+}
+
+func (t *EbpfTracker) hasDied() bool {
+	t.Lock()
+	defer t.Unlock()
+
+	return t.dead
+}
+
+func (t *EbpfTracker) initialize() {
+	t.initialized = true
+}
+
+func (t *EbpfTracker) isInitialized() bool {
+	return t.initialized
+}

--- a/probe/endpoint/four_tuple.go
+++ b/probe/endpoint/four_tuple.go
@@ -1,0 +1,43 @@
+package endpoint
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// fourTuple is an (IP, port, IP, port) tuple, representing a connection
+type fourTuple struct {
+	fromAddr, toAddr string
+	fromPort, toPort uint16
+}
+
+func (t fourTuple) String() string {
+	return fmt.Sprintf("%s:%d-%s:%d", t.fromAddr, t.fromPort, t.toAddr, t.toPort)
+}
+
+// key is a sortable direction-independent key for tuples, used to look up a
+// fourTuple when you are unsure of its direction.
+func (t fourTuple) key() string {
+	key := []string{
+		fmt.Sprintf("%s:%d", t.fromAddr, t.fromPort),
+		fmt.Sprintf("%s:%d", t.toAddr, t.toPort),
+	}
+	sort.Strings(key)
+	return strings.Join(key, " ")
+}
+
+// reverse flips the direction of the tuple
+func (t *fourTuple) reverse() {
+	t.fromAddr, t.fromPort, t.toAddr, t.toPort = t.toAddr, t.toPort, t.fromAddr, t.fromPort
+}
+
+// reverse flips the direction of a tuple, without side effects
+func reverse(tuple fourTuple) fourTuple {
+	return fourTuple{
+		fromAddr: tuple.toAddr,
+		toAddr:   tuple.fromAddr,
+		fromPort: tuple.toPort,
+		toPort:   tuple.fromPort,
+	}
+}

--- a/probe/endpoint/procspy/background_reader_linux.go
+++ b/probe/endpoint/procspy/background_reader_linux.go
@@ -46,7 +46,10 @@ func (br *backgroundReader) getWalkedProcPid(buf *bytes.Buffer) (map[uint64]*Pro
 	br.mtx.Lock()
 	defer br.mtx.Unlock()
 
-	_, err := io.Copy(buf, br.latestBuf)
+	// Don't access latestBuf directly but create a reader. In this way,
+	// the buffer will not be empty in the next call of getWalkedProcPid
+	// and it can be copied again.
+	_, err := io.Copy(buf, bytes.NewReader(br.latestBuf.Bytes()))
 
 	return br.latestSockets, err
 }

--- a/probe/endpoint/procspy/background_reader_linux.go
+++ b/probe/endpoint/procspy/background_reader_linux.go
@@ -38,6 +38,28 @@ func newBackgroundReader(walker process.Walker) *backgroundReader {
 	return br
 }
 
+func newForegroundReader(walker process.Walker) *backgroundReader {
+	br := &backgroundReader{
+		stopc:         make(chan struct{}),
+		latestSockets: map[uint64]*Proc{},
+	}
+	var (
+		walkc   = make(chan walkResult)
+		ticker  = time.NewTicker(time.Millisecond) // fire every millisecond
+		pWalker = newPidWalker(walker, ticker.C, fdBlockSize)
+	)
+
+	go performWalk(pWalker, walkc)
+
+	result := <-walkc
+	br.mtx.Lock()
+	br.latestBuf = result.buf
+	br.latestSockets = result.sockets
+	br.mtx.Unlock()
+
+	return br
+}
+
 func (br *backgroundReader) stop() {
 	close(br.stopc)
 }

--- a/probe/endpoint/procspy/spy_darwin.go
+++ b/probe/endpoint/procspy/spy_darwin.go
@@ -18,6 +18,11 @@ func NewConnectionScanner(_ process.Walker) ConnectionScanner {
 	return &darwinScanner{}
 }
 
+// NewSyncConnectionScanner creates a new synchronous Darwin ConnectionScanner
+func NewSyncConnectionScanner(_ process.Walker) ConnectionScanner {
+	return &darwinScanner{}
+}
+
 type darwinScanner struct{}
 
 // Connections returns all established (TCP) connections. No need to be root

--- a/probe/endpoint/procspy/spy_linux.go
+++ b/probe/endpoint/procspy/spy_linux.go
@@ -38,6 +38,12 @@ func NewConnectionScanner(walker process.Walker) ConnectionScanner {
 	return &linuxScanner{br}
 }
 
+// NewSyncConnectionScanner creates a new synchronous Linux ConnectionScanner
+func NewSyncConnectionScanner(walker process.Walker) ConnectionScanner {
+	br := newForegroundReader(walker)
+	return &linuxScanner{br}
+}
+
 type linuxScanner struct {
 	br *backgroundReader
 }

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -1,10 +1,7 @@
 package endpoint
 
 import (
-	"fmt"
-	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -19,6 +16,7 @@ const (
 	Addr            = "addr" // typically IPv4
 	Port            = "port"
 	Conntracked     = "conntracked"
+	EBPF            = "eBPF"
 	Procspied       = "procspied"
 	ReverseDNSNames = "reverse_dns_names"
 	SnoopedDNSNames = "snooped_dns_names"
@@ -31,6 +29,7 @@ type ReporterConfig struct {
 	SpyProcs     bool
 	UseConntrack bool
 	WalkProc     bool
+	UseEbpfConn  bool
 	ProcRoot     string
 	BufferSize   int
 	Scanner      procspy.ConnectionScanner
@@ -41,6 +40,7 @@ type ReporterConfig struct {
 type Reporter struct {
 	conf            ReporterConfig
 	flowWalker      flowWalker // interface
+	ebpfTracker     eventTracker
 	natMapper       natMapper
 	reverseResolver *reverseResolver
 }
@@ -66,6 +66,7 @@ func NewReporter(conf ReporterConfig) *Reporter {
 	return &Reporter{
 		conf:            conf,
 		flowWalker:      newConntrackFlowWalker(conf.UseConntrack, conf.ProcRoot, conf.BufferSize),
+		ebpfTracker:     newEbpfTracker(conf.UseEbpfConn),
 		natMapper:       makeNATMapper(newConntrackFlowWalker(conf.UseConntrack, conf.ProcRoot, conf.BufferSize, "--any-nat")),
 		reverseResolver: newReverseResolver(),
 	}
@@ -80,27 +81,7 @@ func (r *Reporter) Stop() {
 	r.natMapper.stop()
 	r.reverseResolver.stop()
 	r.conf.Scanner.Stop()
-}
-
-type fourTuple struct {
-	fromAddr, toAddr string
-	fromPort, toPort uint16
-}
-
-// key is a sortable direction-independent key for tuples, used to look up a
-// fourTuple, when you are unsure of it's direction.
-func (t fourTuple) key() string {
-	key := []string{
-		fmt.Sprintf("%s:%d", t.fromAddr, t.fromPort),
-		fmt.Sprintf("%s:%d", t.toAddr, t.toPort),
-	}
-	sort.Strings(key)
-	return strings.Join(key, " ")
-}
-
-// reverse flips the direction of the tuple
-func (t *fourTuple) reverse() {
-	t.fromAddr, t.fromPort, t.toAddr, t.toPort = t.toAddr, t.toPort, t.fromAddr, t.fromPort
+	// TODO add a Stop method for ebpfTracker
 }
 
 // Report implements Reporter.
@@ -111,6 +92,7 @@ func (r *Reporter) Report() (report.Report, error) {
 
 	hostNodeID := report.MakeHostNodeID(r.conf.HostID)
 	rpt := report.MakeReport()
+
 	seenTuples := map[string]fourTuple{}
 
 	// Consult the flowWalker for short-lived connections
@@ -144,6 +126,7 @@ func (r *Reporter) Report() (report.Report, error) {
 
 	if r.conf.WalkProc {
 		conns, err := r.conf.Scanner.Connections(r.conf.SpyProcs)
+		defer r.procParsingSwitcher()
 		if err != nil {
 			return rpt, err
 		}
@@ -174,11 +157,39 @@ func (r *Reporter) Report() (report.Report, error) {
 			// the direction.
 			canonical, ok := seenTuples[tuple.key()]
 			if (ok && canonical != tuple) || (!ok && tuple.fromPort < tuple.toPort) {
-				tuple.reverse()
-				toNodeInfo, fromNodeInfo = fromNodeInfo, toNodeInfo
+				r.feedToEbpf(tuple, true, int(conn.Proc.PID), namespaceID)
+				r.addConnection(&rpt, reverse(tuple), namespaceID, toNodeInfo, fromNodeInfo)
+			} else {
+				r.feedToEbpf(tuple, false, int(conn.Proc.PID), namespaceID)
+				r.addConnection(&rpt, tuple, namespaceID, fromNodeInfo, toNodeInfo)
 			}
-			r.addConnection(&rpt, tuple, namespaceID, fromNodeInfo, toNodeInfo)
+
 		}
+	}
+
+	// eBPF
+	if r.conf.UseEbpfConn && !r.ebpfTracker.hasDied() {
+		r.ebpfTracker.walkConnections(func(e ebpfConnection) {
+			fromNodeInfo := map[string]string{
+				Procspied: "true",
+				EBPF:      "true",
+			}
+			toNodeInfo := map[string]string{
+				Procspied: "true",
+				EBPF:      "true",
+			}
+			if e.pid > 0 {
+				fromNodeInfo[process.PID] = strconv.Itoa(e.pid)
+				fromNodeInfo[report.HostNodeID] = hostNodeID
+			}
+
+			if e.incoming {
+				r.addConnection(&rpt, reverse(e.tuple), e.networkNamespace, toNodeInfo, fromNodeInfo)
+			} else {
+				r.addConnection(&rpt, e.tuple, e.networkNamespace, fromNodeInfo, toNodeInfo)
+			}
+
+		})
 	}
 
 	r.natMapper.applyNAT(rpt, r.conf.HostID)
@@ -213,4 +224,28 @@ func (r *Reporter) makeEndpointNode(namespaceID string, addr string, port uint16
 
 func newu64(i uint64) *uint64 {
 	return &i
+}
+
+// procParsingSwitcher make sure that if eBPF tracking is enabled,
+// connections coming from /proc parsing are only walked once.
+func (r *Reporter) procParsingSwitcher() {
+	if r.conf.WalkProc && r.conf.UseEbpfConn {
+		r.conf.WalkProc = false
+		r.ebpfTracker.initialize()
+	}
+}
+
+// if the eBPF tracker is enabled, feed the existing connections into it
+// incoming connections correspond to "accept" events
+// outgoing connections correspond to "connect" events
+func (r Reporter) feedToEbpf(tuple fourTuple, incoming bool, pid int, namespaceID string) {
+	if r.conf.UseEbpfConn && !r.ebpfTracker.isInitialized() {
+		tcpEventType := "connect"
+
+		if incoming {
+			tcpEventType = "accept"
+		}
+
+		r.ebpfTracker.handleConnection(tcpEventType, tuple, pid, namespaceID)
+	}
 }

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -96,7 +96,8 @@ func (r *Reporter) Report() (report.Report, error) {
 	seenTuples := map[string]fourTuple{}
 
 	// Consult the flowWalker for short-lived connections
-	{
+	// With eBPF, this is used only in the first round to build seenTuples for WalkProc
+	if r.conf.WalkProc || !r.conf.UseEbpfConn {
 		extraNodeInfo := map[string]string{
 			Conntracked: "true",
 		}
@@ -232,6 +233,8 @@ func (r *Reporter) procParsingSwitcher() {
 	if r.conf.WalkProc && r.conf.UseEbpfConn {
 		r.conf.WalkProc = false
 		r.ebpfTracker.initialize()
+
+		r.flowWalker.stop()
 	}
 }
 

--- a/prog/main.go
+++ b/prog/main.go
@@ -95,6 +95,7 @@ type probeFlags struct {
 
 	spyProcs    bool // Associate endpoints with processes (must be root)
 	procEnabled bool // Produce process topology & process nodes in endpoint
+	useEbpfConn bool // Enable connection tracking with eBPF
 	procRoot    string
 
 	dockerEnabled  bool
@@ -259,6 +260,7 @@ func main() {
 	flag.BoolVar(&flags.probe.spyProcs, "probe.proc.spy", true, "associate endpoints with processes (needs root)")
 	flag.StringVar(&flags.probe.procRoot, "probe.proc.root", "/proc", "location of the proc filesystem")
 	flag.BoolVar(&flags.probe.procEnabled, "probe.processes", true, "produce process topology & include procspied connections")
+	flag.BoolVar(&flags.probe.useEbpfConn, "probe.ebpf.connections", false, "enable connection tracking with eBPF")
 
 	// Docker
 	flag.BoolVar(&flags.probe.dockerEnabled, "probe.docker", false, "collect Docker-related attributes for processes")

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -143,8 +143,14 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 	var scanner procspy.ConnectionScanner
 	if flags.procEnabled {
 		processCache = process.NewCachingWalker(process.NewWalker(flags.procRoot))
-		scanner = procspy.NewConnectionScanner(processCache)
+		processCache.Tick()
 		p.AddTicker(processCache)
+		// if eBPF tracking is enabled, scan /proc synchronously, and just once
+		if flags.useEbpfConn {
+			scanner = procspy.NewSyncConnectionScanner(processCache)
+		} else {
+			scanner = procspy.NewConnectionScanner(processCache)
+		}
 		p.AddReporter(process.NewReporter(processCache, hostID, process.GetDeltaTotalJiffies))
 	}
 
@@ -161,6 +167,7 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 		SpyProcs:     flags.spyProcs,
 		UseConntrack: flags.useConntrack,
 		WalkProc:     flags.procEnabled,
+		UseEbpfConn:  flags.useEbpfConn,
 		ProcRoot:     flags.procRoot,
 		BufferSize:   flags.conntrackBufferSize,
 		Scanner:      scanner,

--- a/scope
+++ b/scope
@@ -142,6 +142,9 @@ launch_command() {
     echo docker run --privileged -d --name=$SCOPE_CONTAINER_NAME --net=host --pid=host \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v /var/run/scope/plugins:/var/run/scope/plugins \
+            -v /usr/src:/usr/src \
+            -v /lib/modules:/lib/modules \
+            -v /sys/kernel/debug:/sys/kernel/debug \
             -e CHECKPOINT_DISABLE \
             $WEAVESCOPE_DOCKER_ARGS $SCOPE_IMAGE --probe.docker=true
 }

--- a/vendor/github.com/iovisor/gobpf/COPYRIGHT.txt
+++ b/vendor/github.com/iovisor/gobpf/COPYRIGHT.txt
@@ -1,0 +1,13 @@
+Copyright 2016 PLUMgrid
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/github.com/iovisor/gobpf/LICENSE.txt
+++ b/vendor/github.com/iovisor/gobpf/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/iovisor/gobpf/bpf_module.go
+++ b/vendor/github.com/iovisor/gobpf/bpf_module.go
@@ -1,0 +1,225 @@
+// Copyright 2016 PLUMgrid
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"runtime"
+	"sync"
+	"syscall"
+	"unsafe"
+)
+
+/*
+#cgo CFLAGS: -I/usr/include/bcc/compat
+#cgo LDFLAGS: -lbcc
+#include <bcc/bpf_common.h>
+#include <bcc/libbpf.h>
+void perf_reader_free(void *ptr);
+*/
+import "C"
+
+// BpfModule type
+type BpfModule struct {
+	p       unsafe.Pointer
+	funcs   map[string]int
+	kprobes map[string]unsafe.Pointer
+}
+
+type compileRequest struct {
+	code   string
+	cflags []string
+	rspCh  chan *BpfModule
+}
+
+var (
+	defaultCflags []string
+	compileCh     chan compileRequest
+	bpfInitOnce   sync.Once
+)
+
+func bpfInit() {
+	defaultCflags = []string{
+		fmt.Sprintf("-DNUMCPUS=%d", runtime.NumCPU()),
+	}
+	compileCh = make(chan compileRequest)
+	go compile()
+}
+
+// NewBpfModule constructor
+func newBpfModule(code string, cflags []string) *BpfModule {
+	cflagsC := make([]*C.char, len(defaultCflags)+len(cflags))
+	defer func() {
+		for _, cflag := range cflagsC {
+			C.free(unsafe.Pointer(cflag))
+		}
+	}()
+	for i, cflag := range cflags {
+		cflagsC[i] = C.CString(cflag)
+	}
+	for i, cflag := range defaultCflags {
+		cflagsC[len(cflags)+i] = C.CString(cflag)
+	}
+	cs := C.CString(code)
+	defer C.free(unsafe.Pointer(cs))
+	c := C.bpf_module_create_c_from_string(cs, 2, (**C.char)(&cflagsC[0]), C.int(len(cflagsC)))
+	if c == nil {
+		return nil
+	}
+	return &BpfModule{
+		p:       c,
+		funcs:   make(map[string]int),
+		kprobes: make(map[string]unsafe.Pointer),
+	}
+}
+
+func NewBpfModule(code string, cflags []string) *BpfModule {
+	bpfInitOnce.Do(bpfInit)
+	ch := make(chan *BpfModule)
+	compileCh <- compileRequest{code, cflags, ch}
+	return <-ch
+}
+
+func compile() {
+	for {
+		req := <-compileCh
+		req.rspCh <- newBpfModule(req.code, req.cflags)
+	}
+}
+
+func (bpf *BpfModule) Close() {
+	C.bpf_module_destroy(bpf.p)
+	// close the kprobes opened by this module
+	for k, v := range bpf.kprobes {
+		C.perf_reader_free(v)
+		desc := fmt.Sprintf("-:kprobes/%s", k)
+		descCS := C.CString(desc)
+		C.bpf_detach_kprobe(descCS)
+		C.free(unsafe.Pointer(descCS))
+	}
+	for _, fd := range bpf.funcs {
+		syscall.Close(fd)
+	}
+}
+
+func (bpf *BpfModule) LoadNet(name string) (int, error) {
+	return bpf.Load(name, C.BPF_PROG_TYPE_SCHED_ACT)
+}
+func (bpf *BpfModule) LoadKprobe(name string) (int, error) {
+	return bpf.Load(name, C.BPF_PROG_TYPE_KPROBE)
+}
+func (bpf *BpfModule) Load(name string, progType int) (int, error) {
+	fd, ok := bpf.funcs[name]
+	if ok {
+		return fd, nil
+	}
+	fd, err := bpf.load(name, progType)
+	if err != nil {
+		return -1, err
+	}
+	bpf.funcs[name] = fd
+	return fd, nil
+}
+
+func (bpf *BpfModule) load(name string, progType int) (int, error) {
+	nameCS := C.CString(name)
+	defer C.free(unsafe.Pointer(nameCS))
+	start := (*C.struct_bpf_insn)(C.bpf_function_start(bpf.p, nameCS))
+	size := C.int(C.bpf_function_size(bpf.p, nameCS))
+	license := C.bpf_module_license(bpf.p)
+	version := C.bpf_module_kern_version(bpf.p)
+	if start == nil {
+		return -1, fmt.Errorf("BpfModule: unable to find %s", name)
+	}
+	logbuf := make([]byte, 65536)
+	logbufP := (*C.char)(unsafe.Pointer(&logbuf[0]))
+	fd := C.bpf_prog_load(uint32(progType), start, size, license, version, logbufP, C.uint(len(logbuf)))
+	if fd < 0 {
+		msg := string(logbuf[:bytes.IndexByte(logbuf, 0)])
+		return -1, fmt.Errorf("Error loading bpf program:\n%s", msg)
+	}
+	return int(fd), nil
+}
+
+var kprobeRegexp = regexp.MustCompile("[+.]")
+
+func (bpf *BpfModule) attachProbe(evName, desc string, fd int) error {
+	if _, ok := bpf.kprobes[evName]; ok {
+		return nil
+	}
+
+	evNameCS := C.CString(evName)
+	descCS := C.CString(desc)
+	res := C.bpf_attach_kprobe(C.int(fd), evNameCS, descCS, -1, 0, -1, nil, nil)
+	C.free(unsafe.Pointer(evNameCS))
+	C.free(unsafe.Pointer(descCS))
+
+	if res == nil {
+		return fmt.Errorf("Failed to attach BPF kprobe")
+	}
+	bpf.kprobes[evName] = res
+	return nil
+}
+
+func (bpf *BpfModule) AttachKprobe(event string, fd int) error {
+	evName := "p_" + kprobeRegexp.ReplaceAllString(event, "_")
+	desc := fmt.Sprintf("p:kprobes/%s %s", evName, event)
+
+	return bpf.attachProbe(evName, desc, fd)
+}
+
+func (bpf *BpfModule) AttachKretprobe(event string, fd int) error {
+	evName := "r_" + kprobeRegexp.ReplaceAllString(event, "_")
+	desc := fmt.Sprintf("r:kprobes/%s %s", evName, event)
+
+	return bpf.attachProbe(evName, desc, fd)
+}
+
+func (bpf *BpfModule) TableSize() uint64 {
+	size := C.bpf_num_tables(bpf.p)
+	return uint64(size)
+}
+
+func (bpf *BpfModule) TableId(name string) C.size_t {
+	cs := C.CString(name)
+	defer C.free(unsafe.Pointer(cs))
+	return C.bpf_table_id(bpf.p, cs)
+}
+
+func (bpf *BpfModule) TableDesc(id uint64) map[string]interface{} {
+	i := C.size_t(id)
+	return map[string]interface{}{
+		"name":      C.GoString(C.bpf_table_name(bpf.p, i)),
+		"fd":        int(C.bpf_table_fd_id(bpf.p, i)),
+		"key_size":  uint64(C.bpf_table_key_size_id(bpf.p, i)),
+		"leaf_size": uint64(C.bpf_table_leaf_size_id(bpf.p, i)),
+		"key_desc":  C.GoString(C.bpf_table_key_desc_id(bpf.p, i)),
+		"leaf_desc": C.GoString(C.bpf_table_leaf_desc_id(bpf.p, i)),
+	}
+}
+
+func (bpf *BpfModule) TableIter() <-chan map[string]interface{} {
+	ch := make(chan map[string]interface{})
+	go func() {
+		size := C.bpf_num_tables(bpf.p)
+		for i := C.size_t(0); i < size; i++ {
+			ch <- bpf.TableDesc(uint64(i))
+		}
+		close(ch)
+	}()
+	return ch
+}

--- a/vendor/github.com/iovisor/gobpf/bpf_table.go
+++ b/vendor/github.com/iovisor/gobpf/bpf_table.go
@@ -1,0 +1,229 @@
+// Copyright 2016 PLUMgrid
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf
+
+import (
+	"bytes"
+	"fmt"
+	"unsafe"
+)
+
+/*
+#cgo CFLAGS: -I/usr/include/bcc/compat
+#cgo LDFLAGS: -lbcc
+#include <bcc/bpf_common.h>
+#include <bcc/libbpf.h>
+*/
+import "C"
+
+type BpfTable struct {
+	id     C.size_t
+	module *BpfModule
+}
+
+func NewBpfTable(id C.size_t, module *BpfModule) *BpfTable {
+	return &BpfTable{
+		id:     id,
+		module: module,
+	}
+}
+
+func (table *BpfTable) ID() string {
+	return C.GoString(C.bpf_table_name(table.module.p, table.id))
+}
+func (table *BpfTable) Name() string {
+	return C.GoString(C.bpf_table_name(table.module.p, table.id))
+}
+func (table *BpfTable) Config() map[string]interface{} {
+	mod := table.module.p
+	return map[string]interface{}{
+		"name":      C.GoString(C.bpf_table_name(mod, table.id)),
+		"fd":        int(C.bpf_table_fd_id(mod, table.id)),
+		"key_size":  uint64(C.bpf_table_key_size_id(mod, table.id)),
+		"leaf_size": uint64(C.bpf_table_leaf_size_id(mod, table.id)),
+		"key_desc":  C.GoString(C.bpf_table_key_desc_id(mod, table.id)),
+		"leaf_desc": C.GoString(C.bpf_table_leaf_desc_id(mod, table.id)),
+	}
+}
+func (table *BpfTable) keyToString(key []byte) string {
+	key_size := C.bpf_table_key_size_id(table.module.p, table.id)
+	keyP := unsafe.Pointer(&key[0])
+	keyStr := make([]byte, key_size*8)
+	keyStrP := (*C.char)(unsafe.Pointer(&keyStr[0]))
+	r := C.bpf_table_key_snprintf(table.module.p, table.id, keyStrP, C.size_t(len(keyStr)), keyP)
+	if r == 0 {
+		return string(keyStr)
+	}
+	return ""
+}
+func (table *BpfTable) leafToString(leaf []byte) string {
+	leaf_size := C.bpf_table_leaf_size_id(table.module.p, table.id)
+	leafP := unsafe.Pointer(&leaf[0])
+	leafStr := make([]byte, leaf_size*8)
+	leafStrP := (*C.char)(unsafe.Pointer(&leafStr[0]))
+	r := C.bpf_table_leaf_snprintf(table.module.p, table.id, leafStrP, C.size_t(len(leafStr)), leafP)
+	if r == 0 {
+		return string(leafStr)
+	}
+	return ""
+}
+
+func (table *BpfTable) keyToBytes(keyStr string) ([]byte, error) {
+	mod := table.module.p
+	key_size := C.bpf_table_key_size_id(mod, table.id)
+	key := make([]byte, key_size)
+	keyP := unsafe.Pointer(&key[0])
+	keyCS := C.CString(keyStr)
+	defer C.free(unsafe.Pointer(keyCS))
+	r := C.bpf_table_key_sscanf(mod, table.id, keyCS, keyP)
+	if r != 0 {
+		return nil, fmt.Errorf("error scanning key (%v) from string", keyStr)
+	}
+	return key, nil
+}
+
+func (table *BpfTable) leafToBytes(leafStr string) ([]byte, error) {
+	mod := table.module.p
+	leaf_size := C.bpf_table_leaf_size_id(mod, table.id)
+	leaf := make([]byte, leaf_size)
+	leafP := unsafe.Pointer(&leaf[0])
+	leafCS := C.CString(leafStr)
+	defer C.free(unsafe.Pointer(leafCS))
+	r := C.bpf_table_leaf_sscanf(mod, table.id, leafCS, leafP)
+	if r != 0 {
+		return nil, fmt.Errorf("error scanning leaf (%v) from string", leafStr)
+	}
+	return leaf, nil
+}
+
+type Entry struct {
+	Key   string
+	Value string
+}
+
+// Get takes a key and returns the value or nil, and an 'ok' style indicator
+func (table *BpfTable) Get(keyStr string) (interface{}, bool) {
+	mod := table.module.p
+	fd := C.bpf_table_fd_id(mod, table.id)
+	leaf_size := C.bpf_table_leaf_size_id(mod, table.id)
+	key, err := table.keyToBytes(keyStr)
+	if err != nil {
+		return nil, false
+	}
+	leaf := make([]byte, leaf_size)
+	keyP := unsafe.Pointer(&key[0])
+	leafP := unsafe.Pointer(&leaf[0])
+	r := C.bpf_lookup_elem(fd, keyP, leafP)
+	if r != 0 {
+		return nil, false
+	}
+	leafStr := make([]byte, leaf_size*8)
+	leafStrP := (*C.char)(unsafe.Pointer(&leafStr[0]))
+	r = C.bpf_table_leaf_snprintf(mod, table.id, leafStrP, C.size_t(len(leafStr)), leafP)
+	if r != 0 {
+		return nil, false
+	}
+	return Entry{
+		Key:   keyStr,
+		Value: string(leafStr[:bytes.IndexByte(leafStr, 0)]),
+	}, true
+}
+
+func (table *BpfTable) Set(keyStr, leafStr string) error {
+	if table == nil || table.module.p == nil {
+		panic("table is nil")
+	}
+	fd := C.bpf_table_fd_id(table.module.p, table.id)
+	key, err := table.keyToBytes(keyStr)
+	if err != nil {
+		return err
+	}
+	leaf, err := table.leafToBytes(leafStr)
+	if err != nil {
+		return err
+	}
+	keyP := unsafe.Pointer(&key[0])
+	leafP := unsafe.Pointer(&leaf[0])
+	r, err := C.bpf_update_elem(fd, keyP, leafP, 0)
+	if r != 0 {
+		return fmt.Errorf("BpfTable.Set: unable to update element (%s=%s): %s", keyStr, leafStr, err)
+	}
+	return nil
+}
+func (table *BpfTable) Delete(keyStr string) error {
+	fd := C.bpf_table_fd_id(table.module.p, table.id)
+	key, err := table.keyToBytes(keyStr)
+	if err != nil {
+		return err
+	}
+	keyP := unsafe.Pointer(&key[0])
+	r, err := C.bpf_delete_elem(fd, keyP)
+	if r != 0 {
+		return fmt.Errorf("BpfTable.Delete: unable to delete element (%s): %s", keyStr, err)
+	}
+	return nil
+}
+func (table *BpfTable) Iter() <-chan Entry {
+	mod := table.module.p
+	ch := make(chan Entry, 128)
+	go func() {
+		defer close(ch)
+		fd := C.bpf_table_fd_id(mod, table.id)
+		key_size := C.bpf_table_key_size_id(mod, table.id)
+		leaf_size := C.bpf_table_leaf_size_id(mod, table.id)
+		key := make([]byte, key_size)
+		leaf := make([]byte, leaf_size)
+		keyP := unsafe.Pointer(&key[0])
+		leafP := unsafe.Pointer(&leaf[0])
+		alternateKeys := []byte{0xff, 0x55}
+		res := C.bpf_lookup_elem(fd, keyP, leafP)
+		// make sure the start iterator is an invalid key
+		for i := 0; i <= len(alternateKeys); i++ {
+			if res < 0 {
+				break
+			}
+			for j := range key {
+				key[j] = alternateKeys[i]
+			}
+			res = C.bpf_lookup_elem(fd, keyP, leafP)
+		}
+		if res == 0 {
+			return
+		}
+		keyStr := make([]byte, key_size*8)
+		leafStr := make([]byte, leaf_size*8)
+		keyStrP := (*C.char)(unsafe.Pointer(&keyStr[0]))
+		leafStrP := (*C.char)(unsafe.Pointer(&leafStr[0]))
+		for res = C.bpf_get_next_key(fd, keyP, keyP); res == 0; res = C.bpf_get_next_key(fd, keyP, keyP) {
+			r := C.bpf_lookup_elem(fd, keyP, leafP)
+			if r != 0 {
+				continue
+			}
+			r = C.bpf_table_key_snprintf(mod, table.id, keyStrP, C.size_t(len(keyStr)), keyP)
+			if r != 0 {
+				break
+			}
+			r = C.bpf_table_leaf_snprintf(mod, table.id, leafStrP, C.size_t(len(leafStr)), leafP)
+			if r != 0 {
+				break
+			}
+			ch <- Entry{
+				Key:   string(keyStr[:bytes.IndexByte(keyStr, 0)]),
+				Value: string(leafStr[:bytes.IndexByte(leafStr, 0)]),
+			}
+		}
+	}()
+	return ch
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -948,6 +948,14 @@
 			"branch": "master"
 		},
 		{
+			"importpath": "github.com/iovisor/gobpf",
+			"repository": "https://github.com/iovisor/gobpf",
+			"vcs": "git",
+			"revision": "e0dd5caf07ea778d61c91a3219726451459bf70c",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/jmespath/go-jmespath",
 			"repository": "https://github.com/jmespath/go-jmespath",
 			"vcs": "",


### PR DESCRIPTION
This is the second attempt to add eBPF connection tracking. The first one was via https://github.com/weaveworks/scope/pull/1967 by forking a python script using bcc. This one is done in Golang directly thanks to [gobpf](https://github.com/iovisor/gobpf).

This is not enabled by default. For now, it should be enabled manually with:
```
sudo ./scope launch --probe.ebpf.connections=true
```
Scope Probe also falls back on the the old /proc parsing if eBPF is not working (e.g. too old kernel, or missing kernel headers).

This allows scope to get notified of every connection event, without relying on the parsing of `/proc/$pid/net/tcp{,6}` and `/proc/$pid/fd/*`, and therefore improve performance.

The eBPF program is in `probe/endpoint/ebpf.go`. It was discussed in bcc via iovisor/bcc#762.
It is using kprobes on the following kernel functions:
- tcp_v4_connect
- inet_csk_accept
- tcp_close

It generates "connect", "accept" and "close" events containing the connection tuple but also the pid and the netns.

`probe/endpoint/ebpf.go` maintains the list of connections. Similarly to conntrack, we keep the dead connections for one iteration in order to report the short-lived connections.

The code for parsing `/proc/$pid/net/tcp{,6}` and `/proc/$pid/fd/*` is still there and still used at start-up because eBPF only brings us the events and not the initial state. However, the /proc parsing for the initial state is now done in foreground instead of background, via `newForegroundReader()`.

NAT resolutions on connections from eBPF works in the same way as it did on connections from /proc: by using conntrack. One of the two conntrack instances was removed since eBPF is able to get short-lived connections.

The Scope Docker image is bigger because we need a few more packages
for bcc:
- weaveworks/scope in current master:  22 MB (compressed),  71 MB (uncompressed)
- weaveworks/scope with this patchset: 83 MB (compressed), 223 MB (uncompressed)

But @iaguis still has ongoing work to reduce the size of the image.

Limitations:
- [ ] Sets `procspied: true` on connections coming from eBPF
- [ ] Size of the Docker images
- [ ] Requirement on kernel headers for now
- [ ] Location of kernel headers: iovisor/bcc#743
- [ ] Does not support IPv6
- [ ] Uncompleted connections that time out don't disappear (WIP branch to fix this and support IPv6: [iaguis/tcp_tracer_established](https://github.com/kinvolk/bcc/commits/iaguis/tcp_tracer_established))

Fixes #1168 (walking /proc to obtain connections is very expensive)

Fixes #1260 (Short-lived connections not tracked for containers in shared networking namespaces)
