### PR TITLE
Remove upper bound for waypoints count on edges

### DIFF
--- a/client/app/scripts/utils/__tests__/array-utils-test.js
+++ b/client/app/scripts/utils/__tests__/array-utils-test.js
@@ -1,0 +1,36 @@
+import _ from 'lodash';
+
+describe('ArrayUtils', () => {
+  const ArrayUtils = require('../array-utils');
+
+  describe('uniformSelect', () => {
+    const f = ArrayUtils.uniformSelect;
+
+    it('it should select the array elements uniformly, including the endpoints', () => {
+      expect(f(['x', 'y'], 3)).toEqual(['x', 'y']);
+      expect(f(['x', 'y'], 2)).toEqual(['x', 'y']);
+
+      expect(f(['A', 'B', 'C', 'D', 'E'], 6)).toEqual(['A', 'B', 'C', 'D', 'E']);
+      expect(f(['A', 'B', 'C', 'D', 'E'], 5)).toEqual(['A', 'B', 'C', 'D', 'E']);
+      expect(f(['A', 'B', 'C', 'D', 'E'], 4)).toEqual(['A', 'B', 'D', 'E']);
+      expect(f(['A', 'B', 'C', 'D', 'E'], 3)).toEqual(['A', 'C', 'E']);
+      expect(f(['A', 'B', 'C', 'D', 'E'], 2)).toEqual(['A', 'E']);
+
+      expect(f([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], 12)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+      expect(f([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], 11)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+      expect(f([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], 10)).toEqual([1, 2, 3, 4, 5, 7, 8, 9, 10, 11]);
+      expect(f([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], 9)).toEqual([1, 2, 3, 5, 6, 7, 9, 10, 11]);
+      expect(f([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], 8)).toEqual([1, 2, 4, 5, 7, 8, 10, 11]);
+      expect(f([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], 7)).toEqual([1, 2, 4, 6, 8, 10, 11]);
+      expect(f([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], 6)).toEqual([1, 3, 5, 7, 9, 11]);
+      expect(f([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], 5)).toEqual([1, 3, 6, 9, 11]);
+      expect(f([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], 4)).toEqual([1, 4, 8, 11]);
+      expect(f([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], 3)).toEqual([1, 6, 11]);
+      expect(f([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], 2)).toEqual([1, 11]);
+
+      expect(f(_.range(1, 10001), 4)).toEqual([1, 3334, 6667, 10000]);
+      expect(f(_.range(1, 10001), 3)).toEqual([1, 5000, 10000]);
+      expect(f(_.range(1, 10001), 2)).toEqual([1, 10000]);
+    });
+  });
+});

--- a/client/app/scripts/utils/__tests__/math-utils-test.js
+++ b/client/app/scripts/utils/__tests__/math-utils-test.js
@@ -2,7 +2,7 @@
 describe('MathUtils', () => {
   const MathUtils = require('../math-utils');
 
-  describe('module', () => {
+  describe('modulo', () => {
     const f = MathUtils.modulo;
 
     it('it should calculate the modulo (also for negatives)', () => {

--- a/client/app/scripts/utils/array-utils.js
+++ b/client/app/scripts/utils/array-utils.js
@@ -1,0 +1,11 @@
+import _ from 'lodash';
+
+export function uniformSelect(array, size) {
+  if (size > array.length) {
+    return array;
+  }
+
+  return _.range(size).map(index =>
+    array[parseInt(index * array.length / (size - 1 + 1e-9), 10)]
+  );
+}


### PR DESCRIPTION
Fix for #1187.

As long as we are using `dagre` in combination with `react-motion`, we have to have a way of transforming the array of edge waypoints with variable length that `dagre` is producing to a fixed length array that works with `Motion` animations. So far we were assuming the number of waypoints per edge will never go over `30`, but that doesn't hold anymore for big graphs.

In this PR, I introduced `WAYPOINTS_CAP` configurable constant which now basically decides to which precision we want to render the edges.

1. If the `dagre` waypoints array size is **lower** than `WAYPOINTS_CAP`, we add some *fake* copies of the first waypoint (I just left this case intact)
2. If the `dagre` waypoints array size is **higher** than `WAYPOINTS_CAP`, we select exactly `WAYPOINTS_CAP` waypoints uniformly across the `dagre` waypoints array (e.g. `[1, 2, 3, 4, 5] -> [1, 3, 5]` for `WAYPOINTS_CAP = 3`), which is arguably a a good simple heuristics that gives us a very similar resulting edge curve

Obviously, the lower we set the `WAYPOINTS_CAP`, the rougher our edges will look like, but the higher we set it, the worse performance we might get. IMO, value `8` looks like a good choice, even on graphs with a large number of nodes.