### PR TITLE
Removed contrastMode from url state

### DIFF
--- a/client/app/scripts/actions/app-actions.js
+++ b/client/app/scripts/actions/app-actions.js
@@ -668,14 +668,12 @@ export function receiveNotFound(nodeId) {
 }
 
 export function setContrastMode(enabled) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     loadTheme(enabled ? 'contrast' : 'normal');
     dispatch({
       type: ActionTypes.TOGGLE_CONTRAST_MODE,
       enabled,
     });
-
-    updateRoute(getState);
   };
 }
 
@@ -700,10 +698,6 @@ export function route(urlState) {
       state.get('nodeDetails'),
       dispatch
     );
-
-    if (urlState.contrastMode) {
-      dispatch(setContrastMode(true));
-    }
   };
 }
 


### PR DESCRIPTION
Temporary fix for #2293 

Removes contrastMode from the URL state, which means its state will be lost on page refresh. Temporary fix for a nasty bug; the permanent solution will be to prevent a `route` action from happening on a browser `replace`, or something to that effect.