### PR TITLE
Disable XML in conntrack parsing

### DIFF
--- a/probe/endpoint/conntrack.go
+++ b/probe/endpoint/conntrack.go
@@ -54,10 +54,9 @@ type meta struct {
 
 type flow struct {
 	XMLName xml.Name `xml:"flow"`
-	Metas   []meta   `xml:"meta"`
 	Type    string   `xml:"type,attr"`
 
-	Original, Reply, Independent *meta `xml:"-"`
+	Original, Reply, Independent meta `xml:"-"`
 }
 
 type conntrack struct {
@@ -220,17 +219,6 @@ func (c *conntrackWalker) run() {
 	}
 }
 
-func makeEmptyFlow() flow {
-	var f flow
-	metas := make([]meta, 3)
-	f.Metas = metas
-	// TODO: do we really need the direction/protocol type when not using XML?
-	f.Original = &metas[0]
-	f.Reply = &metas[1]
-	f.Independent = &metas[2]
-	return f
-}
-
 func getUntaggedLine(reader *bufio.Reader) (string, error) {
 	// TODO: read bytes?
 	line, err := reader.ReadString('\n')
@@ -246,9 +234,9 @@ func getUntaggedLine(reader *bufio.Reader) (string, error) {
 
 func decodeStreamedFlow(reader *bufio.Reader) (flow, error) {
 	var (
-		// TODO: use ints where possible?
-		omit [10]string
-		f    = makeEmptyFlow()
+		// TODO: use []byte/int where possible?
+		omit [4]string
+		f    flow
 	)
 
 	// Examples:
@@ -329,7 +317,7 @@ func (c *conntrackWalker) existingConnections() ([]flow, error) {
 	reader := bufio.NewReader(stdout)
 	var result []flow
 	for {
-		f, err := readDumpedFlow(reader)
+		f, err := decodeDumpedFlow(reader)
 		if err != nil {
 			if err == io.EOF {
 				break
@@ -342,11 +330,11 @@ func (c *conntrackWalker) existingConnections() ([]flow, error) {
 	return result, nil
 }
 
-func readDumpedFlow(reader *bufio.Reader) (flow, error) {
+func decodeDumpedFlow(reader *bufio.Reader) (flow, error) {
 	var (
-		// TODO: use byteslices where possible?
-		omit [10]string
-		f    = makeEmptyFlow()
+		// TODO: use int/[]byte where possible?
+		omit [4]string
+		f    flow
 	)
 
 	// Example:

--- a/probe/endpoint/conntrack.go
+++ b/probe/endpoint/conntrack.go
@@ -204,7 +204,7 @@ func (c *conntrackWalker) run() {
 	scanner := bufio.NewScanner(bufio.NewReader(stdout))
 	defer log.Infof("conntrack exiting")
 
-	// Lop on the output stream
+	// Loop on the output stream
 	for {
 		f, err := decodeStreamedFlow(scanner)
 		if err != nil {

--- a/probe/endpoint/conntrack_internal_test.go
+++ b/probe/endpoint/conntrack_internal_test.go
@@ -2,176 +2,192 @@ package endpoint
 
 import (
 	"bufio"
-	"encoding/xml"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/weaveworks/common/exec"
-	testexec "github.com/weaveworks/common/test/exec"
 	"github.com/weaveworks/scope/test"
 )
 
-const conntrackCloseTag = "</conntrack>\n"
-const bufferSize = 1024 * 1024
+// Obtained though conntrack -E -p tcp -o id and then tweaked
+const streamedFlowsSource = `[DESTROY] tcp      6 src=10.0.0.1 dst=127.0.0.1 sport=36826 dport=28106 src=10.0.0.2 dst=127.0.0.2 sport=28107 dport=36826 [ASSURED] id=347275904
+    [NEW] tcp      6 120 SYN_SENT src=10.0.0.1 dst=127.0.0.1 sport=36898 dport=28107 [UNREPLIED] src=10.0.0.2 dst=127.0.0.2 sport=28107 dport=36898 id=347275904
+ [UPDATE] tcp      6 60 SYN_RECV src=10.0.0.1 dst=127.0.0.1 sport=36898 dport=28107 src=10.0.0.2 dst=127.0.0.2 sport=28107 dport=36898 id=347275904
+ [UPDATE] tcp      6 432000 ESTABLISHED src=10.0.0.1 dst=127.0.0.1 sport=36898 dport=28107 src=10.0.0.2 dst=127.0.0.2 sport=28107 dport=36898 [ASSURED] id=347275904`
 
-func makeFlow(ty string) flow {
-	return flow{
-		XMLName: xml.Name{
-			Local: "flow",
+var wantStreamedFlows = []flow{
+	{
+		Type: destroyType,
+		Original: meta{
+			Layer3: layer3{
+				SrcIP: "10.0.0.1",
+				DstIP: "127.0.0.1",
+			},
+			Layer4: layer4{
+				SrcPort: 36826,
+				DstPort: 28106,
+				Proto:   "tcp",
+			},
 		},
-		Type: ty,
+		Reply: meta{
+			Layer3: layer3{
+				SrcIP: "10.0.0.2",
+				DstIP: "127.0.0.2",
+			},
+			Layer4: layer4{
+				SrcPort: 28107,
+				DstPort: 36826,
+				Proto:   "tcp",
+			},
+		},
+		Independent: meta{
+			ID: 347275904,
+		},
+	},
+	{
+		Type: newType,
+		Original: meta{
+			Layer3: layer3{
+				SrcIP: "10.0.0.1",
+				DstIP: "127.0.0.1",
+			},
+			Layer4: layer4{
+				SrcPort: 36898,
+				DstPort: 28107,
+				Proto:   "tcp",
+			},
+		},
+		Reply: meta{
+			Layer3: layer3{
+				SrcIP: "10.0.0.2",
+				DstIP: "127.0.0.2",
+			},
+			Layer4: layer4{
+				SrcPort: 28107,
+				DstPort: 36898,
+				Proto:   "tcp",
+			},
+		},
+		Independent: meta{
+			ID:    347275904,
+			State: "SYN_SENT",
+		},
+	},
+	{
+		Type: updateType,
+		Original: meta{
+			Layer3: layer3{
+				SrcIP: "10.0.0.1",
+				DstIP: "127.0.0.1",
+			},
+			Layer4: layer4{
+				SrcPort: 36898,
+				DstPort: 28107,
+				Proto:   "tcp",
+			},
+		},
+		Reply: meta{
+			Layer3: layer3{
+				SrcIP: "10.0.0.2",
+				DstIP: "127.0.0.2",
+			},
+			Layer4: layer4{
+				SrcPort: 28107,
+				DstPort: 36898,
+				Proto:   "tcp",
+			},
+		},
+		Independent: meta{
+			ID:    347275904,
+			State: "SYN_RECV",
+		},
+	},
+	{
+		Type: updateType,
+		Original: meta{
+			Layer3: layer3{
+				SrcIP: "10.0.0.1",
+				DstIP: "127.0.0.1",
+			},
+			Layer4: layer4{
+				SrcPort: 36898,
+				DstPort: 28107,
+				Proto:   "tcp",
+			},
+		},
+		Reply: meta{
+			Layer3: layer3{
+				SrcIP: "10.0.0.2",
+				DstIP: "127.0.0.2",
+			},
+			Layer4: layer4{
+				SrcPort: 28107,
+				DstPort: 36898,
+				Proto:   "tcp",
+			},
+		},
+		Independent: meta{
+			ID:    347275904,
+			State: "ESTABLISHED",
+		},
+	},
+}
+
+func testFlowDecoding(t *testing.T, source string, want []flow, decoder func(scanner *bufio.Scanner) (flow, error)) {
+	scanner := bufio.NewScanner(strings.NewReader(source))
+	d := time.Millisecond * 100
+	for _, wantFlow := range want {
+		haveFlow, err := decoder(scanner)
+		if err != nil {
+			t.Fatalf("Unexpected decoding error: %v", err)
+		}
+		test.Poll(t, d, wantFlow, func() interface{} { return haveFlow })
+	}
+
+	if _, err := decodeStreamedFlow(scanner); err != io.EOF {
+		t.Fatalf("Unexpected error value on empty input: %v", err)
 	}
 }
 
-func addMeta(f *flow, dir, srcIP, dstIP string, srcPort, dstPort int) *meta {
-	meta := meta{
-		XMLName: xml.Name{
-			Local: "meta",
-		},
-		Direction: dir,
-		Layer3: layer3{
-			XMLName: xml.Name{
-				Local: "layer3",
-			},
-			SrcIP: srcIP,
-			DstIP: dstIP,
-		},
-		Layer4: layer4{
-			XMLName: xml.Name{
-				Local: "layer4",
-			},
-			SrcPort: srcPort,
-			DstPort: dstPort,
-			Proto:   tcpProto,
-		},
-	}
-	f.Metas = append(f.Metas, meta)
-	return &meta
+func TestStreamedFlowDecoding(t *testing.T) {
+	testFlowDecoding(t, streamedFlowsSource, wantStreamedFlows, decodeStreamedFlow)
 }
 
-func addIndependant(f *flow, id int64, state string) *meta {
-	meta := meta{
-		XMLName: xml.Name{
-			Local: "meta",
-		},
-		Direction: "independent",
-		ID:        id,
-		State:     state,
-		Layer3: layer3{
-			XMLName: xml.Name{
-				Local: "layer3",
+// Obtained through conntrack -L -p tcp -o id
+const dumpedFlowsSource = `tcp      6 431998 ESTABLISHED src=10.0.2.2 dst=10.0.2.15 sport=49911 dport=22 src=10.0.2.15 dst=10.0.2.2 sport=22 dport=49911 [ASSURED] mark=0 use=1 id=2993966208`
+
+var wantDumpedFlows = []flow{
+	{
+		Original: meta{
+			Layer3: layer3{
+				SrcIP: "10.0.2.2",
+				DstIP: "10.0.2.15",
+			},
+			Layer4: layer4{
+				SrcPort: 49911,
+				DstPort: 22,
+				Proto:   "tcp",
 			},
 		},
-		Layer4: layer4{
-			XMLName: xml.Name{
-				Local: "layer4",
+		Reply: meta{
+			Layer3: layer3{
+				SrcIP: "10.0.2.15",
+				DstIP: "10.0.2.2",
+			},
+			Layer4: layer4{
+				SrcPort: 22,
+				DstPort: 49911,
+				Proto:   "tcp",
 			},
 		},
-	}
-	f.Metas = append(f.Metas, meta)
-	return &meta
+		Independent: meta{
+			ID:    2993966208,
+			State: "ESTABLISHED",
+		},
+	},
 }
 
-func TestConntracker(t *testing.T) {
-	oldExecCmd, oldIsConntrackSupported := exec.Command, IsConntrackSupported
-	defer func() { exec.Command, IsConntrackSupported = oldExecCmd, oldIsConntrackSupported }()
-
-	IsConntrackSupported = func(_ string) error {
-		return nil
-	}
-
-	first := true
-	existingConnectionsReader, existingConnectionsWriter := io.Pipe()
-	reader, writer := io.Pipe()
-	exec.Command = func(name string, args ...string) exec.Cmd {
-		if first {
-			first = false
-			return testexec.NewMockCmd(existingConnectionsReader)
-		}
-		return testexec.NewMockCmd(reader)
-	}
-
-	flowWalker := newConntrackFlowWalker(true, "", bufferSize)
-	defer flowWalker.stop()
-
-	// First write out some empty xml for the existing connections
-	ecbw := bufio.NewWriter(existingConnectionsWriter)
-	if _, err := ecbw.WriteString(xmlHeader); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := ecbw.WriteString(conntrackOpenTag); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := ecbw.WriteString(conntrackCloseTag); err != nil {
-		t.Fatal(err)
-	}
-	if err := ecbw.Flush(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Then write out eventa
-	bw := bufio.NewWriter(writer)
-	if _, err := bw.WriteString(xmlHeader); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := bw.WriteString(conntrackOpenTag); err != nil {
-		t.Fatal(err)
-	}
-	if err := bw.Flush(); err != nil {
-		t.Fatal(err)
-	}
-
-	have := func() interface{} {
-		result := []flow{}
-		flowWalker.walkFlows(func(f flow) {
-			f.Original = nil
-			f.Reply = nil
-			f.Independent = nil
-			result = append(result, f)
-		})
-		return result
-	}
-	ts := 100 * time.Millisecond
-
-	// First, assert we have no flows
-	test.Poll(t, ts, []flow{}, have)
-
-	// Now add some flows
-	xmlEncoder := xml.NewEncoder(bw)
-	writeFlow := func(f flow) {
-		if err := xmlEncoder.Encode(f); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := bw.WriteString("\n"); err != nil {
-			t.Fatal(err)
-		}
-		if err := bw.Flush(); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	flow1 := makeFlow(updateType)
-	addMeta(&flow1, "original", "1.2.3.4", "2.3.4.5", 2, 3)
-	addIndependant(&flow1, 1, "")
-	writeFlow(flow1)
-	test.Poll(t, ts, []flow{flow1}, have)
-
-	// Now check when we remove the flow, we still get it in the next Walk
-	flow2 := makeFlow(destroyType)
-	addMeta(&flow2, "original", "1.2.3.4", "2.3.4.5", 2, 3)
-	addIndependant(&flow2, 1, "")
-	writeFlow(flow2)
-	test.Poll(t, ts, []flow{flow1}, have)
-	test.Poll(t, ts, []flow{}, have)
-
-	// This time we're not going to remove it, but put it in state TIME_WAIT
-	flow1.Type = updateType
-	writeFlow(flow1)
-	test.Poll(t, ts, []flow{flow1}, have)
-
-	flow1.Metas[1].State = timeWait
-	writeFlow(flow1)
-	test.Poll(t, ts, []flow{flow1}, have)
-	test.Poll(t, ts, []flow{}, have)
+func TestDumpedFlowDecoding(t *testing.T) {
+	testFlowDecoding(t, dumpedFlowsSource, wantDumpedFlows, decodeDumpedFlow)
 }

--- a/probe/endpoint/nat_internal_test.go
+++ b/probe/endpoint/nat_internal_test.go
@@ -29,15 +29,40 @@ func TestNat(t *testing.T) {
 	// correctly.
 	// the setup is this:
 	//
-	// container2 (10.0.47.2:222222), host2 (2.3.4.5:22223) ->
+	// container2 (10.0.47.2:22222), host2 (2.3.4.5:22223) ->
 	//     host1 (1.2.3.4:80), container1 (10.0.47.1:80)
 
 	// from the PoV of host1
 	{
-		f := makeFlow(updateType)
-		addIndependant(&f, 1, "")
-		f.Original = addMeta(&f, "original", "2.3.4.5", "1.2.3.4", 222222, 80)
-		f.Reply = addMeta(&f, "reply", "10.0.47.1", "2.3.4.5", 80, 222222)
+		f := flow{
+			Type: updateType,
+			Original: meta{
+				Layer3: layer3{
+					SrcIP: "2.3.4.5",
+					DstIP: "1.2.3.4",
+				},
+				Layer4: layer4{
+					SrcPort: 22222,
+					DstPort: 80,
+					Proto:   "tcp",
+				},
+			},
+			Reply: meta{
+				Layer3: layer3{
+					SrcIP: "10.0.47.1",
+					DstIP: "2.3.4.5",
+				},
+				Layer4: layer4{
+					SrcPort: 80,
+					DstPort: 22222,
+					Proto:   "tcp",
+				},
+			},
+			Independent: meta{
+				ID: 1,
+			},
+		}
+
 		ct := &mockFlowWalker{
 			flows: []flow{f},
 		}
@@ -69,10 +94,34 @@ func TestNat(t *testing.T) {
 
 	// form the PoV of host2
 	{
-		f := makeFlow(updateType)
-		addIndependant(&f, 2, "")
-		f.Original = addMeta(&f, "original", "10.0.47.2", "1.2.3.4", 22222, 80)
-		f.Reply = addMeta(&f, "reply", "1.2.3.4", "2.3.4.5", 80, 22223)
+		f := flow{
+			Type: updateType,
+			Original: meta{
+				Layer3: layer3{
+					SrcIP: "10.0.47.2",
+					DstIP: "1.2.3.4",
+				},
+				Layer4: layer4{
+					SrcPort: 22222,
+					DstPort: 80,
+					Proto:   "tcp",
+				},
+			},
+			Reply: meta{
+				Layer3: layer3{
+					SrcIP: "1.2.3.4",
+					DstIP: "2.3.4.5",
+				},
+				Layer4: layer4{
+					SrcPort: 80,
+					DstPort: 22223,
+					Proto:   "tcp",
+				},
+			},
+			Independent: meta{
+				ID: 2,
+			},
+		}
 		ct := &mockFlowWalker{
 			flows: []flow{f},
 		}


### PR DESCRIPTION
This attempts to improve the performance problems from #1991 

Parsing the default output of conntrack instead of XML turns out to be more difficult than we thought since some fields are optional and context-based.

I put together this hacky non-optimal parser to see if it's better than XML. If there's a considerable difference I will improve it and write a proper parser, otherwise I may just bite the bullet and fix https://github.com/vishvananda/netlink/issues/171