### PR TITLE
Release 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,6 @@ Internal improvements and cleanup:
 - Fix force-push to master
 	[#2094](https://github.com/weaveworks/scope/pull/2094)
 - Upgraded eslint & eslint-config-airbnb	
-- Reapplied all the eslint upgrade changes
 	[#2058](https://github.com/weaveworks/scope/pull/2058)
 	[#2084](https://github.com/weaveworks/scope/pull/2084)
 	[#2089](https://github.com/weaveworks/scope/pull/2089)
@@ -139,7 +138,9 @@ Internal improvements and cleanup:
 	[#2021](https://github.com/weaveworks/scope/pull/2021)
 - Using `webpack-dev-middleware` instead of `webpack-dev-server` directly
 	[#2034](https://github.com/weaveworks/scope/pull/2034)
-
+- Create `latest_release` Docker image tag during release process
+	[#2216](https://github.com/weaveworks/scope/issues/2216)
+	
 Weave Cloud related changes:
 - Deploy to quay when merging to master
 	[#2134](https://github.com/weaveworks/scope/pull/2134)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Performance improvements:
 	[#2128](https://github.com/weaveworks/scope/pull/2128)
 	[#2179](https://github.com/weaveworks/scope/pull/2179)
 	[#2180](https://github.com/weaveworks/scope/pull/2180)
+	[#2210](https://github.com/weaveworks/scope/pull/2210)
 - Disable XML in conntrack parsing
 	[#2095](https://github.com/weaveworks/scope/pull/2095)
 	[#2118](https://github.com/weaveworks/scope/pull/2118)
@@ -67,6 +68,10 @@ Bug fixes:
 	[#1187](https://github.com/weaveworks/scope/issues/1187)
 - Fix two bugs caused by transition to D3 v4
 	[#2048](https://github.com/weaveworks/scope/pull/2048)
+- Popped out terminal styles don't quite align with in-scope terminal styles
+	[#2209](https://github.com/weaveworks/scope/issues/2209)
+- Radii of rounded-corner shape don't quite align
+	[#2212](https://github.com/weaveworks/scope/issues/2212)
 	
 Documentation:
 - Fix Scope arguments in Docker Compose installation docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,149 @@
+## Release 1.2.0
+
+Highlights:
+- Performance improvements (both in UI and probes).
+- Scope now requires Docker version >= 1.10.
+
+New features and enhancements:
+- ECS: service details panel should list its tasks
+	[#2041](https://github.com/weaveworks/scope/issues/2041)
+- Prioritize ecs topologies on initial load if available
+	[#2105](https://github.com/weaveworks/scope/pull/2105)
+- Add control status icon to Terminal header
+	[#2087](https://github.com/weaveworks/scope/pull/2087)
+- scope launch script improvements
+	[#2077](https://github.com/weaveworks/scope/pull/2077)
+	[#2093](https://github.com/weaveworks/scope/pull/2093)
+- Maintain focus on hovered node table rows
+	[#2115](https://github.com/weaveworks/scope/pull/2115)
+- Add control to reset local view state
+	[#2080](https://github.com/weaveworks/scope/pull/2080)
+- Check that conntrack events are enabled in the kernel
+	[#2112](https://github.com/weaveworks/scope/pull/2112)
+- Hardcode 127.0.0.1 as loopback IP for default target
+	[#2103](https://github.com/weaveworks/scope/pull/2103)
+- prog/main: use flags.app.port for default target
+	[#2096](https://github.com/weaveworks/scope/pull/2096)
+
+Performance improvements:
+- Graph layout optimizations
+	[#2128](https://github.com/weaveworks/scope/pull/2128)
+	[#2179](https://github.com/weaveworks/scope/pull/2179)
+	[#2180](https://github.com/weaveworks/scope/pull/2180)
+- Disable XML in conntrack parsing
+	[#2095](https://github.com/weaveworks/scope/pull/2095)
+	[#2118](https://github.com/weaveworks/scope/pull/2118)
+
+Bug fixes:
+- ECS reporter throttled by AWS API
+	[#2050](https://github.com/weaveworks/scope/issues/2050)
+- Already closed connections showing up in the containers tab
+	[#2181](https://github.com/weaveworks/scope/issues/2181)
+- Node details spinner Chrome display bug fix
+	[#2177](https://github.com/weaveworks/scope/pull/2177)
+- fix error when docker daemon is running with user namespace enabled.
+	[#2161](https://github.com/weaveworks/scope/pull/2161)
+	[#2176](https://github.com/weaveworks/scope/pull/2176)
+- DNSSnooper: Support Dot1Q and limit decoding errors
+	[#2155](https://github.com/weaveworks/scope/issues/2155)
+- Contrast mode not working
+	[#2165](https://github.com/weaveworks/scope/issues/2165)
+	[#2138](https://github.com/weaveworks/scope/issues/2138)	
+- Scope does not create special nodes within the same VPC
+	[#2163](https://github.com/weaveworks/scope/issues/2163)
+- default view fails to select 'application containers only'
+	[#2120](https://github.com/weaveworks/scope/issues/2120)
+- ECS: Missing link to task on container details panel
+	[#2040](https://github.com/weaveworks/scope/issues/2040)
+- kubernetes reporter is broken on katacoda
+	[#2049](https://github.com/weaveworks/scope/pull/2049)
+- probe's procspy does not report netcat's half-duplex long-lived connections
+	[#1972](https://github.com/weaveworks/scope/issues/1972)
+- Sparkline component throws errors when a container is turned off
+	[#2072](https://github.com/weaveworks/scope/pull/2072)
+- Graph/table buttons don't resize nicely
+	[#2056](https://github.com/weaveworks/scope/issues/2056)
+- JS error on edges with lots of waypoints
+	[#1187](https://github.com/weaveworks/scope/issues/1187)
+- Fix two bugs caused by transition to D3 v4
+	[#2048](https://github.com/weaveworks/scope/pull/2048)
+	
+Documentation:
+- Fix Scope arguments in Docker Compose installation docs
+	[#2143](https://github.com/weaveworks/scope/pull/2143)
+- Document how to run tests on website
+	[#2131](https://github.com/weaveworks/scope/pull/2131)
+- Follow redirections in curl when getting k8s resources
+	[#2067](https://github.com/weaveworks/scope/pull/2067)
+
+Internal improvements and cleanup:
+- Embed and require Docker >= 1.10
+	[#2190](https://github.com/weaveworks/scope/pull/2190)
+- don't attempt to make 'make clean' work on old checkouts
+	[#2189](https://github.com/weaveworks/scope/pull/2189)
+- Fix linter errors
+	[#2068](https://github.com/weaveworks/scope/pull/2068)
+	[#2166](https://github.com/weaveworks/scope/pull/2166)
+- Fix ownership issues with client/build-external
+	[#2153](https://github.com/weaveworks/scope/pull/2153)
+- Allow Scope UI to be installed as a Node module
+	[#2144](https://github.com/weaveworks/scope/pull/2144)
+	[#2159](https://github.com/weaveworks/scope/pull/2159)
+- Upgrade container base image to alpine:3.5
+	[#2158](https://github.com/weaveworks/scope/pull/2158)
+- Use Sass instead of Less
+	[#2141](https://github.com/weaveworks/scope/pull/2141)
+- probe: refactor probeMain
+	[#2148](https://github.com/weaveworks/scope/pull/2148)
+- Update to go1.7.4
+	[#2147](https://github.com/weaveworks/scope/pull/2147)
+- Bump tools subtree and fix integration tests
+	[#2136](https://github.com/weaveworks/scope/pull/2136)
+- Add support for generic multicolumn tables
+	[#2109](https://github.com/weaveworks/scope/pull/2109)
+- extras/dialer: move dialer.go to sub directory
+	[#2108](https://github.com/weaveworks/scope/pull/2108)
+- Forward OS/Kernel version to checkpoint
+	[#2101](https://github.com/weaveworks/scope/pull/2101)
+- Fix force-push to master
+	[#2094](https://github.com/weaveworks/scope/pull/2094)
+- Upgraded eslint & eslint-config-airbnb	
+- Reapplied all the eslint upgrade changes
+	[#2058](https://github.com/weaveworks/scope/pull/2058)
+	[#2084](https://github.com/weaveworks/scope/pull/2084)
+	[#2089](https://github.com/weaveworks/scope/pull/2089)
+- ecs reporter: Fix some log lines that were passing *string instead of string
+	[#2060](https://github.com/weaveworks/scope/pull/2060)
+- Add flag for logging headers
+	[#2086](https://github.com/weaveworks/scope/pull/2086)
+- Add extras/dialer
+	[#2082](https://github.com/weaveworks/scope/pull/2082)
+- Remove wcloud
+	[#2081](https://github.com/weaveworks/scope/pull/2081)
+- Add client linting to CI config
+	[#2076](https://github.com/weaveworks/scope/pull/2076)
+- Importing lodash util functions explicitly
+	[#2053](https://github.com/weaveworks/scope/pull/2053)
+- procspy: use a Reader to copy the background reader buffer
+	[#2020](https://github.com/weaveworks/scope/pull/2020)
+- Use newly-created 'common' repo
+	[#2061](https://github.com/weaveworks/scope/pull/2061)
+- Fix all the npm library versions
+	[#2057](https://github.com/weaveworks/scope/pull/2057)
+- linter: fix punctuation and capitalization
+	[#2021](https://github.com/weaveworks/scope/pull/2021)
+- Using `webpack-dev-middleware` instead of `webpack-dev-server` directly
+	[#2034](https://github.com/weaveworks/scope/pull/2034)
+
+Weave Cloud related changes:
+- Deploy to quay when merging to master
+	[#2134](https://github.com/weaveworks/scope/pull/2134)
+- Removed leading slash from getAllNodes() api request
+	[#2124](https://github.com/weaveworks/scope/pull/2124)
+- Correctly instrument websocket handshakes
+	[#2074](https://github.com/weaveworks/scope/pull/2074)
+
+
 ## Release 1.1.0
 
 Highlights:

--- a/bin/release
+++ b/bin/release
@@ -206,7 +206,7 @@ publish() {
 
         echo "== Tagging and pushing images on docker hub as user $DOCKERHUB_USER"
         $SUDO docker tag "$DOCKERHUB_USER"/scope "$DOCKERHUB_USER/scope:$VERSION"
-        $SUDO docker push "$DOCKERHUB_USER"/scope:$"VERSION"
+        $SUDO docker push "$DOCKERHUB_USER/scope:$VERSION"
         $SUDO docker tag "$DOCKERHUB_USER/scope:$VERSION" "$DOCKERHUB_USER/scope:latest_release"
         $SUDO docker push "$DOCKERHUB_USER/scope:latest_release"
         echo "** Docker images tagged and pushed"

--- a/bin/release
+++ b/bin/release
@@ -172,6 +172,8 @@ publish() {
         echo "== Tagging and pushing images on docker hub as user $DOCKERHUB_USER"
         $SUDO docker tag -f "$DOCKERHUB_USER"/scope "$DOCKERHUB_USER/scope:$VERSION"
         $SUDO docker push "$DOCKERHUB_USER/scope:$VERSION"
+        $SUDO docker tag -f "$DOCKERHUB_USER/scope:$VERSION" "$DOCKERHUB_USER/scope:latest_release"
+        $SUDO docker push "$DOCKERHUB_USER/scope:latest_release"
         echo "** Docker images tagged and pushed"
 
         echo "== Publishing pre-release on GitHub"
@@ -205,6 +207,8 @@ publish() {
         echo "== Tagging and pushing images on docker hub as user $DOCKERHUB_USER"
         $SUDO docker tag -f "$DOCKERHUB_USER"/scope "$DOCKERHUB_USER/scope:$VERSION"
         $SUDO docker push "$DOCKERHUB_USER"/scope:$"VERSION"
+        $SUDO docker tag -f "$DOCKERHUB_USER/scope:$VERSION" "$DOCKERHUB_USER/scope:latest_release"
+        $SUDO docker push "$DOCKERHUB_USER/scope:latest_release"
         echo "** Docker images tagged and pushed"
 
         echo "== Publishing release on GitHub"

--- a/bin/release
+++ b/bin/release
@@ -170,9 +170,9 @@ publish() {
 
     if [ "$RELEASE_TYPE" = 'PRERELEASE' ]; then
         echo "== Tagging and pushing images on docker hub as user $DOCKERHUB_USER"
-        $SUDO docker tag -f "$DOCKERHUB_USER"/scope "$DOCKERHUB_USER/scope:$VERSION"
+        $SUDO docker tag "$DOCKERHUB_USER"/scope "$DOCKERHUB_USER/scope:$VERSION"
         $SUDO docker push "$DOCKERHUB_USER/scope:$VERSION"
-        $SUDO docker tag -f "$DOCKERHUB_USER/scope:$VERSION" "$DOCKERHUB_USER/scope:latest_release"
+        $SUDO docker tag "$DOCKERHUB_USER/scope:$VERSION" "$DOCKERHUB_USER/scope:latest_release"
         $SUDO docker push "$DOCKERHUB_USER/scope:latest_release"
         echo "** Docker images tagged and pushed"
 
@@ -205,9 +205,9 @@ publish() {
         echo '** Sanity checks OK for publishing tag' "$LATEST_TAG" as "$DOCKERHUB_USER/scope:$VERSION"
 
         echo "== Tagging and pushing images on docker hub as user $DOCKERHUB_USER"
-        $SUDO docker tag -f "$DOCKERHUB_USER"/scope "$DOCKERHUB_USER/scope:$VERSION"
+        $SUDO docker tag "$DOCKERHUB_USER"/scope "$DOCKERHUB_USER/scope:$VERSION"
         $SUDO docker push "$DOCKERHUB_USER"/scope:$"VERSION"
-        $SUDO docker tag -f "$DOCKERHUB_USER/scope:$VERSION" "$DOCKERHUB_USER/scope:latest_release"
+        $SUDO docker tag "$DOCKERHUB_USER/scope:$VERSION" "$DOCKERHUB_USER/scope:latest_release"
         $SUDO docker push "$DOCKERHUB_USER/scope:latest_release"
         echo "** Docker images tagged and pushed"
 

--- a/client/app/scripts/charts/node-shape-square.js
+++ b/client/app/scripts/charts/node-shape-square.js
@@ -34,7 +34,7 @@ export default function NodeShapeSquare({ id, highlighted, color, rx = 0, ry = 0
       {hasMetric && getClipPathDefinition(clipId, height)}
       {highlighted && <rect className="highlighted" {...rectProps(NODE_SHAPE_HIGHLIGHT_RADIUS)} />}
       <rect className="border" stroke={color} {...rectProps(NODE_SHAPE_BORDER_RADIUS)} />
-      <rect className="shadow" {...rectProps(NODE_SHAPE_SHADOW_RADIUS)} />
+      <rect className="shadow" {...rectProps(NODE_SHAPE_SHADOW_RADIUS, 0.85)} />
       {hasMetric && <rect
         className="metric-fill"
         clipPath={`url(#${clipId})`}

--- a/client/app/scripts/charts/node-shape-stack.js
+++ b/client/app/scripts/charts/node-shape-stack.js
@@ -1,9 +1,12 @@
 import React from 'react';
+
+import { NODE_BASE_SIZE } from '../constants/styles';
 import { isContrastMode } from '../utils/contrast-utils';
 
 export default function NodeShapeStack(props) {
-  const dy = isContrastMode() ? 0.15 : 0.1;
-  const highlightScale = [1, 1 + dy];
+  const shift = isContrastMode() ? 0.15 : 0.1;
+  const highlightScale = [1, 1 + shift];
+  const dy = NODE_BASE_SIZE * shift;
 
   const Shape = props.shape;
   return (

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -61,7 +61,7 @@
   opacity: 0;
 }
 
-.scope-app {
+.scope-app, .terminal-app {
   -webkit-font-smoothing: antialiased;
   background: $body-background-color;
   bottom: 0;
@@ -977,11 +977,6 @@
 .terminal {
 
   &-app {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
     display: flex;
     flex-flow: column;
   }

--- a/site/installing.md
+++ b/site/installing.md
@@ -121,7 +121,7 @@ After it’s been launched, open your browser to `http://localhost:4040`.
 **Docker Compose Format Version 1:**
 
     scope:
-      image: weaveworks/scope:1.1.0
+      image: weaveworks/scope:1.2.0
       net: "host"
       pid: "host"
       privileged: true
@@ -137,7 +137,7 @@ After it’s been launched, open your browser to `http://localhost:4040`.
     version: '2'
     services:
       scope:
-        image: weaveworks/scope:1.1.0
+        image: weaveworks/scope:1.2.0
         network_mode: "host"
         pid: "host"
         privileged: true
@@ -169,7 +169,7 @@ After it’s been launched, open your web browser to [https://cloud.weave.works]
 **Docker Compose Format Version 1:**
 
     probe:
-      image: weaveworks/scope:1.1.0
+      image: weaveworks/scope:1.2.0
       net: "host"
       pid: "host"
       privileged: true
@@ -186,7 +186,7 @@ After it’s been launched, open your web browser to [https://cloud.weave.works]
     version: '2'
     services:
       probe:
-        image: weaveworks/scope:1.1.0
+        image: weaveworks/scope:1.2.0
         network_mode: "host"
         pid: "host"
         privileged: true


### PR DESCRIPTION
@davkal @foot @ekimekim @bowenli @jpellizzari @tomwilkie @abuehrle @pidster @errordeveloper @rade Please chip in by testing this release branch in the scenarios below and tick off what you tested afterwards (including your name at the end). Have a look at the CHANGELOG to prioritize your testing.

To make things  easier to test I have pushed the image `weaveworks/scope:release-1.2-9e33e7e`
Thanks!

- [ ] Start a 2 node cluster and leave a UI connected, watch for performance regression
- [x] Run a Scope cluster on ECS (mike)
- [x] Run Scope on https://github.com/microservices-demo/microservices-demo/ (mike)
- [x] Run Scope on Docker For Mac (Stuart)
- [ ] Start and stop Scope in standalone mode
  - [x] Linux (mike)
  - [ ] docker-machine
- [x] Connect probes from release candidate to Weave Cloud (fons)
  - [x] Local scope in probe-only mode connects to Weave Cloud and renders correctly
    - [x] dev
    - [x] prod
  - [x] Controls appear for containers and function correctly
    - [x] dev
    - [x] prod
  - [x] No new errors in logging or telemetry
    - [x] dev
    - [x] prod
- [ ] UI integration
  - [ ] Hot-reloading `cd client && npm i && npm start` and open http://localhost:4042
  - [x] UI under prefix path  `cd client && npm run build && npm start-production` and open http://localhost:4043/scoped/
  - [x] URL parameters: Run previous release and click around, keep UI open, start new release, reload page
- [x] UI features
  (To test: clone [microservices demo](https://github.com/microservices-demo/microservices-demo) and run `cd deploy/docker-compose && docker-compose up`)
  - [x] General: switch between topologies, see nodes and edges, details panel (Stuart)
  - [x] Zoom and pan, switch between topologies
  - [x] Topology filters: namespaces, system containers, etc. (Stuart)
  - [x] Metrics on canvas, try pinning/unpinning (Stuart)
  - [x] Search
    - [x] by container name
    - [x] by usage `cpu < 2%`
  - [x] Terminal (fons)
    - [x] Attach to container to see logs
    - [x] Exec to container and type `ls`
    - [x] Pop out terminal
  - [x] Contrast mode (fons)
  - [x] Download report
  - [x] Pause button

## Things to think about
- ECS Integration
- Kubernetes Integration
- CPU and memory usage