### PR TITLE
Fix help menu not opening from 'search' hint

### DIFF
--- a/client/app/scripts/components/search.js
+++ b/client/app/scripts/components/search.js
@@ -140,7 +140,7 @@ class Search extends React.Component {
           {!showPinnedSearches && <div className="search-hint">
             {getHint(nodes)} <span
               className="search-help-link fa fa-question-circle"
-              onClick={onClickHelp} />
+              onMouseDown={onClickHelp} />
           </div>}
         </div>
       </div>

--- a/client/app/scripts/utils/search-utils.js
+++ b/client/app/scripts/utils/search-utils.js
@@ -271,7 +271,7 @@ export function getSearchableFields(nodes) {
 
   const tableRowLabels = nodes.reduce((labels, node) => (
     labels.union(get(node, 'tables').flatMap(t => (t.get('rows') || makeList)
-      .map(f => f.get('label'))
+      .map(f => f.getIn(['entries', 'label']))
     ))
   ), makeSet());
 


### PR DESCRIPTION
Fix for #2227 

Fixes the issue where the help menu wasn't opening unless there was text in the field. Also changed the debug menu icon to a 'warning' icon (the bug didn't make sense anymore).