### PR TITLE
Upgraded xterm.js to 2.2.3

### DIFF
--- a/client/app/scripts/components/terminal.js
+++ b/client/app/scripts/components/terminal.js
@@ -144,12 +144,7 @@ class Terminal extends React.Component {
     socket.onmessage = (event) => {
       log('pipe data', event.data.size);
       const input = ab2str(event.data);
-      const scrolledToBottom = term.ydisp === term.ybase;
-      const savedScrollPosition = term.ydisp;
       term.write(input);
-      if (!scrolledToBottom) {
-        this.scrollTo(savedScrollPosition);
-      }
     };
 
     this.socket = socket;
@@ -159,19 +154,6 @@ class Terminal extends React.Component {
     if (this.props.connect !== nextProps.connect && nextProps.connect) {
       this.mountTerminal();
     }
-  }
-
-  scrollToBottom() {
-    this.scrollTo(this.term.ybase);
-  }
-
-  scrollTo(y) {
-    if (!this.term) {
-      return;
-    }
-    this.term.ydisp = y;
-    this.term.emit('scroll', y);
-    this.term.refresh(0, this.term.rows - 1);
   }
 
   componentDidMount() {
@@ -192,7 +174,6 @@ class Terminal extends React.Component {
 
     this.term.open(this.innerFlex);
     this.term.on('data', (data) => {
-      this.scrollToBottom();
       if (this.socket) {
         this.socket.send(data);
       }

--- a/client/package.json
+++ b/client/package.json
@@ -42,7 +42,7 @@
     "timely": "0.1.0",
     "whatwg-fetch": "2.0.1",
     "react-addons-perf": "15.4.1",
-    "xterm": "2.1.0"
+    "xterm": "2.2.3"
   },
   "devDependencies": {
     "autoprefixer": "6.5.3",

--- a/client/webpack.production.config.js
+++ b/client/webpack.production.config.js
@@ -103,7 +103,8 @@ module.exports = {
     new webpack.DefinePlugin(GLOBALS),
     new webpack.optimize.CommonsChunkPlugin('vendors', 'vendors-[chunkhash].js'),
     new webpack.optimize.OccurenceOrderPlugin(true),
-    new webpack.IgnorePlugin(/^\.\/locale$/, [/moment$/]),
+    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+    new webpack.IgnorePlugin(/.*\.map$/, /xterm\/lib\/addons/),
     new webpack.optimize.UglifyJsPlugin({
       sourceMap: false,
       compress: {


### PR DESCRIPTION
Fix for #2121

New messages to stdout should no longer scroll down to the bottom.

@foot Please review.