### PR TITLE
Add eBPF connection tracking, without dependencies on kernel headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ scope.tar
 prog/scope
 docker/scope
 docker/docker.tgz
+docker/ebpf.tgz
 docker/weave
 docker/runsvinit
 extras/fixprobe/fixprobe

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ CODECGEN_TARGETS=report/report.codecgen.go render/detailed/detailed.codecgen.go
 RM=--rm
 RUN_FLAGS=-ti
 BUILD_IN_CONTAINER=true
-GO_ENV=GOGC=off
-GO_ENV_ARM=$(GO_ENV) CC=/usr/bin/arm-linux-gnueabihf-gcc CGO_ENABLED=1
+GO_ENV=GOGC=off CGO_ENABLED=1
+GO_ENV_ARM=$(GO_ENV) CC=/usr/bin/arm-linux-gnueabihf-gcc
 GO_BUILD_INSTALL_DEPS=-i
 GO_BUILD_TAGS='netgo unsafe'
 GO_BUILD_FLAGS=$(GO_BUILD_INSTALL_DEPS) -ldflags "-extldflags \"-static\" -X main.version=$(SCOPE_VERSION) -s -w" -tags $(GO_BUILD_TAGS)

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ NO_CROSS_COMP=unset GOOS GOARCH
 GO_HOST=$(NO_CROSS_COMP); env $(GO_ENV) go
 WITH_GO_HOST_ENV=$(NO_CROSS_COMP); $(GO_ENV)
 IMAGE_TAG=$(shell ./tools/image-tag)
-EBPF_IMAGE=kinvolk/tcptracer-bpf:semaphore-master-3f7c26b
+EBPF_IMAGE=kinvolk/tcptracer-bpf:semaphore-master-475be63
 
 all: $(SCOPE_EXPORT)
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:yakkety
 ENV GOPATH /go
 ENV PATH /go/bin:/usr/lib/go-1.7/bin:/usr/bin:/bin:/usr/sbin:/sbin
 RUN apt-get update && \
-	apt-get install -y libpcap-dev python-requests time file shellcheck golang-1.7 git && \
+	apt-get install -y libpcap-dev python-requests time file shellcheck golang-1.7 git gcc-arm-linux-gnueabihf && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN go clean -i net && \
 	go install -tags netgo std && \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,8 @@
-FROM golang:1.7.1
+FROM ubuntu:yakkety
+ENV GOPATH /go
+ENV PATH /go/bin:/usr/lib/go-1.7/bin:/usr/bin:/bin:/usr/sbin:/sbin
 RUN apt-get update && \
