### PR TITLE
scope launch script improvements

### DIFF
--- a/scope
+++ b/scope
@@ -171,8 +171,8 @@ launch_docker4mac_app_command() {
 launch() {
     check_not_running "$SCOPE_CONTAINER_NAME" "$SCOPE_IMAGE_NAME"
     docker rm -f "$SCOPE_CONTAINER_NAME" >/dev/null 2>&1 || true
-    CONTAINER=$($(launch_command) "$@")
-    echo "$CONTAINER"
+    $(launch_command) "$@"
+    echo "Scope probe started"
 }
 
 print_app_endpoints() {
@@ -228,8 +228,8 @@ case "$COMMAND" in
             check_not_running "$SCOPE_APP_CONTAINER_NAME" "$SCOPE_IMAGE_NAME"
             check_not_running "$SCOPE_CONTAINER_NAME" "$SCOPE_IMAGE_NAME"
             docker rm -f "$SCOPE_APP_CONTAINER_NAME" >/dev/null 2>&1 || true
-            CONTAINER=$($(launch_docker4mac_app_command) "$@")
-            echo "$CONTAINER"
+            $(launch_docker4mac_app_command) "$@"
+            echo "Scope probe started"
             app_ip=$(docker inspect -f '{{.NetworkSettings.IPAddress}}' "${CONTAINER}")
             docker rm -f "$SCOPE_CONTAINER_NAME" >/dev/null 2>&1 || true
             CONTAINER=$($(launch_command --no-app "$@" "${app_ip}:4040"))

--- a/scope
+++ b/scope
@@ -23,13 +23,14 @@ usage() {
     name=$(basename "$0")
     cat >&2 <<-EOF
 		Usage:
-		$name launch {ARGS} - Launch Scope
-		$name stop          - Stop Scope
-		$name command       - Print the docker command used to start Scope
-		$name help          - Print usage info
-		$name version       - Print version info
+		$name launch {OPTIONS} {PEERS} - Launch Scope
+		$name stop                     - Stop Scope
+		$name command                  - Print the docker command used to start Scope
+		$name help                     - Print usage info
+		$name version                  - Print version info
 
-		Launch arguments:
+		PEERS are of the form HOST[:PORT], and HOST may be an ip or hostname.
+		Launch options:
 	EOF
     docker run --rm -e CHECKPOINT_DISABLE --entrypoint=/home/weave/scope \
         $WEAVESCOPE_DOCKER_ARGS "$SCOPE_IMAGE" -h >&2 ||

--- a/scope
+++ b/scope
@@ -172,8 +172,16 @@ check_docker_version
 
 case "$COMMAND" in
     command)
-	# TODO: properly escape/quote the output of "$@"
-        echo "$(launch_command)" "$@"
+        # Most systems should have printf, but the %q specifier isn't mandated by posix
+        # and can't be guaranteed. Since this is mainly a cosmetic output and the alternative
+        # is not making any attempt to do escaping at all, we might as well try.
+        quoted=$(printf '%q ' "$@" 2>/dev/null || true)
+        # printf %q behaves oddly with zero args (it acts as though it recieved one empty arg)
+        # so we ignore that case.
+        if [ -z "$quoted" ] || [ $# -eq 0 ]; then
+            quoted="$*"
+        fi
+        echo "$(launch_command) $quoted"
         ;;
 
     version)
@@ -245,7 +253,7 @@ EOF
         fi
         if check_docker_for_mac ; then
             if docker inspect "$SCOPE_APP_CONTAINER_NAME" >/dev/null 2>&1 ; then
-		docker stop "$SCOPE_APP_CONTAINER_NAME" >/dev/null
+        docker stop "$SCOPE_APP_CONTAINER_NAME" >/dev/null
             fi
         fi
         ;;

--- a/scope
+++ b/scope
@@ -3,17 +3,6 @@
 set -eu
 
 ARGS="$*"
-
-usage() {
-    echo "Usage:"
-    echo "scope launch [<peer> ...]"
-    echo "scope stop"
-    echo "scope command"
-    echo
-    echo "scope <peer>    is of the form <ip_address_or_fqdn>[:<port>]"
-    exit 1
-}
-
 SCRIPT_VERSION="(unreleased version)"
 if [ "$SCRIPT_VERSION" = "(unreleased version)" ] ; then
     IMAGE_VERSION=latest
@@ -30,7 +19,29 @@ IP_ADDR_CMD="find /sys/class/net -type l | xargs -n1 basename | grep -vE 'docker
     xargs -n1 ip addr show | grep inet | awk '{ print \$2 }' | grep -oE '$IP_REGEXP'"
 WEAVESCOPE_DOCKER_ARGS=${WEAVESCOPE_DOCKER_ARGS:-}
 
-[ $# -gt 0 ] || usage
+usage() {
+    name=$(basename "$0")
+    cat >&2 <<-EOF
+		Usage:
+		$name launch {ARGS} - Launch Scope
+		$name stop          - Stop Scope
+		$name command       - Print the docker command used to start Scope
+		$name help          - Print usage info
+		$name version       - Print version info
+
+		Launch arguments:
+	EOF
+    docker run --rm -e CHECKPOINT_DISABLE --entrypoint=/home/weave/scope \
+        $WEAVESCOPE_DOCKER_ARGS "$SCOPE_IMAGE" -h >&2 ||
+        echo "Error listing launch arguments" >&2
+}
+
+usage_and_die() {
+    usage
+    exit 1
+}
+
+[ $# -gt 0 ] || usage_and_die
 COMMAND=$1
 shift 1
 
@@ -190,23 +201,7 @@ case "$COMMAND" in
         ;;
 
     help)
-        cat >&2 <<EOF
-Usage:
-
-scope help     - Print this
-
-scope launch   - Launch Scope
-EOF
-        docker run --rm -e CHECKPOINT_DISABLE --entrypoint=/home/weave/scope \
-            $WEAVESCOPE_DOCKER_ARGS "$SCOPE_IMAGE" -h
-
-        cat >&2 <<EOF
-
-scope stop     - Stop Scope
-
-scope command  - Print the docker command used to start Scope
-
-EOF
+        usage
         ;;
 
     launch)
@@ -247,7 +242,7 @@ EOF
         ;;
 
     stop)
-        [ $# -eq 0 ] || usage
+        [ $# -eq 0 ] || usage_and_die
         if docker inspect "$SCOPE_CONTAINER_NAME" >/dev/null 2>&1 ; then
            docker stop "$SCOPE_CONTAINER_NAME" >/dev/null
         fi
@@ -260,7 +255,7 @@ EOF
 
     *)
         echo "Unknown scope command '$COMMAND'" >&2
-        usage
+        usage_and_die
         ;;
 
 esac

--- a/scope
+++ b/scope
@@ -36,8 +36,7 @@ usage() {
 		Launch options:
 	EOF
     docker run --rm -e CHECKPOINT_DISABLE --entrypoint=/home/weave/scope \
-        $WEAVESCOPE_DOCKER_ARGS "$SCOPE_IMAGE" -h >&2 ||
-        echo "Error listing launch arguments" >&2
+        $WEAVESCOPE_DOCKER_ARGS "$SCOPE_IMAGE" -h >&2
 }
 
 usage_and_die() {

--- a/scope
+++ b/scope
@@ -29,7 +29,10 @@ usage() {
 		$name help                     - Print usage info
 		$name version                  - Print version info
 
-		PEERS are of the form HOST[:PORT], and HOST may be an ip or hostname.
+		PEERS are of the form HOST[:PORT]
+		HOST may be an ip or hostname.
+		PORT defaults to 4040.
+
 		Launch options:
 	EOF
     docker run --rm -e CHECKPOINT_DISABLE --entrypoint=/home/weave/scope \

--- a/scope
+++ b/scope
@@ -200,7 +200,7 @@ case "$COMMAND" in
             $WEAVESCOPE_DOCKER_ARGS "$SCOPE_IMAGE" --mode=version
         ;;
 
-    help)
+    -h|help|-help|--help)
         usage
         ;;
 

--- a/scope
+++ b/scope
@@ -2,7 +2,7 @@
 
 set -eu
 
-ARGS="$@"
+ARGS="$*"
 
 usage() {
     echo "Usage:"
@@ -18,11 +18,11 @@ SCRIPT_VERSION="(unreleased version)"
 if [ "$SCRIPT_VERSION" = "(unreleased version)" ] ; then
     IMAGE_VERSION=latest
 else
-    IMAGE_VERSION=$SCRIPT_VERSION
+    IMAGE_VERSION="$SCRIPT_VERSION"
 fi
 IMAGE_VERSION=${VERSION:-$IMAGE_VERSION}
 SCOPE_IMAGE_NAME=weaveworks/scope
-SCOPE_IMAGE=$SCOPE_IMAGE_NAME:$IMAGE_VERSION
+SCOPE_IMAGE="$SCOPE_IMAGE_NAME:$IMAGE_VERSION"
 SCOPE_CONTAINER_NAME=weavescope
 SCOPE_APP_CONTAINER_NAME=weavescope-app
 IP_REGEXP="[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}"
@@ -98,7 +98,7 @@ check_docker_for_mac() {
 
 # Check that a container named $1 with image $2 is not running
 check_not_running() {
-    case $(docker inspect --format='{{.State.Running}} {{.Config.Image}}' $1 2>/dev/null) in
+    case $(docker inspect --format='{{.State.Running}} {{.Config.Image}}' "$1" 2>/dev/null) in
         "true $2")
             echo "$1 is already running." >&2
             exit 1
@@ -108,10 +108,10 @@ check_not_running() {
             exit 1
             ;;
         "false $2")
-            docker rm $1 >/dev/null
+            docker rm "$1" >/dev/null
             ;;
         "false $2:"*)
-            docker rm $1 >/dev/null
+            docker rm "$1" >/dev/null
             ;;
         true*)
             echo "Found another running container named '$1'. Aborting." >&2
@@ -135,29 +135,29 @@ create_plugins_dir() {
    # sockets do not cross VM boundaries. We need this directory to exits on the VM.
    docker run --rm --entrypoint=/bin/sh \
             -v /var/run:/var/run \
-            $SCOPE_IMAGE -c "mkdir -p /var/run/scope/plugins"
+            "$SCOPE_IMAGE" -c "mkdir -p /var/run/scope/plugins"
 }
 
 launch_command() {
-    echo docker run --privileged -d --name=$SCOPE_CONTAINER_NAME --net=host --pid=host \
+    echo docker run --privileged -d --name="$SCOPE_CONTAINER_NAME" --net=host --pid=host \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v /var/run/scope/plugins:/var/run/scope/plugins \
             -e CHECKPOINT_DISABLE \
-            $WEAVESCOPE_DOCKER_ARGS $SCOPE_IMAGE --probe.docker=true
+            $WEAVESCOPE_DOCKER_ARGS "$SCOPE_IMAGE" --probe.docker=true
 }
 
 launch_docker4mac_app_command() {
-    echo docker run -d --name=$SCOPE_APP_CONTAINER_NAME \
+    echo docker run -d --name="$SCOPE_APP_CONTAINER_NAME" \
             -e CHECKPOINT_DISABLE \
             -p 0.0.0.0:4040:4040 \
-            $WEAVESCOPE_DOCKER_ARGS $SCOPE_IMAGE --no-probe
+            $WEAVESCOPE_DOCKER_ARGS "$SCOPE_IMAGE" --no-probe
 }
 
 launch() {
-    check_not_running $SCOPE_CONTAINER_NAME $SCOPE_IMAGE_NAME
-    docker rm -f $SCOPE_CONTAINER_NAME >/dev/null 2>&1 || true
+    check_not_running "$SCOPE_CONTAINER_NAME" "$SCOPE_IMAGE_NAME"
+    docker rm -f "$SCOPE_CONTAINER_NAME" >/dev/null 2>&1 || true
     CONTAINER=$($(launch_command) "$@")
-    echo $CONTAINER
+    echo "$CONTAINER"
 }
 
 print_app_endpoints() {
@@ -173,12 +173,12 @@ check_docker_version
 case "$COMMAND" in
     command)
 	# TODO: properly escape/quote the output of "$@"
-        echo $(launch_command) "$@"
+        echo "$(launch_command)" "$@"
         ;;
 
     version)
         docker run --rm -e CHECKPOINT_DISABLE --entrypoint=/home/weave/scope \
-            $WEAVESCOPE_DOCKER_ARGS $SCOPE_IMAGE --mode=version
+            $WEAVESCOPE_DOCKER_ARGS "$SCOPE_IMAGE" --mode=version
         ;;
 
     help)
