### PR TITLE
Fix grid-mode-selector styling

### DIFF
--- a/client/app/styles/main.less
+++ b/client/app/styles/main.less
@@ -1262,10 +1262,19 @@ h2 {
 
   margin-top: 8px;
   margin-left: 8px;
+  min-width: 161px;
 
   &-wrapper {
     pointer-events: all;
     border-color: @background-darker-secondary-color;
+    overflow: hidden;
+  }
+
+  &:first-child,
+  &:last-child {
+    .grid-mode-selector-action {
+      border-radius: 0;
+    }
   }
 
   &-action {


### PR DESCRIPTION
Fixes #2056.

Nothing else in the header tries to re-size to accommodate  smaller screens, so neither should the graph/table selector. This sets it to a minimum width to prevent the wrapping behavior.

Before:
![screen shot 2016-12-07 at 4 33 10 pm](https://cloud.githubusercontent.com/assets/2802257/20992733/eceded16-bc9a-11e6-84e7-d5aad57fc3d9.png)
After:
![screen shot 2016-12-07 at 4 33 19 pm](https://cloud.githubusercontent.com/assets/2802257/20992740/f36417f6-bc9a-11e6-91b2-76ae68301f7c.png)

@bowenli Could you review pretty please?