### PR TITLE
integration: restart docker daemon after each test

### DIFF
--- a/integration/config.sh
+++ b/integration/config.sh
@@ -31,7 +31,12 @@ weave_on() {
 scope_end_suite() {
     end_suite
     for host in $HOSTS; do
-        docker_on "$host" rm -f "$(docker_on "$host" ps -a -q)" 2>/dev/null 1>&2 || true
+        docker_on "$host" rm -f "$(docker_on "$host" ps -a -q)" || true
+        # Unfortunately, "docker rm" might not work: the CircleCI's Docker
+        # client is unable to delete containers on GCE's Docker server. As a
+        # workaround, restart the Docker daemon: at least the containers from
+        # previous tests will not be running.
+        run_on "$host" "sudo service docker restart"
     done
 }
 


### PR DESCRIPTION
To be sure that containers from previous tests are not running in the
next test.

The issue was causing failures on master too.

-----

On the failed run https://circleci.com/gh/weaveworks/scope/6648, 106_launch_with_peers_test (1 node) is running after 320_container_edge_cross_host_2_test (2 nodes), and is reusing one of the 2 nodes.

Whereas on the successful run https://circleci.com/gh/weaveworks/scope/6646, 106_launch_with_peers_test and 320_container_edge_cross_host_2_test are started on different CircleCI containers and don't share any GCE nodes.

The scheduler can schedules jobs differently from one time to another.

After a test terminates, all containers (including Scope) are supposed to be stopped by [scope_end_suite](https://github.com/weaveworks/scope/blob/master/integration/config.sh#L34):

```
scope_end_suite() {
    end_suite
    for host in $HOSTS; do
        docker_on "$host" rm -f "$(docker_on "$host" ps -a -q)" 2>/dev/null 1>&2 || true
    done
}
```
This was introduced by https://github.com/weaveworks/scope/commit/8a8520ffc9734b3b64eefab48ec8012e9a6e6f7a ("Stop all containers when test finishes").

Note that if the "docker rm -f" fails to stop the Scope container, we will not know about it and the error is ignored. If that happens, that would explain both why test 106 has two nodes instead of one, and why some ebpf tests have endpoints without ebpf=true (coming from a previous test).

To verify that, I tried to test https://github.com/alban/scope/commit/80911f7edb6ead616a2b15ea310b33fc0416a4df and I got https://circleci.com/gh/alban/scope/120: a lot of tests fail to terminate containers with the error message such as:

```
List of docker containers on host3-alban-scope-120-0.us-central1-a.scope-integration-tests-158117:
CONTAINER ID        IMAGE                     COMMAND                  CREATED             STATUS              PORTS               NAMES
9acf1f8edc97        peterbourgon/tns-db       "/db db1 db2 db3"        31 seconds ago      Up 30 seconds       9000/tcp            db1
c7a6849e5b73        weaveworks/scope:latest   "/home/weave/entrypoi"   33 seconds ago      Up 32 seconds                           weavescope
Ok, killing all docker containers on host3-alban-scope-120-0.us-central1-a.scope-integration-tests-158117:
Failed to remove container (9acf1f8edc97
c7a6849e5b73): Error response from daemon: {"message":"page not found"}
```

This is a 404 error. https://github.com/docker/docker/issues/17960 suggests a proxy issue ($NO_PROXY, $HTTP_PROXY) but I don't see any such variables defined on CircleCI. It could be CircleCI specific changes on the client side since they use their own changes. Or it could be an API issue between the docker client (CircleCI) and the docker server (GCE):
```
# docker version
Client:
 Version:      1.10.0-circleci
 API version:  1.22
 Go version:   go1.5.3
 Git commit:   543ec7b-unsupported
 Built:        Tue Feb 16 17:11:12 2016
 OS/Arch:      linux/amd64

Server:
 Version:      1.13.1
 API version:  1.26
 Go version:   go1.7.5
 Git commit:   092cba3
 Built:        Wed Feb  8 06:42:29 2017
 OS/Arch:      linux/amd64
```

Note that "docker rm -f" does not work when Docker client & server are on CircleCI:
```
ubuntu@box2121:~$ sudo docker rm -f 9b9982d39009
Failed to remove container (9b9982d39009): Error response from daemon: Unable to remove filesystem for 9b9982d390099c13741daef8f1bd0555cf69a5fa943d383317de0d65f7c2801c: remove /var/lib/docker/containers/9b9982d390099c13741daef8f1bd0555cf69a5fa943d383317de0d65f7c2801c/shm: device or resource busy
ubuntu@box2121:~$ echo $?
1
```

-----

/cc @2opremio @iaguis @schu 