### PR TITLE
bin/setup-circleci-secrets: possibly use generic credentials

### DIFF
--- a/bin/setup-circleci-secrets
+++ b/bin/setup-circleci-secrets
@@ -5,9 +5,10 @@ set -eu
 # openssl enc -in do-setup-circleci-secrets.orig -out setup-circleci-secrets.orig -e -aes256 -pass stdin
 # openssl base64 < setup-circleci-secrets.orig
 
-openssl base64 -d <<EOF | openssl enc \
-    -out bin/do-setup-circleci-secrets \
-    -d -aes256 -pass pass:"$1"
+echo "Checking script..."
+
+if [ -z "${SECRET_SCRIPT}" ]; then
+    read -r -d '' SECRET_SCRIPT <<EOF
 U2FsdGVkX193YHZJXNzxU9GqigQaXWrA0AKd+BIjRcx7bmmKn/zSgOv+FfApRRjn
 KGBd2ulZw9CwsftX0HWHzVdtpgqbJUW+FEma8eNldau4/f+T+yWTVpCNQXGc3DvB
 cWYhmkoTfGWmI2v/0/Bv2TYkw7MAfjCocdluFAv7sSvYnSgIjoYxD4XXkTjLWy1P
@@ -104,5 +105,14 @@ LrFefj0OWhRx4w7pblAnZqUSYunhhhUYimEG40GkM1ZI9b0vDmbgQP/UxMj1M2yB
 aVSSW69rmjO7xjVuJnm+wNq2P3H3MFB5MaswXrn2Ah83K4oegpannt7H1nG+mWh/
 DJcoVj5UyCTFEyZMdtVWloF4TOVODNNxA+zAE9fUgrI=
 EOF
+fi
+
+echo "Decrypting script..."
+
+echo "${SECRET_SCRIPT}" | base64 -d | openssl enc \
+    -out bin/do-setup-circleci-secrets \
+    -d -aes256 -pass pass:"$1"
+
+echo "Script decrypted"
 
 exec sh bin/do-setup-circleci-secrets

--- a/integration/gce.sh
+++ b/integration/gce.sh
@@ -5,8 +5,8 @@ set -e
 # shellcheck disable=SC1091
 . ./config.sh
 
-export PROJECT=scope-integration-tests
-export TEMPLATE_NAME="test-template-5"
+export PROJECT="${PROJECT:-scope-integration-tests}"
+export TEMPLATE_NAME="${TEMPLATE_NAME:-test-template-5}"
 export NUM_HOSTS=5
 # shellcheck disable=SC1091
 . "../tools/integration/gce.sh" "$@"


### PR DESCRIPTION
If the $SECRET_SCRIPT environment variable is defined in CircleCI, this
can override the GCE credentials.

I now use "base64" instead of "openssl base64" in order to support long
lines in base64 text. It's useful when the text comes from a long
environment variable like $SECRET_SCRIPT defined in CircleCI.

Also, the $PROJECT environment variable can now override the GCE project
name. Before, it needed to be named scope-integration-tests.

