### PR TITLE
Fix ownership issues with client/build-external

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,9 @@ ui-build-pkg:
 
 clean:
 	$(GO) clean ./...
+	# build-external was accidentially created as owned by root in earlier versions. This is fixed now,
+	# but we need to fix up old checkouts, since git doesn't track ownership.
+	if [ "$$(stat -c %%U client/build-external)" == "root" ]; then sudo chown "$$USER:$$USER" client/build-external; fi
 	# Don't actually rmi the build images - rm'ing the .uptodate files is enough to ensure
 	# we rebuild the images, and rmi'ing the images causes us to have to redownload a lot of stuff.
 	# $(SUDO) docker rmi $(SCOPE_UI_BUILD_IMAGE) $(SCOPE_BACKEND_BUILD_IMAGE) >/dev/null 2>&1 || true

--- a/client/build-external/.gitignore
+++ b/client/build-external/.gitignore
@@ -1,0 +1,1 @@
+# this file is only present to force git to create this directory in the working tree


### PR DESCRIPTION
When the directory is created during the build process, it is as root.

This prevents us deleting root-owned files inside the directory during make clean.

In client/build/, we get around this because the directory contains a tracked file,
so it's created during git checkout.
We make this the case for build-external by adding a hidden, empty file to track.
This won't fix existing checkouts though, so we also add a fix-up step to make clean.

Fixes https://github.com/weaveworks/scope/issues/2031