### PR TITLE
don't attempt to make 'make clean' work on old checkouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,12 +174,9 @@ ui-build-pkg:
 
 clean:
 	$(GO) clean ./...
-	# build-external was accidentially created as owned by root in earlier versions. This is fixed now,
-	# but we need to fix up old checkouts, since git doesn't track ownership.
-	if [ "$$(stat -c %%U client/build-external)" == "root" ]; then sudo chown "$$USER:$$USER" client/build-external; fi
-	# Don't actually rmi the build images - rm'ing the .uptodate files is enough to ensure
-	# we rebuild the images, and rmi'ing the images causes us to have to redownload a lot of stuff.
-	# $(SUDO) docker rmi $(SCOPE_UI_BUILD_IMAGE) $(SCOPE_BACKEND_BUILD_IMAGE) >/dev/null 2>&1 || true
+# Don't actually rmi the build images - rm'ing the .uptodate files is enough to ensure
+# we rebuild the images, and rmi'ing the images causes us to have to redownload a lot of stuff.
+# $(SUDO) docker rmi $(SCOPE_UI_BUILD_IMAGE) $(SCOPE_BACKEND_BUILD_IMAGE) >/dev/null 2>&1 || true
 	rm -rf $(SCOPE_EXPORT) $(SCOPE_UI_BUILD_UPTODATE) $(SCOPE_BACKEND_BUILD_UPTODATE) \
 		$(SCOPE_EXE) $(RUNSVINIT) prog/staticui/staticui.go prog/externalui/externalui.go client/build/*.js client/build-external/*.js docker/weave .pkg \
 		$(CODECGEN_TARGETS) $(CODECGEN_DIR)/bin


### PR DESCRIPTION
It's just not worth the extra complication in the Makefile, and the code for it was actually broken.

Also, outdent comment so it doesn't get splattered onto the console.

Fixes #2188.