### PR TITLE
Fix kubelet failure fallback and make port configurable

### DIFF
--- a/probe/kubernetes/kubelet.go
+++ b/probe/kubernetes/kubelet.go
@@ -1,13 +1,11 @@
 package kubernetes
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/ugorji/go/codec"
 )
-
-// KubeletURL is just exported for testing
-var KubeletURL = "http://localhost:10255"
 
 // Intentionally not using the full kubernetes library DS
 // to make parsing faster and more tolerant to schema changes
@@ -20,8 +18,9 @@ type podList struct {
 }
 
 // GetLocalPodUIDs obtains the UID of the pods run locally (it's just exported for testing)
-var GetLocalPodUIDs = func() (map[string]struct{}, error) {
-	resp, err := http.Get(KubeletURL + "/pods/")
+var GetLocalPodUIDs = func(kubeletHost string) (map[string]struct{}, error) {
+	url := fmt.Sprintf("http://%s/pods/", kubeletHost)
+	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err
 	}

--- a/probe/kubernetes/kubelet_test.go
+++ b/probe/kubernetes/kubelet_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/weaveworks/scope/probe/kubernetes"
@@ -31,7 +32,8 @@ func TestGetLocalPodUIDs(t *testing.T) {
 	))
 	defer server.Close()
 
-	uids, err := kubernetes.GetLocalPodUIDs(server.URL.Host)
+	serverURL, _ := url.Parse(server.URL)
+	uids, err := kubernetes.GetLocalPodUIDs(serverURL.Host)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/probe/kubernetes/kubelet_test.go
+++ b/probe/kubernetes/kubelet_test.go
@@ -30,11 +30,8 @@ func TestGetLocalPodUIDs(t *testing.T) {
 		},
 	))
 	defer server.Close()
-	var savedKubeletURL string
-	savedKubeletURL, kubernetes.KubeletURL = kubernetes.KubeletURL, server.URL
-	defer func() { kubernetes.KubeletURL = savedKubeletURL }()
 
