### PR TITLE
Add control status icon to Terminal header

### DIFF
--- a/client/app/scripts/actions/app-actions.js
+++ b/client/app/scripts/actions/app-actions.js
@@ -366,7 +366,8 @@ export function doControl(nodeId, control) {
   return (dispatch) => {
     dispatch({
       type: ActionTypes.DO_CONTROL,
-      nodeId
+      nodeId,
+      control
     });
     doControlRequest(nodeId, control, dispatch);
   };
@@ -590,7 +591,7 @@ export function receiveControlPipeFromParams(pipeId, rawTty, resizeTtyControl) {
   };
 }
 
-export function receiveControlPipe(pipeId, nodeId, rawTty, resizeTtyControl) {
+export function receiveControlPipe(pipeId, nodeId, rawTty, resizeTtyControl, control) {
   return (dispatch, getState) => {
     const state = getState();
     if (state.get('nodeDetails').last()
@@ -610,7 +611,8 @@ export function receiveControlPipe(pipeId, nodeId, rawTty, resizeTtyControl) {
       nodeId,
       pipeId,
       rawTty,
-      resizeTtyControl
+      resizeTtyControl,
+      control
     });
 
     updateRoute(getState);

--- a/client/app/scripts/components/terminal.js
+++ b/client/app/scripts/components/terminal.js
@@ -316,6 +316,7 @@ class Terminal extends React.Component {
           <span title="Close" className="terminal-header-tools-item-icon fa fa-close"
             onClick={this.handleCloseClick} />
         </div>
+        {this.getControlStatusIcon()}
         <span className="terminal-header-title">{this.getTitle()}</span>
       </div>
     );
@@ -382,12 +383,26 @@ class Terminal extends React.Component {
       </div>
     );
   }
+  getControlStatusIcon() {
+    const icon = this.props.controlStatus && this.props.controlStatus.get('control').icon;
+    return (
+      <span
+        style={{marginRight: '8px', width: '14px'}}
+        className={classNames('fa', {[icon]: icon})}
+      />
+    );
+  }
 }
 
+function mapStateToProps(state, ownProps) {
+  const controlStatus = state.get('controlPipes').find((pipe) =>
+    pipe.get('nodeId') === ownProps.pipe.get('nodeId')
+  );
+  return { controlStatus };
+}
 
 Terminal.defaultProps = {
   connect: true
 };
 
-
-export default connect()(Terminal);
+export default connect(mapStateToProps)(Terminal);

--- a/client/app/scripts/reducers/root.js
+++ b/client/app/scripts/reducers/root.js
@@ -469,6 +469,7 @@ export function rootReducer(state = initialState, action) {
         nodeId: action.nodeId,
         raw: action.rawTty,
         resizeTtyControl: action.resizeTtyControl,
+        control: action.control
       }));
     }
 

--- a/client/app/scripts/utils/web-api-utils.js
+++ b/client/app/scripts/utils/web-api-utils.js
@@ -238,7 +238,9 @@ export function doControlRequest(nodeId, control, dispatch) {
             res.pipe,
             nodeId,
             res.raw_tty,
-            resizeTtyControl));
+            resizeTtyControl,
+            control
+          ));
         }
         if (res.removedNode) {
           dispatch(receiveControlNodeRemoved(nodeId));


### PR DESCRIPTION
Implements #1982 

This change will indicate the control status of the terminal. For example, if you are using the `exec` control a terminal icon will appear in the upper left (same for the 'attach' command):
![screen shot 2016-12-12 at 1 49 48 pm](https://cloud.githubusercontent.com/assets/2802257/21118376/779a2094-c072-11e6-89cf-23d64df8d90a.png)

 The icon is tightly coupled to the human name of the controls: "Attach" and "Exec shell". This will break if we ever change those values. If there is a different value to lookup (like an ID) that might be better.

@foot could you review please?
