### PR TITLE
scope: fix URL

### DIFF
--- a/scope
+++ b/scope
@@ -250,7 +250,8 @@ case "$COMMAND" in
         launch "$@"
         if ! check_probe_only; then
             IP_ADDRS=$(docker run --rm --net=host --entrypoint /bin/sh "$SCOPE_IMAGE" -c "$IP_ADDR_CMD")
-            print_app_endpoints "$IP_ADDRS"
+            # shellcheck disable=SC2086
+            print_app_endpoints $IP_ADDRS
         fi
 
         ;;


### PR DESCRIPTION
Symptoms: the Scope URL are printed this way:

```
Weave Scope is reachable at the following URL(s):
  * http://10.2.2.1
172.16.28.1
172.16.28.1
192.168.99.1
192.168.35.117
172.16.28.1
172.16.28.1
192.168.122.1:4040/
```

Regression from https://github.com/weaveworks/scope/pull/2068