### PR TITLE
circle.yml: Fix ui upload step so it doesn't build twice

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -77,7 +77,7 @@ deployment:
           )) &&
           docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope &&
           docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope:$(./tools/image-tag) &&
-          (test -z "${UI_BUCKET_KEY_ID}" || make ui-upload)
+          (test -z "${UI_BUCKET_KEY_ID}" || (cd $SRCDIR && make ui-upload))
         )
       - |
         test -z "${QUAY_USER}" || (


### PR DESCRIPTION
There are two source checkouts in circle, and we were building in the wrong one
(ie. not the one where the earlier build happened). This was wasteful at best
and buggy at worst due to build differences.

Fixes https://github.com/weaveworks/scope/issues/1918