### PR TITLE
Fix details panel links

### DIFF
--- a/client/app/scripts/components/node-details/node-details-control-button.js
+++ b/client/app/scripts/components/node-details/node-details-control-button.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { doControl } from '../../actions/app-actions';
 
-export default class NodeDetailsControlButton extends React.PureComponent {
+class NodeDetailsControlButton extends React.Component {
   constructor(props, context) {
     super(props, context);
     this.handleClick = this.handleClick.bind(this);
@@ -23,3 +24,6 @@ export default class NodeDetailsControlButton extends React.PureComponent {
     this.props.dispatch(doControl(this.props.nodeId, this.props.control));
   }
 }
+
+// Using this instead of PureComponent because of props.dispatch
+export default connect()(NodeDetailsControlButton);

--- a/client/app/scripts/components/node-details/node-details-relatives-link.js
+++ b/client/app/scripts/components/node-details/node-details-relatives-link.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { clickRelative } from '../../actions/app-actions';
 import MatchedText from '../matched-text';
 
-export default class NodeDetailsRelativesLink extends React.PureComponent {
+class NodeDetailsRelativesLink extends React.Component {
   constructor(props, context) {
     super(props, context);
     this.handleClick = this.handleClick.bind(this);
@@ -35,3 +36,6 @@ export default class NodeDetailsRelativesLink extends React.PureComponent {
     );
   }
 }
+
+// Using this instead of PureComponent because of props.dispatch
+export default connect()(NodeDetailsRelativesLink);

--- a/client/app/scripts/components/node-details/node-details-table-node-link.js
+++ b/client/app/scripts/components/node-details/node-details-table-node-link.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { clickRelative } from '../../actions/app-actions';
 
-export default class NodeDetailsTableNodeLink extends React.PureComponent {
+class NodeDetailsTableNodeLink extends React.Component {
   constructor(props, context) {
     super(props, context);
     this.handleClick = this.handleClick.bind(this);
@@ -43,3 +44,6 @@ export default class NodeDetailsTableNodeLink extends React.PureComponent {
     );
   }
 }
+
+// Using this instead of PureComponent because of props.dispatch
+export default connect()(NodeDetailsTableNodeLink);


### PR DESCRIPTION
Fixes #2263 that was caused by accidentally disconnecting `NodeDetailsControlButton`, `NodeDetailsRelativesLink` and `NodeDetailsTableNodeLink` components from Redux in the PR #2221 (commit https://github.com/weaveworks/scope/pull/2221/commits/e5c655aa880e9a7931c359ae275d3d732afc6033).