### PR TITLE
Embed a copy of weaveutil instead of calling via docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ prog/scope
 docker/scope
 docker/docker.tgz
 docker/weave
+docker/weaveutil
 docker/runsvinit
 extras/fixprobe/fixprobe
 extras/fixprobe/*.json

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ SCOPE_UI_BUILD_UPTODATE=.scope_ui_build.uptodate
 SCOPE_BACKEND_BUILD_IMAGE=$(DOCKERHUB_USER)/scope-backend-build
 SCOPE_BACKEND_BUILD_UPTODATE=.scope_backend_build.uptodate
 SCOPE_VERSION=$(shell git rev-parse --short HEAD)
+WEAVENET_VERSION=1.9.0
 DOCKER_VERSION=1.10.3
 DOCKER_DISTRIB=.pkg/docker-$(DOCKER_VERSION).tgz
 DOCKER_DISTRIB_URL=https://get.docker.com/builds/Linux/x86_64/docker-$(DOCKER_VERSION).tgz
@@ -38,7 +39,7 @@ $(DOCKER_DISTRIB):
 	curl -o $(DOCKER_DISTRIB) $(DOCKER_DISTRIB_URL)
 
 docker/weave:
-	curl -L git.io/weave -o docker/weave
+	curl -L https://github.com/weaveworks/weave/releases/download/v$(WEAVENET_VERSION)/weave -o docker/weave
 	chmod u+x docker/weave
 
 $(SCOPE_EXPORT): $(SCOPE_EXE) $(DOCKER_DISTRIB) docker/weave $(RUNSVINIT) docker/Dockerfile docker/demo.json docker/run-app docker/run-probe docker/entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,13 @@ docker/weave:
 	curl -L https://github.com/weaveworks/weave/releases/download/v$(WEAVENET_VERSION)/weave -o docker/weave
 	chmod u+x docker/weave
 
-$(SCOPE_EXPORT): $(SCOPE_EXE) $(DOCKER_DISTRIB) docker/weave $(RUNSVINIT) docker/Dockerfile docker/demo.json docker/run-app docker/run-probe docker/entrypoint.sh
+docker/weaveutil:
+	docker pull weaveworks/weaveexec:$(WEAVENET_VERSION)
+	docker create --name=throwaway weaveworks/weaveexec:$(WEAVENET_VERSION)
+	docker cp throwaway:/usr/bin/weaveutil docker/weaveutil
+	docker rm throwaway
+
+$(SCOPE_EXPORT): $(SCOPE_EXE) $(DOCKER_DISTRIB) docker/weave docker/weaveutil $(RUNSVINIT) docker/Dockerfile docker/demo.json docker/run-app docker/run-probe docker/entrypoint.sh
 	cp $(SCOPE_EXE) $(RUNSVINIT) docker/
 	cp $(DOCKER_DISTRIB) docker/docker.tgz
 	$(SUDO) docker build -t $(SCOPE_IMAGE) docker/

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,8 @@ docker/weave:
 	chmod u+x docker/weave
 
 docker/weaveutil:
-	docker pull weaveworks/weaveexec:$(WEAVENET_VERSION)
-	docker create --name=throwaway weaveworks/weaveexec:$(WEAVENET_VERSION)
-	docker cp throwaway:/usr/bin/weaveutil docker/weaveutil
-	docker rm throwaway
+	$(SUDO) docker run --rm  --entrypoint=cat weaveworks/weaveexec:$(WEAVENET_VERSION) /usr/bin/weaveutil > $@
+	chmod +x $@
 
 $(SCOPE_EXPORT): $(SCOPE_EXE) $(DOCKER_DISTRIB) docker/weave docker/weaveutil $(RUNSVINIT) docker/Dockerfile docker/demo.json docker/run-app docker/run-probe docker/entrypoint.sh
 	cp $(SCOPE_EXE) $(RUNSVINIT) docker/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --update bash runit conntrack-tools iproute2 util-linux curl && \
 	rm -rf /var/cache/apk/*
 ADD ./docker.tgz /
 ADD ./demo.json /
-ADD ./weave /usr/bin/
+ADD ./weave ./weaveutil /usr/bin/
 COPY ./scope ./runsvinit ./entrypoint.sh /home/weave/
 COPY ./run-app /etc/service/app/run
 COPY ./run-probe /etc/service/probe/run


### PR DESCRIPTION
Scope calls the `weave` script, which checks to see if it can exec `weaveutil` directly and, if not, execs it via a Docker image `weaveexec`.  This PR downloads that image and copies the binary into the Scope image, which saves all the indirection and overhead of running Docker every time.

This mechanism is used when `weave ps` is run, which is every few seconds.