### PR TITLE
Document how to run tests on website

### DIFF
--- a/site/building.md
+++ b/site/building.md
@@ -26,6 +26,14 @@ If needed, install the tools used for managing dependencies, managing releases, 
 
     make deps
 
+Scope unit tests for `probe` and `app` components can be run via:
+
+    make tests
+
+Similarly the frontent client tests can be run via:
+
+    make client-test
+
 
 >**Note:** The tools from `make deps` depend on a local install of
 [Go](https://golang.org).


### PR DESCRIPTION
Saves prospective developers from digging into the Makefile to work out how to run the test suites.