@@ -190,7 +190,7 @@ scope help     - Print this
 scope launch   - Launch Scope
 EOF
         docker run --rm -e CHECKPOINT_DISABLE --entrypoint=/home/weave/scope \
-            $WEAVESCOPE_DOCKER_ARGS $SCOPE_IMAGE -h
+            $WEAVESCOPE_DOCKER_ARGS "$SCOPE_IMAGE" -h
 
         cat >&2 <<EOF
 
@@ -205,7 +205,7 @@ EOF
         # Do a dry run of scope in the foreground, so it can parse args etc
         # avoiding the entrypoint script in the process.
         docker run --rm -e CHECKPOINT_DISABLE --entrypoint=/home/weave/scope \
-            $WEAVESCOPE_DOCKER_ARGS $SCOPE_IMAGE --dry-run "$@"
+            $WEAVESCOPE_DOCKER_ARGS "$SCOPE_IMAGE" --dry-run "$@"
 
         if check_docker_for_mac ; then
             create_plugins_dir
@@ -218,13 +218,13 @@ EOF
             # access to host ports of the VM.
             # - https://github.com/weaveworks/scope/issues/1411
             # - https://forums.docker.com/t/ports-in-host-network-namespace-are-not-accessible/10789
-            check_not_running $SCOPE_APP_CONTAINER_NAME $SCOPE_IMAGE_NAME
-            check_not_running $SCOPE_CONTAINER_NAME $SCOPE_IMAGE_NAME
-            docker rm -f $SCOPE_APP_CONTAINER_NAME >/dev/null 2>&1 || true
+            check_not_running "$SCOPE_APP_CONTAINER_NAME" "$SCOPE_IMAGE_NAME"
+            check_not_running "$SCOPE_CONTAINER_NAME" "$SCOPE_IMAGE_NAME"
+            docker rm -f "$SCOPE_APP_CONTAINER_NAME" >/dev/null 2>&1 || true
             CONTAINER=$($(launch_docker4mac_app_command) "$@")
