### PR TITLE
bin/setup-circleci-secrets: fix shell "unbound variable"

### DIFF
--- a/bin/setup-circleci-secrets
+++ b/bin/setup-circleci-secrets
@@ -7,7 +7,7 @@ set -eu
 
 echo "Checking script..."
 
-if [ -z "${SECRET_SCRIPT}" ]; then
+if [ -z "${SECRET_SCRIPT+x}" ]; then
     read -r -d '' SECRET_SCRIPT <<EOF
 U2FsdGVkX193YHZJXNzxU9GqigQaXWrA0AKd+BIjRcx7bmmKn/zSgOv+FfApRRjn
 KGBd2ulZw9CwsftX0HWHzVdtpgqbJUW+FEma8eNldau4/f+T+yWTVpCNQXGc3DvB


### PR DESCRIPTION
Since this shell script uses "set -u", we must not use unset variables
directly.

Symptoms:
> https://circleci.com/gh/weaveworks/scope/6384
> bin/setup-circleci-secrets: line 10: SECRET_SCRIPT: unbound variable

Instead, we should use the parameter expansion "+" to test if the
variable is set. See:
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02