### PR TITLE
Upgrade container base image to alpine:3.5

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,8 @@
-FROM alpine:3.3
+FROM alpine:3.5
 MAINTAINER Weaveworks Inc <help@weave.works>
 LABEL works.weave.role=system
 WORKDIR /home/weave
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >>/etc/apk/repositories && \
-	apk add --update bash runit conntrack-tools iproute2 util-linux curl && \
+RUN apk add --update bash runit conntrack-tools iproute2 util-linux curl && \
 	rm -rf /var/cache/apk/*
 ADD ./docker.tgz /
 ADD ./demo.json /


### PR DESCRIPTION
As well as upgrading to latest stable being nice in general,
this was triggered by an issue where we could no longer find the bash package in 3.3

This upgrade also lets us get rid of reliance on the edge (rolling latest) repository
for runit, since 3.5 now contains runit natively.

I've done some basic tests and nothing seems to be broken by the version changes.