### PR TITLE
Forward OS/Kernel version to checkpoint

### DIFF
--- a/probe/host/reporter.go
+++ b/probe/host/reporter.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"fmt"
 	"net"
 	"runtime"
 	"sync"
@@ -120,10 +121,11 @@ func (r *Reporter) Report() (report.Report, error) {
 		return rep, err
 	}
 
-	kernel, err := GetKernelVersion()
+	kernelRelease, kernelVersion, err := GetKernelReleaseAndVersion()
 	if err != nil {
 		return rep, err
 	}
+	kernel := fmt.Sprintf("%s %s", kernelRelease, kernelVersion)
 
 	rep.Host = rep.Host.WithMetadataTemplates(MetadataTemplates)
 	rep.Host = rep.Host.WithMetricTemplates(MetricTemplates)

--- a/probe/host/reporter_test.go
+++ b/probe/host/reporter_test.go
@@ -34,22 +34,22 @@ func TestReporter(t *testing.T) {
 	defer mtime.NowReset()
 
 	var (
-		oldGetKernelVersion    = host.GetKernelVersion
-		oldGetLoad             = host.GetLoad
-		oldGetUptime           = host.GetUptime
-		oldGetCPUUsagePercent  = host.GetCPUUsagePercent
-		oldGetMemoryUsageBytes = host.GetMemoryUsageBytes
-		oldGetLocalNetworks    = host.GetLocalNetworks
+		oldGetKernelReleaseAndVersion = host.GetKernelReleaseAndVersion
+		oldGetLoad                    = host.GetLoad
+		oldGetUptime                  = host.GetUptime
+		oldGetCPUUsagePercent         = host.GetCPUUsagePercent
+		oldGetMemoryUsageBytes        = host.GetMemoryUsageBytes
+		oldGetLocalNetworks           = host.GetLocalNetworks
 	)
 	defer func() {
-		host.GetKernelVersion = oldGetKernelVersion
+		host.GetKernelReleaseAndVersion = oldGetKernelReleaseAndVersion
 		host.GetLoad = oldGetLoad
 		host.GetUptime = oldGetUptime
 		host.GetCPUUsagePercent = oldGetCPUUsagePercent
 		host.GetMemoryUsageBytes = oldGetMemoryUsageBytes
 		host.GetLocalNetworks = oldGetLocalNetworks
 	}()
-	host.GetKernelVersion = func() (string, error) { return release + " " + version, nil }
+	host.GetKernelReleaseAndVersion = func() (string, string, error) { return release, version, nil }
 	host.GetLoad = func(time.Time) report.Metrics { return metrics }
 	host.GetUptime = func() (time.Duration, error) { return time.ParseDuration(uptime) }
 	host.GetCPUUsagePercent = func() (float64, float64) { return 30.0, 100.0 }

--- a/probe/host/system_darwin.go
+++ b/probe/host/system_darwin.go
@@ -1,7 +1,7 @@
 package host
 
 import (
-	"fmt"
+	"bytes"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -11,22 +11,23 @@ import (
 )
 
 var (
-	unameRe  = regexp.MustCompile(`Darwin Kernel Version ([0-9\.]+)\:`)
 	loadRe   = regexp.MustCompile(`load averages: ([0-9\.]+) ([0-9\.]+) ([0-9\.]+)`)
 	uptimeRe = regexp.MustCompile(`up ([0-9]+) day[s]*,[ ]+([0-9]+)\:([0-9][0-9])`)
 )
 
-// GetKernelVersion returns the kernel version as reported by uname.
-var GetKernelVersion = func() (string, error) {
-	out, err := exec.Command("uname", "-v").CombinedOutput()
+// GetKernelReleaseAndVersion returns the kernel version as reported by uname.
+var GetKernelReleaseAndVersion = func() (string, string, error) {
+	release, err := exec.Command("uname", "-r").CombinedOutput()
 	if err != nil {
-		return "Darwin unknown", err
+		return "unknown", "unknown", err
 	}
-	matches := unameRe.FindAllStringSubmatch(string(out), -1)
-	if matches == nil || len(matches) < 1 || len(matches[0]) < 1 {
-		return "Darwin unknown", nil
+	release = bytes.Trim(release, " \n")
+	version, err := exec.Command("uname", "-v").CombinedOutput()
+	if err != nil {
+		return string(release), "unknown", err
 	}
-	return fmt.Sprintf("Darwin %s", matches[0][1]), nil
+	version = bytes.Trim(version, " \n")
+	return string(release), string(version), nil
 }
 
 // GetLoad returns the current load averages as metrics.

--- a/probe/host/system_linux.go
+++ b/probe/host/system_linux.go
@@ -19,15 +19,15 @@ const kb = 1024
 // Uname is swappable for mocking in tests.
 var Uname = syscall.Uname
 
-// GetKernelVersion returns the kernel version as reported by uname.
-var GetKernelVersion = func() (string, error) {
+// GetKernelReleaseAndVersion returns the kernel version as reported by uname.
+var GetKernelReleaseAndVersion = func() (string, string, error) {
 	var utsname syscall.Utsname
 	if err := Uname(&utsname); err != nil {
-		return "unknown", err
+		return "unknown", "unknown", err
 	}
 	release := marshal.FromUtsname(utsname.Release)
 	version := marshal.FromUtsname(utsname.Version)
-	return fmt.Sprintf("%s %s", release, version), nil
+	return release, version, nil
 }
 
 // GetLoad returns the current load averages as metrics.

--- a/probe/host/system_linux_test.go
+++ b/probe/host/system_linux_test.go
@@ -22,10 +22,11 @@ func TestUname(t *testing.T) {
 		return nil
 	}
 
-	have, err := host.GetKernelVersion()
+	haveRelease, haveVersion, err := host.GetKernelReleaseAndVersion()
 	if err != nil {
 		t.Fatal(err)
 	}
+	have := fmt.Sprintf("%s %s", haveRelease, haveVersion)
 	if want := fmt.Sprintf("%s %s", release, version); want != have {
 		t.Errorf("want %q, have %q", want, have)
 	}

--- a/probe/host/system_test.go
+++ b/probe/host/system_test.go
@@ -1,6 +1,7 @@
 package host_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -9,10 +10,11 @@ import (
 )
 
 func TestGetKernelVersion(t *testing.T) {
-	have, err := host.GetKernelVersion()
+	release, version, err := host.GetKernelReleaseAndVersion()
 	if err != nil {
 		t.Fatal(err)
 	}
+	have := fmt.Sprintf("%s %s", release, version)
 	if strings.Contains(have, "unknown") {
 		t.Fatal(have)
 	}

--- a/prog/app.go
+++ b/prog/app.go
@@ -246,6 +246,7 @@ func appMain(flags appFlags) {
 	checkpoint.CheckInterval(&checkpoint.CheckParams{
 		Product: "scope-app",
 		Version: app.Version,
+		Flags:   makeBaseCheckpointFlags(),
 	}, versionCheckPeriod, func(r *checkpoint.CheckResponse, err error) {
 		if err != nil {
 			log.Errorf("Error checking version: %v", err)

--- a/prog/main.go
+++ b/prog/main.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/weaveworks/scope/app"
 	"github.com/weaveworks/scope/common/xfer"
 	"github.com/weaveworks/scope/probe/appclient"
+	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/probe/kubernetes"
 	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/weave/common"
@@ -213,6 +215,18 @@ func logCensoredArgs() {
 		prettyPrintedArgs += " " + arg
 	}
 	log.Infof("command line args:%s", prettyPrintedArgs)
+}
+
+func makeBaseCheckpointFlags() map[string]string {
+	release, _, err := host.GetKernelReleaseAndVersion()
+	if err != nil {
+		release = "unknown"
+	}
+	return map[string]string{
+		// Inconsistent key (using a dash) to match Weave Net
+		"kernel-version": release,
+		"os":             runtime.GOOS,
+	}
 }
 
 func main() {

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -91,7 +91,8 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 		hostID   = hostName // TODO(pb): we should sanitize the hostname
 	)
 	log.Infof("probe starting, version %s, ID %s", version, probeID)
-	checkpointFlags := map[string]string{}
+
+	checkpointFlags := makeBaseCheckpointFlags()
 	if flags.kubernetesEnabled {
 		checkpointFlags["kubernetes_enabled"] = "true"
 	}


### PR DESCRIPTION
Useful to prioritize ebpf testing

Also:
* Make treatment of kernel release and version consistent across Darwin/Linux
* ~~Unify extraction of kernel version/release across Linux/Darwin~~ (Can't be done since OSX doesn't provide the `Uname` syscall)

cc @alban 