-	uids, err := kubernetes.GetLocalPodUIDs()
+	uids, err := kubernetes.GetLocalPodUIDs(server.URL.Host)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/probe/kubernetes/reporter_test.go
+++ b/probe/kubernetes/reporter_test.go
@@ -182,7 +182,7 @@ func (c mockPipeClient) PipeClose(appID, id string) error {
 func TestReporter(t *testing.T) {
 	oldGetNodeName := kubernetes.GetLocalPodUIDs
 	defer func() { kubernetes.GetLocalPodUIDs = oldGetNodeName }()
-	kubernetes.GetLocalPodUIDs = func() (map[string]struct{}, error) {
+	kubernetes.GetLocalPodUIDs = func(string) (map[string]struct{}, error) {
 		uids := map[string]struct{}{
 			pod1UID: {},
 			pod2UID: {},
@@ -194,7 +194,7 @@ func TestReporter(t *testing.T) {
 	pod2ID := report.MakePodNodeID(pod2UID)
 	serviceID := report.MakeServiceNodeID(serviceUID)
 	hr := controls.NewDefaultHandlerRegistry()
-	rpt, _ := kubernetes.NewReporter(newMockClient(), nil, "", "foo", nil, hr).Report()
+	rpt, _ := kubernetes.NewReporter(newMockClient(), nil, "", "foo", nil, hr, 0).Report()
 
 	// Reporter should have added the following pods
 	for _, pod := range []struct {
@@ -255,7 +255,7 @@ func TestTagger(t *testing.T) {
 	}))
 
 	hr := controls.NewDefaultHandlerRegistry()
-	rpt, err := kubernetes.NewReporter(newMockClient(), nil, "", "", nil, hr).Tag(rpt)
+	rpt, err := kubernetes.NewReporter(newMockClient(), nil, "", "", nil, hr, 0).Tag(rpt)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -277,14 +277,14 @@ func (c *callbackReadCloser) Close() error { return c.close() }
 func TestReporterGetLogs(t *testing.T) {
 	oldGetNodeName := kubernetes.GetLocalPodUIDs
 	defer func() { kubernetes.GetLocalPodUIDs = oldGetNodeName }()
-	kubernetes.GetLocalPodUIDs = func() (map[string]struct{}, error) {
+	kubernetes.GetLocalPodUIDs = func(string) (map[string]struct{}, error) {
 		return map[string]struct{}{}, nil
 	}
 
 	client := newMockClient()
 	pipes := mockPipeClient{}
 	hr := controls.NewDefaultHandlerRegistry()
-	reporter := kubernetes.NewReporter(client, pipes, "", "", nil, hr)
+	reporter := kubernetes.NewReporter(client, pipes, "", "", nil, hr, 0)
 
 	// Should error on invalid IDs
 	{

--- a/prog/main.go
+++ b/prog/main.go
@@ -103,8 +103,9 @@ type probeFlags struct {
 	dockerInterval time.Duration
 	dockerBridge   string
 
-	kubernetesEnabled bool
-	kubernetesConfig  kubernetes.ClientConfig
+	kubernetesEnabled      bool
+	kubernetesClientConfig kubernetes.ClientConfig
+	kubernetesKubeletPort  uint
 
 	ecsEnabled     bool
 	ecsCacheSize   int
@@ -286,20 +287,21 @@ func main() {
 
 	// K8s
 	flag.BoolVar(&flags.probe.kubernetesEnabled, "probe.kubernetes", false, "collect kubernetes-related attributes for containers, should only be enabled on the master node")
-	flag.DurationVar(&flags.probe.kubernetesConfig.Interval, "probe.kubernetes.interval", 10*time.Second, "how often to do a full resync of the kubernetes data")
-	flag.StringVar(&flags.probe.kubernetesConfig.Server, "probe.kubernetes.api", "", "The address and port of the Kubernetes API server (deprecated in favor of equivalent probe.kubernetes.server)")
-	flag.StringVar(&flags.probe.kubernetesConfig.CertificateAuthority, "probe.kubernetes.certificate-authority", "", "Path to a cert. file for the certificate authority")
-	flag.StringVar(&flags.probe.kubernetesConfig.ClientCertificate, "probe.kubernetes.client-certificate", "", "Path to a client certificate file for TLS")
-	flag.StringVar(&flags.probe.kubernetesConfig.ClientKey, "probe.kubernetes.client-key", "", "Path to a client key file for TLS")
-	flag.StringVar(&flags.probe.kubernetesConfig.Cluster, "probe.kubernetes.cluster", "", "The name of the kubeconfig cluster to use")
-	flag.StringVar(&flags.probe.kubernetesConfig.Context, "probe.kubernetes.context", "", "The name of the kubeconfig context to use")
-	flag.BoolVar(&flags.probe.kubernetesConfig.Insecure, "probe.kubernetes.insecure-skip-tls-verify", false, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure")
-	flag.StringVar(&flags.probe.kubernetesConfig.Kubeconfig, "probe.kubernetes.kubeconfig", "", "Path to the kubeconfig file to use")
-	flag.StringVar(&flags.probe.kubernetesConfig.Password, kubernetesPasswordFlag, "", "Password for basic authentication to the API server")
-	flag.StringVar(&flags.probe.kubernetesConfig.Server, "probe.kubernetes.server", "", "The address and port of the Kubernetes API server")
-	flag.StringVar(&flags.probe.kubernetesConfig.Token, kubernetesTokenFlag, "", "Bearer token for authentication to the API server")
-	flag.StringVar(&flags.probe.kubernetesConfig.User, "probe.kubernetes.user", "", "The name of the kubeconfig user to use")
-	flag.StringVar(&flags.probe.kubernetesConfig.Username, "probe.kubernetes.username", "", "Username for basic authentication to the API server")
+	flag.DurationVar(&flags.probe.kubernetesClientConfig.Interval, "probe.kubernetes.interval", 10*time.Second, "how often to do a full resync of the kubernetes data")
+	flag.StringVar(&flags.probe.kubernetesClientConfig.Server, "probe.kubernetes.api", "", "The address and port of the Kubernetes API server (deprecated in favor of equivalent probe.kubernetes.server)")
+	flag.StringVar(&flags.probe.kubernetesClientConfig.CertificateAuthority, "probe.kubernetes.certificate-authority", "", "Path to a cert. file for the certificate authority")
+	flag.StringVar(&flags.probe.kubernetesClientConfig.ClientCertificate, "probe.kubernetes.client-certificate", "", "Path to a client certificate file for TLS")
+	flag.StringVar(&flags.probe.kubernetesClientConfig.ClientKey, "probe.kubernetes.client-key", "", "Path to a client key file for TLS")
+	flag.StringVar(&flags.probe.kubernetesClientConfig.Cluster, "probe.kubernetes.cluster", "", "The name of the kubeconfig cluster to use")
+	flag.StringVar(&flags.probe.kubernetesClientConfig.Context, "probe.kubernetes.context", "", "The name of the kubeconfig context to use")
+	flag.BoolVar(&flags.probe.kubernetesClientConfig.Insecure, "probe.kubernetes.insecure-skip-tls-verify", false, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure")
+	flag.StringVar(&flags.probe.kubernetesClientConfig.Kubeconfig, "probe.kubernetes.kubeconfig", "", "Path to the kubeconfig file to use")
+	flag.StringVar(&flags.probe.kubernetesClientConfig.Password, kubernetesPasswordFlag, "", "Password for basic authentication to the API server")
+	flag.StringVar(&flags.probe.kubernetesClientConfig.Server, "probe.kubernetes.server", "", "The address and port of the Kubernetes API server")
+	flag.StringVar(&flags.probe.kubernetesClientConfig.Token, kubernetesTokenFlag, "", "Bearer token for authentication to the API server")
+	flag.StringVar(&flags.probe.kubernetesClientConfig.User, "probe.kubernetes.user", "", "The name of the kubeconfig user to use")
+	flag.StringVar(&flags.probe.kubernetesClientConfig.Username, "probe.kubernetes.username", "", "Username for basic authentication to the API server")
+	flag.UintVar(&flags.probe.kubernetesKubeletPort, "probe.kubernetes.kubelet-port", 10255, "Node-local TCP port for contacting kubelet")
 
 	// AWS ECS
 	flag.BoolVar(&flags.probe.ecsEnabled, "probe.ecs", false, "Collect ecs-related attributes for containers on this node")

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -207,9 +207,9 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 	}
 
 	if flags.kubernetesEnabled {
-		if client, err := kubernetes.NewClient(flags.kubernetesConfig); err == nil {
+		if client, err := kubernetes.NewClient(flags.kubernetesClientConfig); err == nil {
 			defer client.Stop()
-			reporter := kubernetes.NewReporter(client, clients, probeID, hostID, p, handlerRegistry)
+			reporter := kubernetes.NewReporter(client, clients, probeID, hostID, p, handlerRegistry, flags.kubernetesKubeletPort)
 			defer reporter.Stop()
 			p.AddReporter(reporter)
 			p.AddTagger(reporter)


### PR DESCRIPTION
Fixes #2258 (problem introduced by https://github.com/weaveworks/scope/pull/2132 ) and adds a new flag to configure kubelet's port (`--probe.kubernetes.kubelet-port`)

@errordeveloper Can you please test this in Openshift in these two scenarios?

1. Without setting the kubelet port appropriately (to make sure the fallback works)
2. Setting the kubelet port appropriately