### PR TITLE
Removed leading slash from getAllNodes() api request

### DIFF
--- a/client/app/scripts/utils/web-api-utils.js
+++ b/client/app/scripts/utils/web-api-utils.js
@@ -1,5 +1,6 @@
 import debug from 'debug';
 import reqwest from 'reqwest';
+import trimStart from 'lodash/trimStart';
 
 import { blurSearch, clearControlError, closeWebsocket, openWebsocket, receiveError,
   receiveApiDetails, receiveNodesDelta, receiveNodeDetails, receiveControlError,
@@ -123,7 +124,9 @@ export function getAllNodes(getState, dispatch) {
   state.get('topologyUrlsById')
     .reduce((sequence, topologyUrl, topologyId) => sequence.then(() => {
       const optionsQuery = buildOptionsQuery(topologyOptions.get(topologyId));
-      return fetch(`${topologyUrl}?${optionsQuery}`);
+      // Trim the leading slash from the url before requesting.
+      // This ensures that scope will request from the correct route if embedded in an iframe.
+      return fetch(`${trimStart(topologyUrl, '/')}?${optionsQuery}`);
     })
     .then(response => response.json())
     .then(json => dispatch(receiveNodesForTopology(json.nodes, topologyId))),


### PR DESCRIPTION
Fix for #2123 

Removes a leading slash that was causing requests to api/topology/containers to return the index.html file instead of the JSON response. 

@foot Could you review please? This feels like it should be fixed in the output from the back-end, but I'm worried that other stuff (including other services) might be relying on that extra slash being there.