### PR TITLE
Report data structure documentation

### DIFF
--- a/site/plugins.md
+++ b/site/plugins.md
@@ -459,8 +459,7 @@ Nodes are represented as follows:
 ```
 
 Nodes are stored in a dictionary.
-The ID of nodes representing hosts or containers has the format `ID;<type>`, with type equal to the literal string `host` or `container` respectively.
-`ID` is the alphanumeric identifier of the nodes.
+The ID of nodes is different depending on the node topology. For instance, nodes representing hosts or containers have the format `ID;<type>`, where `ID` is the alphanumeric identifier of the nodes and type is the literal string `host` or `container` respectively. A node representing an endpoint could look like `pc-4026531969;127.0.0.1;36238`.
 
 A node contains all the information about the represented object (e.g. host, container, pod, etc.).
 In particular, a node may contain:

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -395,7 +395,7 @@ func (p *Plugin) Report(w http.ResponseWriter, r *http.Request) {
 A report can contain many types of information.
 If you go back to the [Reporter Interface](#reporter-interface) section, you see the top-level `Plugins` attribute.
 Along with that, a report may contain multiple topologies.
-An example of a report containing few topologies is the following:
+An example of a report containing a few topologies is the following:
 
 ```json
 {
@@ -409,7 +409,7 @@ An example of a report containing few topologies is the following:
 
 ### Topologies
 Topologies can be of various types.
-Each topology consists of a list of nodes and other information about the topology.
+Each topology consists of some general information and a list of nodes.
 The available topologies are:
 
 - `Endpoint` nodes are (address, port) tuples on each host.
@@ -431,12 +431,13 @@ The topology structure consists of the following attributes:
 - `table_templates` - contains the templates used to render tables into the Scope UI.
 - `metric_templates` - contains the templates used to render metrics into the Scope UI.
 
-**Note**: These attribute are not required. But a topology with no `nodes` does not have any information to render, `metadata_templates`, as well as `table_templates`, are needed to know how to render the information carried by `nodes` in the Scope UI.
+**Note**: These attribute are not required. But a topology with no `nodes` does not have any information to render.
+`metadata_templates`, as well as `table_templates`, are needed to know how to render the information carried by `nodes` in the Scope UI.
 
 ### Nodes
 A Node contains information about a specific element of a topology.
-For example the Host topology will contain nodes describing all the hosts in it.
-The same is for containers and Container topology, pods and Pod topology and so on.
+For example, the Host topology will contain nodes describing all the hosts in it.
+The same applies for containers and the Container topology, pods and the Pod topology and so on.
 Nodes are represented as follows:
 
 ```json
@@ -455,18 +456,21 @@ Nodes are represented as follows:
 }
 ```
 
-Nodes are stored in dictionary. The ID of nodes representing hosts or containers have the format `ID;<type>`, with type equal to the literal string `host` or `container` accordingly. The `ID` is the alphanumeric identifier of the nodes.
-A node contains all the information about the represented object (e.g. host, container, pod, etc.).
-In particular a node may contain:
+Nodes are stored in a dictionary.
+The ID of nodes representing hosts or containers has the format `ID;<type>`, with type equal to the literal string `host` or `container` respectively.
+`ID` is the alphanumeric identifier of the nodes.
 
-- `latest` - an id-value map containing the latest values. These values are a single piece of information.
+A node contains all the information about the represented object (e.g. host, container, pod, etc.).
+In particular, a node may contain:
+
+- `latest` - an id-value map containing the latest values. As opposed to the values in metrics, these values will not normally change.
 - `latestControls` - the latest available controls.
 - `metrics` - the collection of metrics to display in the UI.
 
 ### Controls
 Controls describe interfaces that expose actions that the user can perform on different objects (e.g. host, container, etc.).
 Controls are an element of nodes. In this way, each control in a node is attached to it and performs an action on the object described by the node itself. Below is an example of how controls are represented in the JSON report.
-In the report the attribute `latest_controls` contains all the controls exposed by scope and/or plugins, but only the alive ones will be listed in the attribute `controls`.
+In the report the attribute `latest_controls` contains all the controls exposed by scope and/or plugins, but only those alive will be listed in the attribute `controls`.
 
 ```json
 "controls": {
@@ -491,7 +495,7 @@ In the report the attribute `latest_controls` contains all the controls exposed 
 }
 ```
 
-- `timestamp` is the timestamp of when the control was exposed.
+- `timestamp` specifies when the control was exposed.
 - `value` is an object containing the control value. At the moment, only the state is available.
  - `dead` is a boolean to know the state (active, dead) of a control. It is useful to show controls only when they are in a usable state.
 
@@ -540,7 +544,7 @@ This description is used to extract metadata from a node and display it on Scope
 - `metadata-template-identifier` and `id` identify a particular metadata template.
 - `label` contains the label that will be used by Scope UI.
 - `dataType` specifies the type of data, this will determine how the value is displayed. Possible values for this attribute are: "number", "ip", "datetime" and "" for strings.
-- `priority` is a floating point value used to decide the display ordering (lower values are displayed before higher ones). If it is omitted the UI display the value as last.
+- `priority` is a floating point value used to decide the display ordering (lower values are displayed before higher ones). If omitted, the UI will display it last.
 - `from` indicates where to look for the metadata. The possible values are:
  - `latest`
  - `sets`
@@ -564,13 +568,13 @@ Table Templates describe a table and how to identify which metadata templates be
 - `label` contains the label that will be used by Scope UI.
 - `prefix` is used to identify which metadata templates belong to the table.
 
-If you want to display data in a table, you have to define a table template and prepend the table prefix to all the metadata templates that identifies the data you want to put in such table.
+If you want to display data in a table, you have to define a table template and prepend the table prefix to all the metadata templates that identify the data you want to put in such table.
 
 ### Metrics
 Metrics are a particular kind of data that can be plotted on the UI as a graph.
 Scope uses the `metric_templates` to know how to display such data. To pair a metric with its template, it is necessary to use the `metric-template-id` as key to identify that particular metric.
 Metrics are suitable for information such as CPU and memory usage, HTTP requests rate, I/O operations, etc.
-The following is an example of a report with a metric and a its metric template:
+The following is an example of a report with a metric preceded by its metric template:
 
 ```json
 "metric_templates": {
@@ -629,7 +633,7 @@ A report may have an attribute called `Window`.
 This is the time window, expressed as duration, within which the data contained in the report are considered valid.
 The default window is 15 seconds.
 You may change the window value using the option `-app.window <SECONDS>` when launching scope.
-However, using values less than 15 seconds increases the change of information not be correctly displayed.
+However, using values less than 15 seconds increases the chance of information not being correctly displayed.
 
 **See Also**
 

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -393,7 +393,7 @@ func (p *Plugin) Report(w http.ResponseWriter, r *http.Request) {
 
 ### <a id="report-data-structures"></a>Report Data structures
 A report can contain many types of information.
-If you go back to the [Reporter Interface](#reporter-interface) section, you see the top-level `Plugins` attribute.
+If you go back to the [Reporter Interface](#reporter-interface) section, you will see the top-level `Plugins` attribute.
 Along with that, a report may contain multiple topologies.
 An example of a report containing a few topologies is the following:
 
@@ -410,9 +410,9 @@ An example of a report containing a few topologies is the following:
 ### Topologies
 Topologies can be of various types.
 Each topology consists of some general information and a list of nodes.
-The available topologies are:
+These are the available topologies:
 
-- `Endpoint` nodes are (address, port) tuples on each host.
+- `Endpoint` nodes are `(address, port)` tuples on each host.
 - `Process` nodes are processes on each host.
 - `Container` nodes represent all Docker containers on hosts running probes.
 - `Pods` nodes represent all Kubernetes pods running on hosts running probes.
@@ -470,7 +470,7 @@ In particular, a node may contain:
 ### Controls
 Controls describe interfaces that expose actions that the user can perform on different objects (e.g. host, container, etc.).
 Controls are an element of nodes. In this way, each control in a node is attached to it and performs an action on the object described by the node itself. Below is an example of how controls are represented in the JSON report.
-In the report the attribute `latest_controls` contains all the controls exposed by scope and/or plugins, but only those alive will be listed in the attribute `controls`.
+In the report, the attribute `latest_controls` contains all the controls exposed by scope and/or plugins, but only those alive will be listed in the attribute `controls`.
 
 ```json
 "controls": {
@@ -502,7 +502,7 @@ In the report the attribute `latest_controls` contains all the controls exposed 
 ### Metadata
 All metadata entries are placed within nodes in the section named `latest`.
 This section contains the latest values to display and consists of `timestamp` and `value`.
-Both should be written as strings in the json (with the double quotes).
+Both should be written as json strings (with double quotes).
 Scope uses `metadata_templates` to know how to display such data.
 To pair metadata with its template, it is necessary to use the `metadata-template-id` as a key to identify that particular piece of data. Example:
 
@@ -546,9 +546,9 @@ This description is used to extract metadata from a node and display it on Scope
 - `dataType` specifies the type of data, this will determine how the value is displayed. Possible values for this attribute are: "number", "ip", "datetime" and "" for strings.
 - `priority` is a floating point value used to decide the display ordering (lower values are displayed before higher ones). If omitted, the UI will display it last.
 - `from` indicates where to look for the metadata. The possible values are:
- - `latest`
- - `sets`
- - `counters`
+  - `latest`
+  - `sets`
+  - `counters`
 
 ### Table Templates
 Table Templates describe a table and how to identify which metadata templates belong to the table.
@@ -627,9 +627,9 @@ The following is an example of metric template:
 - `metric-template-id` and `id` identify a particular metric template.
 - `label` contains the label that will be used by Scope UI.
 - `format` describes how the metrics is formatted.
- - `percent` the metric value is a percentage.
- - `filesize` the metric value is a file size (e.g. memory usage), it is displayed with the suffix KB, MB, GB, etc.
- - `integer` the metric value is an integer.
+  - `percent` the metric value is a percentage.
+  - `filesize` the metric value is a file size (e.g. memory usage), it is displayed with the suffix KB, MB, GB, etc.
+  - `integer` the metric value is an integer.
 - `priority` is a floating point value used to decide the display ordering (lower values are displayed before higher ones).
 
 ### Time Window

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -498,11 +498,12 @@ In the report the attribute `latest_controls` contains all the controls exposed 
 ### Metadata
 All metadata entries are placed within nodes in the section named `latest`.
 This section contains the latest values to display and consists of `timestamp` and `value`.
+Both should be written as strings in the json (with the double quotes).
 Scope uses `metadata_templates` to know how to display such data.
 To pair metadata with its template, it is necessary to use the `metadata-template-id` as a key to identify that particular piece of data. Example:
 
 ```json
-"metadata-templates": {
+"metadata_templates": {
       "metadata-templates-id": {
         "id": "metadata-templates-id",
         "label": "Human-readable description",
@@ -514,7 +515,7 @@ To pair metadata with its template, it is necessary to use the `metadata-templat
 "latest": {
 	"metadata-templates-id": {
 		"timestamp": "2016-11-17T08:53:02.189193735Z",
-		"value": "-"
+		"value": "42"
 	}
 }
 ```
@@ -538,7 +539,7 @@ This description is used to extract metadata from a node and display it on Scope
 
 - `metadata-template-identifier` and `id` identify a particular metadata template.
 - `label` contains the label that will be used by Scope UI.
-- `dataType` specifies the type of data, this will determine how the value is displayed. Possible values for this attribute are: number, ip, and datetime.
+- `dataType` specifies the type of data, this will determine how the value is displayed. Possible values for this attribute are: "number", "ip", "datetime" and "" for strings.
 - `priority` is a floating point value used to decide the display ordering (lower values are displayed before higher ones). If it is omitted the UI display the value as last.
 - `from` indicates where to look for the metadata. The possible values are:
  - `latest`

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -19,7 +19,7 @@ The following topics are discussed:
   * [Defining the Reporter Interface](#defining-reporter-interface)
   * [Report Data Structures](#report-data-structures)
 
-Any kind of metrics can be generated and inserted into Scope using custom plugins. Metrics generated through your plugin are displayed in the user interface alongside the standard set of metrics that are found in Weave Scope.
+Any kind of metric can be generated and inserted in Scope with custom plugins. Metrics generated through a plugin are displayed in the user interface alongside the standard metrics found in Weave Scope.
 
 ![Custom Metrics With Plugins](images/plugin-features.png)
 
@@ -408,8 +408,7 @@ An example of a report containing a few topologies is the following:
 ```
 
 ### Topologies
-Topologies can be of various types.
-Each topology consists of some general information and a list of nodes.
+A topology consists of a list of nodes along with controls and templates described below.
 These are the available topologies:
 
 - `Endpoint` nodes are `(address, port)` tuples on each host.
@@ -505,8 +504,8 @@ In the report, the attribute `latest_controls` contains all the controls exposed
 ### Metadata
 All metadata entries are placed within nodes in the section named `latest`.
 This section contains the latest values to display and consists of `timestamp` and `value`.
-Both should be written as json strings (with double quotes).
-Scope uses `metadata_templates` to know how to display such data.
+Both should be written as JSON strings (with double quotes).
+Scope uses `metadata_templates` to display this data.
 To pair metadata with its template, it is necessary to use the `metadata-template-id` as a key to identify that particular piece of data. Example:
 
 ```json
@@ -528,8 +527,8 @@ To pair metadata with its template, it is necessary to use the `metadata-templat
 ```
 
 ### Metadata Templates
-Metadata Templates describe a particular metadata item.
-This description is used to extract metadata from a node and display it on Scope UI.
+A metadata template describes a kind of metadata that is present in zero, one or several nodes and it specifies how to display such metadata in Scope.
+Metadata templates are not placed within nodes but in the `metadata_templates` section so that the same information do not need to be repeated in all nodes that use it.
 
 ```json
 "metadata_templates": {
@@ -545,16 +544,16 @@ This description is used to extract metadata from a node and display it on Scope
 ```
 
 - `id` is a string identifying the particular metadata template (here `traffic-control-pktloss`) and is also used as a key to the template value.
-- `label` contains the label that will be used by Scope UI.
-- `dataType` specifies the type of data, this will determine how the value is displayed. Possible values for this attribute are: "number", "ip", "datetime" and "" for strings.
-- `priority` is a floating point value used to decide the display ordering (lower values are displayed before higher ones). If omitted, the UI will display it last.
+- `label` contains the label used by the Scope UI.
+- `dataType` specifies the type of data, and determines how the value is displayed. Possible values for this attribute are: "number", "ip", "datetime" and "" for strings.
+- `priority` is a floating point value used to decide the display ordering (lower values are displayed before higher ones). If omitted, the UI displays it last.
 - `from` indicates where to look for the metadata. The possible values are:
   - `latest`
   - `sets`
   - `counters`
 
 ### Table Templates
-Table Templates describe a table and how to identify which metadata templates belong to the table.
+Table Templates describe a table and also how to identify the metadata templates that belong to the table.
 
 ```json
 "table_templates": {
@@ -568,15 +567,15 @@ Table Templates describe a table and how to identify which metadata templates be
 ```
 
 - `table-template-identifier` and `id` identify a particular table template.
-- `label` contains the label that will be used by Scope UI.
+- `label` contains the label used by the Scope UI.
 - `prefix` is used to identify which metadata templates belong to the table.
 
-If you want to display data in a table, you have to define a table template and prepend the table prefix to all the metadata templates that identify the data you want to put in such table.
+To display data in a table, define a table template and prepend the table prefix to all of the metadata templates that identify the data you want to put into the table.
 
 ### Metrics
 Metrics are a particular kind of data that can be plotted on the UI as a graph.
-Scope uses the `metric_templates` to know how to display such data. To pair a metric with its template, it is necessary to use the `metric-template-id` as key to identify that particular metric.
-Metrics are suitable for information such as CPU and memory usage, HTTP requests rate, I/O operations, etc.
+Scope uses `metric_templates` to display graph data in Scope. To pair a metric with its template, use the `metric-template-id` as the key for identifying a particular metric.
+Metrics can be used to display CPU and memory usage, HTTP requests rate, I/O operations, etc.
 The following is an example of a report with a metric preceded by its metric template:
 
 ```json
@@ -627,17 +626,16 @@ The following is an example of metric template:
 }
 ```
 
-- `metric-template-id` and `id` identify a particular metric template.
-- `label` contains the label that will be used by Scope UI.
-- `format` describes how the metrics is formatted.
+- `metric-template-id` and `id` identify a specific metric template.
+- `label` contains the label used by Scope UI.
+- `format` describes how the metrics are formatted and can be:
   - `percent` the metric value is a percentage.
   - `filesize` the metric value is a file size (e.g. memory usage), it is displayed with the suffix KB, MB, GB, etc.
   - `integer` the metric value is an integer.
 - `priority` is a floating point value used to decide the display ordering (lower values are displayed before higher ones).
 
 ### Time Window
-A report may have an attribute called `Window`.
-This is the time window, expressed as duration, within which the data contained in the report are considered valid.
+The `Window` attribute is a time window, expressed as a duration and it defines the period from which data in the report is considered valid.
 The default window is 15 seconds.
 You may change the window value using the option `-app.window <SECONDS>` when launching scope.
 However, using values smaller than 15 seconds increases the chance of information not being correctly displayed.

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -527,8 +527,8 @@ To pair metadata with its template, it is necessary to use the `metadata-templat
 ```
 
 ### Metadata Templates
-A metadata template describes a kind of metadata that is present in zero, one or several nodes and it specifies how to display such metadata in Scope.
-Metadata templates are not placed within nodes but in the `metadata_templates` section so that the same information do not need to be repeated in all nodes that use it.
+A metadata template describes a kind of metadata that is present in zero, one or several nodes of the topology and specifies how to display such metadata in Scope.
+Metadata templates are not placed within nodes but in the `metadata_templates` section of the JSON file.
 
 ```json
 "metadata_templates": {

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -467,6 +467,8 @@ In particular, a node may contain:
 - `latest` - an id-value map containing the latest values. Each id has only one value.
 - `latestControls` - the latest available controls.
 - `metrics` - the collection of metrics to display in the UI. Each metric has multiple timestamped values.
+- `sets` - a string->set-of-strings map, for example a list of local networks.
+- `counters` - a string->int map.
 
 ### Controls
 Controls describe interfaces that expose actions that the user can perform on different objects (e.g. host, container, etc.).

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -421,6 +421,8 @@ These are the available topologies:
 - `ReplicaSet` nodes represent all Kubernetes ReplicaSets running on hosts running probes.
 - `ContainerImage` nodes represent all Docker container images on hosts running probes.
 - `Host` nodes are physical hosts that run probes.
+- `ECSTask` nodes represent [AWS ECS](https://aws.amazon.com/ecs/) [tasks](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html).
+- `ECSService` nodes represent [AWS ECS services](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html).
 - `Overlay` nodes are active peers in any software-defined network that's overlaid on the infrastructure.
 
 The topology structure consists of the following attributes:

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -532,18 +532,18 @@ This description is used to extract metadata from a node and display it on Scope
 
 ```json
 "metadata_templates": {
-      "metadata-template-id": {
-        "id": "metadata-template-id",
+      "traffic-control-pktloss": {
+        "id": "traffic-control-pktloss",
         "label": "Human-readable description",
         "dataType": "number",
         "priority": 13.5,
         "from": "latest"
       },
-      "another-metadata-template-id": {...}
+      "another-plugins-id": {...}
 }
 ```
 
-- `metadata-template-identifier` and `id` identify a particular metadata template.
+- `id` is a string identifying the particular metadata template (here `traffic-control-pktloss`) and is also used as a key to the template value.
 - `label` contains the label that will be used by Scope UI.
 - `dataType` specifies the type of data, this will determine how the value is displayed. Possible values for this attribute are: "number", "ip", "datetime" and "" for strings.
 - `priority` is a floating point value used to decide the display ordering (lower values are displayed before higher ones). If omitted, the UI will display it last.

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -463,9 +463,9 @@ The ID of nodes representing hosts or containers has the format `ID;<type>`, wit
 A node contains all the information about the represented object (e.g. host, container, pod, etc.).
 In particular, a node may contain:
 
-- `latest` - an id-value map containing the latest values. As opposed to the values in metrics, these values will not normally change.
+- `latest` - an id-value map containing the latest values. Each id has only one value.
 - `latestControls` - the latest available controls.
-- `metrics` - the collection of metrics to display in the UI.
+- `metrics` - the collection of metrics to display in the UI. Each metric has multiple timestamped values.
 
 ### Controls
 Controls describe interfaces that expose actions that the user can perform on different objects (e.g. host, container, etc.).
@@ -592,6 +592,10 @@ The following is an example of a report with a metric preceded by its metric tem
 			{
 				"date": "2016-11-17T08:53:03.171424664Z",
 				"value": 98.24
+			},
+			{
+				"date": "2016-11-17T08:53:04.171789887Z",
+				"value": 80.11
 			}
 		],
 		"min": 0,

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -637,7 +637,7 @@ A report may have an attribute called `Window`.
 This is the time window, expressed as duration, within which the data contained in the report are considered valid.
 The default window is 15 seconds.
 You may change the window value using the option `-app.window <SECONDS>` when launching scope.
-However, using values less than 15 seconds increases the chance of information not being correctly displayed.
+However, using values smaller than 15 seconds increases the chance of information not being correctly displayed.
 
 **See Also**
 


### PR DESCRIPTION
This PR adds documentation for the primary data structures used to create a report. It will be of great help to developers that want to build their plugins.

I did this work on the website. Do you want me to add the same information on https://github.com/weaveworks/scope/blob/master/examples/plugins/README.md?

Relevant to https://github.com/weaveworks/scope/issues/1963

/cc @2opremio @abuehrle 