### PR TITLE
Show loading indicator on topology changes

### DIFF
--- a/client/app/scripts/reducers/__tests__/root-test.js
+++ b/client/app/scripts/reducers/__tests__/root-test.js
@@ -499,6 +499,7 @@ describe('RootReducer', () => {
     let nextState = initialState.set('currentTopology', fromJS(topologies[0]));
     nextState = reducer(nextState, {type: ActionTypes.SET_RECEIVED_NODES_DELTA});
     expect(nextState.get('gridMode')).toBe(true);
+    expect(nextState.get('initialNodesLoaded')).toBe(true);
   });
   it('cleans up old adjacencies', () => {
     // Add some nodes

--- a/client/app/scripts/reducers/root.js
+++ b/client/app/scripts/reducers/root.js
@@ -281,6 +281,7 @@ export function rootReducer(state = initialState, action) {
         state = state.update('nodes', nodes => nodes.clear());
       }
       state = state.set('availableCanvasMetrics', makeList());
+      state = state.set('nodesLoaded', false);
       return state;
     }
 
@@ -293,6 +294,7 @@ export function rootReducer(state = initialState, action) {
         state = state.update('nodes', nodes => nodes.clear());
       }
       state = state.set('availableCanvasMetrics', makeList());
+      state = state.set('nodesLoaded', false);
       return state;
     }
 


### PR DESCRIPTION
Implements #1804 

When a user changes topologies via click on the topology filter, or by clicking 'SHOW IN <topology>', the loading indicator will show after 1 second. It will be cleared by the first nodes delta data arriving via websockets.