### PR TITLE
render.detailed: Teach detailed node view how to display ECS topologies as children

### DIFF
--- a/render/detailed/node.go
+++ b/render/detailed/node.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ugorji/go/codec"
 
+	"github.com/weaveworks/scope/probe/awsecs"
 	"github.com/weaveworks/scope/probe/docker"
 	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/probe/kubernetes"
@@ -173,6 +174,27 @@ var (
 					{ID: kubernetes.State, Label: "State"},
 					{ID: report.Container, Label: "# Containers", Datatype: "number"},
 					{ID: kubernetes.IP, Label: "IP", Datatype: "ip"},
+				},
+			},
+		},
+		{
+			topologyID: report.ECSService,
+			NodeSummaryGroup: NodeSummaryGroup{
+				TopologyID: "ecs-services",
+				Label:      "Services",
+				Columns: []Column{
+					{ID: awsecs.ServiceRunningCount, Label: "Running", Datatype: "number"},
+					{ID: awsecs.ServiceDesiredCount, Label: "Desired", Datatype: "number"},
+				},
+			},
+		},
+		{
+			topologyID: report.ECSTask,
+			NodeSummaryGroup: NodeSummaryGroup{
+				TopologyID: "ecs-tasks",
+				Label:      "Tasks",
+				Columns: []Column{
+					{ID: awsecs.CreatedAt, Label: "Created At", Datatype: "datetime"},
 				},
 			},
 		},


### PR DESCRIPTION
Previously, they were omitted.

Fixes #2041

![screenshot](https://cloud.githubusercontent.com/assets/570052/22171088/ba6e4ef8-df3b-11e6-9f70-2df1e0d68cb6.png)
