### PR TITLE
Fix for incorrect iFrame API URLs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -75,8 +75,7 @@ deployment:
           )) &&
           docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope &&
           docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope:$(./tools/image-tag) &&
-          (test -z "${UI_BUCKET_KEY_ID}" || make ui-upload) &&
-          make ui-build-pkg
+          (test -z "${UI_BUCKET_KEY_ID}" || make ui-upload)
         )
       - |
         test -z "${QUAY_USER}" || (

--- a/circle.yml
+++ b/circle.yml
@@ -75,7 +75,8 @@ deployment:
           )) &&
           docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope &&
           docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope:$(./tools/image-tag) &&
-          (test -z "${UI_BUCKET_KEY_ID}" || make ui-upload)
+          (test -z "${UI_BUCKET_KEY_ID}" || make ui-upload) &&
+          make ui-build-pkg
         )
       - |
         test -z "${QUAY_USER}" || (

--- a/client/app/scripts/index.js
+++ b/client/app/scripts/index.js
@@ -1,0 +1,3 @@
+exports.reducer = require('./reducers/root').default;
+exports.Scope = require('./components/app').default;
+exports.ActionTypes = require('./constants/action-types').default;

--- a/client/index.js
+++ b/client/index.js
@@ -1,3 +1,0 @@
-exports.reducer = require('./dist/reducers/root').default;
-exports.Scope = require('./dist/components/app').default;
-exports.ActionTypes = require('./dist/constants/action-types').default;


### PR DESCRIPTION
Should have been included in #2144 

Ensures that scope uses the correct API URLs when running as a dependency, or as an iFrame.