### PR TITLE
Change topologies option from 'notsystem' to 'application'

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -16,21 +16,21 @@ import (
 )
 
 const (
-	apiTopologyURL               = "/api/topology/"
-	processesID                  = "processes"
-	processesByNameID            = "processes-by-name"
-	containerLabelFiltersGroupID = "container-label-filters-group"
-	containersID                 = "containers"
-	containersByHostnameID       = "containers-by-hostname"
-	containersByImageID          = "containers-by-image"
-	podsID                       = "pods"
-	replicaSetsID                = "replica-sets"
-	deploymentsID                = "deployments"
-	servicesID                   = "services"
-	hostsID                      = "hosts"
-	weaveID                      = "weave"
-	ecsTasksID                   = "ecs-tasks"
-	ecsServicesID                = "ecs-services"
+	apiTopologyURL         = "/api/topology/"
+	processesID            = "processes"
+	processesByNameID      = "processes-by-name"
+	systemGroupID          = "system"
+	containersID           = "containers"
+	containersByHostnameID = "containers-by-hostname"
+	containersByImageID    = "containers-by-image"
+	podsID                 = "pods"
+	replicaSetsID          = "replica-sets"
+	deploymentsID          = "deployments"
+	servicesID             = "services"
+	hostsID                = "hosts"
+	weaveID                = "weave"
+	ecsTasksID             = "ecs-tasks"
+	ecsServicesID          = "ecs-services"
 )
 
 var (
@@ -117,7 +117,7 @@ func MakeRegistry() *Registry {
 	}
 	containerFilters := []APITopologyOptionGroup{
 		{
-			ID:      containerLabelFiltersGroupID,
+			ID:      systemGroupID,
 			Default: "application",
 			Options: []APITopologyOption{
 				{Value: "all", Label: "All", filter: nil, filterPseudo: false},
@@ -312,7 +312,7 @@ func (r *Registry) AddContainerFilters(newFilters ...APITopologyOption) {
 	defer r.Unlock()
 	for _, key := range []string{containersID, containersByHostnameID, containersByImageID} {
 		for i := range r.items[key].Options {
-			if r.items[key].Options[i].ID == containerLabelFiltersGroupID {
+			if r.items[key].Options[i].ID == systemGroupID {
 				r.items[key].Options[i].Options = append(r.items[key].Options[i].Options, newFilters...)
 				break
 			}

--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -122,7 +122,7 @@ func MakeRegistry() *Registry {
 			Options: []APITopologyOption{
 				{Value: "all", Label: "All", filter: nil, filterPseudo: false},
 				{Value: "system", Label: "System Containers", filter: render.IsSystem, filterPseudo: false},
-				{Value: "notsystem", Label: "Application Containers", filter: render.IsApplication, filterPseudo: false}},
+				{Value: "application", Label: "Application Containers", filter: render.IsApplication, filterPseudo: false}},
 		},
 		{
 			ID:      "stopped",

--- a/app/api_topologies_test.go
+++ b/app/api_topologies_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	containerLabelFiltersGroupID    = "container-label-filters-group"
+	systemGroupID                   = "system"
 	customAPITopologyOptionFilterID = "containerLabelFilter0"
 )
 
@@ -108,7 +108,7 @@ func getTestContainerLabelFilterTopologySummary(t *testing.T, exclude bool) (det
 	topologyRegistry.AddContainerFilters(option)
 
 	urlvalues := url.Values{}
-	urlvalues.Set(containerLabelFiltersGroupID, customAPITopologyOptionFilterID)
+	urlvalues.Set(systemGroupID, customAPITopologyOptionFilterID)
 	renderer, decorator, err := topologyRegistry.RendererForTopology("containers", urlvalues, fixture.Report)
 	if err != nil {
 		return nil, err

--- a/integration/config.sh
+++ b/integration/config.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # NB only to be sourced
 
 set -e
@@ -7,51 +8,52 @@ set -e
 export SSH_DIR="$PWD"
 export HOSTS
 
+# shellcheck disable=SC1091
 . "../tools/integration/config.sh"
 
 WEAVE="./weave"
 SCOPE="../scope"
 
 scope_on() {
-	local host=$1
-	shift 1
-	[ -z "$DEBUG" ] || greyly echo "Scope on $host: $@" >&2
-	DOCKER_HOST=tcp://$host:$DOCKER_PORT CHECKPOINT_DISABLE=true $SCOPE "$@"
+    local host=$1
+    shift 1
+    [ -z "$DEBUG" ] || greyly echo "Scope on $host: $*" >&2
+    DOCKER_HOST=tcp://$host:$DOCKER_PORT CHECKPOINT_DISABLE=true "$SCOPE" "$@"
 }
 
 weave_on() {
-	local host=$1
-	shift 1
-	[ -z "$DEBUG" ] || greyly echo "Weave on $host: $@" >&2
-	DOCKER_HOST=tcp://$host:$DOCKER_PORT CHECKPOINT_DISABLE=true $WEAVE "$@"
+    local host=$1
+    shift 1
+    [ -z "$DEBUG" ] || greyly echo "Weave on $host: $*" >&2
+    DOCKER_HOST=tcp://$host:$DOCKER_PORT CHECKPOINT_DISABLE=true "$WEAVE" "$@"
 }
 
 scope_end_suite() {
-	end_suite
-	for host in $HOSTS; do
-		docker_on $host rm -f $(docker_on $host ps -a -q) 2>/dev/null 1>&2 || true
-	done
+    end_suite
+    for host in $HOSTS; do
+        docker_on "$host" rm -f "$(docker_on "$host" ps -a -q)" 2>/dev/null 1>&2 || true
+    done
 }
 
 # this checks we have a named node in the given view
 has() {
-	local view=$1
-	local host=$2
-	local name=$3
-	local count=${4:-1}
-	assert "curl -s http://${host}:4040/api/topology/${view}?system=system | jq -r '[.nodes[] | select(.label == \"${name}\")] | length'" $count
+    local view=$1
+    local host=$2
+    local name=$3
+    local count=${4:-1}
+    assert "curl -s http://${host}:4040/api/topology/${view}?system=show | jq -r '[.nodes[] | select(.label == \"${name}\")] | length'" "$count"
 }
 
 # this checks we have a named container
 has_container() {
-	has containers "$@"
+    has containers "$@"
 }
 
 node_id() {
     local view="$1"
-	local host="$2"
-	local name="$3"
-	echo $(curl -s http://${host}:4040/api/topology/${view}?system=system | jq -r ".nodes[] | select(.label == \"${name}\") | .id")
+    local host="$2"
+    local name="$3"
+    curl -s "http://${host}:4040/api/topology/${view}?system=show" | jq -r ".nodes[] | select(.label == \"${name}\") | .id"
 }
 
 container_id() {
@@ -60,67 +62,73 @@ container_id() {
 
 # this checks we have an edge from container 1 to container 2
 has_connection_by_id() {
-	local view="$1"
-	local host="$2"
-	local from_id="$3"
-	local to_id="$4"
-	local timeout="${5:-60}"
+    local view="$1"
+    local host="$2"
+    local from_id="$3"
+    local to_id="$4"
+    local timeout="${5:-60}"
 
-	for i in $(seq $timeout); do
-		local nodes="$(curl -s http://$host:4040/api/topology/${view}?system=system)"
-		local edge=$(echo "$nodes" |  jq -r ".nodes[\"$from_id\"].adjacency | contains([\"$to_id\"])" 2>/dev/null)
-		if [ "$edge" = "true" ]; then
-			echo "Found edge $from -> $to after $i secs"
-			assert "curl -s http://$host:4040/api/topology/${view}?system=system |  jq -r '.nodes[\"$from_id\"].adjacency | contains([\"$to_id\"])'" true
-			return
-		fi
-		sleep 1
-	done
+    for i in $(seq "$timeout"); do
+        local nodes
+        local edge
+        edge=$(echo "$nodes" | (jq -r ".nodes[\"$from_id\"].adjacency | contains([\"$to_id\"])" || true) 2>/dev/null)
+        nodes=$(curl -s "http://$host:4040/api/topology/${view}?system=show" || true)
+        if [ "$edge" = "true" ]; then
+            echo "Found edge $from -> $to after $i secs"
+            assert "curl -s http://$host:4040/api/topology/${view}?system=show |  jq -r '.nodes[\"$from_id\"].adjacency | contains([\"$to_id\"])'" true
+            return
+        fi
+        sleep 1
+    done
 
-	echo "Failed to find edge $from -> $to after $timeout secs"
-	assert "curl -s http://$host:4040/api/topology/${view}?system=system |  jq -r '.nodes[\"$from_id\"].adjacency | contains([\"$to_id\"])'" true
+    echo "Failed to find edge $from -> $to after $timeout secs"
+    assert "curl -s http://$host:4040/api/topology/${view}?system=show |  jq -r '.nodes[\"$from_id\"].adjacency | contains([\"$to_id\"])'" true
 }
 
 has_connection() {
-	local view="$1"
-	local host="$2"
-	local from="$3"
-	local to="$4"
-	local timeout="${5:-60}"
-    local from_id="$(node_id "${view}" "${host}" "${from}")"
-    local to_id="$(node_id "${view}" "${host}" "${to}")"
+    local view="$1"
+    local host="$2"
+    local from="$3"
+    local to="$4"
+    local timeout="${5:-60}"
+    local from_id
+    local to_id
+
+    from_id="$(node_id "${view}" "${host}" "${from}")"
+    to_id="$(node_id "${view}" "${host}" "${to}")"
 
     has_connection_by_id "${view}" "${host}" "${from_id}" "${to_id}" "${timeout}"
 }
 
 wait_for() {
-	local view="$1"
-	local host="$2"
-	local timeout="$3"
-	shift 3
+    local view="$1"
+    local host="$2"
+    local timeout="$3"
+    shift 3
 
-	for i in $(seq ${timeout}); do
-		local nodes="$(curl -s http://$host:4040/api/topology/${view}?system=system)"
-		local found=0
-		for name in "$@"; do
-			local count=$(echo "${nodes}" | jq -r "[.nodes[] | select(.label == \"${name}\")] | length")
-			if [ -n "${count}" ] && [ "${count}" -ge 1 ]; then
-				found=$(( found + 1 ))
-			fi
-		done
+    for i in $(seq "${timeout}"); do
+        local nodes
+        local found=0
+        nodes=$(curl -s "http://$host:4040/api/topology/${view}?system=show" || true)
+        for name in "$@"; do
+            local count
+            count=$(echo "${nodes}" | jq -r "[.nodes[] | select(.label == \"${name}\")] | length")
+            if [ -n "${count}" ] && [ "${count}" -ge 1 ]; then
+                found=$((found + 1))
+            fi
+        done
 
-		if [ "${found}" -eq $# ]; then
-			echo "Found ${found} nodes after $i secs"
-			return
-		fi
+        if [ "${found}" -eq $# ]; then
+            echo "Found ${found} nodes after $i secs"
+            return
+        fi
 
-		sleep 1
-	done
+        sleep 1
+    done
 
-	echo "Failed to find nodes $@ after $i secs"
+    echo "Failed to find nodes $* after $i secs"
 }
 
-
 wait_for_containers() {
-	wait_for containers "$@"
+    wait_for containers "$@"
 }

--- a/integration/config.sh
+++ b/integration/config.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # NB only to be sourced
 
 set -e
@@ -8,52 +7,51 @@ set -e
 export SSH_DIR="$PWD"
 export HOSTS
 
-# shellcheck disable=SC1091
 . "../tools/integration/config.sh"
 
 WEAVE="./weave"
 SCOPE="../scope"
 
 scope_on() {
-    local host=$1
-    shift 1
-    [ -z "$DEBUG" ] || greyly echo "Scope on $host: $*" >&2
-    DOCKER_HOST=tcp://$host:$DOCKER_PORT CHECKPOINT_DISABLE=true "$SCOPE" "$@"
+	local host=$1
+	shift 1
+	[ -z "$DEBUG" ] || greyly echo "Scope on $host: $@" >&2
+	DOCKER_HOST=tcp://$host:$DOCKER_PORT CHECKPOINT_DISABLE=true $SCOPE "$@"
 }
 
 weave_on() {
-    local host=$1
-    shift 1
-    [ -z "$DEBUG" ] || greyly echo "Weave on $host: $*" >&2
-    DOCKER_HOST=tcp://$host:$DOCKER_PORT CHECKPOINT_DISABLE=true "$WEAVE" "$@"
+	local host=$1
+	shift 1
+	[ -z "$DEBUG" ] || greyly echo "Weave on $host: $@" >&2
+	DOCKER_HOST=tcp://$host:$DOCKER_PORT CHECKPOINT_DISABLE=true $WEAVE "$@"
 }
 
 scope_end_suite() {
-    end_suite
-    for host in $HOSTS; do
-        docker_on "$host" rm -f "$(docker_on "$host" ps -a -q)" 2>/dev/null 1>&2 || true
-    done
+	end_suite
+	for host in $HOSTS; do
+		docker_on $host rm -f $(docker_on $host ps -a -q) 2>/dev/null 1>&2 || true
+	done
 }
 
 # this checks we have a named node in the given view
 has() {
-    local view=$1
-    local host=$2
-    local name=$3
-    local count=${4:-1}
-    assert "curl -s http://${host}:4040/api/topology/${view}?system=show | jq -r '[.nodes[] | select(.label == \"${name}\")] | length'" "$count"
+	local view=$1
+	local host=$2
+	local name=$3
+	local count=${4:-1}
+	assert "curl -s http://${host}:4040/api/topology/${view}?system=system | jq -r '[.nodes[] | select(.label == \"${name}\")] | length'" $count
 }
 
 # this checks we have a named container
 has_container() {
-    has containers "$@"
+	has containers "$@"
 }
 
 node_id() {
     local view="$1"
-    local host="$2"
-    local name="$3"
-    curl -s "http://${host}:4040/api/topology/${view}?system=show" | jq -r ".nodes[] | select(.label == \"${name}\") | .id"
+	local host="$2"
+	local name="$3"
+	echo $(curl -s http://${host}:4040/api/topology/${view}?system=system | jq -r ".nodes[] | select(.label == \"${name}\") | .id")
 }
 
 container_id() {
@@ -62,73 +60,67 @@ container_id() {
 
 # this checks we have an edge from container 1 to container 2
 has_connection_by_id() {
-    local view="$1"
-    local host="$2"
-    local from_id="$3"
-    local to_id="$4"
-    local timeout="${5:-60}"
+	local view="$1"
+	local host="$2"
+	local from_id="$3"
+	local to_id="$4"
+	local timeout="${5:-60}"
 
-    for i in $(seq "$timeout"); do
-        local nodes
-        local edge
-        edge=$(echo "$nodes" | (jq -r ".nodes[\"$from_id\"].adjacency | contains([\"$to_id\"])" || true) 2>/dev/null)
-        nodes=$(curl -s "http://$host:4040/api/topology/${view}?system=show" || true)
-        if [ "$edge" = "true" ]; then
-            echo "Found edge $from -> $to after $i secs"
-            assert "curl -s http://$host:4040/api/topology/${view}?system=show |  jq -r '.nodes[\"$from_id\"].adjacency | contains([\"$to_id\"])'" true
-            return
-        fi
-        sleep 1
-    done
+	for i in $(seq $timeout); do
+		local nodes="$(curl -s http://$host:4040/api/topology/${view}?system=system)"
+		local edge=$(echo "$nodes" |  jq -r ".nodes[\"$from_id\"].adjacency | contains([\"$to_id\"])" 2>/dev/null)
+		if [ "$edge" = "true" ]; then
+			echo "Found edge $from -> $to after $i secs"
+			assert "curl -s http://$host:4040/api/topology/${view}?system=system |  jq -r '.nodes[\"$from_id\"].adjacency | contains([\"$to_id\"])'" true
+			return
+		fi
+		sleep 1
+	done
 
-    echo "Failed to find edge $from -> $to after $timeout secs"
-    assert "curl -s http://$host:4040/api/topology/${view}?system=show |  jq -r '.nodes[\"$from_id\"].adjacency | contains([\"$to_id\"])'" true
+	echo "Failed to find edge $from -> $to after $timeout secs"
+	assert "curl -s http://$host:4040/api/topology/${view}?system=system |  jq -r '.nodes[\"$from_id\"].adjacency | contains([\"$to_id\"])'" true
 }
 
 has_connection() {
-    local view="$1"
-    local host="$2"
-    local from="$3"
-    local to="$4"
-    local timeout="${5:-60}"
-    local from_id
-    local to_id
-
-    from_id="$(node_id "${view}" "${host}" "${from}")"
-    to_id="$(node_id "${view}" "${host}" "${to}")"
+	local view="$1"
+	local host="$2"
+	local from="$3"
+	local to="$4"
+	local timeout="${5:-60}"
+    local from_id="$(node_id "${view}" "${host}" "${from}")"
+    local to_id="$(node_id "${view}" "${host}" "${to}")"
 
     has_connection_by_id "${view}" "${host}" "${from_id}" "${to_id}" "${timeout}"
 }
 
 wait_for() {
-    local view="$1"
-    local host="$2"
-    local timeout="$3"
-    shift 3
+	local view="$1"
+	local host="$2"
+	local timeout="$3"
+	shift 3
 
-    for i in $(seq "${timeout}"); do
-        local nodes
-        local found=0
-        nodes=$(curl -s "http://$host:4040/api/topology/${view}?system=show" || true)
-        for name in "$@"; do
-            local count
-            count=$(echo "${nodes}" | jq -r "[.nodes[] | select(.label == \"${name}\")] | length")
-            if [ -n "${count}" ] && [ "${count}" -ge 1 ]; then
-                found=$((found + 1))
-            fi
-        done
+	for i in $(seq ${timeout}); do
+		local nodes="$(curl -s http://$host:4040/api/topology/${view}?system=system)"
+		local found=0
+		for name in "$@"; do
+			local count=$(echo "${nodes}" | jq -r "[.nodes[] | select(.label == \"${name}\")] | length")
+			if [ -n "${count}" ] && [ "${count}" -ge 1 ]; then
+				found=$(( found + 1 ))
+			fi
+		done
 
-        if [ "${found}" -eq $# ]; then
-            echo "Found ${found} nodes after $i secs"
-            return
-        fi
+		if [ "${found}" -eq $# ]; then
+			echo "Found ${found} nodes after $i secs"
+			return
+		fi
 
-        sleep 1
-    done
+		sleep 1
+	done
 
-    echo "Failed to find nodes $* after $i secs"
+	echo "Failed to find nodes $@ after $i secs"
 }
 
+
 wait_for_containers() {
-    wait_for containers "$@"
+	wait_for containers "$@"
 }


### PR DESCRIPTION
Fix for #2120 

A bug was introduced here: https://github.com/weaveworks/scope/commit/9833a854b1638d8bd3270323c8aa0041016ebb98#diff-6126bda540b57df79f551488091760daR56

To test:
1. Click the 'bug' icon in the bottom left of the screen
2. Click the 'Reset your local view state' option
3. When the page reloads, the 'Application' filter should be selected. 