### PR TITLE
report playback

### DIFF
--- a/app/benchmark_internal_test.go
+++ b/app/benchmark_internal_test.go
@@ -22,7 +22,7 @@ func loadReport() (report.Report, error) {
 		return fixture.Report, nil
 	}
 
-	c, err := NewFileCollector(*benchReportFile)
+	c, err := NewFileCollector(*benchReportFile, 0)
 	if err != nil {
 		return fixture.Report, err
 	}

--- a/prog/app.go
+++ b/prog/app.go
@@ -100,7 +100,7 @@ func collectorFactory(userIDer multitenant.UserIDer, collectorURL, s3URL, natsHo
 
 	switch parsed.Scheme {
 	case "file":
-		return app.NewFileCollector(parsed.Path)
+		return app.NewFileCollector(parsed.Path, window)
 	case "dynamodb":
 		s3, err := url.Parse(s3URL)
 		if err != nil {

--- a/prog/main.go
+++ b/prog/main.go
@@ -326,7 +326,7 @@ func main() {
 	flag.Var(&containerLabelFilterFlags, "app.container-label-filter", "Add container label-based view filter, specified as title:label. Multiple flags are accepted. Example: --app.container-label-filter='Database Containers:role=db'")
 	flag.Var(&containerLabelFilterFlagsExclude, "app.container-label-filter-exclude", "Add container label-based view filter that excludes containers with the given label, specified as title:label. Multiple flags are accepted. Example: --app.container-label-filter-exclude='Database Containers:role=db'")
 
-	flag.StringVar(&flags.app.collectorURL, "app.collector", "local", "Collector to use (local, dynamodb, or file)")
+	flag.StringVar(&flags.app.collectorURL, "app.collector", "local", "Collector to use (local, dynamodb, or file/directory)")
 	flag.StringVar(&flags.app.s3URL, "app.collector.s3", "local", "S3 URL to use (when collector is dynamodb)")
 	flag.StringVar(&flags.app.controlRouterURL, "app.control.router", "local", "Control router to use (local or sqs)")
 	flag.StringVar(&flags.app.pipeRouterURL, "app.pipe.router", "local", "Pipe router to use (local)")


### PR DESCRIPTION
Now you can launch the scope app with something like

./prog/scope --mode=app --weave=false --app.collector=file:///tmp/reports

and if the specified dir contains reports with filenames in the form `<timestamp>.{msgpack|json}[.gz]`
e.g. "1488557088545489008.msgpack.gz", then these reports are replayed in a loop at a sequence and speed determined by the timestamps.