### PR TITLE
Revert "bin/setup-circleci-secrets: possibly use generic credentials"

### DIFF
--- a/bin/setup-circleci-secrets
+++ b/bin/setup-circleci-secrets
@@ -5,10 +5,9 @@ set -eu
 # openssl enc -in do-setup-circleci-secrets.orig -out setup-circleci-secrets.orig -e -aes256 -pass stdin
 # openssl base64 < setup-circleci-secrets.orig
 
-echo "Checking script..."
-
-if [ -z "${SECRET_SCRIPT}" ]; then
-    read -r -d '' SECRET_SCRIPT <<EOF
+openssl base64 -d <<EOF | openssl enc \
+    -out bin/do-setup-circleci-secrets \
+    -d -aes256 -pass pass:"$1"
 U2FsdGVkX193YHZJXNzxU9GqigQaXWrA0AKd+BIjRcx7bmmKn/zSgOv+FfApRRjn
 KGBd2ulZw9CwsftX0HWHzVdtpgqbJUW+FEma8eNldau4/f+T+yWTVpCNQXGc3DvB
 cWYhmkoTfGWmI2v/0/Bv2TYkw7MAfjCocdluFAv7sSvYnSgIjoYxD4XXkTjLWy1P
@@ -105,14 +104,5 @@ LrFefj0OWhRx4w7pblAnZqUSYunhhhUYimEG40GkM1ZI9b0vDmbgQP/UxMj1M2yB
 aVSSW69rmjO7xjVuJnm+wNq2P3H3MFB5MaswXrn2Ah83K4oegpannt7H1nG+mWh/
 DJcoVj5UyCTFEyZMdtVWloF4TOVODNNxA+zAE9fUgrI=
 EOF
-fi
-
-echo "Decrypting script..."
-
-echo "${SECRET_SCRIPT}" | base64 -d | openssl enc \
-    -out bin/do-setup-circleci-secrets \
-    -d -aes256 -pass pass:"$1"
-
-echo "Script decrypted"
 
 exec sh bin/do-setup-circleci-secrets

--- a/integration/gce.sh
+++ b/integration/gce.sh
@@ -5,8 +5,8 @@ set -e
 # shellcheck disable=SC1091
 . ./config.sh
 
-export PROJECT="${PROJECT:-scope-integration-tests}"
-export TEMPLATE_NAME="${TEMPLATE_NAME:-test-template-5}"
+export PROJECT=scope-integration-tests
+export TEMPLATE_NAME="test-template-5"
 export NUM_HOSTS=5
 # shellcheck disable=SC1091
 . "../tools/integration/gce.sh" "$@"


### PR DESCRIPTION
This reverts commit d0a5315c5c58c2168e7f3ee7fe65e942ec8cb9bd.

-----

The regression comes from #2223. I tried to fix it in #2225 but the PR is not yet ready. So meanwhile, this is to revert it.

/cc @2opremio 