### PR TITLE
tools/sched: Fix unicode encoding issues

### DIFF
--- a/tools/sched
+++ b/tools/sched
@@ -1,20 +1,20 @@
 #!/usr/bin/python
-import sys, string, json, urllib
+import sys, string, urllib
 import requests
 import optparse
 
 def test_time(target, test_name, runtime):
   r = requests.post(target + "/record/%s/%f" % (urllib.quote(test_name, safe=""), runtime))
-  print r.text
+  print r.text.encode('utf-8')
   assert r.status_code == 204
 
 def test_sched(target, test_run, shard_count, shard_id):
-  tests = json.dumps({'tests': string.split(sys.stdin.read())})
-  r = requests.post(target + "/schedule/%s/%d/%d" % (test_run, shard_count, shard_id), data=tests)
+  tests = {'tests': string.split(sys.stdin.read())}
+  r = requests.post(target + "/schedule/%s/%d/%d" % (test_run, shard_count, shard_id), json=tests)
   assert r.status_code == 200
   result = r.json()
   for test in sorted(result['tests']):
-    print test
+    print test.encode('utf-8')
 
 def usage():
   print "%s (--target=...) <cmd> <args..>" % sys.argv[0]


### PR DESCRIPTION
The response.text and json-parsed string values are both unicode strings.
The print statement requires bytes, as per write(2).
Python is dumb and bad at converting between them properly - in the name of being "safe"
it errors if any non-ascii characters are present, so it works until it doesn't.
We fix this by explicitly encoding as utf-8.