-            echo $CONTAINER
+            echo "$CONTAINER"
             app_ip=$(docker inspect -f '{{.NetworkSettings.IPAddress}}' "${CONTAINER}")
-            docker rm -f $SCOPE_CONTAINER_NAME >/dev/null 2>&1 || true
+            docker rm -f "$SCOPE_CONTAINER_NAME" >/dev/null 2>&1 || true
             CONTAINER=$($(launch_command --no-app "$@" "${app_ip}:4040"))
             print_app_endpoints "localhost"
             exit
@@ -232,7 +232,7 @@ EOF
 
         launch "$@"
         if ! check_probe_only ; then
-            IP_ADDRS=$(docker run --rm --net=host --entrypoint /bin/sh $SCOPE_IMAGE -c "$IP_ADDR_CMD")
+            IP_ADDRS=$(docker run --rm --net=host --entrypoint /bin/sh "$SCOPE_IMAGE" -c "$IP_ADDR_CMD")
             print_app_endpoints $IP_ADDRS
         fi
 
@@ -240,12 +240,12 @@ EOF
 
     stop)
         [ $# -eq 0 ] || usage
-        if docker inspect $SCOPE_CONTAINER_NAME >/dev/null 2>&1 ; then
-           docker stop $SCOPE_CONTAINER_NAME >/dev/null
+        if docker inspect "$SCOPE_CONTAINER_NAME" >/dev/null 2>&1 ; then
+           docker stop "$SCOPE_CONTAINER_NAME" >/dev/null
         fi
         if check_docker_for_mac ; then
-            if docker inspect $SCOPE_APP_CONTAINER_NAME >/dev/null 2>&1 ; then
-		docker stop $SCOPE_APP_CONTAINER_NAME >/dev/null
+            if docker inspect "$SCOPE_APP_CONTAINER_NAME" >/dev/null 2>&1 ; then
+		docker stop "$SCOPE_APP_CONTAINER_NAME" >/dev/null
             fi
         fi
         ;;


### PR DESCRIPTION
* fix linter issues
* make some attempt at correct quoting in `scope command` when available
* fix and rewrite usage/help text for clarity and extra info
* don't print container id as it's confusing when presented out of context, and rarely useful

See individual commits for discussion on each point.

Fixes #2073. Fixes #1556. Fixes https://github.com/weaveworks/scope/issues/1557. Fixes https://github.com/weaveworks/scope/issues/1560.