-	apt-get install -y libpcap-dev python-requests time file shellcheck && \
+	apt-get install -y libpcap-dev python-requests time file shellcheck golang-1.7 git && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN go clean -i net && \
 	go install -tags netgo std && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,7 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >>/etc/apk/reposi
 	apk add --update bash runit conntrack-tools iproute2 util-linux curl && \
 	rm -rf /var/cache/apk/*
 ADD ./docker.tgz /
+ADD ./ebpf.tgz /usr/libexec/scope/
 ADD ./demo.json /
 ADD ./weave /usr/bin/
 COPY ./scope ./runsvinit ./entrypoint.sh /home/weave/

--- a/probe/endpoint/conntrack.go
+++ b/probe/endpoint/conntrack.go
@@ -66,14 +66,14 @@ type conntrack struct {
 // flowWalker is something that maintains flows, and provides an accessor
 // method to walk them.
 type flowWalker interface {
-	walkFlows(f func(flow))
+	walkFlows(f func(flow, bool))
 	stop()
 }
 
 type nilFlowWalker struct{}
 
-func (n nilFlowWalker) stop()                  {}
-func (n nilFlowWalker) walkFlows(f func(flow)) {}
+func (n nilFlowWalker) stop()                        {}
+func (n nilFlowWalker) walkFlows(f func(flow, bool)) {}
 
 // conntrackWalker uses the conntrack command to track network connections and
 // implement flowWalker.
@@ -315,14 +315,14 @@ func (c *conntrackWalker) handleFlow(f flow, forceAdd bool) {
 
 // walkFlows calls f with all active flows and flows that have come and gone
 // since the last call to walkFlows
-func (c *conntrackWalker) walkFlows(f func(flow)) {
+func (c *conntrackWalker) walkFlows(f func(flow, bool)) {
 	c.Lock()
 	defer c.Unlock()
 	for _, flow := range c.activeFlows {
-		f(flow)
+		f(flow, true)
 	}
 	for _, flow := range c.bufferedFlows {
-		f(flow)
+		f(flow, false)
 	}
 	c.bufferedFlows = c.bufferedFlows[:0]
 }

--- a/probe/endpoint/conntrack_internal_test.go
+++ b/probe/endpoint/conntrack_internal_test.go
@@ -124,7 +124,7 @@ func TestConntracker(t *testing.T) {
 
 	have := func() interface{} {
 		result := []flow{}
-		flowWalker.walkFlows(func(f flow) {
+		flowWalker.walkFlows(func(f flow, alive bool) {
 			f.Original = nil
 			f.Reply = nil
 			f.Independent = nil

--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -189,7 +189,7 @@ func tcpEventCallback(event tcpEvent) {
 
 	tuple := fourTuple{sIP.String(), dIP.String(), uint16(sport), uint16(dport)}
 
-	log.Debugf("tcpEventCallback(%s, [%s:%d --> %s:%d], pid=%d, netNS=%d, cpu=%d, ts=%d)",
+	log.Debugf("tcpEventCallback(%v, [%v:%v --> %v:%v], pid=%v, netNS=%v, cpu=%v, ts=%v)",
 		typ.String(), tuple.fromAddr, tuple.fromPort, tuple.toAddr, tuple.toPort, pid, event.NetNS, event.CPU, event.Timestamp)
 	ebpfTracker.handleConnection(typ.String(), tuple, int(pid), strconv.FormatUint(uint64(event.NetNS), 10))
 }

--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -225,7 +225,7 @@ func (t *EbpfTracker) run() {
 		}
 	}()
 
-	t.reader.PollStart("tcp_event_v4", channel)
+	t.reader.PollStart("tcp_event_ipv4", channel)
 }
 
 func (t *EbpfTracker) hasDied() bool {

--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -230,6 +230,8 @@ func tcpEventCallback(event tcpEvent) {
 
 	tuple := fourTuple{sIP.String(), dIP.String(), uint16(sport), uint16(dport)}
 
+	log.Debugf("tcpEventCallback(%s, [%s:%d --> %s:%d], pid=%d, netNS=%d, cpu=%d, ts=%d)",
+		typ.String(), tuple.fromAddr, tuple.fromPort, tuple.toAddr, tuple.toPort, pid, event.NetNS, event.CPU, event.Timestamp)
 	ebpfTracker.handleConnection(typ.String(), tuple, int(pid), strconv.FormatUint(uint64(event.NetNS), 10))
 }
 

--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -174,6 +174,7 @@ func (t *EbpfTracker) handleConnection(eventType string, tuple fourTuple, pid in
 }
 
 func tcpEventCallback(event tcpEvent) {
+	var alive bool
 	typ := eventType(event.Type)
 	pid := event.Pid & 0xffffffff
 
@@ -189,7 +190,12 @@ func tcpEventCallback(event tcpEvent) {
 	sport := event.SPort
 	dport := event.DPort
 
-	tuple := fourTuple{sIP.String(), dIP.String(), uint16(sport), uint16(dport)}
+	if typ.String() == "close" || typ.String() == "unknown" {
+		alive = true
+	} else {
+		alive = false
+	}
+	tuple := fourTuple{sIP.String(), dIP.String(), uint16(sport), uint16(dport), alive}
 
 	log.Debugf("tcpEventCallback(%v, [%v:%v --> %v:%v], pid=%v, netNS=%v, cpu=%v, ts=%v)",
 		typ.String(), tuple.fromAddr, tuple.fromPort, tuple.toAddr, tuple.toPort, pid, event.NetNS, event.CPU, event.Timestamp)

--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -134,7 +134,7 @@ func newEbpfTracker(useEbpfConn bool) eventTracker {
 		openConnections: map[string]ebpfConnection{},
 		reader:          bpfPerfEvent,
 	}
-	go tracker.run()
+	tracker.run()
 
 	ebpfTracker = tracker
 	return tracker

--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -1,0 +1,237 @@
+package endpoint
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"sync"
+	"unsafe"
+	"strconv"
+
+	log "github.com/Sirupsen/logrus"
+	bpflib "github.com/kinvolk/gobpf-elf-loader/bpf"
+)
+
+import "C"
+
+var byteOrder binary.ByteOrder
+
+type eventType uint32
+
+// These constants should be in sync with the equivalent definitions in the ebpf program.
+const (
+	_ eventType = iota
+	EventConnect
+	EventAccept
+	EventClose
+)
+
+func (e eventType) String() string {
+	switch e {
+	case EventConnect:
+		return "connect"
+	case EventAccept:
+		return "accept"
+	case EventClose:
+		return "close"
+	default:
+		return "unknown"
+	}
+}
+
+// tcpEvent should be in sync with the struct in the ebpf maps.
+type tcpEvent struct {
+	// Timestamp must be the first field, the sorting depends on it
+	Timestamp uint64
+
+	CPU   uint64
+	Type  uint32
+	Pid   uint32
+	Comm  [16]byte
+	SAddr uint32
+	DAddr uint32
+	SPort uint16
+	DPort uint16
+	NetNS uint32
+}
+
+// An ebpfConnection represents a TCP connection
+type ebpfConnection struct {
+	tuple            fourTuple
+	networkNamespace string
+	incoming         bool
+	pid              int
+}
+
+type eventTracker interface {
+	handleConnection(eventType string, tuple fourTuple, pid int, networkNamespace string)
+	hasDied() bool
+	run()
+	walkConnections(f func(ebpfConnection))
+	initialize()
+	isInitialized() bool
+	stop()
+}
+
+var ebpfTracker *EbpfTracker
+
+// nilTracker is a tracker that does nothing, and it implements the eventTracker interface.
+// It is returned when the useEbpfConn flag is false.
+type nilTracker struct{}
+
+func (n nilTracker) handleConnection(_ string, _ fourTuple, _ int, _ string) {}
+func (n nilTracker) hasDied() bool                                           { return true }
+func (n nilTracker) run()                                                    {}
+func (n nilTracker) walkConnections(f func(ebpfConnection))                  {}
+func (n nilTracker) initialize()                                             {}
+func (n nilTracker) isInitialized() bool                                     { return false }
+func (n nilTracker) stop()                                                   {}
+
+// EbpfTracker contains the sets of open and closed TCP connections.
+// Closed connections are kept in the `closedConnections` slice for one iteration of `walkConnections`.
+type EbpfTracker struct {
+	sync.Mutex
+	reader      *bpflib.BPFKProbePerf
+	initialized bool
+	dead        bool
+
+	openConnections   map[string]ebpfConnection
+	closedConnections []ebpfConnection
+}
+
+func newEbpfTracker(useEbpfConn bool) eventTracker {
+	var i int32 = 0x01020304
+	u := unsafe.Pointer(&i)
+	pb := (*byte)(u)
+	b := *pb
+	if b == 0x04 {
+		byteOrder = binary.LittleEndian
+	} else {
+		byteOrder = binary.BigEndian
+	}
+
+	if !useEbpfConn {
+		return &nilTracker{}
+	}
+
+	bpfPerfEvent := bpflib.NewBpfPerfEvent("/var/run/scope/ebpf/ebpf.o")
+	err := bpfPerfEvent.Load()
+	if err != nil {
+		log.Errorf("Error loading BPF program: %v", err)
+		return &nilTracker{}
+	}
+
+	tracker := &EbpfTracker{
+		openConnections: map[string]ebpfConnection{},
+		reader:          bpfPerfEvent,
+	}
+	go tracker.run()
+
+	ebpfTracker = tracker
+	return tracker
+}
+
+func (t *EbpfTracker) handleConnection(eventType string, tuple fourTuple, pid int, networkNamespace string) {
+	t.Lock()
+	defer t.Unlock()
+
+	switch eventType {
+	case "connect":
+		conn := ebpfConnection{
+			incoming:         false,
+			tuple:            tuple,
+			pid:              pid,
+			networkNamespace: networkNamespace,
+		}
+		t.openConnections[tuple.String()] = conn
+	case "accept":
+		conn := ebpfConnection{
+			incoming:         true,
+			tuple:            tuple,
+			pid:              pid,
+			networkNamespace: networkNamespace,
+		}
+		t.openConnections[tuple.String()] = conn
+	case "close":
+		if deadConn, ok := t.openConnections[tuple.String()]; ok {
+			delete(t.openConnections, tuple.String())
+			t.closedConnections = append(t.closedConnections, deadConn)
+		} else {
+			log.Errorf("EbpfTracker error: unmatched close event: %s pid=%d netns=%s", tuple.String(), pid, networkNamespace)
+		}
+	}
+}
+
+func tcpEventCallback(event tcpEvent) {
+	typ := eventType(event.Type)
+	pid := event.Pid & 0xffffffff
+
+	saddrbuf := make([]byte, 4)
+	daddrbuf := make([]byte, 4)
+
+	binary.LittleEndian.PutUint32(saddrbuf, uint32(event.SAddr))
+	binary.LittleEndian.PutUint32(daddrbuf, uint32(event.DAddr))
+
+	sIP := net.IPv4(saddrbuf[0], saddrbuf[1], saddrbuf[2], saddrbuf[3])
+	dIP := net.IPv4(daddrbuf[0], daddrbuf[1], daddrbuf[2], daddrbuf[3])
+
+	sport := event.SPort
+	dport := event.DPort
+
+	tuple := fourTuple{sIP.String(), dIP.String(), uint16(sport), uint16(dport)}
+
+	ebpfTracker.handleConnection(typ.String(), tuple, int(pid), strconv.FormatUint(uint64(event.NetNS), 10))
+}
+
+// walkConnections calls f with all open connections and connections that have come and gone
+// since the last call to walkConnections
+func (t *EbpfTracker) walkConnections(f func(ebpfConnection)) {
+	t.Lock()
+	defer t.Unlock()
+
+	for _, connection := range t.openConnections {
+		f(connection)
+	}
+	for _, connection := range t.closedConnections {
+		f(connection)
+	}
+	t.closedConnections = t.closedConnections[:0]
+}
+
+func (t *EbpfTracker) run() {
+	channel := make(chan []byte)
+
+	go func() {
+		var event tcpEvent
+		for {
+			data := <-channel
+			err := binary.Read(bytes.NewBuffer(data), byteOrder, &event)
+			if err != nil {
+				log.Errorf("failed to decode received data: %s\n", err)
+				continue
+			}
+			tcpEventCallback(event)
+		}
+	}()
+
+	t.reader.PollStart("tcp_event_v4", channel)
+}
+
+func (t *EbpfTracker) hasDied() bool {
+	t.Lock()
+	defer t.Unlock()
+
+	return t.dead
+}
+
+func (t *EbpfTracker) initialize() {
+	t.initialized = true
+}
+
+func (t *EbpfTracker) isInitialized() bool {
+	return t.initialized
+}
+
+func (t *EbpfTracker) stop() {
+	// TODO: stop the go routine in run()
+}

--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -143,6 +143,8 @@ func newEbpfTracker(useEbpfConn bool) eventTracker {
 func (t *EbpfTracker) handleConnection(eventType string, tuple fourTuple, pid int, networkNamespace string) {
 	t.Lock()
 	defer t.Unlock()
+	log.Debugf("handleConnection(%v, [%v:%v --> %v:%v], pid=%v, netNS=%v)",
+		eventType, tuple.fromAddr, tuple.fromPort, tuple.toAddr, tuple.toPort, pid, networkNamespace)
 
 	switch eventType {
 	case "connect":

--- a/probe/endpoint/ebpf_linux.go
+++ b/probe/endpoint/ebpf_linux.go
@@ -1,0 +1,51 @@
+//+build linux
+
+package endpoint
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+	"unsafe"
+)
+
+import "C"
+
+func findBpfObjectFile() (string, error) {
+	var buf syscall.Utsname
+	err := syscall.Uname(&buf)
+	if err != nil {
+		return "", err
+	}
+
+	// parse "ID=" in /etc/host-os-release (this is a bind mount of
+	// /etc/os-release on the host)
+	hostDistroFile, err := os.Open("/etc/host-os-release")
+	if err != nil {
+		return "", err
+	}
+	defer hostDistroFile.Close()
+
+	scanner := bufio.NewScanner(hostDistroFile)
+	var distro string
+	for scanner.Scan() {
+		if strings.HasPrefix(scanner.Text(), "ID=") {
+			distro = strings.TrimPrefix(scanner.Text(), "ID=")
+			break
+		}
+	}
+	if err = scanner.Err(); err != nil {
+		return "", err
+	}
+	if distro == "" {
+		return "", fmt.Errorf("distro ID not found")
+	}
+
+	arch := C.GoString((*C.char)(unsafe.Pointer(&buf.Machine[0])))
+	release := C.GoString((*C.char)(unsafe.Pointer(&buf.Release[0])))
+	fileName := fmt.Sprintf("/usr/libexec/scope/ebpf/%s/%s/%s/ebpf.o", distro, arch, release)
+
+	return fileName, nil
+}

--- a/probe/endpoint/ebpf_unsupported.go
+++ b/probe/endpoint/ebpf_unsupported.go
@@ -1,0 +1,9 @@
+//+build !linux
+
+package endpoint
+
+import "fmt"
+
+func findBpfObjectFile() (string, error) {
+	return "", fmt.Errorf("not supported")
+}

--- a/probe/endpoint/four_tuple.go
+++ b/probe/endpoint/four_tuple.go
@@ -10,6 +10,7 @@ import (
 type fourTuple struct {
 	fromAddr, toAddr string
 	fromPort, toPort uint16
+	alive            bool
 }
 
 func (t fourTuple) String() string {

--- a/probe/endpoint/four_tuple.go
+++ b/probe/endpoint/four_tuple.go
@@ -1,0 +1,43 @@
+package endpoint
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// fourTuple is an (IP, port, IP, port) tuple, representing a connection
+type fourTuple struct {
+	fromAddr, toAddr string
+	fromPort, toPort uint16
+}
+
+func (t fourTuple) String() string {
+	return fmt.Sprintf("%s:%d-%s:%d", t.fromAddr, t.fromPort, t.toAddr, t.toPort)
+}
+
+// key is a sortable direction-independent key for tuples, used to look up a
+// fourTuple when you are unsure of its direction.
+func (t fourTuple) key() string {
+	key := []string{
+		fmt.Sprintf("%s:%d", t.fromAddr, t.fromPort),
+		fmt.Sprintf("%s:%d", t.toAddr, t.toPort),
+	}
+	sort.Strings(key)
+	return strings.Join(key, " ")
+}
+
+// reverse flips the direction of the tuple
+func (t *fourTuple) reverse() {
+	t.fromAddr, t.fromPort, t.toAddr, t.toPort = t.toAddr, t.toPort, t.fromAddr, t.fromPort
+}
+
+// reverse flips the direction of a tuple, without side effects
+func reverse(tuple fourTuple) fourTuple {
+	return fourTuple{
+		fromAddr: tuple.toAddr,
+		toAddr:   tuple.fromAddr,
+		fromPort: tuple.toPort,
+		toPort:   tuple.fromPort,
+	}
+}

--- a/probe/endpoint/nat.go
+++ b/probe/endpoint/nat.go
@@ -49,7 +49,7 @@ func toMapping(f flow) *endpointMapping {
 // applyNAT duplicates Nodes in the endpoint topology of a report, based on
 // the NAT table.
 func (n natMapper) applyNAT(rpt report.Report, scope string) {
-	n.flowWalker.walkFlows(func(f flow) {
+	n.flowWalker.walkFlows(func(f flow, alive bool) {
 		mapping := toMapping(f)
 
 		realEndpointPort := strconv.Itoa(mapping.originalPort)

--- a/probe/endpoint/nat_internal_test.go
+++ b/probe/endpoint/nat_internal_test.go
@@ -13,7 +13,7 @@ type mockFlowWalker struct {
 	flows []flow
 }
 
-func (m *mockFlowWalker) walkFlows(f func(flow)) {
+func (m *mockFlowWalker) walkFlows(f func(flow, alive bool)) {
 	for _, flow := range m.flows {
 		f(flow)
 	}

--- a/probe/endpoint/procspy/background_reader_linux.go
+++ b/probe/endpoint/procspy/background_reader_linux.go
@@ -38,6 +38,28 @@ func newBackgroundReader(walker process.Walker) *backgroundReader {
 	return br
 }
 
+func newForegroundReader(walker process.Walker) *backgroundReader {
+	br := &backgroundReader{
+		stopc:         make(chan struct{}),
+		latestSockets: map[uint64]*Proc{},
+	}
+	var (
+		walkc   = make(chan walkResult)
+		ticker  = time.NewTicker(time.Millisecond) // fire every millisecond
+		pWalker = newPidWalker(walker, ticker.C, fdBlockSize)
+	)
+
+	go performWalk(pWalker, walkc)
+
+	result := <-walkc
+	br.mtx.Lock()
+	br.latestBuf = result.buf
+	br.latestSockets = result.sockets
+	br.mtx.Unlock()
+
+	return br
+}
+
 func (br *backgroundReader) stop() {
 	close(br.stopc)
 }

--- a/probe/endpoint/procspy/spy_darwin.go
+++ b/probe/endpoint/procspy/spy_darwin.go
@@ -18,6 +18,11 @@ func NewConnectionScanner(_ process.Walker) ConnectionScanner {
 	return &darwinScanner{}
 }
 
+// NewSyncConnectionScanner creates a new synchronous Darwin ConnectionScanner
+func NewSyncConnectionScanner(_ process.Walker) ConnectionScanner {
+	return &darwinScanner{}
+}
+
 type darwinScanner struct{}
 
 // Connections returns all established (TCP) connections. No need to be root

--- a/probe/endpoint/procspy/spy_linux.go
+++ b/probe/endpoint/procspy/spy_linux.go
@@ -38,6 +38,12 @@ func NewConnectionScanner(walker process.Walker) ConnectionScanner {
 	return &linuxScanner{br}
 }
 
+// NewSyncConnectionScanner creates a new synchronous Linux ConnectionScanner
+func NewSyncConnectionScanner(walker process.Walker) ConnectionScanner {
+	br := newForegroundReader(walker)
+	return &linuxScanner{br}
+}
+
 type linuxScanner struct {
 	br *backgroundReader
 }

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/weaveworks/scope/probe/endpoint/procspy"
 	"github.com/weaveworks/scope/probe/process"
 	"github.com/weaveworks/scope/report"
@@ -183,6 +184,7 @@ func (r *Reporter) Report() (report.Report, error) {
 				fromNodeInfo[process.PID] = strconv.Itoa(e.pid)
 				fromNodeInfo[report.HostNodeID] = hostNodeID
 			}
+			log.Debugf("Report: ebpfTracker %v (%v) (%v)", e.tuple, e.pid, e.incoming)
 
 			if e.incoming {
 				r.addConnection(&rpt, reverse(e.tuple), e.networkNamespace, toNodeInfo, fromNodeInfo)

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -1,10 +1,7 @@
 package endpoint
 
 import (
-	"fmt"
-	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -19,6 +16,7 @@ const (
 	Addr            = "addr" // typically IPv4
 	Port            = "port"
 	Conntracked     = "conntracked"
+	EBPF            = "eBPF"
 	Procspied       = "procspied"
 	ReverseDNSNames = "reverse_dns_names"
 	SnoopedDNSNames = "snooped_dns_names"
@@ -31,6 +29,7 @@ type ReporterConfig struct {
 	SpyProcs     bool
 	UseConntrack bool
 	WalkProc     bool
+	UseEbpfConn  bool
 	ProcRoot     string
 	BufferSize   int
 	Scanner      procspy.ConnectionScanner
@@ -41,6 +40,7 @@ type ReporterConfig struct {
 type Reporter struct {
 	conf            ReporterConfig
 	flowWalker      flowWalker // interface
+	ebpfTracker     eventTracker
 	natMapper       natMapper
 	reverseResolver *reverseResolver
 }
@@ -66,6 +66,7 @@ func NewReporter(conf ReporterConfig) *Reporter {
 	return &Reporter{
 		conf:            conf,
 		flowWalker:      newConntrackFlowWalker(conf.UseConntrack, conf.ProcRoot, conf.BufferSize),
+		ebpfTracker:     newEbpfTracker(conf.UseEbpfConn),
 		natMapper:       makeNATMapper(newConntrackFlowWalker(conf.UseConntrack, conf.ProcRoot, conf.BufferSize, "--any-nat")),
 		reverseResolver: newReverseResolver(),
 	}
@@ -80,27 +81,7 @@ func (r *Reporter) Stop() {
 	r.natMapper.stop()
 	r.reverseResolver.stop()
 	r.conf.Scanner.Stop()
-}
-
-type fourTuple struct {
-	fromAddr, toAddr string
-	fromPort, toPort uint16
-}
-
-// key is a sortable direction-independent key for tuples, used to look up a
-// fourTuple, when you are unsure of it's direction.
-func (t fourTuple) key() string {
-	key := []string{
-		fmt.Sprintf("%s:%d", t.fromAddr, t.fromPort),
-		fmt.Sprintf("%s:%d", t.toAddr, t.toPort),
-	}
-	sort.Strings(key)
-	return strings.Join(key, " ")
-}
-
-// reverse flips the direction of the tuple
-func (t *fourTuple) reverse() {
-	t.fromAddr, t.fromPort, t.toAddr, t.toPort = t.toAddr, t.toPort, t.fromAddr, t.fromPort
+	r.ebpfTracker.stop()
 }
 
 // Report implements Reporter.
@@ -111,10 +92,12 @@ func (r *Reporter) Report() (report.Report, error) {
 
 	hostNodeID := report.MakeHostNodeID(r.conf.HostID)
 	rpt := report.MakeReport()
+
 	seenTuples := map[string]fourTuple{}
 
 	// Consult the flowWalker for short-lived connections
-	{
+	// With eBPF, this is used only in the first round to build seenTuples for WalkProc
+	if r.conf.WalkProc || !r.conf.UseEbpfConn {
 		extraNodeInfo := map[string]string{
 			Conntracked: "true",
 		}
@@ -144,6 +127,7 @@ func (r *Reporter) Report() (report.Report, error) {
 
 	if r.conf.WalkProc {
 		conns, err := r.conf.Scanner.Connections(r.conf.SpyProcs)
+		defer r.procParsingSwitcher()
 		if err != nil {
 			return rpt, err
 		}
@@ -174,11 +158,39 @@ func (r *Reporter) Report() (report.Report, error) {
 			// the direction.
 			canonical, ok := seenTuples[tuple.key()]
 			if (ok && canonical != tuple) || (!ok && tuple.fromPort < tuple.toPort) {
-				tuple.reverse()
-				toNodeInfo, fromNodeInfo = fromNodeInfo, toNodeInfo
+				r.feedToEbpf(tuple, true, int(conn.Proc.PID), namespaceID)
+				r.addConnection(&rpt, reverse(tuple), namespaceID, toNodeInfo, fromNodeInfo)
+			} else {
+				r.feedToEbpf(tuple, false, int(conn.Proc.PID), namespaceID)
+				r.addConnection(&rpt, tuple, namespaceID, fromNodeInfo, toNodeInfo)
 			}
-			r.addConnection(&rpt, tuple, namespaceID, fromNodeInfo, toNodeInfo)
+
 		}
+	}
+
+	// eBPF
+	if r.conf.UseEbpfConn && !r.ebpfTracker.hasDied() {
+		r.ebpfTracker.walkConnections(func(e ebpfConnection) {
+			fromNodeInfo := map[string]string{
+				Procspied: "true",
+				EBPF:      "true",
+			}
+			toNodeInfo := map[string]string{
+				Procspied: "true",
+				EBPF:      "true",
+			}
+			if e.pid > 0 {
+				fromNodeInfo[process.PID] = strconv.Itoa(e.pid)
+				fromNodeInfo[report.HostNodeID] = hostNodeID
+			}
+
+			if e.incoming {
+				r.addConnection(&rpt, reverse(e.tuple), e.networkNamespace, toNodeInfo, fromNodeInfo)
+			} else {
+				r.addConnection(&rpt, e.tuple, e.networkNamespace, fromNodeInfo, toNodeInfo)
+			}
+
+		})
 	}
 
 	r.natMapper.applyNAT(rpt, r.conf.HostID)
@@ -213,4 +225,30 @@ func (r *Reporter) makeEndpointNode(namespaceID string, addr string, port uint16
 
 func newu64(i uint64) *uint64 {
 	return &i
+}
+
+// procParsingSwitcher make sure that if eBPF tracking is enabled,
+// connections coming from /proc parsing are only walked once.
+func (r *Reporter) procParsingSwitcher() {
+	if r.conf.WalkProc && r.conf.UseEbpfConn {
+		r.conf.WalkProc = false
+		r.ebpfTracker.initialize()
+
+		r.flowWalker.stop()
+	}
+}
+
+// if the eBPF tracker is enabled, feed the existing connections into it
+// incoming connections correspond to "accept" events
+// outgoing connections correspond to "connect" events
+func (r Reporter) feedToEbpf(tuple fourTuple, incoming bool, pid int, namespaceID string) {
+	if r.conf.UseEbpfConn && !r.ebpfTracker.isInitialized() {
+		tcpEventType := "connect"
+
+		if incoming {
+			tcpEventType = "accept"
+		}
+
+		r.ebpfTracker.handleConnection(tcpEventType, tuple, pid, namespaceID)
+	}
 }

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -102,12 +102,13 @@ func (r *Reporter) Report() (report.Report, error) {
 		extraNodeInfo := map[string]string{
 			Conntracked: "true",
 		}
-		r.flowWalker.walkFlows(func(f flow) {
+		r.flowWalker.walkFlows(func(f flow, alive bool) {
 			tuple := fourTuple{
 				f.Original.Layer3.SrcIP,
 				f.Original.Layer3.DstIP,
 				uint16(f.Original.Layer4.SrcPort),
 				uint16(f.Original.Layer4.DstPort),
+				alive,
 			}
 			// Handle DNAT-ed short-lived connections.
 			// The NAT mapper won't help since it only runs periodically,
@@ -118,6 +119,7 @@ func (r *Reporter) Report() (report.Report, error) {
 					f.Reply.Layer3.SrcIP,
 					uint16(f.Reply.Layer4.DstPort),
 					uint16(f.Reply.Layer4.SrcPort),
+					alive,
 				}
 			}
 
@@ -140,6 +142,7 @@ func (r *Reporter) Report() (report.Report, error) {
 					conn.RemoteAddress.String(),
 					conn.LocalPort,
 					conn.RemotePort,
+					true,
 				}
 				toNodeInfo   = map[string]string{Procspied: "true"}
 				fromNodeInfo = map[string]string{Procspied: "true"}
@@ -159,10 +162,14 @@ func (r *Reporter) Report() (report.Report, error) {
 			// the direction.
 			canonical, ok := seenTuples[tuple.key()]
 			if (ok && canonical != tuple) || (!ok && tuple.fromPort < tuple.toPort) {
-				r.feedToEbpf(tuple, true, int(conn.Proc.PID), namespaceID)
+				if tuple.alive {
+					r.feedToEbpf(tuple, true, int(conn.Proc.PID), namespaceID)
+				}
 				r.addConnection(&rpt, reverse(tuple), namespaceID, toNodeInfo, fromNodeInfo)
 			} else {
-				r.feedToEbpf(tuple, false, int(conn.Proc.PID), namespaceID)
+				if tuple.alive {
+					r.feedToEbpf(tuple, false, int(conn.Proc.PID), namespaceID)
+				}
 				r.addConnection(&rpt, tuple, namespaceID, fromNodeInfo, toNodeInfo)
 			}
 

--- a/prog/main.go
+++ b/prog/main.go
@@ -97,6 +97,7 @@ type probeFlags struct {
 
 	spyProcs    bool // Associate endpoints with processes (must be root)
 	procEnabled bool // Produce process topology & process nodes in endpoint
+	useEbpfConn bool // Enable connection tracking with eBPF
 	procRoot    string
 
 	dockerEnabled  bool
@@ -276,6 +277,7 @@ func main() {
 	flag.BoolVar(&flags.probe.spyProcs, "probe.proc.spy", true, "associate endpoints with processes (needs root)")
 	flag.StringVar(&flags.probe.procRoot, "probe.proc.root", "/proc", "location of the proc filesystem")
 	flag.BoolVar(&flags.probe.procEnabled, "probe.processes", true, "produce process topology & include procspied connections")
+	flag.BoolVar(&flags.probe.useEbpfConn, "probe.ebpf.connections", false, "enable connection tracking with eBPF")
 
 	// Docker
 	flag.BoolVar(&flags.probe.dockerEnabled, "probe.docker", false, "collect Docker-related attributes for processes")

--- a/scope
+++ b/scope
@@ -160,6 +160,7 @@ launch_command() {
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v /var/run/scope/plugins:/var/run/scope/plugins \
             -v /sys/kernel/debug:/sys/kernel/debug \
+            -v /etc/os-release:/etc/host-os-release \
             -e CHECKPOINT_DISABLE \
             $WEAVESCOPE_DOCKER_ARGS "$SCOPE_IMAGE" --probe.docker=true
 }

--- a/scope
+++ b/scope
@@ -159,6 +159,7 @@ launch_command() {
     echo docker run --privileged -d --name="$SCOPE_CONTAINER_NAME" --net=host --pid=host \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v /var/run/scope/plugins:/var/run/scope/plugins \
+            -v /sys/kernel/debug:/sys/kernel/debug \
             -e CHECKPOINT_DISABLE \
             $WEAVESCOPE_DOCKER_ARGS "$SCOPE_IMAGE" --probe.docker=true
 }

--- a/tools/generate_latest_map
+++ b/tools/generate_latest_map
@@ -38,7 +38,9 @@ function generate_latest_map {
     local empty_latest_map_variable="Empty${latest_map_type}"
     local make_function="Make${latest_map_type}"
 
+    # shellcheck disable=SC2016
     local json_timestamp='`json:"timestamp"`'
+    # shellcheck disable=SC2016
     local json_value='`json:"value"`'
 
     cat << EOF >>"${out_file}"
@@ -168,7 +170,7 @@ outtmp="${out}.tmp"
 
 generate_header "${outtmp}" "${0} ${*}"
 shift
-for t in ${*}; do
+for t in "${@}"; do
     generate_latest_map "${outtmp}" "${t}"
 done
 

--- a/vendor/github.com/kinvolk/gobpf-elf-loader/bpf/bpf.go
+++ b/vendor/github.com/kinvolk/gobpf-elf-loader/bpf/bpf.go
@@ -1,3 +1,5 @@
+//+build linux
+
 package bpf
 
 import (

--- a/vendor/github.com/kinvolk/gobpf-elf-loader/bpf/bpf.go
+++ b/vendor/github.com/kinvolk/gobpf-elf-loader/bpf/bpf.go
@@ -1,0 +1,829 @@
+package bpf
+
+import (
+	"bytes"
+	"debug/elf"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"unsafe"
+)
+
+/*
+#include <sys/types.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+#include <time.h>
+#include <assert.h>
+#include <sys/socket.h>
+#include <linux/unistd.h>
+#include <linux/bpf.h>
+#include <poll.h>
+#include <linux/perf_event.h>
+#include <sys/resource.h>
+
+// from https://github.com/safchain/goebpf
+// Apache License
+
+// bpf map structure used by C program to define maps and
+// used by elf loader.
+typedef struct bpf_map_def {
+  unsigned int type;
+  unsigned int key_size;
+  unsigned int value_size;
+  unsigned int max_entries;
+} bpf_map_def;
+
+typedef struct bpf_map {
+	int         fd;
+	bpf_map_def def;
+} bpf_map;
+
+static __u64 ptr_to_u64(void *ptr)
+{
+	return (__u64) (unsigned long) ptr;
+}
+
+static void bpf_apply_relocation(int fd, struct bpf_insn *insn)
+{
+	insn->src_reg = BPF_PSEUDO_MAP_FD;
+	insn->imm = fd;
+}
+
+static int bpf_create_map(enum bpf_map_type map_type, int key_size,
+	int value_size, int max_entries)
+{
+	int ret;
+	union bpf_attr attr;
+	memset(&attr, 0, sizeof(attr));
+
+	attr.map_type = map_type;
+	attr.key_size = key_size;
+	attr.value_size = value_size;
+	attr.max_entries = max_entries;
+
+	ret = syscall(__NR_bpf, BPF_MAP_CREATE, &attr, sizeof(attr));
+	if (ret < 0 && errno == EPERM) {
+		// When EPERM is returned, two reasons are possible:
+		// 1. user has no permissions for bpf()
+		// 2. user has insufficent rlimit for locked memory
+		// Unfortunately, there is no api to inspect the current usage of locked
+		// mem for the user, so an accurate calculation of how much memory to lock
+		// for this new program is difficult to calculate. As a hack, bump the limit
+		// to unlimited. If program load fails again, return the error.
+
+		struct rlimit rl = {};
+		if (getrlimit(RLIMIT_MEMLOCK, &rl) == 0) {
+			rl.rlim_max = RLIM_INFINITY;
+			rl.rlim_cur = rl.rlim_max;
+			if (setrlimit(RLIMIT_MEMLOCK, &rl) == 0) {
+				ret = syscall(__NR_bpf, BPF_MAP_CREATE, &attr, sizeof(attr));
+			}
+			else {
+				printf("setrlimit() failed with errno=%d\n", errno);
+				return -1;
+			}
+		}
+	}
+
+	return ret;
+}
+
+static bpf_map *bpf_load_map(bpf_map_def *map_def)
+{
+	bpf_map *map;
+
+	map = calloc(1, sizeof(bpf_map));
+	if (map == NULL)
+		return NULL;
+
+	memcpy(&map->def, map_def, sizeof(bpf_map_def));
+
+	map->fd = bpf_create_map(map_def->type,
+		map_def->key_size,
+		map_def->value_size,
+		map_def->max_entries
+	);
+
+	if (map->fd < 0)
+		return 0;
+
+	return map;
+}
+
+static int bpf_prog_load(enum bpf_prog_type prog_type,
+	const struct bpf_insn *insns, int prog_len,
+	const char *license, int kern_version,
+	char *log_buf, int log_size)
+{
+	int ret;
+	union bpf_attr attr;
+	memset(&attr, 0, sizeof(attr));
+
+	attr.prog_type = prog_type;
+	attr.insn_cnt = prog_len / sizeof(struct bpf_insn);
+	attr.insns = ptr_to_u64((void *) insns);
+	attr.license = ptr_to_u64((void *) license);
+	attr.log_buf = ptr_to_u64(log_buf);
+	attr.log_size = log_size;
+	attr.log_level = 1;
+	attr.kern_version = kern_version;
+
+	ret = syscall(__NR_bpf, BPF_PROG_LOAD, &attr, sizeof(attr));
+	if (ret < 0 && errno == EPERM) {
+		// When EPERM is returned, two reasons are possible:
+		// 1. user has no permissions for bpf()
+		// 2. user has insufficent rlimit for locked memory
+		// Unfortunately, there is no api to inspect the current usage of locked
+		// mem for the user, so an accurate calculation of how much memory to lock
+		// for this new program is difficult to calculate. As a hack, bump the limit
+		// to unlimited. If program load fails again, return the error.
+
+		struct rlimit rl = {};
+		if (getrlimit(RLIMIT_MEMLOCK, &rl) == 0) {
+			rl.rlim_max = RLIM_INFINITY;
+			rl.rlim_cur = rl.rlim_max;
+			if (setrlimit(RLIMIT_MEMLOCK, &rl) == 0) {
+				ret = syscall(__NR_bpf, BPF_PROG_LOAD, &attr, sizeof(attr));
+			}
+			else {
+				printf("setrlimit() failed with errno=%d\n", errno);
+				return -1;
+			}
+		}
+	}
+
+	return ret;
+}
+
+static int bpf_update_element(int fd, void *key, void *value, unsigned long long flags)
+{
+	union bpf_attr attr = {
+		.map_fd = fd,
+		.key = ptr_to_u64(key),
+		.value = ptr_to_u64(value),
+		.flags = flags,
+	};
+
+	return syscall(__NR_bpf, BPF_MAP_UPDATE_ELEM, &attr, sizeof(attr));
+}
+
+
+static int perf_event_open_map(int pid, int cpu, int group_fd, unsigned long flags)
+{
+	struct perf_event_attr attr = {0,};
+	attr.type = PERF_TYPE_SOFTWARE;
+	attr.sample_type = PERF_SAMPLE_RAW;
+	attr.wakeup_events = 1;
+
+	attr.size = sizeof(struct perf_event_attr);
+	attr.config = 10; // PERF_COUNT_SW_BPF_OUTPUT
+
+       return syscall(__NR_perf_event_open, &attr, pid, cpu,
+                      group_fd, flags);
+}
+
+static int perf_event_open_tracepoint(int tracepoint_id, int pid, int cpu,
+                           int group_fd, unsigned long flags)
+{
+	struct perf_event_attr attr = {0,};
+	attr.type = PERF_TYPE_TRACEPOINT;
+	attr.sample_type = PERF_SAMPLE_RAW;
+	attr.sample_period = 1;
+	attr.wakeup_events = 1;
+	attr.config = tracepoint_id;
+
+	return syscall(__NR_perf_event_open, &attr, pid, cpu,
+                      group_fd, flags);
+}
+
+#define PAGE_COUNT 8
+
+typedef int (*consume_fn)(void *data, int size, int callbackIndex);
+
+struct perf_event_sample {
+	struct perf_event_header header;
+	__u32 size;
+	char data[];
+};
+
+static int perf_event_read(volatile struct perf_event_mmap_page *header, consume_fn fn, uint64_t callback_data_index)
+{
+	int consumed = 0;
+	int page_size;
+	page_size = getpagesize();
+
+	__u64 data_tail = header->data_tail;
+	__u64 data_head = header->data_head;
+	__u64 buffer_size = PAGE_COUNT * page_size;
+	void *base, *begin, *end;
+	char buf[256];
+
+	asm volatile("" ::: "memory"); // in real code it should be smp_rmb()
+	if (data_head == data_tail)
+		return 0;
+
+	base = ((char *)header) + page_size;
+
+	begin = base + data_tail % buffer_size;
+	end = base + data_head % buffer_size;
+
+	while (begin != end) {
+		struct perf_event_sample *e;
+
+		e = begin;
+		if (begin + e->header.size > base + buffer_size) {
+			long len = base + buffer_size - begin;
+
+			assert(len < e->header.size);
+			memcpy(buf, begin, len);
+			memcpy(buf + len, base, e->header.size - len);
+			e = (void *) buf;
+			begin = base + e->header.size - len;
+		} else if (begin + e->header.size == base + buffer_size) {
+			begin = base;
+		} else {
+			begin += e->header.size;
+		}
+
+		if (e->header.type == PERF_RECORD_SAMPLE) {
+			consumed = fn(e->data, e->size, callback_data_index) || consumed;
+		} else if (e->header.type == PERF_RECORD_LOST) {
+			struct {
+				struct perf_event_header header;
+				__u64 id;
+				__u64 lost;
+			} *lost = (void *) e;
+			printf("lost %lld events\n", lost->lost);
+		} else {
+			printf("unknown event type=%d size=%d\n",
+			       e->header.type, e->header.size);
+		}
+	}
+
+	__sync_synchronize(); // smp_mb()
+	header->data_tail = data_head;
+
+	return consumed;
+}
+
+
+extern int callback_to_go(void *, int, uint64_t);
+*/
+import "C"
+
+type EventCb func([]byte)
+
+var myEventCb EventCb
+
+// BPFMap represents a eBPF map. An eBPF map has to be declared in the C file
+type BPFMap struct {
+	Name       string
+	SectionIdx int
+	Idx        int
+	m          *C.bpf_map
+
+	// only for perf maps
+	pmuFDs  []C.int
+	headers []*C.struct_perf_event_mmap_page
+}
+
+// BPFKProbe represents a kprobe or kretprobe. they have to be declared in the C file
+type BPFKProbe struct {
+	Name string
+	fd   int
+	efd  int
+}
+
+type BPFMapIterator struct {
+	key interface{}
+	m   *BPFMap
+}
+
+type BPFKProbePerf struct {
+	fileName string
+	file     *elf.File
+
+	log    []byte
+	maps   map[string]*BPFMap
+	probes map[string]*BPFKProbe
+}
+
+func NewBpfPerfEvent(fileName string) *BPFKProbePerf {
+	return &BPFKProbePerf{
+		fileName: fileName,
+		maps:     make(map[string]*BPFMap),
+		probes:   make(map[string]*BPFKProbe),
+		log:      make([]byte, 65536),
+	}
+}
+
+// from https://github.com/safchain/goebpf
+// Apache License
+
+func (b *BPFKProbePerf) readLicense() (string, error) {
+	if lsec := b.file.Section("license"); lsec != nil {
+		data, err := lsec.Data()
+		if err != nil {
+			return "", err
+		}
+		return string(data), nil
+	}
+
+	return "", nil
+}
+
+func (b *BPFKProbePerf) readVersion() (int, error) {
+	if vsec := b.file.Section("version"); vsec != nil {
+		data, err := vsec.Data()
+		if err != nil {
+			return 0, err
+		}
+		if len(data) != 4 {
+			return 0, errors.New("version is not a __u32")
+		}
+		version := *(*C.uint32_t)(unsafe.Pointer(&data[0]))
+		if err != nil {
+			return 0, err
+		}
+		return int(version), nil
+	}
+
+	return 0, nil
+}
+
+func (b *BPFKProbePerf) readMaps() error {
+	for sectionIdx, section := range b.file.Sections {
+		if strings.HasPrefix(section.Name, "maps/") {
+			data, err := section.Data()
+			if err != nil {
+				return err
+			}
+
+			name := strings.TrimPrefix(section.Name, "maps/")
+
+			mapCount := len(data) / C.sizeof_struct_bpf_map_def
+			for i := 0; i < mapCount; i++ {
+				pos := i * C.sizeof_struct_bpf_map_def
+				cm := C.bpf_load_map((*C.bpf_map_def)(unsafe.Pointer(&data[pos])))
+				if cm == nil {
+					return fmt.Errorf("Error while loading map %s", section.Name)
+				}
+
+				m := &BPFMap{
+					Name:       name,
+					SectionIdx: sectionIdx,
+					Idx:        i,
+					m:          cm,
+				}
+
+				if oldMap, ok := b.maps[name]; ok {
+					return fmt.Errorf("duplicate map: %q (section %q) and %q (section %q)",
+						oldMap.Name, b.file.Sections[oldMap.SectionIdx].Name,
+						name, section.Name)
+				}
+				b.maps[name] = m
+			}
+		}
+	}
+
+	return nil
+}
+
+func (b *BPFKProbePerf) relocate(data []byte, rdata []byte) error {
+	var symbol elf.Symbol
+	var offset uint64
+
+	symbols, err := b.file.Symbols()
+	if err != nil {
+		return err
+	}
+
+	br := bytes.NewReader(data)
+
+	for {
+		switch b.file.Class {
+		case elf.ELFCLASS64:
+			var rel elf.Rel64
+			err := binary.Read(br, b.file.ByteOrder, &rel)
+			if err != nil {
+				if err == io.EOF {
+					return nil
+				}
+				return err
+			}
+
+			symNo := rel.Info >> 32
+			symbol = symbols[symNo-1]
+
+			offset = rel.Off
+		case elf.ELFCLASS32:
+			var rel elf.Rel32
+			err := binary.Read(br, b.file.ByteOrder, &rel)
+			if err != nil {
+				if err == io.EOF {
+					return nil
+				}
+				return err
+			}
+
+			symNo := rel.Info >> 8
+			symbol = symbols[symNo-1]
+
+			offset = uint64(rel.Off)
+		default:
+			return errors.New("Architecture not supported")
+		}
+
+		rinsn := (*C.struct_bpf_insn)(unsafe.Pointer(&rdata[offset]))
+		if rinsn.code != (C.BPF_LD | C.BPF_IMM | C.BPF_DW) {
+			return errors.New("Invalid relocation")
+		}
+
+		symbolSec := b.file.Sections[symbol.Section]
+		if !strings.HasPrefix(symbolSec.Name, "maps/") {
+			fmt.Printf("https://gist.github.com/alban/161ec3c254f05854aeb3ad90730b3fb5\n")
+			return fmt.Errorf("map location not supported: map %q is in section %q instead of \"maps/%s\"",
+				symbol.Name, symbolSec.Name, symbol.Name)
+		}
+		name := strings.TrimPrefix(symbolSec.Name, "maps/")
+
+		m := b.Map(name)
+		if m == nil {
+			return fmt.Errorf("relocation error, symbol %q not found in section %q",
+				symbol.Name, symbolSec.Name)
+		}
+
+		C.bpf_apply_relocation(m.m.fd, rinsn)
+	}
+}
+
+func (b *BPFKProbePerf) Load() error {
+	fileReader, err := os.Open(b.fileName)
+	if err != nil {
+		return err
+	}
+
+	b.file, err = elf.NewFile(fileReader)
+	if err != nil {
+		return err
+	}
+
+	license, err := b.readLicense()
+	if err != nil {
+		return err
+	}
+
+	lp := unsafe.Pointer(C.CString(license))
+	defer C.free(lp)
+
+	version, err := b.readVersion()
+	if err != nil {
+		return err
+	}
+
+	err = b.readMaps()
+	if err != nil {
+		return err
+	}
+
+	processed := make([]bool, len(b.file.Sections))
+	for i, section := range b.file.Sections {
+		if processed[i] {
+			continue
+		}
+
+		data, err := section.Data()
+		if err != nil {
+			return err
+		}
+
+		if len(data) == 0 {
+			continue
+		}
+
+		if section.Type == elf.SHT_REL {
+			rsection := b.file.Sections[section.Info]
+
+			processed[i] = true
+			processed[section.Info] = true
+
+			secName := rsection.Name
+			isKprobe := strings.HasPrefix(secName, "kprobe/")
+			isKretprobe := strings.HasPrefix(secName, "kretprobe/")
+
+			if isKprobe || isKretprobe {
+				rdata, err := rsection.Data()
+				if err != nil {
+					return err
+				}
+
+				if len(rdata) == 0 {
+					continue
+				}
+
+				err = b.relocate(data, rdata)
+				if err != nil {
+					return err
+				}
+
+				insns := (*C.struct_bpf_insn)(unsafe.Pointer(&rdata[0]))
+
+				progFd := C.bpf_prog_load(C.BPF_PROG_TYPE_KPROBE,
+					insns, C.int(rsection.Size),
+					(*C.char)(lp), C.int(version),
+					(*C.char)(unsafe.Pointer(&b.log[0])), C.int(len(b.log)))
+				if progFd < 0 {
+					return fmt.Errorf("error while loading %q:\n%s", secName, b.log)
+				}
+
+				efd, err := b.EnableKprobe(int(progFd), secName, isKretprobe)
+				if err != nil {
+					return err
+				}
+
+				b.probes[secName] = &BPFKProbe{
+					Name: secName,
+					fd:   int(progFd),
+					efd:  efd,
+				}
+			}
+		}
+	}
+
+	for i, section := range b.file.Sections {
+		if processed[i] {
+			continue
+		}
+
+		if strings.HasPrefix(section.Name, "kprobe/") || strings.HasPrefix(section.Name, "kretprobe/") {
+			data, err := section.Data()
+			if err != nil {
+				panic(err)
+			}
+
+			if len(data) == 0 {
+				continue
+			}
+
+			insns := (*C.struct_bpf_insn)(unsafe.Pointer(&data[0]))
+
+			fd := C.bpf_prog_load(C.BPF_PROG_TYPE_KPROBE,
+				insns, C.int(section.Size),
+				(*C.char)(lp), C.int(version),
+				(*C.char)(unsafe.Pointer(&b.log[0])), C.int(len(b.log)))
+			if fd < 0 {
+				return fmt.Errorf("error while loading %q:\n%s", section.Name, b.log)
+			}
+			b.probes[section.Name] = &BPFKProbe{
+				Name: section.Name,
+				fd:   int(fd),
+			}
+		}
+	}
+
+	for name, _ := range b.maps {
+		var cpu C.int = 0
+
+		for {
+			pmuFD := C.perf_event_open_map(-1 /* pid */, cpu /* cpu */, -1 /* group_fd */, C.PERF_FLAG_FD_CLOEXEC)
+			if pmuFD < 0 {
+				if cpu == 0 {
+					return fmt.Errorf("perf_event_open for map error: %v", err)
+				}
+				break
+			}
+
+			// mmap
+			pageSize := os.Getpagesize()
+			mmapSize := pageSize * (C.PAGE_COUNT + 1)
+
+			base, err := syscall.Mmap(int(pmuFD), 0, mmapSize, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+			if err != nil {
+				return fmt.Errorf("mmap error: %v", err)
+			}
+
+			// enable
+			_, _, err2 := syscall.Syscall(syscall.SYS_IOCTL, uintptr(pmuFD), C.PERF_EVENT_IOC_ENABLE, 0)
+			if err2 != 0 {
+				return fmt.Errorf("error enabling perf event: %v", err2)
+			}
+
+			// assign perf fd tp map
+			ret := C.bpf_update_element(C.int(b.maps[name].m.fd), unsafe.Pointer(&cpu), unsafe.Pointer(&pmuFD), C.BPF_ANY)
+			if ret != 0 {
+				return fmt.Errorf("cannot assign perf fd to map: %d (cpu %d)", syscall.Errno(ret), cpu)
+			}
+
+			b.maps[name].pmuFDs = append(b.maps[name].pmuFDs, pmuFD)
+			b.maps[name].headers = append(b.maps[name].headers, (*C.struct_perf_event_mmap_page)(unsafe.Pointer(&base[0])))
+
+			cpu++
+		}
+	}
+
+	return nil
+}
+
+func (b *BPFKProbePerf) EnableKprobe(progFd int, secName string, isKretprobe bool) (int, error) {
+	var probeType, funcName string
+	if isKretprobe {
+		probeType = "r"
+		funcName = strings.TrimPrefix(secName, "kretprobe/")
+	} else {
+		probeType = "p"
+		funcName = strings.TrimPrefix(secName, "kprobe/")
+	}
+	eventName := probeType + funcName
+
+	kprobeEventsFileName := "/sys/kernel/debug/tracing/kprobe_events"
+	f, err := os.OpenFile(kprobeEventsFileName, os.O_APPEND|os.O_WRONLY, 0666)
+	if err != nil {
+		return 0, fmt.Errorf("cannot open kprobe_events: %v\n", err)
+	}
+	defer f.Close()
+
+	cmd := fmt.Sprintf("%s:%s %s\n", probeType, eventName, funcName)
+	_, err = f.WriteString(cmd)
+	if err != nil {
+		return 0, fmt.Errorf("cannot write %q to kprobe_events: %v\n", cmd, err)
+	}
+
+	kprobeIdFile := fmt.Sprintf("/sys/kernel/debug/tracing/events/kprobes/%s/id", eventName)
+	kprobeIdBytes, err := ioutil.ReadFile(kprobeIdFile)
+	if err != nil {
+		return 0, fmt.Errorf("cannot read kprobe id: %v\n", err)
+	}
+	kprobeId, err := strconv.Atoi(strings.TrimSpace(string(kprobeIdBytes)))
+	if err != nil {
+		return 0, fmt.Errorf("invalid kprobe id): %v\n", err)
+	}
+
+	efd := C.perf_event_open_tracepoint(C.int(kprobeId), -1 /* pid */, 0 /* cpu */, -1 /* group_fd */, C.PERF_FLAG_FD_CLOEXEC)
+	if efd < 0 {
+		return 0, fmt.Errorf("perf_event_open for kprobe error")
+	}
+
+	_, _, err2 := syscall.Syscall(syscall.SYS_IOCTL, uintptr(efd), C.PERF_EVENT_IOC_ENABLE, 0)
+	if err2 != 0 {
+		return 0, fmt.Errorf("error enabling perf event: %v", err2)
+	}
+
+	_, _, err2 = syscall.Syscall(syscall.SYS_IOCTL, uintptr(efd), C.PERF_EVENT_IOC_SET_BPF, uintptr(progFd))
+	if err2 != 0 {
+		return 0, fmt.Errorf("error enabling perf event: %v", err2)
+	}
+	return int(efd), nil
+}
+
+// Map returns the BPFMap for the given name. The name is the name used for
+// the map declaration with the MAP macro is the eBPF C file.
+func (b *BPFKProbePerf) Map(name string) *BPFMap {
+	return b.maps[name]
+}
+
+func perfEventPoll(fds []C.int) error {
+	var pfds []C.struct_pollfd
+
+	for i, _ := range fds {
+		var pfd C.struct_pollfd
+
+		pfd.fd = fds[i]
+		pfd.events = C.POLLIN
+
+		pfds = append(pfds, pfd)
+	}
+	_, err := C.poll(&pfds[0], C.nfds_t(len(fds)), -1)
+	if err != nil {
+		return fmt.Errorf("error polling: %v", err.(syscall.Errno))
+	}
+
+	return nil
+}
+
+// Assume the timestamp is at the beginning of the user struct
+type BytesWithTimestamp [][]byte
+
+func (a BytesWithTimestamp) Len() int      { return len(a) }
+func (a BytesWithTimestamp) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a BytesWithTimestamp) Less(i, j int) bool {
+	return *(*C.uint64_t)(unsafe.Pointer(&a[i][0])) < *(*C.uint64_t)(unsafe.Pointer(&a[j][0]))
+}
+
+type callbackData struct {
+	b            *BPFKProbePerf
+	incoming     BytesWithTimestamp
+	receiverChan chan []byte
+}
+
+var callbackRegister = make(map[uint64]*callbackData)
+var callbackIndex uint64
+var mu sync.Mutex
+
+func registerCallback(data *callbackData) uint64 {
+	mu.Lock()
+	defer mu.Unlock()
+	callbackIndex++
+	for callbackRegister[callbackIndex] != nil {
+		callbackIndex++
+	}
+	callbackRegister[callbackIndex] = data
+	return callbackIndex
+}
+
+func unregisterCallback(i uint64) {
+	mu.Lock()
+	defer mu.Unlock()
+	delete(callbackRegister, i)
+}
+
+// Gateway function as required with CGO Go >= 1.6
+// "If a C-program wants a function pointer, a gateway function has to
+// be written. This is because we can't take the address of a Go
+// function and give that to C-code since the cgo tool will generate a
+// stub in C that should be called."
+//export callback_to_go
+func callback_to_go(data unsafe.Pointer, size C.int, callbackDataIndex C.uint64_t) C.int {
+	callbackData := callbackRegister[uint64(callbackDataIndex)]
+
+	b := C.GoBytes(data, size)
+
+	callbackData.incoming = append(callbackData.incoming, b)
+
+	return 1 // event consumed
+}
+
+// nowNanoseconds returns a time that can be compared to bpf_ktime_get_ns()
+func nowNanoseconds() uint64 {
+	var ts syscall.Timespec
+	syscall.Syscall(syscall.SYS_CLOCK_GETTIME, 1 /* CLOCK_MONOTONIC */, uintptr(unsafe.Pointer(&ts)), 0)
+	sec, nsec := ts.Unix()
+	return 1000*1000*1000*uint64(sec) + uint64(nsec)
+}
+
+func (b *BPFKProbePerf) PollStart(mapName string, receiverChan chan []byte) {
+	callbackData := &callbackData{
+		b:            b,
+		receiverChan: receiverChan,
+	}
+	callbackDataIndex := registerCallback(callbackData)
+
+	if _, ok := b.maps[mapName]; !ok {
+		fmt.Fprintf(os.Stderr, "Cannot find map %q. List of found maps:\n", mapName)
+		for key, _ := range b.maps {
+			fmt.Fprintf(os.Stderr, "%q\n", key)
+		}
+		os.Exit(1)
+	}
+
+	go func() {
+		cpuCount := len(b.maps[mapName].pmuFDs)
+
+		for {
+			perfEventPoll(b.maps[mapName].pmuFDs)
+
+			for {
+				var harvestCount C.int
+				beforeHarvest := nowNanoseconds()
+				for cpu := 0; cpu < cpuCount; cpu++ {
+					harvestCount += C.perf_event_read(b.maps[mapName].headers[cpu],
+						(*[0]byte)(C.callback_to_go),
+						C.uint64_t(callbackDataIndex))
+				}
+
+				sort.Sort(callbackData.incoming)
+
+				for i := 0; i < len(callbackData.incoming); i++ {
+					if *(*uint64)(unsafe.Pointer(&callbackData.incoming[0][0])) > beforeHarvest {
+						// This record has been sent after the beginning of the harvest. Stop
+						// processing here to keep the order. "incoming" is sorted, so the next
+						// elements also must not be processed now.
+						break
+					}
+					receiverChan <- callbackData.incoming[0]
+					// remove first element
+					callbackData.incoming = callbackData.incoming[1:]
+				}
+				if harvestCount == 0 && len(callbackData.incoming) == 0 {
+					break
+				}
+			}
+		}
+	}()
+}
+
+func (b *BPFKProbePerf) PollStop(mapName string) {
+	// TODO
+}

