### PR TITLE
Fix edge directionality in graph layout

### DIFF
--- a/client/app/scripts/utils/__tests__/layouter-utils-test.js
+++ b/client/app/scripts/utils/__tests__/layouter-utils-test.js
@@ -1,0 +1,41 @@
+import { fromJS } from 'immutable';
+
+describe('LayouterUtils', () => {
+  const LayouterUtils = require('../layouter-utils');
+
+  describe('initEdgesFromNodes', () => {
+    const f = LayouterUtils.initEdgesFromNodes;
+
+    it('should return map of edges', () => {
+      const input = fromJS({
+        a: { adjacency: ['b', 'c'] },
+        b: { adjacency: ['a', 'b'] },
+        c: {}
+      });
+      expect(f(input).toJS()).toEqual({
+        'a-b': { id: 'a-b', source: 'a', target: 'b', value: 1 },
+        'a-c': { id: 'a-c', source: 'a', target: 'c', value: 1 },
+        'b-a': { id: 'b-a', source: 'b', target: 'a', value: 1 },
+        'b-b': { id: 'b-b', source: 'b', target: 'b', value: 1 },
+      });
+    });
+  });
+
+  describe('collapseMultiEdges', () => {
+    const f = LayouterUtils.collapseMultiEdges;
+
+    it('should return collapsed multi-edges', () => {
+      const input = fromJS({
+        'a-b': { id: 'a-b', source: 'a', target: 'b' },
+        'a-c': { id: 'a-c', source: 'a', target: 'c' },
+        'b-a': { id: 'b-a', source: 'b', target: 'a' },
+        'b-b': { id: 'b-b', source: 'b', target: 'b' },
+      });
+      expect(f(input).toJS()).toEqual({
+        'a-b': { id: 'a-b', source: 'a', target: 'b', bidirectional: true },
+        'a-c': { id: 'a-c', source: 'a', target: 'c' },
+        'b-b': { id: 'b-b', source: 'b', target: 'b' },
+      });
+    });
+  });
+});

--- a/client/app/scripts/utils/__tests__/layouter-utils-test.js
+++ b/client/app/scripts/utils/__tests__/layouter-utils-test.js
@@ -1,18 +1,20 @@
 import { fromJS } from 'immutable';
 
+import {
+  initEdgesFromNodes,
+  collapseMultiEdges,
+} from '../layouter-utils';
+
+
 describe('LayouterUtils', () => {
-  const LayouterUtils = require('../layouter-utils');
-
   describe('initEdgesFromNodes', () => {
-    const f = LayouterUtils.initEdgesFromNodes;
-
     it('should return map of edges', () => {
       const input = fromJS({
         a: { adjacency: ['b', 'c'] },
         b: { adjacency: ['a', 'b'] },
         c: {}
       });
-      expect(f(input).toJS()).toEqual({
+      expect(initEdgesFromNodes(input).toJS()).toEqual({
         'a-b': { id: 'a-b', source: 'a', target: 'b', value: 1 },
         'a-c': { id: 'a-c', source: 'a', target: 'c', value: 1 },
         'b-a': { id: 'b-a', source: 'b', target: 'a', value: 1 },
@@ -22,8 +24,6 @@ describe('LayouterUtils', () => {
   });
 
   describe('collapseMultiEdges', () => {
-    const f = LayouterUtils.collapseMultiEdges;
-
     it('should return collapsed multi-edges', () => {
       const input = fromJS({
         'a-b': { id: 'a-b', source: 'a', target: 'b' },
@@ -31,7 +31,7 @@ describe('LayouterUtils', () => {
         'b-a': { id: 'b-a', source: 'b', target: 'a' },
         'b-b': { id: 'b-b', source: 'b', target: 'b' },
       });
-      expect(f(input).toJS()).toEqual({
+      expect(collapseMultiEdges(input).toJS()).toEqual({
         'a-b': { id: 'a-b', source: 'a', target: 'b', bidirectional: true },
         'a-c': { id: 'a-c', source: 'a', target: 'c' },
         'b-b': { id: 'b-b', source: 'b', target: 'b' },

--- a/client/app/scripts/utils/layouter-utils.js
+++ b/client/app/scripts/utils/layouter-utils.js
@@ -1,0 +1,55 @@
+import { Map as makeMap } from 'immutable';
+
+import { EDGE_ID_SEPARATOR } from '../constants/naming';
+
+
+function constructEdgeId(source, target) {
+  return [source, target].join(EDGE_ID_SEPARATOR);
+}
+
+// Constructs the edges for the layout engine from the nodes' adjacency table.
+// We don't collapse edge pairs (A->B, B->A) here as we want to let the layout
+// engine decide how to handle bidirectional edges.
+export function initEdgesFromNodes(nodes) {
+  let edges = makeMap();
+
+  nodes.forEach((node, nodeId) => {
+    (node.get('adjacency') || []).forEach((adjacentId) => {
+      const source = nodeId;
+      const target = adjacentId;
+
+      if (nodes.has(target)) {
+        // The direction source->target is important since dagre takes
+        // directionality into account when calculating the layout.
+        const edgeId = constructEdgeId(source, target);
+        const edge = makeMap({ id: edgeId, value: 1, source, target });
+        edges = edges.set(edgeId, edge);
+      }
+    });
+  });
+
+  return edges;
+}
+
+// Replaces all pairs of edges (A->B, B->A) with a single A->B edge that is marked as
+// bidirectional. We do this to prevent double rendering of edges between the same nodes.
+export function collapseMultiEdges(directedEdges) {
+  let collapsedEdges = makeMap();
+
+  directedEdges.forEach((edge, edgeId) => {
+    const source = edge.get('source');
+    const target = edge.get('target');
+    const reversedEdgeId = constructEdgeId(target, source);
+
+    if (collapsedEdges.has(reversedEdgeId)) {
+      // If the edge between the same nodes with the opposite direction already exists,
+      // mark it as bidirectional and don't add any other edges (making graph simple).
+      collapsedEdges = collapsedEdges.setIn([reversedEdgeId, 'bidirectional'], true);
+    } else {
+      // Otherwise just copy the edge.
+      collapsedEdges = collapsedEdges.set(edgeId, edge);
+    }
+  });
+
+  return collapsedEdges;
+}


### PR DESCRIPTION
Fixes #2267.

![layout-fixed](https://cloud.githubusercontent.com/assets/1216874/23211651/69841f72-f903-11e6-86d4-1d3a2327d282.png)

The problem was that we were not making a difference between *source* and *target* nodes when constructing edges for the layout engine (for the purpose of not rendering the same edge twice).

~~**Note:** The bidirectional edges are now represented as two directed edges, both in the layout engine and when rendering. So they are actually rendered as two overlapping edges, although that's currently not visible. I intentionally left it like that so that we could make them non-overlapping if we want or have an easier time drawing the arrows later on.~~