### PR TITLE
Release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## Release 1.2.1
+This is a minor patch release.
+
+Documentation
+- Uploaded new cloud token screenshot
+	[#2248](https://github.com/weaveworks/scope/pull/2248)
+- Updated cloud description
+	[#2249](https://github.com/weaveworks/scope/pull/2249)
+
+Bugfixes
+- Fix help menu not opening from 'search' hint
+	[#2230](https://github.com/weaveworks/scope/pull/2230)
+- Re-factor API URL generation code
+	[#2202](https://github.com/weaveworks/scope/pull/2202)
+
+Improvements
+- Reintroduce probe checkpoint flags for kernel version and OS
+	[#2224](https://github.com/weaveworks/scope/pull/2224)
+- Upgraded xterm.js to 2.2.3
+	[#2126](https://github.com/weaveworks/scope/pull/2126)
+- Allow random seed in dialer
+	[#2206](https://github.com/weaveworks/scope/pull/2206)
+- Rename ECS Service node ids to be cluster;serviceName
+	[#2186](https://github.com/weaveworks/scope/pull/2186)
+
 ## Release 1.2.0
 
 Highlights:
@@ -49,7 +74,7 @@ Bug fixes:
 	[#2155](https://github.com/weaveworks/scope/issues/2155)
 - Contrast mode not working
 	[#2165](https://github.com/weaveworks/scope/issues/2165)
-	[#2138](https://github.com/weaveworks/scope/issues/2138)	
+	[#2138](https://github.com/weaveworks/scope/issues/2138)
 - Scope does not create special nodes within the same VPC
 	[#2163](https://github.com/weaveworks/scope/issues/2163)
 - default view fails to select 'application containers only'
@@ -72,7 +97,7 @@ Bug fixes:
 	[#2209](https://github.com/weaveworks/scope/issues/2209)
 - Radii of rounded-corner shape don't quite align
 	[#2212](https://github.com/weaveworks/scope/issues/2212)
-	
+
 Documentation:
 - Fix Scope arguments in Docker Compose installation docs
 	[#2143](https://github.com/weaveworks/scope/pull/2143)
@@ -112,7 +137,7 @@ Internal improvements and cleanup:
 	[#2101](https://github.com/weaveworks/scope/pull/2101)
 - Fix force-push to master
 	[#2094](https://github.com/weaveworks/scope/pull/2094)
-- Upgraded eslint & eslint-config-airbnb	
+- Upgraded eslint & eslint-config-airbnb
 	[#2058](https://github.com/weaveworks/scope/pull/2058)
 	[#2084](https://github.com/weaveworks/scope/pull/2084)
 	[#2089](https://github.com/weaveworks/scope/pull/2089)
@@ -140,7 +165,7 @@ Internal improvements and cleanup:
 	[#2034](https://github.com/weaveworks/scope/pull/2034)
 - Create `latest_release` Docker image tag during release process
 	[#2216](https://github.com/weaveworks/scope/issues/2216)
-	
+
 Weave Cloud related changes:
 - Deploy to quay when merging to master
 	[#2134](https://github.com/weaveworks/scope/pull/2134)
@@ -407,7 +432,7 @@ Highlights:
 New features and enhancements:
 - Table mode
 	[#1673](https://github.com/weaveworks/scope/pull/1673)
-	[#1747](https://github.com/weaveworks/scope/pull/1747)	
+	[#1747](https://github.com/weaveworks/scope/pull/1747)
 	[#1753](https://github.com/weaveworks/scope/pull/1753)
 	[#1774](https://github.com/weaveworks/scope/pull/1774)
 	[#1775](https://github.com/weaveworks/scope/pull/1775)
@@ -417,16 +442,16 @@ New features and enhancements:
 - Don't show weavescope logo when running in a frame
 	[#1734](https://github.com/weaveworks/scope/pull/1734)
 - Reduce horizontal gap between nodes in topology views
-	[#1693](https://github.com/weaveworks/scope/pull/1693)	
+	[#1693](https://github.com/weaveworks/scope/pull/1693)
 - Elide service-token when logging commandline arguments
 	[#1782](https://github.com/weaveworks/scope/pull/1782)
 - Don't complain when stopping Scope if it wasn't running
 	[#1783](https://github.com/weaveworks/scope/pull/1783)
 - Silence abnormal websocket close
-	[#1768](https://github.com/weaveworks/scope/pull/1768)	
+	[#1768](https://github.com/weaveworks/scope/pull/1768)
 - Eliminate stats log noise from stopped containers
 	[#1687](https://github.com/weaveworks/scope/pull/1687)
-	[#1798](https://github.com/weaveworks/scope/pull/1798)	
+	[#1798](https://github.com/weaveworks/scope/pull/1798)
 - Hide uncontained/unmanaged by default
 	[#1694](https://github.com/weaveworks/scope/pull/1694)
 
@@ -520,7 +545,7 @@ Bug fixes:
 	[#1667](https://github.com/weaveworks/scope/pull/1667)
 - Scope fails to launch on latest Docker for Mac (beta18)
 	[#1650](https://github.com/weaveworks/scope/pull/1650)
-	[#1669](https://github.com/weaveworks/scope/pull/1669)	
+	[#1669](https://github.com/weaveworks/scope/pull/1669)
 - Fixes terminal wrapping by syncing docker/term.js terminal widths.
 	[#1648](https://github.com/weaveworks/scope/pull/1648)
 - Wrongly attributed local side in outbound internet connections

--- a/bin/release
+++ b/bin/release
@@ -26,27 +26,23 @@ setup() {
     # shellcheck disable=SC2116
     # shellcheck disable=SC2005
     TAG_COUNT=$(echo "$(echo "$HEAD_TAGS" | wc -w)") # mac hack
-    case $TAG_COUNT in
-        1)
-            if [ "$HEAD_TAGS" != "latest_release" ]; then
-                LATEST_TAG=$HEAD_TAGS
-            else
-                echo "Cannot determine version - latest_release points at HEAD" >&2
-                exit 1
-            fi
-            ;;
-        0)
-            echo "Cannot determine version - no tags point at HEAD" >&2
+    if [ "$TAG_COUNT" -eq 1 ]; then
+        if [ "$HEAD_TAGS" != "latest_release" ]; then
+            LATEST_TAG=$HEAD_TAGS
+        else
+            echo "Cannot determine version - latest_release points at HEAD" >&2
             exit 1
-            ;;
-        *)
-            echo "Cannot determine version - multiple tags point at HEAD:" >&2
-            for TAG in $HEAD_TAGS; do
-                echo -e "\t$TAG" >&2
-            done
-            exit 1
-            ;;
-    esac
+        fi
+    elif [ "$TAG_COUNT" -eq 0 ]; then
+        echo "Cannot determine version - no tags point at HEAD" >&2
+        exit 1
+    else
+        echo "Cannot determine version - multiple tags point at HEAD:" >&2
+        for TAG in $HEAD_TAGS; do
+            echo -e "\t$TAG" >&2
+        done
+        exit 1
+    fi
 
     RELEASE_TYPE=$(infer_release_type "$LATEST_TAG")
     echo "== Inferred release type $RELEASE_TYPE from tag $LATEST_TAG"

--- a/site/installing.md
+++ b/site/installing.md
@@ -35,13 +35,13 @@ To install Scope in stand-alone mode, run the following commands:
     sudo chmod a+x /usr/local/bin/scope
     scope launch
 
-This script downloads and runs a recent Scope image from Docker Hub. Scope needs to be installed onto every machine that you want to monitor. 
+This script downloads and runs a recent Scope image from Docker Hub. Scope needs to be installed onto every machine that you want to monitor.
 
 After Scope is installed, open your browser to `http://localhost:4040`.  
 
 If you are using docker-machine, you can find the IP by running, `docker-machine ip <VM name>`.
 
-Where, 
+Where,
 
  * `<VM name>` is the name you gave to your virtual machine with docker-machine.
 
@@ -63,14 +63,14 @@ Where,
 
 * `--service-token=<token>` is the token you obtained from Weave Cloud.
 
-This script downloads and runs a recent Scope Docker image from the Docker Hub. Scope needs to be installed onto every machine that you want to monitor. 
+This script downloads and runs a recent Scope Docker image from the Docker Hub. Scope needs to be installed onto every machine that you want to monitor.
 
 Open your web browser to [https://cloud.weave.works](https://cloud.weave.works) and login. Click 'View Instance' to see the Scope user interface.
 
 
 ###<a name="cluster-no-net"></a>Installing Scope on a Local Cluster Without Weave Net
 
-This example assumes a local cluster that is not networked with Weave Net, and also has no special hostnames or DNS settings. You will launch Scope with the IP addresses of all of the nodes in the cluster. 
+This example assumes a local cluster that is not networked with Weave Net, and also has no special hostnames or DNS settings. You will launch Scope with the IP addresses of all of the nodes in the cluster.
 
 Suppose you have the following nodes in a cluster:
 
@@ -79,10 +79,16 @@ Suppose you have the following nodes in a cluster:
  192.168.100.18
  192.168.100.19
  192.168.100.20
- 
- Using the IP addresses, you will manually peer each node with all of the other nodes during Scope launch. 
- 
+
+ Using the IP addresses, you will manually peer each node with all of the other nodes during Scope launch.
+
 **1. Run the following on each node:**
+=======
+
+ In the steps that follow, you will manually peer each node with all of the other nodes during Scope launch.
+
+**1. To begin run the following on each node:**
+>>>>>>> Docs update with new version
 
      sudo curl -L git.io/scope -o /usr/local/bin/scope
      sudo chmod a+x /usr/local/bin/scope
@@ -123,7 +129,7 @@ After it’s been launched, open your browser to `http://localhost:4040`.
 **Docker Compose Format Version 1:**
 
     scope:
-      image: weaveworks/scope:1.2.0
+      image: weaveworks/scope:1.2.1
       net: "host"
       pid: "host"
       privileged: true
@@ -139,7 +145,7 @@ After it’s been launched, open your browser to `http://localhost:4040`.
     version: '2'
     services:
       scope:
-        image: weaveworks/scope:1.2.0
+        image: weaveworks/scope:1.2.1
         network_mode: "host"
         pid: "host"
         privileged: true
@@ -163,7 +169,7 @@ Version 2 of this YAML file supports networks and volumes as defined by any plug
 **Docker Compose Format Version 1:**
 
     probe:
-      image: weaveworks/scope:1.2.0
+      image: weaveworks/scope:1.2.1
       net: "host"
       pid: "host"
       privileged: true
@@ -180,7 +186,7 @@ Version 2 of this YAML file supports networks and volumes as defined by any plug
     version: '2'
     services:
       probe:
-        image: weaveworks/scope:1.2.0
+        image: weaveworks/scope:1.2.1
         network_mode: "host"
         pid: "host"
         privileged: true
@@ -202,7 +208,7 @@ Where,
 
 * `SCOPE_SERVICE_TOKEN=<token>` is the token you obtained after you signed up for Weave Cloud.
 
-Note that you will need to launch Scope onto every node that you want to monitor. 
+Note that you will need to launch Scope onto every node that you want to monitor.
 
 **4.** Go to [https://cloud.weave.works](https://cloud.weave.works) and click 'View Instance'.
 
@@ -240,7 +246,7 @@ To download and read the Scope manifest run:
 
     kubectl port-forward $(kubectl get pod --selector=weave-scope-component=app -o jsonpath='{.items..metadata.name}') 4040
 
-The URL is: http://localhost:4040. 
+The URL is: http://localhost:4040.
 
 ##<a name="ecs"></a>Installing Scope on Amazon ECS
 


### PR DESCRIPTION
Patch release to pull in #2202 for API URL problem reported in #2247.

Things to test:

Check that API requests (XHR and Websockets) work when running from:

- [x] Stand-alone scope
- [x] An iframe
- [x] As a component
- [x] An arbitrary path, such as /demo/
- [x] An HTML page, such as contrast.html
- [x] An HTML page, while running in an iframe