### PR TITLE
Reintroduce probe checkpoint flags for kernel version and OS

### DIFF
--- a/prog/probe.go
+++ b/prog/probe.go
@@ -47,7 +47,7 @@ var (
 )
 
 func checkNewScopeVersion(flags probeFlags) {
-	checkpointFlags := map[string]string{}
+	checkpointFlags := makeBaseCheckpointFlags()
 	if flags.kubernetesEnabled {
 		checkpointFlags["kubernetes_enabled"] = "true"
 	}


### PR DESCRIPTION
Removed unintentionally in https://github.com/weaveworks/scope/pull/2148

Unfortunately this means we won't get kernel version information for the probes until the next Scope release :(