### PR TITLE
Add ECS Service scale up/down controls

### DIFF
--- a/probe/awsecs/client.go
+++ b/probe/awsecs/client.go
@@ -1,6 +1,7 @@
 package awsecs
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -20,6 +21,8 @@ const servicePrefix = "ecs-svc" // Task StartedBy field begins with this if it w
 type EcsClient interface {
 	// Returns a EcsInfo struct containing data needed for a report.
 	GetInfo([]string) EcsInfo
+	// Scales a service up or down by amount
+	ScaleService(string, int) error
 }
 
 // actual implementation
@@ -378,4 +381,10 @@ func (c ecsClientImpl) GetInfo(taskARNs []string) EcsInfo {
 	info := c.makeECSInfo(taskARNs, taskServiceMap)
 
 	return info
+}
+
+// Implements EcsClient.ScaleService
+func (c ecsClientImpl) ScaleService(serviceName string, amount int) error {
+	// TODO placeholder
+	return fmt.Errorf("ScaleService stub: %s, %d", serviceName, amount)
 }

--- a/probe/awsecs/client.go
+++ b/probe/awsecs/client.go
@@ -396,8 +396,8 @@ func (c ecsClientImpl) ScaleService(serviceName string, amount int) error {
 	}
 
 	newCount := service.DesiredCount + int64(amount)
-	if newCount < 0 {
-		return fmt.Errorf("Cannot reduce count below zero")
+	if newCount < 1 {
+		return fmt.Errorf("Cannot reduce count below one")
 	}
 	_, err := c.client.UpdateService(&ecs.UpdateServiceInput{
 		Cluster:      &c.cluster,

--- a/probe/awsecs/reporter.go
+++ b/probe/awsecs/reporter.go
@@ -153,7 +153,12 @@ func (r Reporter) Tag(rpt report.Report) (report.Report, error) {
 				ServiceDesiredCount:   fmt.Sprintf("%d", service.DesiredCount),
 				ServiceRunningCount:   fmt.Sprintf("%d", service.RunningCount),
 				report.ControlProbeID: r.probeID,
-			}).WithLatestActiveControls(ScaleUp, ScaleDown))
+			}).WithLatestControls(map[string]report.NodeControlData{
+				ScaleUp: {Dead: false},
+				// We've decided for now to disable ScaleDown when only 1 task is desired,
+				// since scaling down to 0 would cause the service to disappear (#2085)
+				ScaleDown: {Dead: service.DesiredCount <= 1},
+			}))
 		}
 		log.Debugf("Created %v ECS service nodes", len(ecsInfo.Services))
 

--- a/probe/awsecs/reporter_test.go
+++ b/probe/awsecs/reporter_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/weaveworks/scope/probe/awsecs"
+	"github.com/weaveworks/scope/probe/controls"
 	"github.com/weaveworks/scope/probe/docker"
 	"github.com/weaveworks/scope/report"
 )
@@ -36,7 +37,8 @@ func getTestContainerNode() report.Node {
 }
 
 func TestGetLabelInfo(t *testing.T) {
-	r := awsecs.Make(1e6, time.Hour)
+	hr := controls.NewDefaultHandlerRegistry()
+	r := awsecs.Make(1e6, time.Hour, hr, "test-probe-id")
 	rpt, err := r.Report()
 	if err != nil {
 		t.Fatalf("Error making report: %v", err)
@@ -84,8 +86,13 @@ func (c mockEcsClient) GetInfo(taskARNs []string) awsecs.EcsInfo {
 	return c.info
 }
 
+func (c mockEcsClient) ScaleService(serviceName string, amount int) error {
+	return nil
+}
+
 func TestTagReport(t *testing.T) {
-	r := awsecs.Make(1e6, time.Hour)
+	hr := controls.NewDefaultHandlerRegistry()
+	r := awsecs.Make(1e6, time.Hour, hr, "test-probe-id")
 
 	r.ClientsByCluster[testCluster] = newMockEcsClient(
 		t,

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -220,7 +220,8 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 	}
 
 	if flags.ecsEnabled {
-		reporter := awsecs.Make(flags.ecsCacheSize, flags.ecsCacheExpiry)
+		reporter := awsecs.Make(flags.ecsCacheSize, flags.ecsCacheExpiry, handlerRegistry, probeID)
+		defer reporter.Stop()
 		p.AddReporter(reporter)
 		p.AddTagger(reporter)
 	}


### PR DESCRIPTION
Adds Scale Up / Scale Down controls for ECS services in the same manner as Kubernetes Replica Sets/Deployments.

Note this requires an additional permission "ecs:UpdateService". Documentation will need to be changed to include this.
However I don't know where that particular documentation is kept (perhaps an argument for keeping the documentation in-repo,
so it can be modified in conjunction with code changes instead of as an afterthought).

Partially addresses https://github.com/weaveworks/scope/issues/2051