### PR TITLE
Remove the throb animation for graph view search matches

### DIFF
--- a/client/app/scripts/charts/node.js
+++ b/client/app/scripts/charts/node.js
@@ -94,22 +94,14 @@ class Node extends React.Component {
 
   render() {
     const { focused, highlighted, networks, pseudo, rank, label, transform,
-      exportingGraph, showingNetworks, stack, id, metric, matches = makeMap() } = this.props;
+      exportingGraph, showingNetworks, stack, id, metric } = this.props;
     const { hovered } = this.state;
 
     const color = getNodeColor(rank, label, pseudo);
     const truncate = !focused && !hovered;
     const labelOffsetY = (showingNetworks && networks) ? 40 : 28;
 
-    const nodeClassName = classnames('node', {
-      // NOTE: Having a CSS animation here might not be the best idea.
-      // See https://github.com/weaveworks/scope/issues/2255
-      matched: !matches.isEmpty(),
-      highlighted,
-      hovered,
-      pseudo
-    });
-
+    const nodeClassName = classnames('node', { highlighted, hovered, pseudo });
     const labelClassName = classnames('node-label', { truncate });
     const labelMinorClassName = classnames('node-label-minor', { truncate });
 

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -300,7 +300,7 @@
   }
 
   .nodes-chart-nodes .node {
-    transition: opacity .5s $base-ease;
+    transition: opacity .2s $base-ease;
     text-align: center;
 
     .node-network {
@@ -386,10 +386,6 @@
         opacity: $node-pseudo-opacity;
         stroke: $text-tertiary-color;
       }
-    }
-
-    &.matched .shape {
-      animation: throb 0.5s $base-ease;
     }
 
     .node-label, .node-label-minor {
@@ -1492,14 +1488,6 @@
     opacity: 1.0;
   } 25% {
     opacity: 0.5;
-  }
-}
-
-@keyframes throb {
-  0%, 50%, 100% {
-    transform: scale(1);
-  } 25%, 75% {
-    transform: scale(1.2);
   }
 }
 


### PR DESCRIPTION
Resolves #2255 trivially (and also decreases the opacity transition constant for the graph nodes).

I first tried a couple of different approaches to fix the bug, but all of them that worked were introducing a lot of overhead on the animations:

* Since the issue was coming from reordering the nodes, I thought React [Keyed Fragments](https://facebook.github.io/react/docs/create-fragment.html) were tailor made for cases like ours but turns out that using it instead of our sorting slowed down things a lot (pressumably because it only takes rendered stuff as input, so the caching only happens later on).
* Since the animation is happening with pure SVG elements, I thought of trying out [SVG animations](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/animateTransform), but I got the impression that it's not yet fully supported on all platforms and that it might be hard to fully control it and use it if we ever wanted to include non-SVG elements in the animation.
* Finally, I thought of trying to control the animation fully from Javascript, perhaps with something like [Velocity.js](http://velocityjs.org/), but using it directly doesn't play well with the best React top-down practices, so I checked out [Velocity React](https://github.com/twitter-fabric/velocity-react) library for the "componentized" approach, but unfortunately, it also proved to be very slow :/

Then after all these failed attempts, I decided to follow @davkal's tip to remove the animation altogether. Now that I did it, it's not obvious to me what its value was exactly, since on big graphs its effects were not so visible and on smaller ones, there were already a couple of transitions going on (smooth fadeout of non-matched nodes; highlighting of matched labels), so I think the whole experience still feels dynamic, maybe even smoother! :)
