### PR TITLE
Prioritize ecs topologies on initial load if available

### DIFF
--- a/client/app/scripts/utils/topology-utils.js
+++ b/client/app/scripts/utils/topology-utils.js
@@ -6,6 +6,8 @@ import { Set as makeSet, List as makeList } from 'immutable';
 // top priority first
 //
 const TOPOLOGY_DISPLAY_PRIORITY = [
+  'ecs-services',
+  'ecs-tasks',
   'services',
   'deployments',
   'replica-sets',


### PR DESCRIPTION
Global topo order priority:
 - Check url for topoid
 - Check localStorage for topoid
 - Check topo-utils.js for what to show first!

Fixes #2042 