### PR TITLE
	k8s: Make node-name obtention more robust

### DIFF
--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -1,13 +1,15 @@
 package kubernetes
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/labels"
 
+	"fmt"
+	log "github.com/Sirupsen/logrus"
 	"github.com/weaveworks/common/mtime"
 	"github.com/weaveworks/scope/probe"
 	"github.com/weaveworks/scope/probe/controls"
@@ -95,10 +97,15 @@ type Reporter struct {
 	probe           *probe.Probe
 	hostID          string
 	handlerRegistry *controls.HandlerRegistry
+	thisNodeName    string
 }
 
 // NewReporter makes a new Reporter
 func NewReporter(client Client, pipes controls.PipeClient, probeID string, hostID string, probe *probe.Probe, handlerRegistry *controls.HandlerRegistry) *Reporter {
+	thisNodeName, err := GetNodeName(client)
+	if err != nil {
+		log.Warnf("cannot obtain k8s node name: all pods will be reported: %v", err)
+	}
 	reporter := &Reporter{
 		client:          client,
 		pipes:           pipes,
@@ -106,6 +113,7 @@ func NewReporter(client Client, pipes controls.PipeClient, probeID string, hostI
 		probe:           probe,
 		hostID:          hostID,
 		handlerRegistry: handlerRegistry,
+		thisNodeName:    thisNodeName,
 	}
 	reporter.registerControls()
 	client.WatchPods(reporter.podEvent)
@@ -316,18 +324,17 @@ func (r *Reporter) replicaSetTopology(probeID string, deployments []Deployment) 
 
 // GetNodeName return the k8s node name for the current machine.
 // It is exported for testing.
-var GetNodeName = func(r *Reporter) (string, error) {
-	uuidBytes, err := ioutil.ReadFile("/sys/class/dmi/id/product_uuid")
-	if os.IsNotExist(err) {
-		uuidBytes, err = ioutil.ReadFile("/sys/hypervisor/uuid")
-	}
+var GetNodeName = func(client Client) (string, error) {
+	hostname, err := os.Hostname()
 	if err != nil {
 		return "", err
 	}
-	uuid := strings.Trim(string(uuidBytes), "\n")
 	nodeName := ""
-	err = r.client.WalkNodes(func(node *api.Node) error {
-		if node.Status.NodeInfo.SystemUUID == string(uuid) {
+	err = client.WalkNodes(func(node *api.Node) error {
+		if nodeHostname, ok := node.Labels[unversioned.LabelHostname]; !ok {
+			return fmt.Errorf("node %s is unexpectedly missing label %s",
+				node.ObjectMeta.Name, unversioned.LabelHostname)
+		} else if hostname == nodeHostname {
 			nodeName = node.ObjectMeta.Name
 		}
 		return nil
@@ -387,12 +394,9 @@ func (r *Reporter) podTopology(services []Service, replicaSets []ReplicaSet) (re
 		))
 	}
 
-	thisNodeName, err := GetNodeName(r)
-	if err != nil {
-		return pods, err
-	}
-	err = r.client.WalkPods(func(p Pod) error {
-		if p.NodeName() != thisNodeName {
+	err := r.client.WalkPods(func(p Pod) error {
+		// Filter out pods not scheduled in this machine (if we know this node's name)
+		if r.thisNodeName != "" && p.NodeName() != r.thisNodeName {
 			return nil
 		}
 		for _, selector := range selectors {

--- a/probe/kubernetes/reporter_test.go
+++ b/probe/kubernetes/reporter_test.go
@@ -182,7 +182,7 @@ func (c mockPipeClient) PipeClose(appID, id string) error {
 func TestReporter(t *testing.T) {
 	oldGetNodeName := kubernetes.GetNodeName
 	defer func() { kubernetes.GetNodeName = oldGetNodeName }()
-	kubernetes.GetNodeName = func(*kubernetes.Reporter) (string, error) {
+	kubernetes.GetNodeName = func(kubernetes.Client) (string, error) {
 		return nodeName, nil
 	}
 
@@ -273,7 +273,7 @@ func (c *callbackReadCloser) Close() error { return c.close() }
 func TestReporterGetLogs(t *testing.T) {
 	oldGetNodeName := kubernetes.GetNodeName
 	defer func() { kubernetes.GetNodeName = oldGetNodeName }()
-	kubernetes.GetNodeName = func(*kubernetes.Reporter) (string, error) {
+	kubernetes.GetNodeName = func(kubernetes.Client) (string, error) {
 		return nodeName, nil
 	}
 


### PR DESCRIPTION
* ~Align with kubernetes on how the system uuid is obtained~
* Base node-name obtention on the hostname instead of the system uuid (which can be hard to find and may not be unique per machine).
* Fall back to report all pods (printing a warning) if the node name cannot be obtained

Fixes #2049 
