### PR TITLE
prog/main: use flags.app.port for default target

### DIFF
--- a/prog/main.go
+++ b/prog/main.go
@@ -344,7 +344,7 @@ func main() {
 	flags.probe.noApp = *noApp || *probeOnly
 
 	// Special case for #1191, check listen address is well formed
-	_, _, err := net.SplitHostPort(flags.app.listen)
+	_, port, err := net.SplitHostPort(flags.app.listen)
 	if err != nil {
 		log.Fatalf("Invalid value for -app.http.address: %v", err)
 	}
@@ -365,7 +365,7 @@ func main() {
 				args = append(args, defaultServiceHost)
 			}
 		} else if !flags.probe.noApp {
-			args = append(args, fmt.Sprintf("localhost:%d", xfer.AppPort))
+			args = append(args, fmt.Sprintf("localhost:%s", port))
 		}
 		args = append(args, flag.Args()...)
 		if !dryRun {


### PR DESCRIPTION
User can control the webserver listen address with `-app.http.address`.
If they do, `scope --mode probe ...` should use the port part of address
in the default target and not ':4040'. Otherwise we encounter a
`dial tcp 127.0.0.1:4040: getsockopt: connection refused` error and
`scope-probe` cannot report.

Signed-off-by: Michael Schubert <michael@kinvolk.io>