### PR TITLE
ECS reporter: Minimize API calls by caching task and service data

### DIFF
--- a/probe/awsecs/client.go
+++ b/probe/awsecs/client.go
@@ -60,7 +60,7 @@ type ecsInfo struct {
 	taskServiceMap map[string]string
 }
 
-func newClient(cluster string, cacheSize int, cacheExpiry time.Duration) (*ecsClient, error) {
+func newClient(cluster string, cacheSize int, cacheExpiry time.Duration) (ecsClient, error) {
 	sess := session.New()
 
 	region, err := ec2metadata.New(sess).Region()

--- a/probe/awsecs/client.go
+++ b/probe/awsecs/client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/bluele/gcache"
 )
 
-// A wrapper around an AWS client that makes all the needed calls and just exposes the final results.
+// EcsClient is a wrapper around an AWS client that makes all the needed calls and just exposes the final results.
 // We create an interface so we can mock for testing.
 type EcsClient interface {
 	// Returns a EcsInfo struct containing data needed for a report.
@@ -28,6 +28,7 @@ type ecsClientImpl struct {
 	serviceCache gcache.Cache // Keys are service names.
 }
 
+// EcsTask describes the parts of ECS tasks we care about.
 // Since we're caching tasks heavily, we ensure no mistakes by casting into a structure
 // that only contains immutable attributes of the resource.
 // Exported for test.
@@ -42,6 +43,7 @@ type EcsTask struct {
 	StartedBy string // tag or deployment id
 }
 
+// EcsService describes the parts of ECS services we care about.
 // Services are highly mutable and so we can only cache them on a best-effort basis.
 // We have to refresh referenced (ie. has an associated task) services each report
 // but we avoid re-listing services unless we can't find a service for a task.
@@ -56,7 +58,7 @@ type EcsService struct {
 	TaskDefinitionARN string
 }
 
-// Exported for test
+// EcsInfo is exported for test
 type EcsInfo struct {
 	Tasks          map[string]EcsTask
 	Services       map[string]EcsService

--- a/probe/awsecs/client.go
+++ b/probe/awsecs/client.go
@@ -2,6 +2,7 @@ package awsecs
 
 import (
 	"sync"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
@@ -14,11 +15,49 @@ import (
 type ecsClient struct {
 	client  *ecs.ECS
 	cluster string
+	taskCache map[string]ecsTask
+	serviceCache map[string]ecsService
+}
+
+// Since we're caching tasks heavily, we ensure no mistakes by casting into a structure
+// that only contains immutable attributes of the resource.
+type ecsTask struct {
+	taskARN string
+	createdAt time.Time
+	taskDefinitionARN string
+
+	// These started fields are immutable once set, and guarenteed to be set once the task is running,
+	// which we know it is because otherwise we wouldn't be looking at it.
+	startedAt time.Time
+	startedBy string // tag or deployment id
+
+	// Metadata about this cache copy
+	fetchedAt time.Time
+	lastUsedAt time.Time
+}
+
+// Services are highly mutable and so we can only cache them on a best-effort basis.
+// We have to refresh referenced (ie. has an associated task) services each report
+// but we avoid re-listing services unless we can't find a service for a task.
+type ecsService struct {
+	serviceName string
+	createdAt time.Time
+
+	// The following values may be stale in a cached copy
+	deploymentIDs []string
+	desiredCount int64
+	pendingCount int64
+	runningCount int64
+	taskDefinitionARN string
+
+	// Metadata about this cache copy
+	fetchedAt time.Time
+	lastUsedAt time.Time
 }
 
 type ecsInfo struct {
-	tasks          map[string]*ecs.Task
-	services       map[string]*ecs.Service
+	tasks          map[string]ecsTask
+	services       map[string]ecsService
 	taskServiceMap map[string]string
 }
 
@@ -33,67 +72,116 @@ func newClient(cluster string) (*ecsClient, error) {
 	return &ecsClient{
 		client:  ecs.New(sess, &aws.Config{Region: aws.String(region)}),
 		cluster: cluster,
+		taskCache: map[string]ecsTask{},
+		serviceCache: map[string]ecsService{},
 	}, nil
 }
 
-// returns a map from deployment ids to service names
-func (c ecsClient) getDeploymentMap(services map[string]*ecs.Service) map[string]string {
-	results := map[string]string{}
-	for serviceName, service := range services {
-		for _, deployment := range service.Deployments {
-			results[*deployment.Id] = serviceName
+func newECSTask(task *ecs.Task) ecsTask {
+	now = time.Now()
+	return ecsTask{
+		taskARN: *task.TaskARN,
+		createdAt: *task.CreatedAt,
+		taskDefinitionARN: *task.TaskDefinitionArn,
+		startedAt: *task.StartedAt,
+		startedBy: *task.StartedBy,
+		fetchedAt: now,
+		lastUsedAt: now,
+	}
+}
+
+func newECSService(service *ecs.Service) ecsService {
+	now = time.Now()
+	deploymentIDs = make([]string, 0, len(service.Deployments))
+	for _, deployment := range service.Deployments {
+		deploymentIDs = append(deploymentIDs, *deployment.ID)
+	}
+	return ecsService{
+		serviceName: *service.ServiceName,
+		createdAt: *service.CreatedAt,
+		deploymentIDs: deploymentIDs,
+		desiredCount: *service.DesiredCount,
+		pendingCount: *service.PendingCount,
+		runningCount: *service.RunningCount,
+		taskDefinitionARN: *service.TaskDefinitionARN,
+		fetchedAt: now,
+		lastUsedAt: now,
+	}
+}
+
+// Returns a channel from which service ARNs can be read.
+// Cannot fail as it will attempt to deliver partial results, though that may end up being no results.
+func (c ecsClient) listServices() <-chan string {
+	results := make(chan string)
+	go func() {
+		err := c.client.ListServicesPages(
+			&ecs.ListServicesInput{Cluster: &c.cluster},
+			func(page *ecs.ListServicesOutput, lastPage bool) bool {
+				for _, arn := range page.ServiceArns {
+					results <- arn
+				}
+			}
+		)
+		if err != nil {
+			log.Warnf("Error listing ECS services, ECS service report may be incomplete: %v", err)
 		}
-	}
+		close(results)
+	}()
 	return results
 }
 
-// cannot fail as it will attempt to deliver partial results, though that may end up being no results
-func (c ecsClient) getServices() map[string]*ecs.Service {
-	results := map[string]*ecs.Service{}
-	lock := sync.Mutex{} // lock mediates access to results
+// Returns (input, done) channels. Service ARNs given to input are batched and details are fetched,
+// with full ecsService objects being put into the cache. Closes done when finished.
+func (c ecsClient) describeServices() (chan<- string, <-chan bool) {
+	input := make(chan string)
 
-	group := sync.WaitGroup{}
+	go func() {
+		const MAX_SERVICES = 10 // How many services we can put in one Describe command
+		group := sync.WaitGroup{}
+		lock := sync.Mutex{} // mediates access to the service cache when writing results
 
-	err := c.client.ListServicesPages(
-		&ecs.ListServicesInput{Cluster: &c.cluster},
-		func(page *ecs.ListServicesOutput, lastPage bool) bool {
-			// describe each page of 10 (the max for one describe command) concurrently
-			group.Add(1)
-			serviceArns := page.ServiceArns
-			go func() {
-				defer group.Done()
+		page := make([]string, 0, MAX_SERVICES)
+		for arn := range input {
+			page = append(page, arn)
+			if len(page) == MAX_SERVICES {
+				group.Add(1)
 
-				resp, err := c.client.DescribeServices(&ecs.DescribeServicesInput{
-					Cluster:  &c.cluster,
-					Services: serviceArns,
-				})
-				if err != nil {
-					log.Warnf("Error describing some ECS services, ECS service report may be incomplete: %v", err)
-					return
-				}
+				go func(arns []string) {
+					defer group.Done()
 
-				for _, failure := range resp.Failures {
-					log.Warnf("Failed to describe ECS service %s, ECS service report may be incomplete: %s", *failure.Arn, *failure.Reason)
-				}
+					resp, err := c.client.DescribeServices(&ecs.DescribeServicesInput{
+						Cluster:  &c.cluster,
+						Services: arns,
+					})
+					if err != nil {
+						log.Warnf("Error describing some ECS services, ECS service report may be incomplete: %v", err)
+						return
+					}
 
-				lock.Lock()
-				for _, service := range resp.Services {
-					results[*service.ServiceName] = service
-				}
-				lock.Unlock()
-			}()
-			return true
-		},
-	)
-	group.Wait()
+					for _, failure := range resp.Failures {
+						log.Warnf("Failed to describe ECS service %s, ECS service report may be incomplete: %s", *failure.Arn, failure.Reason)
+					}
 
-	if err != nil {
-		log.Warnf("Error listing ECS services, ECS service report may be incomplete: %v", err)
-	}
-	return results
+					mutex.Lock()
+					for _, service := range resp.Services {
+						c.serviceCache[*service.ServiceName] = newECSService(service)
+					}
+					mutex.Unlock()
+				}(page)
+
+				page = make([]string, 0, MAX_SERVICES)
+			}
+		}
+
+		group.Wait()
+		close(done)
+	}()
+
+	return input, done
 }
 
-func (c ecsClient) getTasks(taskArns []string) (map[string]*ecs.Task, error) {
+// get details on given tasks, updating cache with the results
+func (c ecsClient) getTasks(taskArns []string) {
 	taskPtrs := make([]*string, len(taskArns))
 	for i := range taskArns {
 		taskPtrs[i] = &taskArns[i]
@@ -106,45 +194,160 @@ func (c ecsClient) getTasks(taskArns []string) (map[string]*ecs.Task, error) {
 		Tasks:   taskPtrs,
 	})
 	if err != nil {
-		return nil, err
+		log.Warnf("Failed to describe ECS tasks, ECS service report may be incomplete: %v", err)
+		return
 	}
 
 	for _, failure := range resp.Failures {
 		log.Warnf("Failed to describe ECS task %s, ECS service report may be incomplete: %s", *failure.Arn, *failure.Reason)
 	}
 
-	results := make(map[string]*ecs.Task, len(resp.Tasks))
 	for _, task := range resp.Tasks {
-		results[*task.TaskArn] = task
+		c.taskCache[*task.TaskArn] = newECSTask(task)
 	}
-	return results, nil
 }
 
-// returns a map from task ARNs to service names
-func (c ecsClient) getInfo(taskArns []string) (ecsInfo, error) {
-	servicesChan := make(chan map[string]*ecs.Service)
-	go func() {
-		servicesChan <- c.getServices()
-	}()
+// Evict entries from the caches which have not been used within the eviction interval.
+func (c ecsClient) evictOldCacheItems() {
+	const EVICT_TIME = time.Minute
+	now = time.Now()
 
-	// do these two fetches in parallel
-	tasks, err := c.getTasks(taskArns)
-	services := <-servicesChan
-
-	if err != nil {
-		return ecsInfo{}, err
-	}
-
-	deploymentMap := c.getDeploymentMap(services)
-
-	taskServiceMap := map[string]string{}
-	for taskArn, task := range tasks {
-		// Note not all tasks map to a deployment, or we could otherwise mismatch due to races.
-		// It's safe to just ignore all these cases and consider them "non-service" tasks.
-		if serviceName, ok := deploymentMap[*task.StartedBy]; ok {
-			taskServiceMap[taskArn] = serviceName
+	for arn, task := range c.taskCache {
+		if now - task.lastUsedAt > EVICT_TIME {
+			delete(c.taskCache, arn)
 		}
 	}
 
-	return ecsInfo{services: services, tasks: tasks, taskServiceMap: taskServiceMap}, nil
+	for name, service := range c.serviceCache {
+		if now - service.lastUsedAt > EVICT_TIME {
+			delete(c.serviceCache, name)
+		}
+	}
+}
+
+// Try to match a list of task ARNs to service names using cached info.
+// Returns (task to service map, unmatched tasks). Ignores tasks whose startedby values
+// don't appear to point to a service.
+func (c ecsClient) matchTasksServices(taskARNs []string) (map[string]string, []string) {
+	const SERVICE_PREFIX = "aws-svc" // TODO confirm this
+
+	deploymentMap := map[string]string{}
+	for serviceName, service := range c.serviceCache {
+		for _, deployment := range service.DeploymentIDs {
+			deploymentMap[deployment] = serviceName
+		}
+	}
+
+	results := map[string]string{}
+	unmatched := []string{}
+	for _, taskARN := range taskARNs {
+		task, ok := c.taskCache[taskARN]
+		if ! ok {
+			// this can happen if we have a failure while describing tasks, just pretend the task doesn't exist
+			continue
+		}
+		if ! strings.HasPrefix(task.startedBy, SERVICE_PREFIX) {
+			// task was not started by a service
+			continue
+		}
+		if service, ok := deploymentMap[task.startedBy]; ok {
+			results[taskARN] = service.serviceName
+		} else {
+			unmatched = append(unmatched, taskARN)
+		}
+	}
+
+	return results, unmatched
+}
+
+// Returns a ecsInfo struct containing data needed for a report.
+func (c ecsClient) getInfo(taskARNs []string) ecsInfo {
+
+	// We do a weird order of operations here to minimize unneeded cache refreshes.
+	// First, we ensure we have all the tasks we need, and fetch the ones we don't.
+	// We also mark the tasks as being used here to prevent eviction.
+	tasksToFetch := []string{}
+	now = Time.Now()
+	for _, taskARN := range taskARNs {
+		if task, ok := c.taskCache[taskARN]; ok {
+			task.lastUsedAt = now
+		} else {
+			tasksToFetch = append(tasksToFetch, taskARN)
+		}
+	}
+	// This might not fully succeed, but we only try once and ignore any further missing tasks.
+	c.getTasks(tasksToFetch)
+
+	// We're going to do this matching process potentially several times, but that's ok - it's quite cheap.
+	// First, we want to see how far we get with existing data, and identify the set of services
+	// we'll need to refresh regardless.
+	taskServiceMap, unmatched := c.matchTasksServices(taskARNs)
+
+	// In order to ensure service details are fresh, we need to refresh any referenced services
+	toDescribe, done := describeServices()
+	servicesRefreshed := map[string]bool{}
+	for taskARN, serviceName := range taskServiceMap {
+		if servicesRefreshed[serviceName] {
+			continue
+		}
+		toDescribe <- serviceName
+		servicesRefreshed[serviceName] = true
+	}
+	close(toDescribe)
+	<-done
+
+	// In refreshing, we may have picked up any new deployment ids.
+	// If we still have tasks unmatched, we try again.
+	if len(unmatched) > 0 {
+		taskServiceMap, unmatched = c.matchTasksServices(taskARNs)
+	}
+
+	// If we still have tasks unmatched, we'll have to try harder. Get a list of all services and,
+	// if not already refreshed, fetch them.
+	if len(unmatched) > 0 {
+		serviceNamesChan := listServices()
+		toDescribe, done := describeServices()
+		go func() {
+			for serviceName := range serviceNamesChan {
+				if ! servicesRefreshed[serviceName] {
+					toDescribe <- serviceName
+					servicesRefreshed[serviceName] = true
+				}
+				close(toDescribe)
+			}
+		}()
+		<-done
+
+		taskServiceMap, unmatched = c.matchTasksServices(taskARNs)
+		// If we still have unmatched at this point, we don't care - this may be due to partial failures,
+		// race conditions, and other weirdness.
+	}
+
+	// The maps to return are the referenced subsets of the full caches
+	tasks := map[string]ecsTask{}
+	for _, taskARN := range taskARNs {
+		// It's possible that tasks could still be missing from the cache if describe tasks failed.
+		// We'll just pretend they don't exist.
+		if task, ok := c.taskCache[taskARN]; ok {
+			tasks[taskARN] = task
+		}
+	}
+
+	services := map[string]ecsService{}
+	for taskARN, serviceName := range taskServiceMap {
+		if _, ok := taskServiceMap[serviceName]; ok {
+			// Already present. This is expected since multiple tasks can map to the same service.
+			continue
+		}
+		if service, ok := c.serviceCache[serviceName]; ok {
+			services[serviceName] = service
+		} else {
+			log.Errorf("Service %s referenced by task %s in service map but not found in cache, this shouldn't be able to happen. Removing task and continuing.", serviceName, taskARN)
+			delete(taskServiceMap, taskARN)
+		}
+	}
+
+	c.evictOldCacheItems()
+
+	return ecsInfo{services: services, tasks: tasks, taskServiceMap: taskServiceMap}
 }

--- a/probe/awsecs/reporter.go
+++ b/probe/awsecs/reporter.go
@@ -81,6 +81,7 @@ type Reporter struct {
 	clients map[string]*ecsClient
 }
 
+// New creates a new Reporter
 func New() Reporter {
 	return Reporter{
 		clients: map[string]*ecsClient{},

--- a/probe/awsecs/reporter.go
+++ b/probe/awsecs/reporter.go
@@ -101,7 +101,7 @@ func (r Reporter) Tag(rpt report.Report) (report.Report, error) {
 		if !ok {
 			log.Debugf("Creating new ECS client")
 			var err error
-			client, err = newClient(cluster)
+			client, err = newClient(cluster, 1e6, time.Hour) // TODO remove these temporary magic values
 			if err != nil {
 				return rpt, err
 			}

--- a/probe/awsecs/reporter.go
+++ b/probe/awsecs/reporter.go
@@ -78,13 +78,17 @@ func getLabelInfo(rpt report.Report) map[string]map[string]*taskLabelInfo {
 
 // Reporter implements Tagger, Reporter
 type Reporter struct {
-	clientsByCluster map[string]*ecsClient
+	clientsByCluster map[string]ecsClient
+	cacheSize        int
+	cacheExpiry      time.Duration
 }
 
 // Make creates a new Reporter
-func Make() Reporter {
+func Make(cacheSize int, cacheExpiry time.Duration) Reporter {
 	return Reporter{
-		clientsByCluster: map[string]*ecsClient{},
+		clientsByCluster: map[string]ecsClient{},
+		cacheSize:        cacheSize,
+		cacheExpiry:      cacheExpiry,
 	}
 }
 
@@ -101,7 +105,7 @@ func (r Reporter) Tag(rpt report.Report) (report.Report, error) {
 		if !ok {
 			log.Debugf("Creating new ECS client")
 			var err error
-			client, err = newClient(cluster, 1e6, time.Hour) // TODO remove these temporary magic values
+			client, err = newClient(cluster, r.cacheSize, r.cacheExpiry)
 			if err != nil {
 				return rpt, err
 			}

--- a/probe/awsecs/reporter.go
+++ b/probe/awsecs/reporter.go
@@ -32,14 +32,16 @@ var (
 	}
 )
 
-type taskLabelInfo struct {
-	containerIDs []string
-	family       string
+// Used in return value of GetLabelInfo. Exported for test.
+type TaskLabelInfo struct {
+	ContainerIDs []string
+	Family       string
 }
 
-// return map from cluster to map of task arns to task infos
-func getLabelInfo(rpt report.Report) map[string]map[string]*taskLabelInfo {
-	results := map[string]map[string]*taskLabelInfo{}
+// Return map from cluster to map of task arns to task infos.
+// Exported for test.
+func GetLabelInfo(rpt report.Report) map[string]map[string]*TaskLabelInfo {
+	results := map[string]map[string]*TaskLabelInfo{}
 	log.Debug("scanning for ECS containers")
 	for nodeID, node := range rpt.Container.Nodes {
 
@@ -60,17 +62,17 @@ func getLabelInfo(rpt report.Report) map[string]map[string]*taskLabelInfo {
 
 		taskMap, ok := results[cluster]
 		if !ok {
-			taskMap = map[string]*taskLabelInfo{}
+			taskMap = map[string]*TaskLabelInfo{}
 			results[cluster] = taskMap
 		}
 
 		task, ok := taskMap[taskArn]
 		if !ok {
-			task = &taskLabelInfo{containerIDs: []string{}, family: family}
+			task = &TaskLabelInfo{ContainerIDs: []string{}, Family: family}
 			taskMap[taskArn] = task
 		}
 
-		task.containerIDs = append(task.containerIDs, nodeID)
+		task.ContainerIDs = append(task.ContainerIDs, nodeID)
 	}
 	log.Debug("Got ECS container info: %v", results)
 	return results
@@ -78,7 +80,7 @@ func getLabelInfo(rpt report.Report) map[string]map[string]*taskLabelInfo {
 
 // Reporter implements Tagger, Reporter
 type Reporter struct {
-	clientsByCluster map[string]ecsClient
+	ClientsByCluster map[string]EcsClient // Exported for test
 	cacheSize        int
 	cacheExpiry      time.Duration
 }
@@ -86,7 +88,7 @@ type Reporter struct {
 // Make creates a new Reporter
 func Make(cacheSize int, cacheExpiry time.Duration) Reporter {
 	return Reporter{
-		clientsByCluster: map[string]ecsClient{},
+		ClientsByCluster: map[string]EcsClient{},
 		cacheSize:        cacheSize,
 		cacheExpiry:      cacheExpiry,
 	}
@@ -96,12 +98,12 @@ func Make(cacheSize int, cacheExpiry time.Duration) Reporter {
 func (r Reporter) Tag(rpt report.Report) (report.Report, error) {
 	rpt = rpt.Copy()
 
-	clusterMap := getLabelInfo(rpt)
+	clusterMap := GetLabelInfo(rpt)
 
 	for cluster, taskMap := range clusterMap {
 		log.Debugf("Fetching ECS info for cluster %v with %v tasks", cluster, len(taskMap))
 
-		client, ok := r.clientsByCluster[cluster]
+		client, ok := r.ClientsByCluster[cluster]
 		if !ok {
 			log.Debugf("Creating new ECS client")
 			var err error
@@ -109,7 +111,7 @@ func (r Reporter) Tag(rpt report.Report) (report.Report, error) {
 			if err != nil {
 				return rpt, err
 			}
-			r.clientsByCluster[cluster] = client
+			r.ClientsByCluster[cluster] = client
 		}
 
 		taskArns := make([]string, 0, len(taskMap))
@@ -117,22 +119,22 @@ func (r Reporter) Tag(rpt report.Report) (report.Report, error) {
 			taskArns = append(taskArns, taskArn)
 		}
 
-		ecsInfo := client.getInfo(taskArns)
-		log.Debugf("Got info from ECS: %d tasks, %d services", len(ecsInfo.tasks), len(ecsInfo.services))
+		ecsInfo := client.GetInfo(taskArns)
+		log.Debugf("Got info from ECS: %d tasks, %d services", len(ecsInfo.Tasks), len(ecsInfo.Services))
 
 		// Create all the services first
-		for serviceName, service := range ecsInfo.services {
+		for serviceName, service := range ecsInfo.Services {
 			serviceID := report.MakeECSServiceNodeID(serviceName)
 			rpt.ECSService = rpt.ECSService.AddNode(report.MakeNodeWith(serviceID, map[string]string{
 				Cluster:             cluster,
-				ServiceDesiredCount: fmt.Sprintf("%d", service.desiredCount),
-				ServiceRunningCount: fmt.Sprintf("%d", service.runningCount),
+				ServiceDesiredCount: fmt.Sprintf("%d", service.DesiredCount),
+				ServiceRunningCount: fmt.Sprintf("%d", service.RunningCount),
 			}))
 		}
-		log.Debugf("Created %v ECS service nodes", len(ecsInfo.services))
+		log.Debugf("Created %v ECS service nodes", len(ecsInfo.Services))
 
 		for taskArn, info := range taskMap {
-			task, ok := ecsInfo.tasks[taskArn]
+			task, ok := ecsInfo.Tasks[taskArn]
 			if !ok {
 				// can happen due to partial failures, just skip it
 				continue
@@ -141,20 +143,20 @@ func (r Reporter) Tag(rpt report.Report) (report.Report, error) {
 			// new task node
 			taskID := report.MakeECSTaskNodeID(taskArn)
 			node := report.MakeNodeWith(taskID, map[string]string{
-				TaskFamily: info.family,
+				TaskFamily: info.Family,
 				Cluster:    cluster,
-				CreatedAt:  task.createdAt.Format(time.RFC3339Nano),
+				CreatedAt:  task.CreatedAt.Format(time.RFC3339Nano),
 			})
 			rpt.ECSTask = rpt.ECSTask.AddNode(node)
 
 			// parents sets to merge into all matching container nodes
 			parentsSets := report.MakeSets()
 			parentsSets = parentsSets.Add(report.ECSTask, report.MakeStringSet(taskID))
-			if serviceName, ok := ecsInfo.taskServiceMap[taskArn]; ok {
+			if serviceName, ok := ecsInfo.TaskServiceMap[taskArn]; ok {
 				serviceID := report.MakeECSServiceNodeID(serviceName)
 				parentsSets = parentsSets.Add(report.ECSService, report.MakeStringSet(serviceID))
 			}
-			for _, containerID := range info.containerIDs {
+			for _, containerID := range info.ContainerIDs {
 				if containerNode, ok := rpt.Container.Nodes[containerID]; ok {
 					rpt.Container.Nodes[containerID] = containerNode.WithParents(parentsSets)
 				} else {

--- a/probe/awsecs/reporter.go
+++ b/probe/awsecs/reporter.go
@@ -32,13 +32,13 @@ var (
 	}
 )
 
-// Used in return value of GetLabelInfo. Exported for test.
+// TaskLabelInfo is used in return value of GetLabelInfo. Exported for test.
 type TaskLabelInfo struct {
 	ContainerIDs []string
 	Family       string
 }
 
-// Return map from cluster to map of task arns to task infos.
+// GetLabelInfo returns map from cluster to map of task arns to task infos.
 // Exported for test.
 func GetLabelInfo(rpt report.Report) map[string]map[string]*TaskLabelInfo {
 	results := map[string]map[string]*TaskLabelInfo{}

--- a/probe/awsecs/reporter.go
+++ b/probe/awsecs/reporter.go
@@ -81,7 +81,7 @@ type Reporter struct {
 	clientsByCluster map[string]*ecsClient
 }
 
-// New creates a new Reporter
+// Make creates a new Reporter
 func Make() Reporter {
 	return Reporter{
 		clientsByCluster: map[string]*ecsClient{},

--- a/probe/awsecs/reporter.go
+++ b/probe/awsecs/reporter.go
@@ -100,7 +100,7 @@ func (r Reporter) Tag(rpt report.Report) (report.Report, error) {
 		client, ok := r.clientsByCluster[cluster]
 		if !ok {
 			log.Debugf("Creating new ECS client")
-			var err error // can't use := on the next line without shadowing outer client var
+			var err error
 			client, err = newClient(cluster)
 			if err != nil {
 				return rpt, err

--- a/probe/awsecs/reporter.go
+++ b/probe/awsecs/reporter.go
@@ -78,13 +78,13 @@ func getLabelInfo(rpt report.Report) map[string]map[string]*taskLabelInfo {
 
 // Reporter implements Tagger, Reporter
 type Reporter struct {
-	clients map[string]*ecsClient
+	clientsByCluster map[string]*ecsClient
 }
 
 // New creates a new Reporter
-func New() Reporter {
+func Make() Reporter {
 	return Reporter{
-		clients: map[string]*ecsClient{},
+		clientsByCluster: map[string]*ecsClient{},
 	}
 }
 
@@ -97,7 +97,7 @@ func (r Reporter) Tag(rpt report.Report) (report.Report, error) {
 	for cluster, taskMap := range clusterMap {
 		log.Debugf("Fetching ECS info for cluster %v with %v tasks", cluster, len(taskMap))
 
-		client, ok := r.clients[cluster]
+		client, ok := r.clientsByCluster[cluster]
 		if !ok {
 			log.Debugf("Creating new ECS client")
 			var err error // can't use := on the next line without shadowing outer client var
@@ -105,7 +105,7 @@ func (r Reporter) Tag(rpt report.Report) (report.Report, error) {
 			if err != nil {
 				return rpt, err
 			}
-			r.clients[cluster] = client
+			r.clientsByCluster[cluster] = client
 		}
 
 		taskArns := make([]string, 0, len(taskMap))

--- a/probe/awsecs/reporter.go
+++ b/probe/awsecs/reporter.go
@@ -99,11 +99,13 @@ func (r Reporter) Tag(rpt report.Report) (report.Report, error) {
 
 		client, ok := r.clients[cluster]
 		if !ok {
+			log.Debugf("Creating new ECS client")
 			var err error // can't use := on the next line without shadowing outer client var
 			client, err = newClient(cluster)
 			if err != nil {
 				return rpt, err
 			}
+			r.clients[cluster] = client
 		}
 
 		taskArns := make([]string, 0, len(taskMap))
@@ -112,6 +114,7 @@ func (r Reporter) Tag(rpt report.Report) (report.Report, error) {
 		}
 
 		ecsInfo := client.getInfo(taskArns)
+		log.Debugf("Got info from ECS: %d tasks, %d services", len(ecsInfo.tasks), len(ecsInfo.services))
 
 		// Create all the services first
 		for serviceName, service := range ecsInfo.services {

--- a/probe/awsecs/reporter.go
+++ b/probe/awsecs/reporter.go
@@ -78,12 +78,12 @@ func getLabelInfo(rpt report.Report) map[string]map[string]*taskLabelInfo {
 
 // Reporter implements Tagger, Reporter
 type Reporter struct {
-	clients map[string]ecsClient
+	clients map[string]*ecsClient
 }
 
 func New() Reporter {
 	return Reporter{
-		clients: map[string]ecsClient{},
+		clients: map[string]*ecsClient{},
 	}
 }
 
@@ -98,7 +98,8 @@ func (r Reporter) Tag(rpt report.Report) (report.Report, error) {
 
 		client, ok := r.clients[cluster]
 		if !ok {
-			client, err := newClient(cluster)
+			var err error // can't use := on the next line without shadowing outer client var
+			client, err = newClient(cluster)
 			if err != nil {
 				return rpt, err
 			}

--- a/probe/awsecs/reporter.go
+++ b/probe/awsecs/reporter.go
@@ -99,18 +99,15 @@ func (Reporter) Tag(rpt report.Report) (report.Report, error) {
 			taskArns = append(taskArns, taskArn)
 		}
 
-		ecsInfo, err := client.getInfo(taskArns)
-		if err != nil {
-			return rpt, err
-		}
+		ecsInfo := client.getInfo(taskArns)
 
 		// Create all the services first
 		for serviceName, service := range ecsInfo.services {
 			serviceID := report.MakeECSServiceNodeID(serviceName)
 			rpt.ECSService = rpt.ECSService.AddNode(report.MakeNodeWith(serviceID, map[string]string{
 				Cluster:             cluster,
-				ServiceDesiredCount: fmt.Sprintf("%d", *service.DesiredCount),
-				ServiceRunningCount: fmt.Sprintf("%d", *service.RunningCount),
+				ServiceDesiredCount: fmt.Sprintf("%d", service.desiredCount),
+				ServiceRunningCount: fmt.Sprintf("%d", service.runningCount),
 			}))
 		}
 		log.Debugf("Created %v ECS service nodes", len(ecsInfo.services))
@@ -127,7 +124,7 @@ func (Reporter) Tag(rpt report.Report) (report.Report, error) {
 			node := report.MakeNodeWith(taskID, map[string]string{
 				TaskFamily: info.family,
 				Cluster:    cluster,
-				CreatedAt:  task.CreatedAt.Format(time.RFC3339Nano),
+				CreatedAt:  task.createdAt.Format(time.RFC3339Nano),
 			})
 			rpt.ECSTask = rpt.ECSTask.AddNode(node)
 

--- a/probe/awsecs/reporter_test.go
+++ b/probe/awsecs/reporter_test.go
@@ -5,6 +5,28 @@ import (
 	"testing"
 )
 
+const (
+	testCluster = "test-cluster"
+	testFamily = "test-family"
+	testTaskARN = "arn:aws:ecs:us-east-1:123456789012:task/12345678-9abc-def0-1234-56789abcdef0"
+	testContainer = "test-container"
+	testContainerData = map[string]string{
+		docker.LabelPrefix + "com.amazonaws.ecs.task-arn":
+			testTaskARN,
+		docker.LabelPrefix + "com.amazonaws.ecs.cluster":
+			testCluster,
+		docker.LabelPrefix + "com.amazonaws.ecs.task-definition-family":
+			testFamily,
+	}
+)
+
+func getTestContainerNode() report.Node {
+	return report.MakeNodeWith(
+		report.MakeContainerNodeID("test-container"),
+		testContainerData
+	)
+}
+
 func TestGetLabelInfo(t *testing.T) {
 	r := Make()
 	rpt, err := r.Report()
@@ -17,29 +39,61 @@ func TestGetLabelInfo(t *testing.T) {
 		t.Error("Empty report did not produce empty label info: %v != %v", labelInfo, expected)
 	}
 
-	rpt.Containers = rpt.Containers.AddNode(
-		report.MakeNodeWith(
-			report.MakeContainerNodeID("test-container"),
-			map[string]string{
-				docker.LabelPrefix + "com.amazonaws.ecs.task-arn":
-					"arn:aws:ecs:us-east-1:123456789012:task/12345678-9abc-def0-1234-56789abcdef0",
-				docker.LabelPrefix + "com.amazonaws.ecs.cluster":
-					"test-cluster",
-				docker.LabelPrefix + "com.amazonaws.ecs.task-definition-family":
-					"test-family",
-			}
-		)
-	)
+	rpt.Containers = rpt.Containers.AddNode(getTestContainerNode())
 	labelInfo = r.getLabelInfo(rpt)
 	expected = map[string]map[string]*taskLabelInfo{
-		"test-cluster": map[string]*taskLabelInfo{
-			"arn:aws:ecs:us-east-1:123456789012:task/12345678-9abc-def0-1234-56789abcdef0": &taskLabelInfo{
-				containerIDs: []string{"test-container"},
-				family: "test-family",
+		testCluster: map[string]*taskLabelInfo{
+			testTaskARN: &taskLabelInfo{
+				containerIDs: []string{testContainer},
+				family: testFamily,
 			}
 		}
 	}
 	if !reflect.DeepEqual(labelInfo, expected) {
 		t.Error("Did not get expected label info: %v != %v", labelInfo, expected)
 	}
+}
+
+// Implements ecsClient
+type mockEcsClient {
+	t *testing.T
+	expectedARNs []string
+	info ecsInfo
+}
+
+func newMockEcsClient(t *testing.T, expectedARNs []string, info ecsInfo) *ecsClient {
+	return &mockEcsClient{
+		t,
+		expectedARNs,
+		info,
+	}
+}
+
+func (c mockEcsClient) getInfo(taskARNs []string) ecsInfo {
+	if !reflect.DeepEqual(taskARNs, c.expectedARNs) {
+		c.t.Fatal("getInfo called with wrong ARNs: %v != %v", taskARNs, c.expectedARNs)
+	}
+	return c.info
+}
+
+func TestTagReport(t *testing.T) {
+	r := Make()
+
+	r.clientsByCluster[testCluster] = newMockEcsClient(
+		t,
+		[]string{},
+		ecsInfo{
+			// TODO fill in values below
+			tasks: map[string]ecsTask{},
+			services: map[string]ecsService{},
+			taskServiceMap: map[string]string{},
+		},
+	)
+
+	rpt, err := r.Report()
+	if err != nil {
+		t.Fatal("Error making report")
+	}
+	rpt = r.Tag(rpt)
+	// TODO check it matches
 }

--- a/probe/awsecs/reporter_test.go
+++ b/probe/awsecs/reporter_test.go
@@ -1,0 +1,45 @@
+package awsecs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetLabelInfo(t *testing.T) {
+	r := Make()
+	rpt, err := r.Report()
+	if err != nil {
+		t.Fatal("Error making report", err)
+	}
+	labelInfo := r.getLabelInfo(rpt)
+	expected := map[string]map[string]*taskLabelInfo{}
+	if !reflect.DeepEqual(labelInfo, expected) {
+		t.Error("Empty report did not produce empty label info: %v != %v", labelInfo, expected)
+	}
+
+	rpt.Containers = rpt.Containers.AddNode(
+		report.MakeNodeWith(
+			report.MakeContainerNodeID("test-container"),
+			map[string]string{
+				docker.LabelPrefix + "com.amazonaws.ecs.task-arn":
+					"arn:aws:ecs:us-east-1:123456789012:task/12345678-9abc-def0-1234-56789abcdef0",
+				docker.LabelPrefix + "com.amazonaws.ecs.cluster":
+					"test-cluster",
+				docker.LabelPrefix + "com.amazonaws.ecs.task-definition-family":
+					"test-family",
+			}
+		)
+	)
+	labelInfo = r.getLabelInfo(rpt)
+	expected = map[string]map[string]*taskLabelInfo{
+		"test-cluster": map[string]*taskLabelInfo{
+			"arn:aws:ecs:us-east-1:123456789012:task/12345678-9abc-def0-1234-56789abcdef0": &taskLabelInfo{
+				containerIDs: []string{"test-container"},
+				family: "test-family",
+			}
+		}
+	}
+	if !reflect.DeepEqual(labelInfo, expected) {
+		t.Error("Did not get expected label info: %v != %v", labelInfo, expected)
+	}
+}

--- a/probe/awsecs/reporter_test.go
+++ b/probe/awsecs/reporter_test.go
@@ -3,12 +3,22 @@ package awsecs
 import (
 	"reflect"
 	"testing"
+	"time"
+
+	"github.com/weaveworks/scope/probe/docker"
+	"github.com/weaveworks/scope/report"
 )
 
-const (
+var (
 	testCluster = "test-cluster"
 	testFamily = "test-family"
 	testTaskARN = "arn:aws:ecs:us-east-1:123456789012:task/12345678-9abc-def0-1234-56789abcdef0"
+	testTaskCreatedAt = time.Unix(1483228800, 0)
+	testTaskDefinitionARN = "arn:aws:ecs:us-east-1:123456789012:task-definition/deadbeef-dead-beef-dead-beefdeadbeef"
+	testTaskStartedAt = time.Unix(1483228805, 0)
+	testDeploymentID = "ecs-svc/1121123211234321"
+	testServiceName = "test-service"
+	testServiceCount = 1
 	testContainer = "test-container"
 	testContainerData = map[string]string{
 		docker.LabelPrefix + "com.amazonaws.ecs.task-arn":
@@ -22,46 +32,46 @@ const (
 
 func getTestContainerNode() report.Node {
 	return report.MakeNodeWith(
-		report.MakeContainerNodeID("test-container"),
-		testContainerData
+		report.MakeContainerNodeID(testContainer),
+		testContainerData,
 	)
 }
 
 func TestGetLabelInfo(t *testing.T) {
-	r := Make()
+	r := Make(1e6, time.Hour)
 	rpt, err := r.Report()
 	if err != nil {
-		t.Fatal("Error making report", err)
+		t.Fatalf("Error making report", err)
 	}
-	labelInfo := r.getLabelInfo(rpt)
+	labelInfo := getLabelInfo(rpt)
 	expected := map[string]map[string]*taskLabelInfo{}
 	if !reflect.DeepEqual(labelInfo, expected) {
-		t.Error("Empty report did not produce empty label info: %v != %v", labelInfo, expected)
+		t.Errorf("Empty report did not produce empty label info: %v != %v", labelInfo, expected)
 	}
 
-	rpt.Containers = rpt.Containers.AddNode(getTestContainerNode())
-	labelInfo = r.getLabelInfo(rpt)
+	rpt.Container = rpt.Container.AddNode(getTestContainerNode())
+	labelInfo = getLabelInfo(rpt)
 	expected = map[string]map[string]*taskLabelInfo{
 		testCluster: map[string]*taskLabelInfo{
 			testTaskARN: &taskLabelInfo{
-				containerIDs: []string{testContainer},
+				containerIDs: []string{report.MakeContainerNodeID(testContainer)},
 				family: testFamily,
-			}
-		}
+			},
+		},
 	}
 	if !reflect.DeepEqual(labelInfo, expected) {
-		t.Error("Did not get expected label info: %v != %v", labelInfo, expected)
+		t.Errorf("Did not get expected label info: %v != %v", labelInfo, expected)
 	}
 }
 
 // Implements ecsClient
-type mockEcsClient {
+type mockEcsClient struct {
 	t *testing.T
 	expectedARNs []string
 	info ecsInfo
 }
 
-func newMockEcsClient(t *testing.T, expectedARNs []string, info ecsInfo) *ecsClient {
+func newMockEcsClient(t *testing.T, expectedARNs []string, info ecsInfo) ecsClient {
 	return &mockEcsClient{
 		t,
 		expectedARNs,
@@ -71,29 +81,111 @@ func newMockEcsClient(t *testing.T, expectedARNs []string, info ecsInfo) *ecsCli
 
 func (c mockEcsClient) getInfo(taskARNs []string) ecsInfo {
 	if !reflect.DeepEqual(taskARNs, c.expectedARNs) {
-		c.t.Fatal("getInfo called with wrong ARNs: %v != %v", taskARNs, c.expectedARNs)
+		c.t.Fatalf("getInfo called with wrong ARNs: %v != %v", taskARNs, c.expectedARNs)
 	}
 	return c.info
 }
 
 func TestTagReport(t *testing.T) {
-	r := Make()
+	r := Make(1e6, time.Hour)
 
 	r.clientsByCluster[testCluster] = newMockEcsClient(
 		t,
-		[]string{},
+		[]string{testTaskARN},
 		ecsInfo{
-			// TODO fill in values below
-			tasks: map[string]ecsTask{},
-			services: map[string]ecsService{},
-			taskServiceMap: map[string]string{},
+			tasks: map[string]ecsTask{
+				testTaskARN: ecsTask{
+					taskARN: testTaskARN,
+					createdAt: testTaskCreatedAt,
+					taskDefinitionARN: testTaskDefinitionARN,
+					startedAt: testTaskStartedAt,
+					startedBy: testDeploymentID,
+				},
+			},
+			services: map[string]ecsService{
+				testServiceName: ecsService{
+					serviceName: testServiceName,
+					deploymentIDs: []string{testDeploymentID},
+					desiredCount: 1,
+					pendingCount: 0,
+					runningCount: 1,
+					taskDefinitionARN: testTaskDefinitionARN,
+				},
+			},
+			taskServiceMap: map[string]string{
+				testTaskARN: testServiceName,
+			},
 		},
 	)
 
 	rpt, err := r.Report()
 	if err != nil {
-		t.Fatal("Error making report")
+		t.Fatalf("Error making report")
 	}
-	rpt = r.Tag(rpt)
-	// TODO check it matches
+	rpt.Container = rpt.Container.AddNode(getTestContainerNode())
+	rpt, err = r.Tag(rpt)
+	if err != nil {
+		t.Fatalf("Failed to tag: %v", err)
+	}
+
+	// Check task node is present and contains expected values
+	task, ok := rpt.ECSTask.Nodes[report.MakeECSTaskNodeID(testTaskARN)]
+	if !ok {
+		t.Fatalf("Result report did not contain task %v: %v", testTaskARN, rpt.ECSTask.Nodes)
+	}
+	taskExpected := map[string]string{
+		TaskFamily: testFamily,
+		Cluster: testCluster,
+		CreatedAt: testTaskCreatedAt.Format(time.RFC3339Nano),
+	}
+	for key, expectedValue := range taskExpected {
+		value, ok := task.Latest.Lookup(key)
+		if !ok {
+			t.Errorf("Result task did not contain expected key %v: %v", key, task.Latest)
+			continue
+		}
+		if value != expectedValue {
+			t.Errorf("Result task did not contain expected value for key %v: %v != %v", key, value, expectedValue)
+		}
+	}
+
+	// Check service node is present and contains expected values
+	service, ok := rpt.ECSService.Nodes[report.MakeECSServiceNodeID(testServiceName)]
+	if !ok {
+		t.Fatalf("Result report did not contain service %v: %v", testServiceName, rpt.ECSService.Nodes)
+	}
+	serviceExpected := map[string]string{
+		Cluster: testCluster,
+		ServiceDesiredCount: "1",
+		ServiceRunningCount: "1",
+	}
+	for key, expectedValue := range serviceExpected {
+		value, ok := service.Latest.Lookup(key)
+		if !ok {
+			t.Errorf("Result service did not contain expected key %v: %v", key, service.Latest)
+			continue
+		}
+		if value != expectedValue {
+			t.Errorf("Result service did not contain expected value for key %v: %v != %v", key, value, expectedValue)
+		}
+	}
+
+	// Check container node is present and contains expected parents
+	container, ok := rpt.Container.Nodes[report.MakeContainerNodeID(testContainer)]
+	if !ok {
+		t.Fatalf("Result report did not contain container %v: %v", testContainer, rpt.Container.Nodes)
+	}
+	containerParentsExpected := map[string]string{
+		report.ECSTask: report.MakeECSTaskNodeID(testTaskARN),
+		report.ECSService: report.MakeECSServiceNodeID(testServiceName),
+	}
+	for key, expectedValue := range containerParentsExpected {
+		values, ok := container.Parents.Lookup(key)
+		if !ok {
+			t.Errorf("Result container did not have any parents for key %v: %v", key, container.Parents)
+		}
+		if !values.Contains(expectedValue) {
+			t.Errorf("Result container did not contain expected value %v as a parent for key %v: %v", expectedValue, key, values)
+		}
+	}
 }

--- a/prog/main.go
+++ b/prog/main.go
@@ -104,7 +104,9 @@ type probeFlags struct {
 	kubernetesEnabled bool
 	kubernetesConfig  kubernetes.ClientConfig
 
-	ecsEnabled bool
+	ecsEnabled     bool
+	ecsCacheSize   int
+	ecsCacheExpiry time.Duration
 
 	weaveEnabled  bool
 	weaveAddr     string
@@ -287,6 +289,8 @@ func main() {
 
 	// AWS ECS
 	flag.BoolVar(&flags.probe.ecsEnabled, "probe.ecs", false, "Collect ecs-related attributes for containers on this node")
+	flag.IntVar(&flags.probe.ecsCacheSize, "probe.ecs.cache.size", 1024*1024, "Max size of cached info for each ECS cluster")
+	flag.DurationVar(&flags.probe.ecsCacheExpiry, "probe.ecs.cache.expiry", time.Hour, "How long to keep cached ECS info")
 
 	// Weave
 	flag.StringVar(&flags.probe.weaveAddr, "probe.weave.addr", "127.0.0.1:6784", "IP address & port of the Weave router")

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -206,7 +206,7 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 	}
 
 	if flags.ecsEnabled {
-		reporter := awsecs.Reporter{}
+		reporter := awsecs.New()
 		p.AddReporter(reporter)
 		p.AddTagger(reporter)
 	}

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -206,7 +206,7 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 	}
 
 	if flags.ecsEnabled {
-		reporter := awsecs.New()
+		reporter := awsecs.Make()
 		p.AddReporter(reporter)
 		p.AddTagger(reporter)
 	}

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -206,7 +206,7 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 	}
 
 	if flags.ecsEnabled {
-		reporter := awsecs.Make()
+		reporter := awsecs.Make(flags.ecsCacheSize, flags.ecsCacheExpiry)
 		p.AddReporter(reporter)
 		p.AddTagger(reporter)
 	}


### PR DESCRIPTION
Fixes https://github.com/weaveworks/scope/issues/2050

Due to AWS API rate limits, we need to minimize API calls as much as
possible.

Our stated objectives:
* for all displayed tasks and services to have up-to-date metadata
* for all tasks to map to services if able

My approach here:
* Tasks only contain immutable fields (that we care about). We cache tasks forever.
 We only DescribeTasks the first time we see a new task.
* We attempt to match tasks to services with what info we have. Any "referenced" services,
 ie. a service with at least one matching task, needs to be updated to refresh changing data.
* In the event that a task doesn't match any of the (updated) services, ie. a new service entirely
 needs to be found, we do a full list and detail of all services (we don't re-detail ones we just refreshed).
* To avoid unbounded memory usage, we evict tasks and services from the cache after 1 minute without use.
 This should be long enough for things like temporary failures to be glossed over.

This gives us exactly one call per task, and one call per referenced service per report, which is unavoidable to maintain fresh data. Expensive "describe all" service queries are kept to only when newly-referenced services appear, which should be rare.

We could make a few very minor improvements here, such as trying to refresh unreferenced but known services before doing a list query, or getting details one by one when "describing all" and stopping when all matches have been found, but I believe these would produce very minor, if any, gains in number of calls while having an unjustifiable effect on latency since we wouldn't be able to do requests as concurrently.

Speaking of which, this change has a minor performance impact. Even though we're now doing less calls, we can't do them as concurrently.

Old code:
```
concurrently:
	describe tasks (1 call)
	sequentially:
		list services (1 call)
		describe services (N calls concurrently)
```
Assuming full concurrency, total latency: 2 end-to-end calls

New code (worst case):
```
sequentially:
	describe tasks (1 call)
	describe services (N calls concurrently)
	list services (1 call)
	describe services (N calls concurrently)
```
Assuming full concurrency, total latency: 4 end-to-end calls

In practical terms, I don't expect this to matter.