### PR TITLE
Add ECS views

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -183,11 +183,10 @@ func AddInitialTopologiesToRegistry(registry *Registry) {
 			Rank:     4,
 		},
 		APITopologyDesc{
-			id:          weaveID,
-			parent:      hostsID,
-			renderer:    render.WeaveRenderer,
-			Name:        "weave net",
-			HideIfEmpty: true,
+			id:       weaveID,
+			parent:   hostsID,
+			renderer: render.WeaveRenderer,
+			Name:     "Weave Net",
 		},
 	)
 }

--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -35,7 +35,7 @@ const (
 
 var (
 	topologyRegistry = MakeRegistry()
-	k8sPseudoFilter  = APITopologyOptionGroup{
+	unmanagedFilter  = APITopologyOptionGroup{
 		ID:      "pseudo",
 		Default: "hide",
 		Options: []APITopologyOption{
@@ -165,6 +165,7 @@ func AddInitialTopologiesToRegistry(registry *Registry) {
 			renderer:    render.ECSTaskRenderer,
 			Name:        "Tasks",
 			Rank:        3,
+			Options:     []APITopologyOptionGroup{unmanagedFilter},
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{
@@ -172,6 +173,7 @@ func AddInitialTopologiesToRegistry(registry *Registry) {
 			parent:      ecsTasksID,
 			renderer:    render.ECSServiceRenderer,
 			Name:        "services",
+			Options:     []APITopologyOptionGroup{unmanagedFilter},
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{
@@ -228,7 +230,7 @@ func updateFilters(rpt report.Report, topologies []APITopologyDesc) []APITopolog
 	for i, t := range topologies {
 		if t.id == podsID || t.id == servicesID || t.id == deploymentsID || t.id == replicaSetsID {
 			topologies[i] = updateTopologyFilters(t, []APITopologyOptionGroup{
-				kubernetesFilters(ns...), k8sPseudoFilter,
+				kubernetesFilters(ns...), unmanagedFilter,
 			})
 		}
 	}

--- a/app/merger.go
+++ b/app/merger.go
@@ -49,8 +49,8 @@ func (smartMerger) Merge(reports []report.Report) report.Report {
 		return reports[0]
 	}
 	c := make(chan *report.Report, l)
-	for _, r := range reports {
-		c <- &r
+	for i := range reports {
+		c <- &reports[i]
 	}
 	for ; l > 1; l-- {
 		go func(left, right *report.Report) {

--- a/app/merger.go
+++ b/app/merger.go
@@ -48,14 +48,15 @@ func (smartMerger) Merge(reports []report.Report) report.Report {
 	case 1:
 		return reports[0]
 	}
-	c := make(chan report.Report, l)
+	c := make(chan *report.Report, l)
 	for _, r := range reports {
-		c <- r
+		c <- &r
 	}
 	for ; l > 1; l-- {
-		go func(left, right report.Report) {
-			c <- left.Merge(right)
+		go func(left, right *report.Report) {
+			r := left.Merge(*right)
+			c <- &r
 		}(<-c, <-c)
 	}
-	return <-c
+	return *<-c
 }

--- a/app/merger.go
+++ b/app/merger.go
@@ -48,15 +48,15 @@ func (smartMerger) Merge(reports []report.Report) report.Report {
 	case 1:
 		return reports[0]
 	}
-	c := make(chan *report.Report, l)
-	for i := range reports {
-		c <- &reports[i]
+	c := make(chan report.Report, l)
+	for _, r := range reports {
+		c <- r
 	}
 	for ; l > 1; l-- {
-		go func(left, right *report.Report) {
-			r := left.Merge(*right)
-			c <- &r
-		}(<-c, <-c)
+		left, right := <-c, <-c
+		go func() {
+			c <- left.Merge(right)
+		}()
 	}
-	return *<-c
+	return <-c
 }

--- a/probe/appclient/app_client_internal_test.go
+++ b/probe/appclient/app_client_internal_test.go
@@ -83,6 +83,8 @@ func TestAppClientPublish(t *testing.T) {
 	rpt.ReplicaSet = report.MakeTopology()
 	rpt.Host = report.MakeTopology()
 	rpt.Overlay = report.MakeTopology()
+	rpt.ECSTask = report.MakeTopology()
+	rpt.ECSService = report.MakeTopology()
 	rpt.Endpoint.Controls = nil
 	rpt.Process.Controls = nil
 	rpt.Container.Controls = nil
@@ -93,6 +95,8 @@ func TestAppClientPublish(t *testing.T) {
 	rpt.ReplicaSet.Controls = nil
 	rpt.Host.Controls = nil
 	rpt.Overlay.Controls = nil
+	rpt.ECSTask.Controls = nil
+	rpt.ECSService.Controls = nil
 
 	s := dummyServer(t, token, id, version, rpt, done)
 	defer s.Close()

--- a/probe/awsecs/client.go
+++ b/probe/awsecs/client.go
@@ -1,0 +1,138 @@
+package awsecs
+
+import (
+	"sync"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecs"
+)
+
+// a wrapper around an AWS client that makes all the needed calls and just exposes the final results
+type ecsClient struct {
+	client  *ecs.ECS
+	cluster string
+}
+
+func newClient(cluster string) (*ecsClient, error) {
+	sess := session.New()
+
+	region, err := ec2metadata.New(sess).Region()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ecsClient{
+		client:  ecs.New(sess, &aws.Config{Region: aws.String(region)}),
+		cluster: cluster,
+	}, nil
+}
+
+// returns a map from deployment ids to service names
+// cannot fail as it will attempt to deliver partial results, though that may end up being no results
+func (c ecsClient) getDeploymentMap() map[string]string {
+	results := make(map[string]string)
+	lock := sync.Mutex{} // lock mediates access to results
+
+	group := sync.WaitGroup{}
+
+	err := c.client.ListServicesPages(
+		&ecs.ListServicesInput{Cluster: &c.cluster},
+		func(page *ecs.ListServicesOutput, lastPage bool) bool {
+			// describe each page of 10 (the max for one describe command) concurrently
+			group.Add(1)
+			go func() {
+				defer group.Done()
+
+				resp, err := c.client.DescribeServices(&ecs.DescribeServicesInput{
+					Cluster:  &c.cluster,
+					Services: page.ServiceArns,
+				})
+				if err != nil {
+					// rather than trying to propogate errors up, just log a warning here
+					log.Warnf("Error describing some ECS services, ECS service report may be incomplete: %v", err)
+					return
+				}
+
+				for _, failure := range resp.Failures {
+					// log the failures but still continue with what succeeded
+					log.Warnf("Failed to describe ECS service %s, ECS service report may be incomplete: %s", failure.Arn, failure.Reason)
+				}
+
+				lock.Lock()
+				for _, service := range resp.Services {
+					for _, deployment := range service.Deployments {
+						results[*deployment.Id] = *service.ServiceName
+					}
+				}
+				lock.Unlock()
+			}()
+			return true
+		},
+	)
+	group.Wait()
+
+	if err != nil {
+		// We want to still return partial results if we have any, so just log a warning
+		log.Warnf("Error listing ECS services, ECS service report may be incomplete: %v", err)
+	}
+	return results
+}
+
+// returns a map from task ARNs to deployment ids
+func (c ecsClient) getTaskDeployments(taskArns []string) (map[string]string, error) {
+	taskPtrs := make([]*string, len(taskArns))
+	for i := range taskArns {
+		taskPtrs[i] = &taskArns[i]
+	}
+
+	// You'd think there's a limit on how many tasks can be described here,
+	// but the docs don't mention anything.
+	resp, err := c.client.DescribeTasks(&ecs.DescribeTasksInput{
+		Cluster: &c.cluster,
+		Tasks:   taskPtrs,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, failure := range resp.Failures {
+		// log the failures but still continue with what succeeded
+		log.Warnf("Failed to describe ECS task %s, ECS service report may be incomplete: %s", failure.Arn, failure.Reason)
+	}
+
+	results := make(map[string]string)
+	for _, task := range resp.Tasks {
+		results[*task.TaskArn] = *task.StartedBy
+	}
+	return results, nil
+}
+
+// returns a map from task ARNs to service names
+func (c ecsClient) getTaskServices(taskArns []string) (map[string]string, error) {
+	deploymentMapChan := make(chan map[string]string)
+	go func() {
+		deploymentMapChan <- c.getDeploymentMap()
+	}()
+
+	// do these two fetches in parallel
+	taskDeployments, err := c.getTaskDeployments(taskArns)
+	deploymentMap := <-deploymentMapChan
+
+	if err != nil {
+		return nil, err
+	}
+
+	results := make(map[string]string)
+	for taskArn, depID := range taskDeployments {
+		// Note not all tasks map to a deployment, or we could otherwise mismatch due to races.
+		// It's safe to just ignore all these cases and consider them "non-service" tasks.
+		if service, ok := deploymentMap[depID]; ok {
+			results[taskArn] = service
+		}
+	}
+
+	return results, nil
+}

--- a/probe/awsecs/client.go
+++ b/probe/awsecs/client.go
@@ -51,7 +51,7 @@ func (c ecsClient) getDeploymentMap() map[string]string {
 					Services: page.ServiceArns,
 				})
 				if err != nil {
-					// rather than trying to propogate errors up, just log a warning here
+					// rather than trying to propagate errors up, just log a warning here
 					log.Warnf("Error describing some ECS services, ECS service report may be incomplete: %v", err)
 					return
 				}

--- a/probe/awsecs/client.go
+++ b/probe/awsecs/client.go
@@ -109,7 +109,7 @@ func (c ecsClient) getTaskDeployments(taskArns []string) (map[string]string, err
 
 // returns a map from task ARNs to service names
 func (c ecsClient) getTaskServices(taskArns []string) (map[string]string, error) {
-	deploymentMapChan := chan map[string]string{}
+	deploymentMapChan := make(chan map[string]string)
 	go func() {
 		deploymentMapChan <- c.getDeploymentMap()
 	}()

--- a/probe/awsecs/reporter.go
+++ b/probe/awsecs/reporter.go
@@ -1,0 +1,118 @@
+package awsecs
+
+import (
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/weaveworks/scope/probe/docker"
+	"github.com/weaveworks/scope/report"
+)
+
+type taskInfo struct {
+	containerIDs []string
+	family       string
+}
+
+// return map from cluster to map of task arns to task infos
+func getLabelInfo(rpt report.Report) map[string]map[string]*taskInfo {
+	results := make(map[string]map[string]*taskInfo)
+	log.Debug("scanning for ECS containers")
+	for nodeID, node := range rpt.Container.Nodes {
+
+		taskArn, taskArnOk := node.Latest.Lookup(docker.LabelPrefix + "com.amazonaws.ecs.task-arn")
+		cluster, clusterOk := node.Latest.Lookup(docker.LabelPrefix + "com.amazonaws.ecs.cluster")
+		family, familyOk := node.Latest.Lookup(docker.LabelPrefix + "com.amazonaws.ecs.task-definition-family")
+
+		if taskArnOk && clusterOk && familyOk {
+			taskMap, ok := results[cluster]
+			if !ok {
+				taskMap = make(map[string]*taskInfo)
+				results[cluster] = taskMap
+			}
+
+			task, ok := taskMap[taskArn]
+			if !ok {
+				task = &taskInfo{containerIDs: make([]string, 0), family: family}
+				taskMap[taskArn] = task
+			}
+
+			task.containerIDs = append(task.containerIDs, nodeID)
+		}
+	}
+	log.Debug("Got ECS container info: %v", results)
+	return results
+}
+
+// implements Tagger
+type Reporter struct {
+}
+
+// Tag needed for Tagger
+func (r Reporter) Tag(rpt report.Report) (report.Report, error) {
+	rpt = rpt.Copy()
+
+	clusterMap := getLabelInfo(rpt)
+
+	for cluster, taskMap := range clusterMap {
+		log.Debugf("Fetching ECS info for cluster %v with %v tasks", cluster, len(taskMap))
+
+		client, err := newClient(cluster)
+		if err != nil {
+			return rpt, err
+		}
+
+		taskArns := make([]string, 0, len(taskMap))
+		for taskArn := range taskMap {
+			taskArns = append(taskArns, taskArn)
+		}
+
+		taskServices, err := client.getTaskServices(taskArns)
+		if err != nil {
+			return rpt, err
+		}
+
+		// Create all the services first
+		unique := make(map[string]bool)
+		for _, serviceName := range taskServices {
+			if !unique[serviceName] {
+				rpt.ECSService = rpt.ECSService.AddNode(report.MakeNode(serviceNodeID(serviceName)))
+				unique[serviceName] = true
+			}
+		}
+		log.Debugf("Created %v ECS service nodes", len(taskServices))
+
+		for taskArn, info := range taskMap {
+
+			// new task node
+			node := report.MakeNodeWith(taskNodeID(taskArn), map[string]string{"family": info.family})
+
+			rpt.ECSTask = rpt.ECSTask.AddNode(node)
+
+			for _, containerID := range info.containerIDs {
+				// TODO set task node as parent of container
+				log.Debugf("task %v has container %v", taskArn, containerID)
+			}
+
+			if serviceName, ok := taskServices[taskArn]; ok {
+				// TODO set service node as parent of task node
+				log.Debugf("service %v has task %v", serviceName, taskArn)
+			}
+		}
+
+	}
+
+	return rpt, nil
+}
+
+// Name needed for Tagger
+func (r Reporter) Name() string {
+	return "awsecs"
+}
+
+func serviceNodeID(id string) string {
+	return fmt.Sprintf("%s;ECSService", id)
+}
+
+func taskNodeID(id string) string {
+	return fmt.Sprintf("%s;ECSTask", id)
+}

--- a/probe/awsecs/reporter.go
+++ b/probe/awsecs/reporter.go
@@ -93,10 +93,10 @@ func (r Reporter) Tag(rpt report.Report) (report.Report, error) {
 
 			// parents sets to merge into all matching container nodes
 			parentsSets := report.MakeSets()
-			parentsSets.Add(report.ECSTask, report.MakeStringSet(taskID))
+			parentsSets = parentsSets.Add(report.ECSTask, report.MakeStringSet(taskID))
 			if serviceName, ok := taskServices[taskArn]; ok {
 				serviceID := report.MakeECSServiceNodeID(serviceName)
-				parentsSets.Add(report.ECSService, report.MakeStringSet(serviceID))
+				parentsSets = parentsSets.Add(report.ECSService, report.MakeStringSet(serviceID))
 			}
 
 			for _, containerID := range info.containerIDs {

--- a/probe/awsecs/reporter.go
+++ b/probe/awsecs/reporter.go
@@ -6,6 +6,7 @@ import (
 	"github.com/weaveworks/scope/report"
 )
 
+// TaskFamily is the key that stores the task family of an ECS Task
 const (
 	TaskFamily = "ecs_task_family"
 )
@@ -45,7 +46,7 @@ func getLabelInfo(rpt report.Report) map[string]map[string]*taskInfo {
 	return results
 }
 
-// implements Tagger
+// Reporter implements Tagger
 type Reporter struct {
 }
 

--- a/probe/probe_internal_test.go
+++ b/probe/probe_internal_test.go
@@ -91,6 +91,8 @@ func TestProbe(t *testing.T) {
 	want.ReplicaSet.Controls = nil
 	want.Host.Controls = nil
 	want.Overlay.Controls = nil
+	want.ECSTask.Controls = nil
+	want.ECSService.Controls = nil
 	want.Endpoint.AddNode(node)
 
 	pub := mockPublisher{make(chan report.Report, 10)}

--- a/probe/topology_tagger.go
+++ b/probe/topology_tagger.go
@@ -23,6 +23,8 @@ func (topologyTagger) Tag(r report.Report) (report.Report, error) {
 		report.ContainerImage: &(r.ContainerImage),
 		report.Pod:            &(r.Pod),
 		report.Service:        &(r.Service),
+		report.ECSTask:        &(r.ECSTask),
+		report.ECSService:     &(r.ECSService),
 		report.Host:           &(r.Host),
 		report.Overlay:        &(r.Overlay),
 	} {

--- a/prog/main.go
+++ b/prog/main.go
@@ -104,6 +104,8 @@ type probeFlags struct {
 	kubernetesEnabled bool
 	kubernetesConfig  kubernetes.ClientConfig
 
+	ecsEnabled bool
+
 	weaveEnabled  bool
 	weaveAddr     string
 	weaveHostname string
@@ -281,6 +283,9 @@ func main() {
 	flag.StringVar(&flags.probe.kubernetesConfig.Token, kubernetesTokenFlag, "", "Bearer token for authentication to the API server")
 	flag.StringVar(&flags.probe.kubernetesConfig.User, "probe.kubernetes.user", "", "The name of the kubeconfig user to use")
 	flag.StringVar(&flags.probe.kubernetesConfig.Username, "probe.kubernetes.username", "", "Username for basic authentication to the API server")
+
+	// AWS ECS
+	flag.BoolVar(&flags.probe.ecsEnabled, "probe.ecs", false, "collect ecs-related attributes for containers on this node")
 
 	// Weave
 	flag.StringVar(&flags.probe.weaveAddr, "probe.weave.addr", "127.0.0.1:6784", "IP address & port of the Weave router")

--- a/prog/main.go
+++ b/prog/main.go
@@ -285,7 +285,7 @@ func main() {
 	flag.StringVar(&flags.probe.kubernetesConfig.Username, "probe.kubernetes.username", "", "Username for basic authentication to the API server")
 
 	// AWS ECS
-	flag.BoolVar(&flags.probe.ecsEnabled, "probe.ecs", false, "collect ecs-related attributes for containers on this node")
+	flag.BoolVar(&flags.probe.ecsEnabled, "probe.ecs", false, "Collect ecs-related attributes for containers on this node")
 
 	// Weave
 	flag.StringVar(&flags.probe.weaveAddr, "probe.weave.addr", "127.0.0.1:6784", "IP address & port of the Weave router")

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaveworks/scope/common/xfer"
 	"github.com/weaveworks/scope/probe"
 	"github.com/weaveworks/scope/probe/appclient"
+	"github.com/weaveworks/scope/probe/awsecs"
 	"github.com/weaveworks/scope/probe/controls"
 	"github.com/weaveworks/scope/probe/docker"
 	"github.com/weaveworks/scope/probe/endpoint"
@@ -199,6 +200,10 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 			log.Errorf("Kubernetes: failed to start client: %v", err)
 			log.Errorf("Kubernetes: make sure to run Scope inside a POD with a service account or provide valid probe.kubernetes.* flags")
 		}
+	}
+
+	if flags.ecsEnabled {
+		p.AddTagger(awsecs.Reporter{})
 	}
 
 	if flags.weaveEnabled {

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -206,7 +206,9 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 	}
 
 	if flags.ecsEnabled {
-		p.AddTagger(awsecs.Reporter{})
+		reporter := awsecs.Reporter{}
+		p.AddReporter(reporter)
+		p.AddTagger(reporter)
 	}
 
 	if flags.weaveEnabled {

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -95,6 +95,9 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 	if flags.kubernetesEnabled {
 		checkpointFlags["kubernetes_enabled"] = "true"
 	}
+	if flags.ecsEnabled {
+		checkpointFlags["ecs_enabled"] = "true"
+	}
 	go check(checkpointFlags)
 
 	handlerRegistry := controls.NewDefaultHandlerRegistry()

--- a/render/detailed/summary.go
+++ b/render/detailed/summary.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/weaveworks/scope/probe/awsecs"
 	"github.com/weaveworks/scope/probe/docker"
 	"github.com/weaveworks/scope/probe/endpoint"
 	"github.com/weaveworks/scope/probe/host"
@@ -68,6 +69,8 @@ var renderers = map[string]func(NodeSummary, report.Node) (NodeSummary, bool){
 	report.Service:        podGroupNodeSummary,
 	report.Deployment:     podGroupNodeSummary,
 	report.ReplicaSet:     podGroupNodeSummary,
+	report.ECSTask:        ecsTaskNodeSummary,
+	report.ECSService:     ecsServiceNodeSummary,
 	report.Host:           hostNodeSummary,
 	report.Overlay:        weaveNodeSummary,
 }
@@ -237,6 +240,17 @@ func podGroupNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
 	// counts.
 	base.LabelMinor = pluralize(n.Counters, report.Pod, "pod", "pods")
 
+	return base, true
+}
+
+func ecsTaskNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
+	base.Label, _ = n.Latest.Lookup(awsecs.TaskFamily)
+	return base, true
+}
+
+func ecsServiceNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
+	base.Label, _ = report.ParseECSServiceNodeID(n.ID)
+	base.Stack = true
 	return base, true
 }
 

--- a/render/ecs.go
+++ b/render/ecs.go
@@ -1,0 +1,19 @@
+package render
+
+import (
+	"github.com/weaveworks/scope/report"
+)
+
+// ECSTaskRenderer is a Renderer for Amazon ECS tasks.
+var ECSTaskRenderer = MakeFilter(
+	// TODO
+	func(n report.Node) bool { return true },
+	SelectECSTask,
+)
+
+// ECSServiceRenderer is a Renderer for Amazon ECS services.
+var ECSServiceRenderer = MakeFilter(
+	// TODO
+	func(n report.Node) bool { return true },
+	SelectECSService,
+)

--- a/render/ecs.go
+++ b/render/ecs.go
@@ -1,19 +1,86 @@
 package render
 
 import (
+	"strings"
+
+	"github.com/weaveworks/scope/probe/docker"
 	"github.com/weaveworks/scope/report"
 )
 
 // ECSTaskRenderer is a Renderer for Amazon ECS tasks.
-var ECSTaskRenderer = MakeFilter(
-	// TODO
-	func(n report.Node) bool { return true },
-	SelectECSTask,
+var ECSTaskRenderer = ConditionalRenderer(renderECSTopologies,
+	ApplyDecorators(
+		MakeMap(
+			PropagateSingleMetrics(report.Container),
+			MakeReduce(
+				MakeMap(
+					MapContainer2ECSTask,
+					ContainerWithImageNameRenderer,
+				),
+				SelectECSTask,
+			),
+		),
+	),
 )
 
 // ECSServiceRenderer is a Renderer for Amazon ECS services.
-var ECSServiceRenderer = MakeFilter(
-	// TODO
-	func(n report.Node) bool { return true },
-	SelectECSService,
+var ECSServiceRenderer = ConditionalRenderer(renderECSTopologies,
+	ApplyDecorators(
+		MakeMap(
+			PropagateSingleMetrics(report.ECSTask),
+			MakeReduce(
+				MakeMap(
+					Map2Parent(report.ECSService),
+					ECSTaskRenderer,
+				),
+				SelectECSService,
+			),
+		),
+	),
 )
+
+// MapContainer2ECSTask maps container Nodes to ECS Task
+// Nodes.
+//
+// If this function is given a node without an ECS Task parent
+// (including other pseudo nodes), it will produce an "Unmanaged"
+// pseudo node.
+//
+// TODO: worth merging with MapContainer2Pod?
+func MapContainer2ECSTask(n report.Node, _ report.Networks) report.Nodes {
+	// Uncontained becomes unmanaged in the tasks view
+	if strings.HasPrefix(n.ID, MakePseudoNodeID(UncontainedID)) {
+		id := MakePseudoNodeID(UnmanagedID, report.ExtractHostID(n))
+		node := NewDerivedPseudoNode(id, n)
+		return report.Nodes{id: node}
+	}
+
+	// Propagate all pseudo nodes
+	if n.Topology == Pseudo {
+		return report.Nodes{n.ID: n}
+	}
+
+	// Ignore non-running containers
+	if state, ok := n.Latest.Lookup(docker.ContainerState); ok && state != docker.StateRunning {
+		return report.Nodes{}
+	}
+
+	taskIDSet, ok := n.Parents.Lookup(report.ECSTask)
+	if !ok || len(taskIDSet) == 0 {
+		id := MakePseudoNodeID(UnmanagedID, report.ExtractHostID(n))
+		node := NewDerivedPseudoNode(id, n)
+		return report.Nodes{id: node}
+	}
+	nodeID := taskIDSet[0]
+	node := NewDerivedNode(nodeID, n).WithTopology(report.ECSTask)
+	// Propagate parent service
+	if serviceIDSet, ok := n.Parents.Lookup(report.ECSService); ok {
+		node = node.WithParents(report.MakeSets().Add(report.ECSService, serviceIDSet))
+	}
+	node.Counters = node.Counters.Add(n.Topology, 1)
+	return report.Nodes{nodeID: node}
+}
+
+func renderECSTopologies(rpt report.Report) bool {
+	return len(rpt.ECSTask.Nodes)+len(rpt.ECSService.Nodes) >= 1
+}

--- a/render/selectors.go
+++ b/render/selectors.go
@@ -31,5 +31,7 @@ var (
 	SelectService        = TopologySelector(report.Service)
 	SelectDeployment     = TopologySelector(report.Deployment)
 	SelectReplicaSet     = TopologySelector(report.ReplicaSet)
+	SelectECSTask        = TopologySelector(report.ECSTask)
+	SelectECSService     = TopologySelector(report.ECSService)
 	SelectOverlay        = TopologySelector(report.Overlay)
 )

--- a/report/id.go
+++ b/report/id.go
@@ -119,6 +119,18 @@ var (
 
 	// ParseReplicaSetNodeID parses a replica set node ID
 	ParseReplicaSetNodeID = parseSingleComponentID("replica_set")
+
+	// MakeECSTaskNodeID produces a replica set node ID from its composite parts.
+	MakeECSTaskNodeID = makeSingleComponentID("ecs_task")
+
+	// ParseECSTaskNodeID parses a replica set node ID
+	ParseECSTaskNodeID = parseSingleComponentID("ecs_task")
+
+	// MakeECSServiceNodeID produces a replica set node ID from its composite parts.
+	MakeECSServiceNodeID = makeSingleComponentID("ecs_service")
+
+	// ParseECSServiceNodeID parses a replica set node ID
+	ParseECSServiceNodeID = parseSingleComponentID("ecs_service")
 )
 
 // makeSingleComponentID makes a single-component node id encoder

--- a/report/report.go
+++ b/report/report.go
@@ -22,6 +22,8 @@ const (
 	ContainerImage = "container_image"
 	Host           = "host"
 	Overlay        = "overlay"
+	ECSService     = "ecs_service"
+	ECSTask        = "ecs_task"
 
 	// Shapes used for different nodes
 	Circle   = "circle"
@@ -80,6 +82,15 @@ type Report struct {
 	// like operating system, load, etc. The information is scraped by the
 	// probes with each published report. Edges are not present.
 	Host Topology
+
+	// ECS Task nodes are AWS ECS tasks, which represent a group of containers.
+	// Metadata is limited for now, more to come later. Edges are not present.
+	ECSTask Topology
+
+	// ECS Service nodes are AWS ECS services, which represent a specification for a
+	// desired count of tasks with a task definition template.
+	// Metadata is limited for now, more to come later. Edges are not present.
+	ECSService Topology
 
 	// Overlay nodes are active peers in any software-defined network that's
 	// overlaid on the infrastructure. The information is scraped by polling
@@ -149,6 +160,14 @@ func MakeReport() Report {
 
 		Overlay: MakeTopology(),
 
+		ECSTask: MakeTopology().
+			WithShape(Heptagon).
+			WithLabel("task", "tasks"),
+
+		ECSService: MakeTopology().
+			WithShape(Heptagon).
+			WithLabel("service", "services"),
+
 		Sampling: Sampling{},
 		Window:   0,
 		Plugins:  xfer.MakePluginSpecs(),
@@ -169,6 +188,8 @@ func (r Report) Copy() Report {
 		Deployment:     r.Deployment.Copy(),
 		ReplicaSet:     r.ReplicaSet.Copy(),
 		Overlay:        r.Overlay.Copy(),
+		ECSTask:        r.ECSTask.Copy(),
+		ECSService:     r.ECSService.Copy(),
 		Sampling:       r.Sampling,
 		Window:         r.Window,
 		Plugins:        r.Plugins.Copy(),
@@ -190,6 +211,8 @@ func (r Report) Merge(other Report) Report {
 		Deployment:     r.Deployment.Merge(other.Deployment),
 		ReplicaSet:     r.ReplicaSet.Merge(other.ReplicaSet),
 		Overlay:        r.Overlay.Merge(other.Overlay),
+		ECSTask:        r.ECSTask.Merge(other.ECSTask),
+		ECSService:     r.ECSService.Merge(other.ECSService),
 		Sampling:       r.Sampling.Merge(other.Sampling),
 		Window:         r.Window + other.Window,
 		Plugins:        r.Plugins.Merge(other.Plugins),
@@ -219,6 +242,8 @@ func (r *Report) WalkTopologies(f func(*Topology)) {
 	f(&r.ReplicaSet)
 	f(&r.Host)
 	f(&r.Overlay)
+	f(&r.ECSTask)
+	f(&r.ECSService)
 }
 
 // Topology gets a topology by name
@@ -234,6 +259,8 @@ func (r Report) Topology(name string) (Topology, bool) {
 		ReplicaSet:     r.ReplicaSet,
 		Host:           r.Host,
 		Overlay:        r.Overlay,
+		ECSTask:        r.ECSTask,
+		ECSService:     r.ECSService,
 	}[name]
 	return t, ok
 }

--- a/report/report.go
+++ b/report/report.go
@@ -158,7 +158,9 @@ func MakeReport() Report {
 			WithShape(Heptagon).
 			WithLabel("replica set", "replica sets"),
 
-		Overlay: MakeTopology(),
+		Overlay: MakeTopology().
+			WithShape(Circle).
+			WithLabel("peer", "peers"),
 
 		ECSTask: MakeTopology().
 			WithShape(Heptagon).


### PR DESCRIPTION
This PR adds two new ECS-specific topologes, ECSTasks and ECSServices,
and adds a probe which collects info to populate it.

The probe uses the instance's IAM role to look up task and service info. It requires the following permissions:
ListServices
DescribeTasks
DescribeServices

@2opremio: For rendering: I've associated a container with 0 or 1 ECSTasks and ECSServices, under the Node.Parents Sets.
ie. if a container X is associated with task Y and service Z, then rpt.Container.Nodes[X].Parents contains:
```json
{
	"ecstask": [
		"Y;ecstask"
	],
	"ecsservice": [
		"Z;ecsservice"
	]
}
```
and so any endpoints associated with the container should be assoicated with the given task and service,
so that communication between containers is visible on the tasks view, etc.

TODO:
- [x] ~Unit tests~ (moved to #2026 )
- [x] Test on Socks shop: https://microservices-demo.github.io/microservices-demo/deployment/ecs.html
- [x] Look for performance regressions (in the socks shop for instance)
- [x] ~Document required permissions~ (No need, created #2039 , see  https://github.com/weaveworks/scope/pull/2026#issuecomment-263597159 for details) 
- [x] Add checkpoint flag (like we do for k8s, see https://github.com/weaveworks/scope/pull/1391)
- [x] Extend metadata shown in the details panel
- [x] Rendering
- [x] Make the topology appear along the top (`app/api_topology.go`)
- [x] Actually get the parent stuff described above working - there's a bug I can't work out right now and I need to go sleep. Something to do with the immutable/copying stuff, because I appear to be successfully making the change but it doesn't actually appear in the report.