--- a/vendor/github.com/kinvolk/gobpf-elf-loader/bpf/bpf_unsupported.go
+++ b/vendor/github.com/kinvolk/gobpf-elf-loader/bpf/bpf_unsupported.go
@@ -1,0 +1,29 @@
+//+build !linux
+
+package bpf
+
+import (
+	"fmt"
+)
+
+// not supported; dummy struct
+type BPFKProbePerf struct{}
+
+func NewBpfPerfEvent(fileName string) *BPFKProbePerf {
+	// not supported
+	return nil
+}
+
+func (b *BPFKProbePerf) Load() error {
+	return fmt.Errorf("not supported")
+}
+
+func (b *BPFKProbePerf) PollStart(mapName string, receiverChan chan []byte) {
+	// not supported
+	return
+}
+
+func (b *BPFKProbePerf) PollStop(mapName string) {
+	// not supported
+	return
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -995,6 +995,15 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/kinvolk/gobpf-elf-loader/bpf",
+			"repository": "https://github.com/kinvolk/gobpf-elf-loader",
+			"vcs": "git",
+			"revision": "ab0a324d990709a732e56fe11af8daa9fb0ae1f8",
+			"branch": "master",
+			"path": "/bpf",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/kr/pty",
 			"repository": "https://github.com/kr/pty",
 			"vcs": "",

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -987,20 +987,20 @@
 			"branch": "master"
 		},
 		{
+			"importpath": "github.com/kinvolk/gobpf-elf-loader/bpf",
+			"repository": "https://github.com/kinvolk/gobpf-elf-loader",
+			"vcs": "git",
+			"revision": "330e875fea4562210d7fd296bc0f11d90890902c",
+			"branch": "master",
+			"path": "/bpf",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/kr/pretty",
 			"repository": "https://github.com/kr/pretty",
 			"vcs": "git",
 			"revision": "cfb55aafdaf3ec08f0db22699ab822c50091b1c4",
 			"branch": "master",
-			"notests": true
-		},
-		{
-			"importpath": "github.com/kinvolk/gobpf-elf-loader/bpf",
-			"repository": "https://github.com/kinvolk/gobpf-elf-loader",
-			"vcs": "git",
-			"revision": "ab0a324d990709a732e56fe11af8daa9fb0ae1f8",
-			"branch": "master",
-			"path": "/bpf",
 			"notests": true
 		},
 		{


### PR DESCRIPTION
Based on work from Lorenzo, updated by Iago, Alban, and Alessandro

This PR adds connection tracking using eBPF. This feature is not enabled by default.
For now, you can enable it by launching scope with the following command:
```
sudo ./scope launch --probe.ebpf.connections=true
```
Scope Probe also falls back on the old /proc parsing if eBPF is not working
(e.g. too old kernel, or pre-compiled eBPF program missing for the current kernel).
This patch allows scope to get notified of every connection event, without relying
on the parsing of /proc/$pid/net/tcp{,6} and /proc/$pid/fd/*, and therefore
improve performance.

We vendor https://github.com/kinvolk/gobpf-elf-loader in Scope to load and
receive information from the ebpf programs. The Scope build fetches the pre-compiled
ebpf programs from https://hub.docker.com/r/kinvolk/tcptracer-bpf/
(see https://github.com/kinvolk/tcptracer-bpf)

At the moment, the eBPF programs are pre-compiled for:
- Arch 4.8.11-1
- fedora-24
- debian-testing
- coreos

The ebpf programs use kprobes on the following kernel functions:
- tcp_v4_connect
- tcp_v6_connect
- inet_csk_accept
- tcp_close

It generates "connect", "accept" and "close" events containing the
connection tuple but also pid and netns.
Note: the IPv6 events are not plugged in Scope.

probe/endpoint/ebpf.go maintains the list of connections. Similarly to
conntrack, it also keeps the dead connections for one iteration in order
to report short-lived connections.

The code for parsing /proc/$pid/net/tcp{,6} and /proc/$pid/fd/* is still
there and still used at start-up because eBPF only brings us the events
and not the initial state. However, the /proc parsing for the initial
state is now done in foreground instead of background, via newForegroundReader().

NAT resolution on connections from eBPF works in the same way as it did on connections
from /proc: by using conntrack. One of the two conntrack instances was removed since
eBPF detects short-lived connections.

The Scope Docker image size comparison:
- weaveworks/scope in current master:  22 MB (compressed),  68 MB
  (uncompressed)
- weaveworks/scope with this patchset: 24 MB (compressed), 70 MB
  (uncompressed)

Fixes #1168 (walking /proc to obtain connections is very expensive)
Fixes #1260 (Short-lived connections not tracked for containers in
shared networking namespaces)
Fixes #1962 (Port ebpf tracker to Go)
Fixes #1961 (Remove runtime kernel header dependency from ebpf tracker)

Supersedes #2024 