### PR TITLE
Add support for generic multicolumn tables

### DIFF
--- a/client/app/scripts/components/node-details.js
+++ b/client/app/scripts/components/node-details.js
@@ -11,15 +11,15 @@ import { resetDocumentTitle, setDocumentTitle } from '../utils/title-utils';
 import MatchedText from './matched-text';
 import NodeDetailsControls from './node-details/node-details-controls';
 import NodeDetailsGenericTable from './node-details/node-details-generic-table';
+import NodeDetailsPropertyList from './node-details/node-details-property-list';
 import NodeDetailsHealth from './node-details/node-details-health';
 import NodeDetailsInfo from './node-details/node-details-info';
-import NodeDetailsLabels from './node-details/node-details-labels';
 import NodeDetailsRelatives from './node-details/node-details-relatives';
 import NodeDetailsTable from './node-details/node-details-table';
 import Warning from './warning';
 
 
-const logError = debug('scope:error');
+const log = debug('scope:node-details');
 
 function getTruncationText(count) {
   return 'This section was too long to be handled efficiently and has been truncated'
@@ -213,7 +213,7 @@ class NodeDetails extends React.Component {
               return (
                 <div className="node-details-content-section" key={table.id}>
                   <div className="node-details-content-section-header">
-                    {table.label.length > 0 && table.label}
+                    {table.label && table.label.length > 0 && table.label}
                     {table.truncationCount > 0 && <span
                       className="node-details-content-section-header-warning">
                       <Warning text={getTruncationText(table.truncationCount)} />
@@ -242,14 +242,14 @@ class NodeDetails extends React.Component {
       );
     } else if (isPropertyList(table)) {
       return (
-        <NodeDetailsLabels
+        <NodeDetailsPropertyList
           rows={table.rows} controls={table.controls}
-          matches={nodeMatches.get('labels')}
+          matches={nodeMatches.get('property-lists')}
         />
       );
     }
 
-    logError(`Undefined type '${table.type}' for table ${table.id}`);
+    log(`Undefined type '${table.type}' for table ${table.id}`);
     return null;
   }
 

--- a/client/app/scripts/components/node-details.js
+++ b/client/app/scripts/components/node-details.js
@@ -1,3 +1,4 @@
+import debug from 'debug';
 import React from 'react';
 import { connect } from 'react-redux';
 import { Map as makeMap } from 'immutable';
@@ -8,6 +9,7 @@ import { resetDocumentTitle, setDocumentTitle } from '../utils/title-utils';
 
 import MatchedText from './matched-text';
 import NodeDetailsControls from './node-details/node-details-controls';
+import NodeDetailsGenericTable from './node-details/node-details-generic-table';
 import NodeDetailsHealth from './node-details/node-details-health';
 import NodeDetailsInfo from './node-details/node-details-info';
 import NodeDetailsLabels from './node-details/node-details-labels';
@@ -15,13 +17,18 @@ import NodeDetailsRelatives from './node-details/node-details-relatives';
 import NodeDetailsTable from './node-details/node-details-table';
 import Warning from './warning';
 
+
+const logError = debug('scope:error');
+
 function getTruncationText(count) {
   return 'This section was too long to be handled efficiently and has been truncated'
   + ` (${count} extra entries not included). We are working to remove this limitation.`;
 }
 
-class NodeDetails extends React.Component {
+const TABLE_TYPE_PROPERTY_LIST = 'property-list';
+const TABLE_TYPE_GENERIC = 'multicolumn-table';
 
+class NodeDetails extends React.Component {
   constructor(props, context) {
     super(props, context);
     this.handleClickClose = this.handleClickClose.bind(this);
@@ -214,9 +221,7 @@ class NodeDetails extends React.Component {
                       <Warning text={getTruncationText(table.truncationCount)} />
                     </span>}
                   </div>
-                  <NodeDetailsLabels
-                    rows={table.rows} controls={table.controls}
-                    matches={nodeMatches.get('tables')} />
+                  {this.renderTable(table)}
                 </div>
               );
             }
@@ -225,6 +230,29 @@ class NodeDetails extends React.Component {
         </div>
       </div>
     );
+  }
+
+  renderTable(table) {
+    const { nodeMatches = makeMap() } = this.props;
+    switch (table.type) {
+      case TABLE_TYPE_GENERIC:
+        return (
+          <NodeDetailsGenericTable
+            rows={table.rows} columns={table.columns}
+            matches={nodeMatches.get('tables')}
+          />
+        );
+      case TABLE_TYPE_PROPERTY_LIST:
+        return (
+          <NodeDetailsLabels
+            rows={table.rows} controls={table.controls}
+            matches={nodeMatches.get('tables')}
+          />
+        );
+      default:
+        logError(`Undefined type '${table.type}' for table ${table.id}`);
+        return null;
+    }
   }
 
   componentDidUpdate() {

--- a/client/app/scripts/components/node-details.js
+++ b/client/app/scripts/components/node-details.js
@@ -5,6 +5,7 @@ import { Map as makeMap } from 'immutable';
 
 import { clickCloseDetails, clickShowTopologyForNode } from '../actions/app-actions';
 import { brightenColor, getNeutralColor, getNodeColorDark } from '../utils/color-utils';
+import { isGenericTable, isPropertyList } from '../utils/node-details-utils';
 import { resetDocumentTitle, setDocumentTitle } from '../utils/title-utils';
 
 import MatchedText from './matched-text';
@@ -24,9 +25,6 @@ function getTruncationText(count) {
   return 'This section was too long to be handled efficiently and has been truncated'
   + ` (${count} extra entries not included). We are working to remove this limitation.`;
 }
-
-const TABLE_TYPE_PROPERTY_LIST = 'property-list';
-const TABLE_TYPE_GENERIC = 'multicolumn-table';
 
 class NodeDetails extends React.Component {
   constructor(props, context) {
@@ -215,7 +213,7 @@ class NodeDetails extends React.Component {
               return (
                 <div className="node-details-content-section" key={table.id}>
                   <div className="node-details-content-section-header">
-                    {table.label}
+                    {table.label.length > 0 && table.label}
                     {table.truncationCount > 0 && <span
                       className="node-details-content-section-header-warning">
                       <Warning text={getTruncationText(table.truncationCount)} />
@@ -234,25 +232,25 @@ class NodeDetails extends React.Component {
 
   renderTable(table) {
     const { nodeMatches = makeMap() } = this.props;
-    switch (table.type) {
-      case TABLE_TYPE_GENERIC:
-        return (
-          <NodeDetailsGenericTable
-            rows={table.rows} columns={table.columns}
-            matches={nodeMatches.get('tables')}
-          />
-        );
-      case TABLE_TYPE_PROPERTY_LIST:
-        return (
-          <NodeDetailsLabels
-            rows={table.rows} controls={table.controls}
-            matches={nodeMatches.get('tables')}
-          />
-        );
-      default:
-        logError(`Undefined type '${table.type}' for table ${table.id}`);
-        return null;
+
+    if (isGenericTable(table)) {
+      return (
+        <NodeDetailsGenericTable
+          rows={table.rows} columns={table.columns}
+          matches={nodeMatches.get('tables')}
+        />
+      );
+    } else if (isPropertyList(table)) {
+      return (
+        <NodeDetailsLabels
+          rows={table.rows} controls={table.controls}
+          matches={nodeMatches.get('labels')}
+        />
+      );
     }
+
+    logError(`Undefined type '${table.type}' for table ${table.id}`);
+    return null;
   }
 
   componentDidUpdate() {

--- a/client/app/scripts/components/node-details/node-details-generic-table.js
+++ b/client/app/scripts/components/node-details/node-details-generic-table.js
@@ -1,10 +1,13 @@
 import React from 'react';
+import sortBy from 'lodash/sortBy';
 import { Map as makeMap } from 'immutable';
-import { sortBy } from 'lodash';
 
 import { NODE_DETAILS_DATA_ROWS_DEFAULT_LIMIT } from '../../constants/limits';
+
 import {
-  isNumber, getTableColumnsStyles, genericTableEntryKey
+  isNumber,
+  getTableColumnsStyles,
+  genericTableEntryKey
 } from '../../utils/node-details-utils';
 import NodeDetailsTableHeaders from './node-details-table-headers';
 import MatchedText from '../matched-text';
@@ -31,7 +34,7 @@ export default class NodeDetailsGenericTable extends React.Component {
     super(props, context);
     this.state = {
       limit: NODE_DETAILS_DATA_ROWS_DEFAULT_LIMIT,
-      sortedBy: props.columns[0].id,
+      sortedBy: props.columns && props.columns[0].id,
       sortedDesc: true
     };
     this.handleLimitClick = this.handleLimitClick.bind(this);
@@ -53,8 +56,7 @@ export default class NodeDetailsGenericTable extends React.Component {
     const { columns, matches = makeMap() } = this.props;
     const expanded = this.state.limit === 0;
 
-    // Stabilize the order of rows
-    let rows = sortBy(this.props.rows || [], row => row.id);
+    let rows = this.props.rows || [];
     let notShown = 0;
 
     // If there are rows that would be hidden behind 'show more', keep them

--- a/client/app/scripts/components/node-details/node-details-generic-table.js
+++ b/client/app/scripts/components/node-details/node-details-generic-table.js
@@ -1,0 +1,129 @@
+import React from 'react';
+import { Map as makeMap } from 'immutable';
+import { sortBy } from 'lodash';
+
+import MatchedText from '../matched-text';
+import ShowMore from '../show-more';
+
+
+function columnStyle(column) {
+  return {
+    textAlign: column.dataType === 'number' ? 'right' : 'left',
+    paddingRight: '10px',
+    maxWidth: '140px'
+  };
+}
+
+function sortedRows(rows, sortedByColumn, sortedDesc) {
+  const orderedRows = sortBy(rows, row => row.id);
+  const sorted = sortBy(orderedRows, (row) => {
+    let value = row.entries[sortedByColumn.id];
+    if (sortedByColumn.dataType === 'number') {
+      value = parseFloat(value);
+    }
+    return value;
+  });
+  if (!sortedDesc) {
+    sorted.reverse();
+  }
+  return sorted;
+}
+
+export default class NodeDetailsGenericTable extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+    this.DEFAULT_LIMIT = 5;
+    this.state = {
+      limit: this.DEFAULT_LIMIT,
+      sortedByColumn: props.columns[0],
+      sortedDesc: true
+    };
+    this.handleLimitClick = this.handleLimitClick.bind(this);
+  }
+
+  handleHeaderClick(ev, column) {
+    ev.preventDefault();
+    this.setState({
+      sortedByColumn: column,
+      sortedDesc: this.state.sortedByColumn.id === column.id
+        ? !this.state.sortedDesc : true
+    });
+  }
+
+  handleLimitClick() {
+    const limit = this.state.limit ? 0 : this.DEFAULT_LIMIT;
+    this.setState({limit});
+  }
+
+  render() {
+    const { sortedByColumn, sortedDesc } = this.state;
+    const { columns, matches = makeMap() } = this.props;
+    let rows = this.props.rows;
+    let notShown = 0;
+    const limited = rows && this.state.limit > 0 && rows.length > this.state.limit;
+    const expanded = this.state.limit === 0;
+    if (rows && limited) {
+      const hasNotShownMatch = rows.filter((row, index) => index >= this.state.limit
+        && matches.has(row.id)).length > 0;
+      if (!hasNotShownMatch) {
+        notShown = rows.length - this.DEFAULT_LIMIT;
+        rows = rows.slice(0, this.state.limit);
+      }
+    }
+
+    return (
+      <div className="node-details-generic-table">
+        <table>
+          <thead>
+            <tr>
+              {columns.map((column) => {
+                const onHeaderClick = (ev) => {
+                  this.handleHeaderClick(ev, column);
+                };
+                const isSorted = column.id === this.state.sortedByColumn.id;
+                const isSortedDesc = isSorted && this.state.sortedDesc;
+                const isSortedAsc = isSorted && !isSortedDesc;
+                const style = Object.assign(columnStyle(column), {
+                  cursor: 'pointer',
+                  fontSize: '11px'
+                });
+                return (
+                  <th
+                    className="node-details-generic-table-header"
+                    key={column.id} style={style} onClick={onHeaderClick}>
+                    {isSortedAsc
+                      && <span className="node-details-table-header-sorter fa fa-caret-up" />}
+                    {isSortedDesc
+                      && <span className="node-details-table-header-sorter fa fa-caret-down" />}
+                    {column.label}
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {sortedRows(rows, sortedByColumn, sortedDesc).map(row => (
+              <tr className="node-details-generic-table-row" key={row.id}>
+                {columns.map((column) => {
+                  const value = row.entries[column.id];
+                  const match = matches.get(column.id);
+                  return (
+                    <td
+                      className="node-details-generic-table-field-value truncate"
+                      title={value} key={column.id} style={columnStyle(column)}>
+                      <MatchedText text={value} match={match} />
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <ShowMore
+          handleClick={this.handleLimitClick} collection={this.props.rows}
+          expanded={expanded} notShown={notShown}
+        />
+      </div>
+    );
+  }
+}

--- a/client/app/scripts/components/node-details/node-details-labels.js
+++ b/client/app/scripts/components/node-details/node-details-labels.js
@@ -6,7 +6,6 @@ import MatchedText from '../matched-text';
 import NodeDetailsControlButton from './node-details-control-button';
 import ShowMore from '../show-more';
 
-
 const Controls = controls => (
   <div className="node-details-labels-controls">
     {sortBy(controls, 'rank').map(control => <NodeDetailsControlButton
@@ -52,11 +51,11 @@ export default class NodeDetailsLabels extends React.Component {
           <div className="node-details-labels-field" key={field.id}>
             <div
               className="node-details-labels-field-label truncate"
-              title={field.label} key={field.id}>
-              {field.label}
+              title={field.entries.label} key={field.id}>
+              {field.entries.label}
             </div>
-            <div className="node-details-labels-field-value truncate" title={field.value}>
-              <MatchedText text={field.value} match={matches.get(field.id)} />
+            <div className="node-details-labels-field-value truncate" title={field.entries.value}>
+              <MatchedText text={field.entries.value} match={matches.get(field.id)} />
             </div>
           </div>
         ))}

--- a/client/app/scripts/components/node-details/node-details-labels.js
+++ b/client/app/scripts/components/node-details/node-details-labels.js
@@ -2,8 +2,9 @@ import React from 'react';
 import { Map as makeMap } from 'immutable';
 import sortBy from 'lodash/sortBy';
 
-import MatchedText from '../matched-text';
+import { NODE_DETAILS_DATA_ROWS_DEFAULT_LIMIT } from '../../constants/limits';
 import NodeDetailsControlButton from './node-details-control-button';
+import MatchedText from '../matched-text';
 import ShowMore from '../show-more';
 
 const Controls = controls => (
@@ -17,15 +18,14 @@ export default class NodeDetailsLabels extends React.Component {
 
   constructor(props, context) {
     super(props, context);
-    this.DEFAULT_LIMIT = 5;
     this.state = {
-      limit: this.DEFAULT_LIMIT,
+      limit: NODE_DETAILS_DATA_ROWS_DEFAULT_LIMIT,
     };
     this.handleLimitClick = this.handleLimitClick.bind(this);
   }
 
   handleLimitClick() {
-    const limit = this.state.limit ? 0 : this.DEFAULT_LIMIT;
+    const limit = this.state.limit ? 0 : NODE_DETAILS_DATA_ROWS_DEFAULT_LIMIT;
     this.setState({limit});
   }
 
@@ -39,7 +39,7 @@ export default class NodeDetailsLabels extends React.Component {
       const hasNotShownMatch = rows.filter((row, index) => index >= this.state.limit
         && matches.has(row.id)).length > 0;
       if (!hasNotShownMatch) {
-        notShown = rows.length - this.DEFAULT_LIMIT;
+        notShown = rows.length - NODE_DETAILS_DATA_ROWS_DEFAULT_LIMIT;
         rows = rows.slice(0, this.state.limit);
       }
     }

--- a/client/app/scripts/components/node-details/node-details-property-list.js
+++ b/client/app/scripts/components/node-details/node-details-property-list.js
@@ -8,14 +8,13 @@ import MatchedText from '../matched-text';
 import ShowMore from '../show-more';
 
 const Controls = controls => (
-  <div className="node-details-labels-controls">
+  <div className="node-details-property-list-controls">
     {sortBy(controls, 'rank').map(control => <NodeDetailsControlButton
       nodeId={control.nodeId} control={control} key={control.id} />)}
   </div>
 );
 
-export default class NodeDetailsLabels extends React.Component {
-
+export default class NodeDetailsPropertyList extends React.Component {
   constructor(props, context) {
     super(props, context);
     this.state = {
@@ -45,16 +44,18 @@ export default class NodeDetailsLabels extends React.Component {
     }
 
     return (
-      <div className="node-details-labels">
+      <div className="node-details-property-list">
         {controls && Controls(controls)}
         {rows.map(field => (
-          <div className="node-details-labels-field" key={field.id}>
+          <div className="node-details-property-list-field" key={field.id}>
             <div
-              className="node-details-labels-field-label truncate"
+              className="node-details-property-list-field-label truncate"
               title={field.entries.label} key={field.id}>
               {field.entries.label}
             </div>
-            <div className="node-details-labels-field-value truncate" title={field.entries.value}>
+            <div
+              className="node-details-property-list-field-value truncate"
+              title={field.entries.value}>
               <MatchedText text={field.entries.value} match={matches.get(field.id)} />
             </div>
           </div>

--- a/client/app/scripts/components/node-details/node-details-relatives.js
+++ b/client/app/scripts/components/node-details/node-details-relatives.js
@@ -1,22 +1,22 @@
 import React from 'react';
 import { Map as makeMap } from 'immutable';
 
+import { NODE_DETAILS_DATA_ROWS_DEFAULT_LIMIT } from '../../constants/limits';
 import NodeDetailsRelativesLink from './node-details-relatives-link';
 
 export default class NodeDetailsRelatives extends React.Component {
 
   constructor(props, context) {
     super(props, context);
-    this.DEFAULT_LIMIT = 5;
     this.state = {
-      limit: this.DEFAULT_LIMIT
+      limit: NODE_DETAILS_DATA_ROWS_DEFAULT_LIMIT
     };
     this.handleLimitClick = this.handleLimitClick.bind(this);
   }
 
   handleLimitClick(ev) {
     ev.preventDefault();
-    const limit = this.state.limit ? 0 : this.DEFAULT_LIMIT;
+    const limit = this.state.limit ? 0 : NODE_DETAILS_DATA_ROWS_DEFAULT_LIMIT;
     this.setState({limit});
   }
 
@@ -26,7 +26,7 @@ export default class NodeDetailsRelatives extends React.Component {
 
     const limited = this.state.limit > 0 && relatives.length > this.state.limit;
     const showLimitAction = limited || (this.state.limit === 0
-      && relatives.length > this.DEFAULT_LIMIT);
+      && relatives.length > NODE_DETAILS_DATA_ROWS_DEFAULT_LIMIT);
     const limitActionText = limited ? 'Show more' : 'Show less';
     if (limited) {
       relatives = relatives.slice(0, this.state.limit);

--- a/client/app/scripts/components/node-details/node-details-table-headers.js
+++ b/client/app/scripts/components/node-details/node-details-table-headers.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { defaultSortDesc, getTableColumnsStyles } from '../../utils/node-details-utils';
+import { NODE_DETAILS_TABLE_CW, NODE_DETAILS_TABLE_XS_LABEL } from '../../constants/styles';
+
+
+export default class NodeDetailsTableHeaders extends React.Component {
+  handleClick(ev, headerId, currentSortedBy, currentSortedDesc) {
+    ev.preventDefault();
+    const header = this.props.headers.find(h => h.id === headerId);
+    const sortedBy = header.id;
+    const sortedDesc = sortedBy === currentSortedBy
+      ? !currentSortedDesc : defaultSortDesc(header);
+    this.props.onClick(sortedBy, sortedDesc);
+  }
+
+  render() {
+    const { headers, sortedBy, sortedDesc } = this.props;
+    const colStyles = getTableColumnsStyles(headers);
+    return (
+      <tr>
+        {headers.map((header, index) => {
+          const headerClasses = ['node-details-table-header', 'truncate'];
+          const onClick = (ev) => {
+            this.handleClick(ev, header.id, sortedBy, sortedDesc);
+          };
+          // sort by first metric by default
+          const isSorted = header.id === sortedBy;
+          const isSortedDesc = isSorted && sortedDesc;
+          const isSortedAsc = isSorted && !isSortedDesc;
+
+          if (isSorted) {
+            headerClasses.push('node-details-table-header-sorted');
+          }
+
+          const style = colStyles[index];
+          const label =
+            (style.width === NODE_DETAILS_TABLE_CW.XS && NODE_DETAILS_TABLE_XS_LABEL[header.id]) ?
+            NODE_DETAILS_TABLE_XS_LABEL[header.id] : header.label;
+
+          return (
+            <td
+              className={headerClasses.join(' ')} style={style} onClick={onClick}
+              title={header.label} key={header.id}>
+              {isSortedAsc
+                && <span className="node-details-table-header-sorter fa fa-caret-up" />}
+              {isSortedDesc
+                && <span className="node-details-table-header-sorter fa fa-caret-down" />}
+              {label}
+            </td>
+          );
+        })}
+      </tr>
+    );
+  }
+}

--- a/client/app/scripts/constants/limits.js
+++ b/client/app/scripts/constants/limits.js
@@ -1,0 +1,2 @@
+
+export const NODE_DETAILS_DATA_ROWS_DEFAULT_LIMIT = 5;

--- a/client/app/scripts/constants/styles.js
+++ b/client/app/scripts/constants/styles.js
@@ -26,3 +26,47 @@ export const MIN_NODE_SIZE = 24;
 export const MAX_NODE_SIZE = 96;
 export const BASE_NODE_LABEL_SIZE = 14;
 export const MIN_NODE_LABEL_SIZE = 12;
+
+// Node details table constants
+export const NODE_DETAILS_TABLE_CW = {
+  XS: '32px',
+  S: '50px',
+  M: '70px',
+  L: '85px',
+  XL: '120px',
+  XXL: '140px',
+  XXXL: '170px',
+};
+
+export const NODE_DETAILS_TABLE_COLUMN_WIDTHS = {
+  count: NODE_DETAILS_TABLE_CW.XS,
+  container: NODE_DETAILS_TABLE_CW.XS,
+  docker_container_created: NODE_DETAILS_TABLE_CW.XXXL,
+  docker_container_restart_count: NODE_DETAILS_TABLE_CW.M,
+  docker_container_state_human: NODE_DETAILS_TABLE_CW.XXXL,
+  docker_container_uptime: NODE_DETAILS_TABLE_CW.L,
+  docker_cpu_total_usage: NODE_DETAILS_TABLE_CW.M,
+  docker_memory_usage: NODE_DETAILS_TABLE_CW.M,
+  open_files_count: NODE_DETAILS_TABLE_CW.M,
+  pid: NODE_DETAILS_TABLE_CW.S,
+  port: NODE_DETAILS_TABLE_CW.S,
+  ppid: NODE_DETAILS_TABLE_CW.S,
+  process_cpu_usage_percent: NODE_DETAILS_TABLE_CW.M,
+  process_memory_usage_bytes: NODE_DETAILS_TABLE_CW.M,
+  threads: NODE_DETAILS_TABLE_CW.M,
+
+  // e.g. details panel > pods
+  kubernetes_ip: NODE_DETAILS_TABLE_CW.XL,
+  kubernetes_state: NODE_DETAILS_TABLE_CW.M,
+
+  // weave connections
+  weave_connection_connection: NODE_DETAILS_TABLE_CW.XXL,
+  weave_connection_state: NODE_DETAILS_TABLE_CW.L,
+  weave_connection_info: NODE_DETAILS_TABLE_CW.XL,
+};
+
+export const NODE_DETAILS_TABLE_XS_LABEL = {
+  count: '#',
+  // TODO: consider changing the name of this field on the BE
+  container: '#',
+};

--- a/client/app/scripts/utils/__tests__/search-utils-test.js
+++ b/client/app/scripts/utils/__tests__/search-utils-test.js
@@ -29,17 +29,50 @@ describe('SearchUtils', () => {
         }],
         tables: [{
           id: 'metric1',
+          type: 'property-list',
           rows: [{
+            id: 'label1',
             entries: {
-              id: 'row1',
-              label: 'Row 1',
-              value: 'Row Value 1'
+              label: 'Label 1',
+              value: 'Label Value 1'
             }
           }, {
+            id: 'label2',
             entries: {
-              id: 'row2',
-              label: 'Row 2',
-              value: 'Row Value 2'
+              label: 'Label 2',
+              value: 'Label Value 2'
+            }
+          }]
+        }, {
+          id: 'metric2',
+          type: 'multicolumn-table',
+          columns: [{
+            id: 'a',
+            label: 'A'
+          }, {
+            id: 'c',
+            label: 'C'
+          }],
+          rows: [{
+            id: 'row1',
+            entries: {
+              a: 'xxxa',
+              b: 'yyya',
+              c: 'zzz1'
+            }
+          }, {
+            id: 'row2',
+            entries: {
+              a: 'yyyb',
+              b: 'xxxb',
+              c: 'zzz2'
+            }
+          }, {
+            id: 'row3',
+            entries: {
+              a: 'Value 1',
+              b: 'Value 2',
+              c: 'Value 3'
             }
           }]
         }],
@@ -80,7 +113,7 @@ describe('SearchUtils', () => {
     it('should filter nodes that do not match a pinned searches', () => {
       let nextState = fromJS({
         nodes: nodeSets.someNodes,
-        pinnedSearches: ['row']
+        pinnedSearches: ['Label Value 1']
       });
       nextState = fun(nextState);
       expect(nextState.get('nodes').filter(node => node.get('filtered')).size).toEqual(1);
@@ -244,11 +277,31 @@ describe('SearchUtils', () => {
       expect(matches.getIn(['n1', 'metrics', 'metric1']).metric).toBeTruthy();
     });
 
-    it('should match on a tables field', () => {
+    it('should match on a property list value', () => {
       const nodes = nodeSets.someNodes;
-      const matches = fun(nodes, {query: 'Row Value 1'});
-      expect(matches.size).toEqual(1);
-      expect(matches.getIn(['n2', 'tables', 'row1']).text).toBe('Row Value 1');
+      const matches = fun(nodes, {query: 'Value 1'});
+      expect(matches.size).toEqual(2);
+      expect(matches.getIn(['n2', 'property-lists']).size).toEqual(1);
+      expect(matches.getIn(['n2', 'property-lists', 'label1']).text).toBe('Label Value 1');
+    });
+
+    it('should match on a generic table values', () => {
+      const nodes = nodeSets.someNodes;
+      const matches1 = fun(nodes, {query: 'xx'}).getIn(['n2', 'tables']);
+      const matches2 = fun(nodes, {query: 'yy'}).getIn(['n2', 'tables']);
+      const matches3 = fun(nodes, {query: 'zz'}).getIn(['n2', 'tables']);
+      const matches4 = fun(nodes, {query: 'a'}).getIn(['n2', 'tables']);
+      expect(matches1.size).toEqual(1);
+      expect(matches2.size).toEqual(1);
+      expect(matches3.size).toEqual(2);
+      expect(matches4.size).toEqual(3);
+      expect(matches1.get('row1_a').text).toBe('xxxa');
+      expect(matches2.get('row2_a').text).toBe('yyyb');
+      expect(matches3.get('row1_c').text).toBe('zzz1');
+      expect(matches3.get('row2_c').text).toBe('zzz2');
+      expect(matches4.get('row1_a').text).toBe('xxxa');
+      expect(matches4.get('row3_a').text).toBe('Value 1');
+      expect(matches4.get('row3_c').text).toBe('Value 3');
     });
   });
 

--- a/client/app/scripts/utils/__tests__/search-utils-test.js
+++ b/client/app/scripts/utils/__tests__/search-utils-test.js
@@ -30,9 +30,17 @@ describe('SearchUtils', () => {
         tables: [{
           id: 'metric1',
           rows: [{
-            id: 'row1',
-            label: 'Row 1',
-            value: 'Row Value 1'
+            entries: {
+              id: 'row1',
+              label: 'Row 1',
+              value: 'Row Value 1'
+            }
+          }, {
+            entries: {
+              id: 'row2',
+              label: 'Row 2',
+              value: 'Row Value 2'
+            }
           }]
         }],
       },

--- a/client/app/scripts/utils/node-details-utils.js
+++ b/client/app/scripts/utils/node-details-utils.js
@@ -1,0 +1,36 @@
+import { NODE_DETAILS_TABLE_COLUMN_WIDTHS } from '../constants/styles';
+
+export function isGenericTable(table) {
+  return (table.type || (table.get && table.get('type'))) === 'multicolumn-table';
+}
+
+export function isPropertyList(table) {
+  return (table.type || (table.get && table.get('type'))) === 'property-list';
+}
+
+export function isNumber(data) {
+  return data.dataType && data.dataType === 'number';
+}
+
+export function isIP(data) {
+  return data.dataType && data.dataType === 'ip';
+}
+
+export function genericTableEntryKey(row, column) {
+  const columnId = column.id || column.get('id');
+  const rowId = row.id || row.get('id');
+  return `${rowId}_${columnId}`;
+}
+
+export function defaultSortDesc(header) {
+  return header && isNumber(header);
+}
+
+export function getTableColumnsStyles(headers) {
+  return headers.map(header => ({
+    // More beauty hacking, ports and counts can only get
+    // so big, free up WS for other longer fields like IPs!
+    width: NODE_DETAILS_TABLE_COLUMN_WIDTHS[header.id],
+    textAlign: isNumber(header) ? 'right' : 'left'
+  }));
+}

--- a/client/app/scripts/utils/node-details-utils.js
+++ b/client/app/scripts/utils/node-details-utils.js
@@ -9,11 +9,11 @@ export function isPropertyList(table) {
 }
 
 export function isNumber(data) {
-  return data.dataType && data.dataType === 'number';
+  return data && data.dataType && data.dataType === 'number';
 }
 
 export function isIP(data) {
-  return data.dataType && data.dataType === 'ip';
+  return data && data.dataType && data.dataType === 'ip';
 }
 
 export function genericTableEntryKey(row, column) {

--- a/client/app/scripts/utils/search-utils.js
+++ b/client/app/scripts/utils/search-utils.js
@@ -154,9 +154,10 @@ export function searchTopology(nodes, { prefix, query, metric, comp, value }) {
         tables.forEach((table) => {
           if (table.get('rows')) {
             table.get('rows').forEach((field) => {
+              const entries = field.get('entries');
               const keyPath = [nodeId, 'tables', field.get('id')];
-              nodeMatches = findNodeMatch(nodeMatches, keyPath, field.get('value'),
-                query, prefix, field.get('label'));
+              nodeMatches = findNodeMatch(nodeMatches, keyPath, entries.get('value'),
+                query, prefix, entries.get('label'));
             });
           }
         });

--- a/client/app/scripts/utils/search-utils.js
+++ b/client/app/scripts/utils/search-utils.js
@@ -153,7 +153,7 @@ export function searchTopology(nodes, { prefix, query, metric, comp, value }) {
       (node.get('tables') || []).filter(isPropertyList).forEach((propertyList) => {
         (propertyList.get('rows') || []).forEach((row) => {
           const entries = row.get('entries');
-          const keyPath = [nodeId, 'labels', row.get('id')];
+          const keyPath = [nodeId, 'property-lists', row.get('id')];
           nodeMatches = findNodeMatch(nodeMatches, keyPath, entries.get('value'),
             query, prefix, entries.get('label'));
         });

--- a/client/app/scripts/utils/search-utils.js
+++ b/client/app/scripts/utils/search-utils.js
@@ -1,6 +1,7 @@
 import { Map as makeMap, Set as makeSet, List as makeList } from 'immutable';
 import { escapeRegExp } from 'lodash';
 
+import { isGenericTable, isPropertyList, genericTableEntryKey } from './node-details-utils';
 import { slugify } from './string-utils';
 
 // topolevel search fields
@@ -148,20 +149,26 @@ export function searchTopology(nodes, { prefix, query, metric, comp, value }) {
         });
       }
 
-      // tables (envvars and labels)
-      const tables = node.get('tables');
-      if (tables) {
-        tables.forEach((table) => {
-          if (table.get('rows')) {
-            table.get('rows').forEach((field) => {
-              const entries = field.get('entries');
-              const keyPath = [nodeId, 'tables', field.get('id')];
-              nodeMatches = findNodeMatch(nodeMatches, keyPath, entries.get('value'),
-                query, prefix, entries.get('label'));
-            });
-          }
+      // property lists
+      (node.get('tables') || []).filter(isPropertyList).forEach((propertyList) => {
+        (propertyList.get('rows') || []).forEach((row) => {
+          const entries = row.get('entries');
+          const keyPath = [nodeId, 'labels', row.get('id')];
+          nodeMatches = findNodeMatch(nodeMatches, keyPath, entries.get('value'),
+            query, prefix, entries.get('label'));
         });
-      }
+      });
+
+      // generic tables
+      (node.get('tables') || []).filter(isGenericTable).forEach((table) => {
+        (table.get('rows') || []).forEach((row) => {
+          table.get('columns').forEach((column) => {
+            const val = row.get('entries').get(column.get('id'));
+            const keyPath = [nodeId, 'tables', genericTableEntryKey(row, column)];
+            nodeMatches = findNodeMatch(nodeMatches, keyPath, val, query);
+          });
+        });
+      });
     } else if (metric) {
       const metrics = node.get('metrics');
       if (metrics) {

--- a/client/app/styles/main.less
+++ b/client/app/styles/main.less
@@ -897,6 +897,17 @@ h2 {
     }
   }
 
+  &-generic-table {
+    width: 100%;
+
+    tr {
+      display: flex;
+      th, td {
+        padding: 0 5px;
+      }
+    }
+  }
+
   &-table {
     width: 100%;
     border-spacing: 0;

--- a/client/app/styles/main.less
+++ b/client/app/styles/main.less
@@ -864,7 +864,7 @@ h2 {
     }
   }
 
-  &-labels {
+  &-property-list {
     &-controls {
       margin-left: -4px;
     }

--- a/probe/docker/container.go
+++ b/probe/docker/container.go
@@ -379,8 +379,8 @@ func (c *container) getBaseNode() report.Node {
 	}).WithParents(report.EmptySets.
 		Add(report.ContainerImage, report.MakeStringSet(report.MakeContainerImageNodeID(c.Image()))),
 	)
-	result = result.AddPrefixLabels(LabelPrefix, c.container.Config.Labels)
-	result = result.AddPrefixLabels(EnvPrefix, c.env())
+	result = result.AddPrefixPropertyList(LabelPrefix, c.container.Config.Labels)
+	result = result.AddPrefixPropertyList(EnvPrefix, c.env())
 	return result
 }
 

--- a/probe/docker/container.go
+++ b/probe/docker/container.go
@@ -379,8 +379,8 @@ func (c *container) getBaseNode() report.Node {
 	}).WithParents(report.EmptySets.
 		Add(report.ContainerImage, report.MakeStringSet(report.MakeContainerImageNodeID(c.Image()))),
 	)
-	result = result.AddPrefixTable(LabelPrefix, c.container.Config.Labels)
-	result = result.AddPrefixTable(EnvPrefix, c.env())
+	result = result.AddPrefixLabels(LabelPrefix, c.container.Config.Labels)
+	result = result.AddPrefixLabels(EnvPrefix, c.env())
 	return result
 }
 

--- a/probe/docker/reporter.go
+++ b/probe/docker/reporter.go
@@ -276,7 +276,7 @@ func (r *Reporter) containerImageTopology() report.Topology {
 		}
 		nodeID := report.MakeContainerImageNodeID(imageID)
 		node := report.MakeNodeWith(nodeID, latests)
-		node = node.AddPrefixLabels(ImageLabelPrefix, image.Labels)
+		node = node.AddPrefixPropertyList(ImageLabelPrefix, image.Labels)
 		result.AddNode(node)
 	})
 

--- a/probe/docker/reporter.go
+++ b/probe/docker/reporter.go
@@ -48,7 +48,10 @@ var (
 	}
 
 	ContainerTableTemplates = report.TableTemplates{
-		ImageTableID: {ID: ImageTableID, Label: "Image",
+		ImageTableID: {
+			ID:    ImageTableID,
+			Label: "Image",
+			Type:  report.PropertyListType,
 			FixedRows: map[string]string{
 				ImageID:          "ID",
 				ImageName:        "Name",
@@ -56,12 +59,27 @@ var (
 				ImageVirtualSize: "Virtual Size",
 			},
 		},
-		LabelPrefix: {ID: LabelPrefix, Label: "Docker Labels", Prefix: LabelPrefix},
-		EnvPrefix:   {ID: EnvPrefix, Label: "Environment Variables", Prefix: EnvPrefix},
+		LabelPrefix: {
+			ID:     LabelPrefix,
+			Label:  "Docker Labels",
+			Type:   report.PropertyListType,
+			Prefix: LabelPrefix,
+		},
+		EnvPrefix: {
+			ID:     EnvPrefix,
+			Label:  "Environment Variables",
+			Type:   report.PropertyListType,
+			Prefix: EnvPrefix,
+		},
 	}
 
 	ContainerImageTableTemplates = report.TableTemplates{
-		ImageLabelPrefix: {ID: ImageLabelPrefix, Label: "Docker Labels", Prefix: ImageLabelPrefix},
+		ImageLabelPrefix: {
+			ID:     ImageLabelPrefix,
+			Label:  "Docker Labels",
+			Type:   report.PropertyListType,
+			Prefix: ImageLabelPrefix,
+		},
 	}
 
 	ContainerControls = []report.Control{

--- a/probe/docker/reporter.go
+++ b/probe/docker/reporter.go
@@ -258,7 +258,7 @@ func (r *Reporter) containerImageTopology() report.Topology {
 		}
 		nodeID := report.MakeContainerImageNodeID(imageID)
 		node := report.MakeNodeWith(nodeID, latests)
-		node = node.AddPrefixTable(ImageLabelPrefix, image.Labels)
+		node = node.AddPrefixLabels(ImageLabelPrefix, image.Labels)
 		result.AddNode(node)
 	})
 

--- a/probe/kubernetes/meta.go
+++ b/probe/kubernetes/meta.go
@@ -56,5 +56,5 @@ func (m meta) MetaNode(id string) report.Node {
 		Name:      m.Name(),
 		Namespace: m.Namespace(),
 		Created:   m.Created(),
-	}).AddPrefixTable(LabelPrefix, m.Labels())
+	}).AddPrefixLabels(LabelPrefix, m.Labels())
 }

--- a/probe/kubernetes/meta.go
+++ b/probe/kubernetes/meta.go
@@ -56,5 +56,5 @@ func (m meta) MetaNode(id string) report.Node {
 		Name:      m.Name(),
 		Namespace: m.Namespace(),
 		Created:   m.Created(),
-	}).AddPrefixLabels(LabelPrefix, m.Labels())
+	}).AddPrefixPropertyList(LabelPrefix, m.Labels())
 }

--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -68,7 +68,12 @@ var (
 	ReplicaSetMetricTemplates = PodMetricTemplates
 
 	TableTemplates = report.TableTemplates{
-		LabelPrefix: {ID: LabelPrefix, Label: "Kubernetes Labels", Prefix: LabelPrefix},
+		LabelPrefix: {
+			ID:     LabelPrefix,
+			Label:  "Kubernetes Labels",
+			Type:   report.PropertyListType,
+			Prefix: LabelPrefix,
+		},
 	}
 
 	ScalingControls = []report.Control{

--- a/probe/overlay/weave.go
+++ b/probe/overlay/weave.go
@@ -121,9 +121,23 @@ var (
 		},
 		WeaveConnectionsMulticolumnTablePrefix: {
 			ID:     WeaveConnectionsMulticolumnTablePrefix,
-			Label:  "Connections",
+			Label:  "Connections (new)",
 			Type:   report.MulticolumnTableType,
 			Prefix: WeaveConnectionsMulticolumnTablePrefix,
+			Columns: []report.Column{
+				report.Column{
+					ID:    "ip",
+					Label: "IP",
+				},
+				report.Column{
+					ID:    "state",
+					Label: "State",
+				},
+				report.Column{
+					ID:    "info",
+					Label: "Info",
+				},
+			},
 		},
 	}
 )

--- a/probe/overlay/weave.go
+++ b/probe/overlay/weave.go
@@ -46,6 +46,9 @@ const (
 	WeavePluginTableID                     = "weave_plugin_table"
 	WeavePluginStatus                      = "weave_plugin_status"
 	WeavePluginDriver                      = "weave_plugin_driver"
+	WeaveConnectionsConnection             = "weave_connection_connection"
+	WeaveConnectionsState                  = "weave_connection_state"
+	WeaveConnectionsInfo                   = "weave_connection_info"
 	WeaveConnectionsTablePrefix            = "weave_connections_table_"
 	WeaveConnectionsMulticolumnTablePrefix = "weave_connections_multicolumn_table_"
 )
@@ -115,26 +118,25 @@ var (
 		},
 		WeaveConnectionsTablePrefix: {
 			ID:     WeaveConnectionsTablePrefix,
-			Label:  "Connections",
+			Label:  "Connections (old)",
 			Type:   report.PropertyListType,
 			Prefix: WeaveConnectionsTablePrefix,
 		},
 		WeaveConnectionsMulticolumnTablePrefix: {
 			ID:     WeaveConnectionsMulticolumnTablePrefix,
-			Label:  "Connections (new)",
 			Type:   report.MulticolumnTableType,
 			Prefix: WeaveConnectionsMulticolumnTablePrefix,
 			Columns: []report.Column{
 				report.Column{
-					ID:    "ip",
-					Label: "IP",
+					ID:    WeaveConnectionsConnection,
+					Label: "Connections",
 				},
 				report.Column{
-					ID:    "state",
+					ID:    WeaveConnectionsState,
 					Label: "State",
 				},
 				report.Column{
-					ID:    "info",
+					ID:    WeaveConnectionsInfo,
 					Label: "Info",
 				},
 			},
@@ -488,9 +490,9 @@ func getConnectionsTable(router weave.Router) []report.Row {
 		table = append(table, report.Row{
 			ID: conn.Address,
 			Entries: map[string]string{
-				"ip":    fmt.Sprintf("%s %s", arrow, conn.Address),
-				"state": conn.State,
-				"info":  conn.Info,
+				WeaveConnectionsConnection: fmt.Sprintf("%s %s", arrow, conn.Address),
+				WeaveConnectionsState:      conn.State,
+				WeaveConnectionsInfo:       conn.Info,
 			},
 		})
 	}

--- a/probe/overlay/weave.go
+++ b/probe/overlay/weave.go
@@ -19,34 +19,35 @@ import (
 
 // Keys for use in Node
 const (
-	WeavePeerName               = "weave_peer_name"
-	WeavePeerNickName           = "weave_peer_nick_name"
-	WeaveDNSHostname            = "weave_dns_hostname"
-	WeaveMACAddress             = "weave_mac_address"
-	WeaveVersion                = "weave_version"
-	WeaveEncryption             = "weave_encryption"
-	WeaveProtocol               = "weave_protocol"
-	WeavePeerDiscovery          = "weave_peer_discovery"
-	WeaveTargetCount            = "weave_target_count"
-	WeaveConnectionCount        = "weave_connection_count"
-	WeavePeerCount              = "weave_peer_count"
-	WeaveTrustedSubnets         = "weave_trusted_subnet_count"
-	WeaveIPAMTableID            = "weave_ipam_table"
-	WeaveIPAMStatus             = "weave_ipam_status"
-	WeaveIPAMRange              = "weave_ipam_range"
-	WeaveIPAMDefaultSubnet      = "weave_ipam_default_subnet"
-	WeaveDNSTableID             = "weave_dns_table"
-	WeaveDNSDomain              = "weave_dns_domain"
-	WeaveDNSUpstream            = "weave_dns_upstream"
-	WeaveDNSTTL                 = "weave_dns_ttl"
-	WeaveDNSEntryCount          = "weave_dns_entry_count"
-	WeaveProxyTableID           = "weave_proxy_table"
-	WeaveProxyStatus            = "weave_proxy_status"
-	WeaveProxyAddress           = "weave_proxy_address"
-	WeavePluginTableID          = "weave_plugin_table"
-	WeavePluginStatus           = "weave_plugin_status"
-	WeavePluginDriver           = "weave_plugin_driver"
-	WeaveConnectionsTablePrefix = "weave_connections_table_"
+	WeavePeerName                          = "weave_peer_name"
+	WeavePeerNickName                      = "weave_peer_nick_name"
+	WeaveDNSHostname                       = "weave_dns_hostname"
+	WeaveMACAddress                        = "weave_mac_address"
+	WeaveVersion                           = "weave_version"
+	WeaveEncryption                        = "weave_encryption"
+	WeaveProtocol                          = "weave_protocol"
+	WeavePeerDiscovery                     = "weave_peer_discovery"
+	WeaveTargetCount                       = "weave_target_count"
+	WeaveConnectionCount                   = "weave_connection_count"
+	WeavePeerCount                         = "weave_peer_count"
+	WeaveTrustedSubnets                    = "weave_trusted_subnet_count"
+	WeaveIPAMTableID                       = "weave_ipam_table"
+	WeaveIPAMStatus                        = "weave_ipam_status"
+	WeaveIPAMRange                         = "weave_ipam_range"
+	WeaveIPAMDefaultSubnet                 = "weave_ipam_default_subnet"
+	WeaveDNSTableID                        = "weave_dns_table"
+	WeaveDNSDomain                         = "weave_dns_domain"
+	WeaveDNSUpstream                       = "weave_dns_upstream"
+	WeaveDNSTTL                            = "weave_dns_ttl"
+	WeaveDNSEntryCount                     = "weave_dns_entry_count"
+	WeaveProxyTableID                      = "weave_proxy_table"
+	WeaveProxyStatus                       = "weave_proxy_status"
+	WeaveProxyAddress                      = "weave_proxy_address"
+	WeavePluginTableID                     = "weave_plugin_table"
+	WeavePluginStatus                      = "weave_plugin_status"
+	WeavePluginDriver                      = "weave_plugin_driver"
+	WeaveConnectionsTablePrefix            = "weave_connections_table_"
+	WeaveConnectionsMulticolumnTablePrefix = "weave_connections_multicolumn_table_"
 )
 
 var (
@@ -73,14 +74,20 @@ var (
 	}
 
 	weaveTableTemplates = report.TableTemplates{
-		WeaveIPAMTableID: {ID: WeaveIPAMTableID, Label: "IPAM",
+		WeaveIPAMTableID: {
+			ID:    WeaveIPAMTableID,
+			Label: "IPAM",
+			Type:  report.PropertyListType,
 			FixedRows: map[string]string{
 				WeaveIPAMStatus:        "Status",
 				WeaveIPAMRange:         "Range",
 				WeaveIPAMDefaultSubnet: "Default Subnet",
 			},
 		},
-		WeaveDNSTableID: {ID: WeaveDNSTableID, Label: "DNS",
+		WeaveDNSTableID: {
+			ID:    WeaveDNSTableID,
+			Label: "DNS",
+			Type:  report.PropertyListType,
 			FixedRows: map[string]string{
 				WeaveDNSDomain:     "Domain",
 				WeaveDNSUpstream:   "Upstream",
@@ -88,13 +95,19 @@ var (
 				WeaveDNSEntryCount: "Entries",
 			},
 		},
-		WeaveProxyTableID: {ID: WeaveProxyTableID, Label: "Proxy",
+		WeaveProxyTableID: {
+			ID:    WeaveProxyTableID,
+			Label: "Proxy",
+			Type:  report.PropertyListType,
 			FixedRows: map[string]string{
 				WeaveProxyStatus:  "Status",
 				WeaveProxyAddress: "Address",
 			},
 		},
-		WeavePluginTableID: {ID: WeavePluginTableID, Label: "Plugin",
+		WeavePluginTableID: {
+			ID:    WeavePluginTableID,
+			Label: "Plugin",
+			Type:  report.PropertyListType,
 			FixedRows: map[string]string{
 				WeavePluginStatus: "Status",
 				WeavePluginDriver: "Driver Name",
@@ -103,7 +116,14 @@ var (
 		WeaveConnectionsTablePrefix: {
 			ID:     WeaveConnectionsTablePrefix,
 			Label:  "Connections",
+			Type:   report.PropertyListType,
 			Prefix: WeaveConnectionsTablePrefix,
+		},
+		WeaveConnectionsMulticolumnTablePrefix: {
+			ID:     WeaveConnectionsMulticolumnTablePrefix,
+			Label:  "Connections",
+			Type:   report.MulticolumnTableType,
+			Prefix: WeaveConnectionsMulticolumnTablePrefix,
 		},
 	}
 )
@@ -434,28 +454,31 @@ func (w *Weave) addCurrentPeerInfo(latests map[string]string, node report.Node) 
 		latests[WeavePluginStatus] = "running"
 		latests[WeavePluginDriver] = "weave"
 	}
-	node = node.AddPrefixTable(WeaveConnectionsTablePrefix, getConnectionsTable(w.statusCache.Router))
+	node = node.AddPrefixTable(WeaveConnectionsMulticolumnTablePrefix, getConnectionsTable(w.statusCache.Router))
 	node = node.WithParents(report.EmptySets.Add(report.Host, report.MakeStringSet(w.hostID)))
 
 	return latests, node
 }
 
-func getConnectionsTable(router weave.Router) map[string]string {
+func getConnectionsTable(router weave.Router) []report.Row {
 	const (
 		outboundArrow = "->"
 		inboundArrow  = "<-"
 	)
-	table := make(map[string]string, len(router.Connections))
+	table := make([]report.Row, len(router.Connections))
 	for _, conn := range router.Connections {
 		arrow := inboundArrow
 		if conn.Outbound {
 			arrow = outboundArrow
 		}
-		// TODO: we should probably use a multicolumn table for this
-		//       but there is no mechanism to support it yet.
-		key := fmt.Sprintf("%s %s", arrow, conn.Address)
-		value := fmt.Sprintf("%s, %s", conn.State, conn.Info)
-		table[key] = value
+		table = append(table, report.Row{
+			ID: conn.Address,
+			Entries: map[string]string{
+				"ip":    fmt.Sprintf("%s %s", arrow, conn.Address),
+				"state": conn.State,
+				"info":  conn.Info,
+			},
+		})
 	}
 	return table
 }

--- a/probe/overlay/weave.go
+++ b/probe/overlay/weave.go
@@ -116,30 +116,31 @@ var (
 				WeavePluginDriver: "Driver Name",
 			},
 		},
-		WeaveConnectionsTablePrefix: {
-			ID:     WeaveConnectionsTablePrefix,
-			Label:  "Connections (old)",
-			Type:   report.PropertyListType,
-			Prefix: WeaveConnectionsTablePrefix,
-		},
 		WeaveConnectionsMulticolumnTablePrefix: {
 			ID:     WeaveConnectionsMulticolumnTablePrefix,
 			Type:   report.MulticolumnTableType,
 			Prefix: WeaveConnectionsMulticolumnTablePrefix,
 			Columns: []report.Column{
-				report.Column{
+				{
 					ID:    WeaveConnectionsConnection,
 					Label: "Connections",
 				},
-				report.Column{
+				{
 					ID:    WeaveConnectionsState,
 					Label: "State",
 				},
-				report.Column{
+				{
 					ID:    WeaveConnectionsInfo,
 					Label: "Info",
 				},
 			},
+		},
+		// Kept for backward-compatibility.
+		WeaveConnectionsTablePrefix: {
+			ID:     WeaveConnectionsTablePrefix,
+			Label:  "Connections",
+			Type:   report.PropertyListType,
+			Prefix: WeaveConnectionsTablePrefix,
 		},
 	}
 )
@@ -470,7 +471,7 @@ func (w *Weave) addCurrentPeerInfo(latests map[string]string, node report.Node) 
 		latests[WeavePluginStatus] = "running"
 		latests[WeavePluginDriver] = "weave"
 	}
-	node = node.AddPrefixTable(WeaveConnectionsMulticolumnTablePrefix, getConnectionsTable(w.statusCache.Router))
+	node = node.AddPrefixMulticolumnTable(WeaveConnectionsMulticolumnTablePrefix, getConnectionsTable(w.statusCache.Router))
 	node = node.WithParents(report.EmptySets.Add(report.Host, report.MakeStringSet(w.hostID)))
 
 	return latests, node

--- a/render/detailed/tables_test.go
+++ b/render/detailed/tables_test.go
@@ -35,23 +35,25 @@ func TestNodeTables(t *testing.T) {
 				{
 					ID:    docker.EnvPrefix,
 					Label: "Environment Variables",
-					Rows:  []report.MetadataRow{},
+					Rows:  []report.Row{},
 				},
 				{
 					ID:    docker.LabelPrefix,
 					Label: "Docker Labels",
-					Rows: []report.MetadataRow{
+					Rows: []report.Row{
 						{
-							ID:    "label_label1",
-							Label: "label1",
-							Value: "label1value",
+							Entries: map[string]string{
+								"id":    "label_label1",
+								"label": "label1",
+								"value": "label1value",
+							},
 						},
 					},
 				},
 				{
 					ID:    docker.ImageTableID,
 					Label: "Image",
-					Rows:  []report.MetadataRow{},
+					Rows:  []report.Row{},
 				},
 			},
 		},

--- a/render/detailed/tables_test.go
+++ b/render/detailed/tables_test.go
@@ -34,16 +34,18 @@ func TestNodeTables(t *testing.T) {
 			want: []report.Table{
 				{
 					ID:    docker.EnvPrefix,
+					Type:  report.PropertyListType,
 					Label: "Environment Variables",
 					Rows:  []report.Row{},
 				},
 				{
 					ID:    docker.LabelPrefix,
+					Type:  report.PropertyListType,
 					Label: "Docker Labels",
 					Rows: []report.Row{
 						{
+							ID: "label_label1",
 							Entries: map[string]string{
-								"id":    "label_label1",
 								"label": "label1",
 								"value": "label1value",
 							},
@@ -52,6 +54,7 @@ func TestNodeTables(t *testing.T) {
 				},
 				{
 					ID:    docker.ImageTableID,
+					Type:  report.PropertyListType,
 					Label: "Image",
 					Rows:  []report.Row{},
 				},

--- a/report/table.go
+++ b/report/table.go
@@ -13,98 +13,135 @@ import (
 // MaxTableRows sets the limit on the table size to render
 // TODO: this won't be needed once we send reports incrementally
 const (
-	MaxTableRows          = 20
-	TruncationCountPrefix = "table_truncation_count_"
-	MulticolumnTableType  = "multicolumn-table"
-	PropertyListType      = "property-list"
+	MaxTableRows           = 20
+	TableEntryKeySeparator = "___"
+	TruncationCountPrefix  = "table_truncation_count_"
+	MulticolumnTableType   = "multicolumn-table"
+	PropertyListType       = "property-list"
 )
 
-// AddPrefixTable appends arbitrary rows to the Node, returning a new node.
-func (node Node) AddPrefixTable(prefix string, rows []Row) Node {
-	count := 0
+// WithTableTruncationInformation appends table truncation info to the node, returning the new node.
+func (node Node) WithTableTruncationInformation(prefix string, totalRowsCount int) Node {
+	if totalRowsCount > MaxTableRows {
+		truncationCount := fmt.Sprintf("%d", totalRowsCount-MaxTableRows)
+		node = node.WithLatest(TruncationCountPrefix+prefix, mtime.Now(), truncationCount)
+	}
+	return node
+}
+
+// AddPrefixMulticolumnTable appends arbitrary rows to the Node, returning a new node.
+func (node Node) AddPrefixMulticolumnTable(prefix string, rows []Row) Node {
+	addedRowsCount := 0
 	for _, row := range rows {
-		if count >= MaxTableRows {
+		if addedRowsCount >= MaxTableRows {
 			break
 		}
-		// TODO: Figure a more natural way of storing rows
-		for column, value := range row.Entries {
-			key := fmt.Sprintf("%s %s", row.ID, column)
+		// Add all the row values as separate entries
+		for columnID, value := range row.Entries {
+			key := strings.Join([]string{row.ID, columnID}, TableEntryKeySeparator)
 			node = node.WithLatest(prefix+key, mtime.Now(), value)
 		}
-		count++
+		addedRowsCount++
 	}
-	if len(rows) > MaxTableRows {
-		truncationCount := fmt.Sprintf("%d", len(rows)-MaxTableRows)
-		node = node.WithLatest(TruncationCountPrefix+prefix, mtime.Now(), truncationCount)
-	}
-	return node
+	return node.WithTableTruncationInformation(prefix, len(rows))
 }
 
-// AddPrefixLabels appends arbitrary key-value pairs to the Node, returning a new node.
-func (node Node) AddPrefixLabels(prefix string, labels map[string]string) Node {
-	count := 0
-	for key, value := range labels {
-		if count >= MaxTableRows {
+// AddPrefixPropertyList appends arbitrary key-value pairs to the Node, returning a new node.
+func (node Node) AddPrefixPropertyList(prefix string, propertyList map[string]string) Node {
+	addedPropertiesCount := 0
+	for label, value := range propertyList {
+		if addedPropertiesCount >= MaxTableRows {
 			break
 		}
-		node = node.WithLatest(prefix+key, mtime.Now(), value)
-		count++
+		node = node.WithLatest(prefix+label, mtime.Now(), value)
+		addedPropertiesCount++
 	}
-	if len(labels) > MaxTableRows {
-		truncationCount := fmt.Sprintf("%d", len(labels)-MaxTableRows)
-		node = node.WithLatest(TruncationCountPrefix+prefix, mtime.Now(), truncationCount)
-	}
-	return node
+	return node.WithTableTruncationInformation(prefix, len(propertyList))
 }
 
-// ExtractTable returns the rows to build a table from this node
+// WithoutPrefix returns the string with trimmed prefix and a
+// boolean information of whether that prefix was really there.
+// NOTE: Consider moving this function to utilities.
+func WithoutPrefix(s string, prefix string) (string, bool) {
+	return strings.TrimPrefix(s, prefix), len(prefix) > 0 && strings.HasPrefix(s, prefix)
+}
+
+// ExtractMulticolumnTable returns the rows to build a multicolumn table from this node
+func (node Node) ExtractMulticolumnTable(template TableTemplate) (rows []Row) {
+	rowsMapByID := map[string]Row{}
+
+	// Itearate through the whole of our map to extract all the values with the key
+	// with the given prefix. Since multicolumn tables don't support fixed rows (yet),
+	// all the table values will be stored under the table prefix.
+	// NOTE: It would be nice to optimize this part by only iterating through the keys
+	// with the given prefix. If it is possible to traverse the keys in the Latest map
+	// in a sorted order, then having LowerBoundEntry(key) and UpperBoundEntry(key)
+	// methods should be enough to implement ForEachWithPrefix(prefix) straightforwardly.
+	node.Latest.ForEach(func(key string, _ time.Time, value string) {
+		if keyWithoutPrefix, ok := WithoutPrefix(key, template.Prefix); ok {
+			ids := strings.Split(keyWithoutPrefix, TableEntryKeySeparator)
+			rowID, columnID := ids[0], ids[1]
+			// If the row with the given ID doesn't yet exist, we create an empty one.
+			if _, ok := rowsMapByID[rowID]; !ok {
+				rowsMapByID[rowID] = Row{
+					ID:      rowID,
+					Entries: map[string]string{},
+				}
+			}
+			// At this point, the row with that ID always exists, so we just update the value.
+			rowsMapByID[rowID].Entries[columnID] = value
+		}
+	})
+
+	// Gather a list of rows.
+	rows = make([]Row, 0, len(rowsMapByID))
+	for _, row := range rowsMapByID {
+		rows = append(rows, row)
+	}
+
+	// Return the rows sorted by ID.
+	sort.Sort(rowsByID(rows))
+	return rows
+}
+
+// ExtractPropertyList returns the rows to build a property list from this node
+func (node Node) ExtractPropertyList(template TableTemplate) (rows []Row) {
+	valuesMapByLabel := map[string]string{}
+
+	// Itearate through the whole of our map to extract all the values with the key
+	// with the given prefix as well as the keys corresponding to the fixed table rows.
+	node.Latest.ForEach(func(key string, _ time.Time, value string) {
+		if label, ok := template.FixedRows[key]; ok {
+			valuesMapByLabel[label] = value
+		} else if label, ok := WithoutPrefix(key, template.Prefix); ok {
+			valuesMapByLabel[label] = value
+		}
+	})
+
+	// Gather a label-value formatted list of rows.
+	rows = make([]Row, 0, len(valuesMapByLabel))
+	for label, value := range valuesMapByLabel {
+		rows = append(rows, Row{
+			ID: "label_" + label,
+			Entries: map[string]string{
+				"label": label,
+				"value": value,
+			},
+		})
+	}
+
+	// Return the rows sorted by ID.
+	sort.Sort(rowsByID(rows))
+	return rows
+}
+
+// ExtractTable returns the rows to build either a property list or a generic table from this node
 func (node Node) ExtractTable(template TableTemplate) (rows []Row, truncationCount int) {
-	rows = []Row{}
 	switch template.Type {
 	case MulticolumnTableType:
-		keyRows := map[string]Row{}
-		node.Latest.ForEach(func(key string, _ time.Time, value string) {
-			if len(template.Prefix) > 0 && strings.HasPrefix(key, template.Prefix) {
-				rowID, column := "", ""
-				fmt.Sscanf(key[len(template.Prefix):], "%s %s", &rowID, &column)
-				if _, ok := keyRows[rowID]; !ok {
-					keyRows[rowID] = Row{
-						ID:      rowID,
-						Entries: map[string]string{},
-					}
-				}
-				keyRows[rowID].Entries[column] = value
-			}
-		})
-		for _, row := range keyRows {
-			rows = append(rows, row)
-		}
-	// By default assume it's a property list (for backward compatibility)
-	default:
-		keyValues := map[string]string{}
-		node.Latest.ForEach(func(key string, _ time.Time, value string) {
-			if label, ok := template.FixedRows[key]; ok {
-				keyValues[label] = value
-			}
-			if len(template.Prefix) > 0 && strings.HasPrefix(key, template.Prefix) {
-				label := key[len(template.Prefix):]
-				keyValues[label] = value
-			}
-		})
-		labels := make([]string, 0, len(rows))
-		for label := range keyValues {
-			labels = append(labels, label)
-		}
-		sort.Strings(labels)
-		for _, label := range labels {
-			rows = append(rows, Row{
-				ID: "label_" + label,
-				Entries: map[string]string{
-					"label": label,
-					"value": keyValues[label],
-				},
-			})
-		}
+		rows = node.ExtractMulticolumnTable(template)
+	default: // By default assume it's a property list (for backward compatibility).
+		rows = node.ExtractPropertyList(template)
 	}
 
 	truncationCount = 0
@@ -117,16 +154,24 @@ func (node Node) ExtractTable(template TableTemplate) (rows []Row, truncationCou
 	return rows, truncationCount
 }
 
+// Column is the type for multi-column tables in the UI.
 type Column struct {
 	ID       string `json:"id"`
 	Label    string `json:"label"`
 	DataType string `json:"dataType"`
 }
 
+// Row is the type that holds the table data for the UI. Entries map from column ID to cell value.
 type Row struct {
 	ID      string            `json:"id"`
 	Entries map[string]string `json:"entries"`
 }
+
+type rowsByID []Row
+
+func (t rowsByID) Len() int           { return len(t) }
+func (t rowsByID) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
+func (t rowsByID) Less(i, j int) bool { return t[i].ID < t[j].ID }
 
 // Copy returns a copy of the Row.
 func (r Row) Copy() Row {
@@ -206,18 +251,18 @@ func (t TableTemplate) Merge(other TableTemplate) TableTemplate {
 		return s2
 	}
 
+	// NOTE: Consider actually merging the columns and fixed rows.
 	fixedRows := t.FixedRows
 	if len(other.FixedRows) > len(fixedRows) {
 		fixedRows = other.FixedRows
 	}
-
 	columns := t.Columns
 	if len(other.Columns) > len(columns) {
 		columns = other.Columns
 	}
 
-	// TODO: Refactor the merging logic, as mixing
-	// the types now might result in invalid tables.
+	// TODO: Refactor the merging logic, as mixing the types now might result in
+	// invalid tables. Maybe we should return an error if the types are different?
 	return TableTemplate{
 		ID:        max(t.ID, other.ID),
 		Label:     max(t.Label, other.Label),
@@ -236,11 +281,17 @@ func (t TableTemplates) Tables(node Node) []Table {
 	var result []Table
 	for _, template := range t {
 		rows, truncationCount := node.ExtractTable(template)
+		// Extract the type from the template; default to
+		// property list for backwards-compatibility.
+		tableType := template.Type
+		if tableType == "" {
+			tableType = PropertyListType
+		}
 		result = append(result, Table{
 			ID:              template.ID,
 			Label:           template.Label,
-			Type:            template.Type,
 			Columns:         template.Columns,
+			Type:            tableType,
 			Rows:            rows,
 			TruncationCount: truncationCount,
 		})

--- a/report/table.go
+++ b/report/table.go
@@ -118,15 +118,24 @@ func (node Node) ExtractTable(template TableTemplate) (rows []Row, truncationCou
 }
 
 type Column struct {
-	ID        string `json:"id"`
-	Label     string `json:"label"`
-	DataType  string `json:"dataType"`
-	Alignment string `json:"alignment"`
+	ID       string `json:"id"`
+	Label    string `json:"label"`
+	DataType string `json:"dataType"`
 }
 
 type Row struct {
 	ID      string            `json:"id"`
 	Entries map[string]string `json:"entries"`
+}
+
+// Copy returns a copy of the Row.
+func (r Row) Copy() Row {
+	entriesCopy := make(map[string]string, len(r.Entries))
+	for key, value := range r.Entries {
+		entriesCopy[key] = value
+	}
+	r.Entries = entriesCopy
+	return r
 }
 
 // Table is the type for a table in the UI.
@@ -202,6 +211,11 @@ func (t TableTemplate) Merge(other TableTemplate) TableTemplate {
 		fixedRows = other.FixedRows
 	}
 
+	columns := t.Columns
+	if len(other.Columns) > len(columns) {
+		columns = other.Columns
+	}
+
 	// TODO: Refactor the merging logic, as mixing
 	// the types now might result in invalid tables.
 	return TableTemplate{
@@ -209,6 +223,7 @@ func (t TableTemplate) Merge(other TableTemplate) TableTemplate {
 		Label:     max(t.Label, other.Label),
 		Prefix:    max(t.Prefix, other.Prefix),
 		Type:      max(t.Type, other.Type),
+		Columns:   columns,
 		FixedRows: fixedRows,
 	}
 }
@@ -225,6 +240,7 @@ func (t TableTemplates) Tables(node Node) []Table {
 			ID:              template.ID,
 			Label:           template.Label,
 			Type:            template.Type,
+			Columns:         template.Columns,
 			Rows:            rows,
 			TruncationCount: truncationCount,
 		})

--- a/report/table_test.go
+++ b/report/table_test.go
@@ -9,15 +9,34 @@ import (
 	"github.com/weaveworks/scope/report"
 )
 
-func TestPrefixTables(t *testing.T) {
-	want := map[string]string{
-		"foo1": "bar1",
-		"foo2": "bar2",
+func TestMulticolumnTables(t *testing.T) {
+	want := []report.Row{
+		{
+			ID: "row1",
+			Entries: map[string]string{
+				"col1": "r1c1",
+				"col2": "r1c2",
+				"col3": "r1c3",
+			},
+		},
+		{
+			ID: "row2",
+			Entries: map[string]string{
+				"col1": "r2c1",
+				"col3": "r2c3",
+			},
+		},
 	}
-	nmd := report.MakeNode("foo1")
 
-	nmd = nmd.AddPrefixLabels("foo_", want)
-	have, truncationCount := nmd.ExtractTable(report.TableTemplate{Prefix: "foo_"})
+	nmd := report.MakeNode("foo1")
+	nmd = nmd.AddPrefixMulticolumnTable("foo_", want)
+
+	template := report.TableTemplate{
+		Type:   report.MulticolumnTableType,
+		Prefix: "foo_",
+	}
+
+	have, truncationCount := nmd.ExtractTable(template)
 
 	if truncationCount != 0 {
 		t.Error("Table shouldn't had been truncated")
@@ -28,49 +47,258 @@ func TestPrefixTables(t *testing.T) {
 	}
 }
 
-func TestFixedTables(t *testing.T) {
-	want := map[string]string{
-		"foo1": "bar1",
-		"foo2": "bar2",
+func TestPrefixPropertyLists(t *testing.T) {
+	want := []report.Row{
+		{
+			ID: "label_foo1",
+			Entries: map[string]string{
+				"label": "foo1",
+				"value": "bar1",
+			},
+		},
+		{
+			ID: "label_foo3",
+			Entries: map[string]string{
+				"label": "foo3",
+				"value": "bar3",
+			},
+		},
 	}
-	nmd := report.MakeNodeWith("foo1", map[string]string{
-		"foo1key": "bar1",
-		"foo2key": "bar2",
+
+	nmd := report.MakeNode("foo1")
+	nmd = nmd.AddPrefixPropertyList("foo_", map[string]string{
+		"foo3": "bar3",
+		"foo1": "bar1",
+	})
+	nmd = nmd.AddPrefixPropertyList("zzz_", map[string]string{
+		"foo2": "bar2",
 	})
 
-	template := report.TableTemplate{FixedRows: map[string]string{
-		"foo1key": "foo1",
-		"foo2key": "foo2",
-	},
+	template := report.TableTemplate{
+		Type:   report.PropertyListType,
+		Prefix: "foo_",
 	}
 
-	have, _ := nmd.ExtractTable(template)
+	have, truncationCount := nmd.ExtractTable(template)
+
+	if truncationCount != 0 {
+		t.Error("Table shouldn't had been truncated")
+	}
 
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}
 }
 
-func TestTruncation(t *testing.T) {
+func TestFixedPropertyLists(t *testing.T) {
+	want := []report.Row{
+		{
+			ID: "label_foo1",
+			Entries: map[string]string{
+				"label": "foo1",
+				"value": "bar1",
+			},
+		},
+		{
+			ID: "label_foo2",
+			Entries: map[string]string{
+				"label": "foo2",
+				"value": "bar2",
+			},
+		},
+	}
+
+	nmd := report.MakeNodeWith("foo1", map[string]string{
+		"foo2key": "bar2",
+		"foo1key": "bar1",
+	})
+
+	template := report.TableTemplate{
+		Type: report.PropertyListType,
+		FixedRows: map[string]string{
+			"foo2key": "foo2",
+			"foo1key": "foo1",
+		},
+	}
+
+	have, truncationCount := nmd.ExtractTable(template)
+
+	if truncationCount != 0 {
+		t.Error("Table shouldn't had been truncated")
+	}
+
+	if !reflect.DeepEqual(want, have) {
+		t.Error(test.Diff(want, have))
+	}
+}
+
+func TestPropertyListTruncation(t *testing.T) {
 	wantTruncationCount := 1
-	want := map[string]string{}
+	propertyList := map[string]string{}
 	for i := 0; i < report.MaxTableRows+wantTruncationCount; i++ {
 		key := fmt.Sprintf("key%d", i)
 		value := fmt.Sprintf("value%d", i)
-		want[key] = value
+		propertyList[key] = value
 	}
 
 	nmd := report.MakeNode("foo1")
+	nmd = nmd.AddPrefixPropertyList("foo_", propertyList)
 
-	nmd = nmd.AddPrefixLabels("foo_", want)
-	_, truncationCount := nmd.ExtractTable(report.TableTemplate{Prefix: "foo_"})
+	template := report.TableTemplate{
+		Type:   report.PropertyListType,
+		Prefix: "foo_",
+	}
+
+	_, truncationCount := nmd.ExtractTable(template)
 
 	if truncationCount != wantTruncationCount {
 		t.Error(
-			"Table should had been truncated by",
+			"Property list should had been truncated by",
 			wantTruncationCount,
 			"and not",
 			truncationCount,
 		)
+	}
+}
+
+func TestMulticolumnTableTruncation(t *testing.T) {
+	wantTruncationCount := 1
+	rows := []report.Row{}
+	for i := 0; i < report.MaxTableRows+wantTruncationCount; i++ {
+		rowID := fmt.Sprintf("row%d", i)
+		colID := fmt.Sprintf("col%d", i)
+		value := fmt.Sprintf("value%d", i)
+		rows = append(rows, report.Row{
+			ID: rowID,
+			Entries: map[string]string{
+				colID: value,
+			},
+		})
+	}
+
+	nmd := report.MakeNode("foo1")
+	nmd = nmd.AddPrefixMulticolumnTable("foo_", rows)
+
+	template := report.TableTemplate{
+		Type:   report.MulticolumnTableType,
+		Prefix: "foo_",
+	}
+
+	_, truncationCount := nmd.ExtractTable(template)
+
+	if truncationCount != wantTruncationCount {
+		t.Error(
+			"Property list should had been truncated by",
+			wantTruncationCount,
+			"and not",
+			truncationCount,
+		)
+	}
+}
+
+func TestTables(t *testing.T) {
+	want := []report.Table{
+		{
+			ID:      "AAA",
+			Label:   "Aaa",
+			Type:    report.PropertyListType,
+			Columns: nil,
+			Rows: []report.Row{
+				{
+					ID: "label_foo1",
+					Entries: map[string]string{
+						"label": "foo1",
+						"value": "bar1",
+					},
+				},
+				{
+					ID: "label_foo3",
+					Entries: map[string]string{
+						"label": "foo3",
+						"value": "bar3",
+					},
+				},
+			},
+		},
+		{
+			ID:      "BBB",
+			Label:   "Bbb",
+			Type:    report.MulticolumnTableType,
+			Columns: []report.Column{{ID: "col1", Label: "Column 1"}},
+			Rows: []report.Row{
+				{
+					ID: "row1",
+					Entries: map[string]string{
+						"col1": "r1c1",
+					},
+				},
+				{
+					ID: "row2",
+					Entries: map[string]string{
+						"col3": "r2c3",
+					},
+				},
+			},
+		},
+		{
+			ID:      "CCC",
+			Label:   "Ccc",
+			Type:    report.PropertyListType,
+			Columns: nil,
+			Rows: []report.Row{
+				{
+					ID: "label_foo3",
+					Entries: map[string]string{
+						"label": "foo3",
+						"value": "bar3",
+					},
+				},
+			},
+		},
+	}
+
+	nmd := report.MakeNodeWith("foo1", map[string]string{
+		"foo3key": "bar3",
+		"foo1key": "bar1",
+	})
+	nmd = nmd.AddPrefixMulticolumnTable("bbb_", []report.Row{
+		{ID: "row1", Entries: map[string]string{"col1": "r1c1"}},
+		{ID: "row2", Entries: map[string]string{"col3": "r2c3"}},
+	})
+	nmd = nmd.AddPrefixPropertyList("aaa_", map[string]string{
+		"foo3": "bar3",
+		"foo1": "bar1",
+	})
+
+	aaaTemplate := report.TableTemplate{
+		ID:     "AAA",
+		Label:  "Aaa",
+		Prefix: "aaa_",
+		Type:   report.PropertyListType,
+	}
+	bbbTemplate := report.TableTemplate{
+		ID:      "BBB",
+		Label:   "Bbb",
+		Prefix:  "bbb_",
+		Type:    report.MulticolumnTableType,
+		Columns: []report.Column{{ID: "col1", Label: "Column 1"}},
+	}
+	cccTemplate := report.TableTemplate{
+		ID:        "CCC",
+		Label:     "Ccc",
+		Prefix:    "ccc_",
+		Type:      report.PropertyListType,
+		FixedRows: map[string]string{"foo3key": "foo3"},
+	}
+	templates := report.TableTemplates{
+		aaaTemplate.ID: aaaTemplate,
+		bbbTemplate.ID: bbbTemplate,
+		cccTemplate.ID: cccTemplate,
+	}
+
+	have := templates.Tables(nmd)
+
+	if !reflect.DeepEqual(want, have) {
+		t.Error(test.Diff(want, have))
 	}
 }

--- a/report/table_test.go
+++ b/report/table_test.go
@@ -16,7 +16,7 @@ func TestPrefixTables(t *testing.T) {
 	}
 	nmd := report.MakeNode("foo1")
 
-	nmd = nmd.AddPrefixTable("foo_", want)
+	nmd = nmd.AddPrefixLabels("foo_", want)
 	have, truncationCount := nmd.ExtractTable(report.TableTemplate{Prefix: "foo_"})
 
 	if truncationCount != 0 {
@@ -62,7 +62,7 @@ func TestTruncation(t *testing.T) {
 
 	nmd := report.MakeNode("foo1")
 
-	nmd = nmd.AddPrefixTable("foo_", want)
+	nmd = nmd.AddPrefixLabels("foo_", want)
 	_, truncationCount := nmd.ExtractTable(report.TableTemplate{Prefix: "foo_"})
 
 	if truncationCount != wantTruncationCount {


### PR DESCRIPTION
Resolves #1980. Prior to this story, we could only render *Node Tables* and *Labels* (renamed to *Property Lists* in this PR) in the node details panel. This PR introduces *Generic Table* as a separate UI component that enables us to render generic data in a multi-column format without associating rows to nodes.

#### Modeling

As @davkal reasoned, it makes sense to have *Property Lists* and *Generic Tables* as distinct components in the UI, so I made them fully independent there, but for backward compatibility reasons, I kept them under the old `Table` model on the backend, which I finally decided to extend like this:

```go
// Column is the type for multi-column tables in the UI.
type Column struct {
	ID       string `json:"id"`
	Label    string `json:"label"`
	DataType string `json:"dataType"`
}

// Row is the type that holds the table data for the UI. Entries map from column ID to cell value.
type Row struct {
	ID      string            `json:"id"`
	Entries map[string]string `json:"entries"`
}

// Table is the type for a table in the UI.
type Table struct {
	ID              string   `json:"id"`
	Label           string   `json:"label"`
	Type            string   `json:"type"`
	Columns         []Column `json:"columns"`
	Rows            []Row    `json:"rows"`
	TruncationCount int      `json:"truncationCount,omitempty"`
}

// TableTemplate describes how to render a table for the UI.
type TableTemplate struct {
	ID        string            `json:"id"`
	Label     string            `json:"label"`
	Prefix    string            `json:"prefix"`
	Type      string            `json:"type"`
	Columns   []Column          `json:"columns"`
	FixedRows map[string]string `json:"fixedRows"`
}
```

where `Columns` is used only with the `multicolumn-table` template type and `FixedRows` in only supported for `property-list`. The main reason I decided not to support fixed rows for generic (multicolumn) tables is that it wasn't clear what the exact use-case might be and how they would be rendered in the UI.

#### Storing

To be consistent with how property lists are being stored on the node, I decided to use the `node.Latest` map with table prefixes to store generic tables as well. The only difference is that since a multi-column table is two-dimensional, the table value is determined not only by *label*, but by (*row*, *column*) pair. Storing whole rows in the `Latest` map was not an option for two reasons:

1. `Latest` is a `string` to `string` map so we can only use it to store strings.
2. I also thought it would be better to use latest info on the cell level instead of row.

To be able to differ between the rows, each of them has to be given an ID (instead of what used to be a label). For backward compatibility with the old reports, property lists label is indeed used as a row ID when sending a table to the UI.

#### Rendering in the UI

*Generic table* is sortable and supports different column types (sent through `Column.DataType` field on the backend). Column headers are the same as for *Node Tables* (they are now in a new component called `NodeDetailsTableHeaders`), and column widths can also be hard-coded on the frontend.

![screenshot from 2017-01-06 11-45-50](https://cloud.githubusercontent.com/assets/1216874/21715731/7d81e36e-d406-11e6-86c5-f9f7207f649d.png)

To see this, run `fixprobe` on [this report](https://github.com/weaveworks/scope/files/689695/report.json.zip)

#### Other Observations

* Right now we iterate once through the whole `node.Latest` map for every table (or a property list) we are extracting, instead of just running through the entries with a given prefix and extracting the fixed row information separately. I haven't looked into the implementation details of our `Map` structure, but maybe it wouldn't be that difficult to add an efficient `ForEachFromTo` kind of method there to run only on selected intervals. That would drop our time complexity of extraction roughly from `O(T * N)` to `O(N + T * log N)` (or `O(N * log N)`, if a lot of entries correspond to fixed rows), where `T` is the number of tables and `N` is the total size of `node.Latest`. Not sure if it's a bottleneck or if it's worth digging into this, but I just wanted to point it out.
* There might other components in `node-details` dir in the UI, like `NodeDetailsInfo`, which are both semantically and implementation-wise similar to `NodeDetailsPropertyList`, so consider refactoring them in some future PR.
