### PR TITLE
Change merge to re-assign when nodes are updated

### DIFF
--- a/client/app/scripts/reducers/__tests__/root-test.js
+++ b/client/app/scripts/reducers/__tests__/root-test.js
@@ -500,4 +500,29 @@ describe('RootReducer', () => {
     nextState = reducer(nextState, {type: ActionTypes.SET_RECEIVED_NODES_DELTA});
     expect(nextState.get('gridMode')).toBe(true);
   });
+  it('cleans up old adjacencies', () => {
+    // Add some nodes
+    const action1 = {
+      type: ActionTypes.RECEIVE_NODES_DELTA,
+      delta: { add: [{ id: 'n1' }, { id: 'n2' }] }
+    };
+    // Show nodes as connected
+    const action2 = {
+      type: ActionTypes.RECEIVE_NODES_DELTA,
+      delta: {
+        update: [{ id: 'n1', adjacency: ['n2'] }]
+      }
+    };
+    // Remove the connection
+    const action3 = {
+      type: ActionTypes.RECEIVE_NODES_DELTA,
+      delta: {
+        update: [{ id: 'n1' }]
+      }
+    };
+    let nextState = reducer(initialState, action1);
+    nextState = reducer(nextState, action2);
+    nextState = reducer(nextState, action3);
+    expect(nextState.getIn(['nodes', 'n1', 'adjacency'])).toBeFalsy();
+  });
 });

--- a/client/app/scripts/reducers/root.js
+++ b/client/app/scripts/reducers/root.js
@@ -553,7 +553,7 @@ export function rootReducer(state = initialState, action) {
       // update existing nodes
       each(action.delta.update, (node) => {
         if (state.hasIn(['nodes', node.id])) {
-          state = state.updateIn(['nodes', node.id], n => n.merge(fromJS(node)));
+          state = state.setIn(['nodes', node.id], fromJS(node));
         }
       });
 


### PR DESCRIPTION
Fix for #2181 

Changes the update function in RECEIVE_NODES_DELTA to completely replace the node, rather than merging it with existing properties. This was causing old adjacencies to hang around because they were not being overwritten by updates. 

Since the `adjacency` key is not present in in updates, a merge would not remove they key from the UI state. `Immutable.merge()` only affects keys that are defined in the source object.

This will remove any extra properties that get written by the UI to the `nodes`. As far as I can tell, there is nothing that mutates the values in the `nodes` key. It would be nice to be able to try an `Object.freeze` on that key to throw runtime errors if something tries to add keys or mutate it, but the Immutable lib doesn't support that.

@davkal Please review. 

cc @2opremio 