### PR TITLE
render.detailed: Add ECS topologies to detailed parents conversion

### DIFF
--- a/render/detailed/parents.go
+++ b/render/detailed/parents.go
@@ -3,6 +3,7 @@ package detailed
 import (
 	"sort"
 
+	"github.com/weaveworks/scope/probe/awsecs"
 	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/probe/kubernetes"
 	"github.com/weaveworks/scope/report"
@@ -38,6 +39,8 @@ func Parents(r report.Report, n report.Node) (result []Parent) {
 		report.ReplicaSet:     {node(r.ReplicaSet), replicaSetParent},
 		report.Deployment:     {node(r.Deployment), deploymentParent},
 		report.Service:        {node(r.Service), serviceParent},
+		report.ECSTask:        {node(r.ECSTask), ecsTaskParent},
+		report.ECSService:     {node(r.ECSService), ecsServiceParent},
 		report.ContainerImage: {fake, containerImageParent},
 		report.Host:           {node(r.Host), hostParent},
 	}
@@ -89,6 +92,24 @@ func kubernetesParent(topology string) func(report.Node) Parent {
 			Label:      name,
 			TopologyID: topology,
 		}
+	}
+}
+
+func ecsTaskParent(n report.Node) Parent {
+	family, _ := n.Latest.Lookup(awsecs.TaskFamily)
+	return Parent{
+		ID:         n.ID,
+		Label:      family,
+		TopologyID: "ecs-tasks",
+	}
+}
+
+func ecsServiceParent(n report.Node) Parent {
+	name, _ := report.ParseECSServiceNodeID(n.ID)
+	return Parent{
+		ID:         n.ID,
+		Label:      name,
+		TopologyID: "ecs-services",
 	}
 }
 


### PR DESCRIPTION
so they will correctly show up in the details view.
Currently, since ECS topologies aren't considered, the ECS parents of nodes are silently dropped.

Fixes #2040

![screenshot](https://cloud.githubusercontent.com/assets/570052/22170573/3925bf04-df34-11e6-8f2c-dd294d5c2ccd.png)
