### PR TITLE
Revert "Revert "Add options to hide args and env vars (#2306)""

### DIFF
--- a/probe/docker/container.go
+++ b/probe/docker/container.go
@@ -98,20 +98,24 @@ type Container interface {
 
 type container struct {
 	sync.RWMutex
-	container    *docker.Container
-	stopStats    chan<- bool
-	latestStats  docker.Stats
-	pendingStats [60]docker.Stats
-	numPending   int
-	hostID       string
-	baseNode     report.Node
+	container              *docker.Container
+	stopStats              chan<- bool
+	latestStats            docker.Stats
+	pendingStats           [60]docker.Stats
+	numPending             int
+	hostID                 string
+	baseNode               report.Node
+	noCommandLineArguments bool
+	noEnvironmentVariables bool
 }
 
 // NewContainer creates a new Container
-func NewContainer(c *docker.Container, hostID string) Container {
+func NewContainer(c *docker.Container, hostID string, noCommandLineArguments bool, noEnvironmentVariables bool) Container {
 	result := &container{
-		container: c,
-		hostID:    hostID,
+		container:              c,
+		hostID:                 hostID,
+		noCommandLineArguments: noCommandLineArguments,
+		noEnvironmentVariables: noEnvironmentVariables,
 	}
 	result.baseNode = result.getBaseNode()
 	return result
@@ -369,18 +373,28 @@ func (c *container) env() map[string]string {
 	return result
 }
 
+func (c *container) getSanitizedCommand() string {
+	result := c.container.Path
+	if !c.noCommandLineArguments {
+		result = result + " " + strings.Join(c.container.Args, " ")
+	}
+	return result
+}
+
 func (c *container) getBaseNode() report.Node {
 	result := report.MakeNodeWith(report.MakeContainerNodeID(c.ID()), map[string]string{
 		ContainerID:       c.ID(),
 		ContainerCreated:  c.container.Created.Format(time.RFC3339Nano),
-		ContainerCommand:  c.container.Path + " " + strings.Join(c.container.Args, " "),
+		ContainerCommand:  c.getSanitizedCommand(),
 		ImageID:           c.Image(),
 		ContainerHostname: c.Hostname(),
 	}).WithParents(report.EmptySets.
 		Add(report.ContainerImage, report.MakeStringSet(report.MakeContainerImageNodeID(c.Image()))),
 	)
 	result = result.AddPrefixPropertyList(LabelPrefix, c.container.Config.Labels)
-	result = result.AddPrefixPropertyList(EnvPrefix, c.env())
+	if !c.noEnvironmentVariables {
+		result = result.AddPrefixPropertyList(EnvPrefix, c.env())
+	}
 	return result
 }
 

--- a/probe/docker/container_test.go
+++ b/probe/docker/container_test.go
@@ -2,6 +2,7 @@ package docker_test
 
 import (
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -40,7 +41,7 @@ func TestContainer(t *testing.T) {
 	defer mtime.NowReset()
 
 	const hostID = "scope"
-	c := docker.NewContainer(container1, hostID)
+	c := docker.NewContainer(container1, hostID, false, false)
 	s := newMockStatsGatherer()
 	err := c.StartGatheringStats(s)
 	if err != nil {
@@ -69,7 +70,7 @@ func TestContainer(t *testing.T) {
 			docker.RemoveContainer:  {Dead: true},
 		}
 		want := report.MakeNodeWith("ping;<container>", map[string]string{
-			"docker_container_command":     " ",
+			"docker_container_command":     "ping foo.bar.local",
 			"docker_container_created":     "0001-01-01T00:00:00Z",
 			"docker_container_id":          "ping",
 			"docker_container_name":        "pong",
@@ -79,6 +80,7 @@ func TestContainer(t *testing.T) {
 			"docker_container_state":       "running",
 			"docker_container_state_human": c.Container().State.String(),
 			"docker_container_uptime":      uptime.String(),
+			"docker_env_FOO":               "secret-bar",
 		}).WithLatestControls(
 			controls,
 		).WithMetrics(report.Metrics{
@@ -124,4 +126,40 @@ func TestContainer(t *testing.T) {
 	if have := docker.ExtractContainerIPs(node); !reflect.DeepEqual(have, []string{"1.2.3.4", "5.6.7.8"}) {
 		t.Errorf("%v != %v", have, []string{"1.2.3.4", "5.6.7.8"})
 	}
+}
+
+func TestContainerHidingArgs(t *testing.T) {
+	const hostID = "scope"
+	c := docker.NewContainer(container1, hostID, true, false)
+	node := c.GetNode()
+	node.Latest.ForEach(func(k string, _ time.Time, v string) {
+		if strings.Contains(v, "foo.bar.local") {
+			t.Errorf("Found command line argument in node")
+		}
+	})
+}
+
+func TestContainerHidingEnv(t *testing.T) {
+	const hostID = "scope"
+	c := docker.NewContainer(container1, hostID, false, true)
+	node := c.GetNode()
+	node.Latest.ForEach(func(k string, _ time.Time, v string) {
+		if strings.Contains(v, "secret-bar") {
+			t.Errorf("Found environment variable in node")
+		}
+	})
+}
+
+func TestContainerHidingBoth(t *testing.T) {
+	const hostID = "scope"
+	c := docker.NewContainer(container1, hostID, true, true)
+	node := c.GetNode()
+	node.Latest.ForEach(func(k string, _ time.Time, v string) {
+		if strings.Contains(v, "foo.bar.local") {
+			t.Errorf("Found command line argument in node")
+		}
+		if strings.Contains(v, "secret-bar") {
+			t.Errorf("Found environment variable in node")
+		}
+	})
 }

--- a/probe/docker/controls_test.go
+++ b/probe/docker/controls_test.go
@@ -18,7 +18,10 @@ func TestControls(t *testing.T) {
 	mdc := newMockClient()
 	setupStubs(mdc, func() {
 		hr := controls.NewDefaultHandlerRegistry()
-		registry, _ := docker.NewRegistry(10*time.Second, nil, false, "", hr, "")
+		registry, _ := docker.NewRegistry(docker.RegistryOptions{
+			Interval:        10 * time.Second,
+			HandlerRegistry: hr,
+		})
 		defer registry.Stop()
 
 		for _, tc := range []struct{ command, result string }{
@@ -59,7 +62,10 @@ func TestPipes(t *testing.T) {
 	mdc := newMockClient()
 	setupStubs(mdc, func() {
 		hr := controls.NewDefaultHandlerRegistry()
-		registry, _ := docker.NewRegistry(10*time.Second, nil, false, "", hr, "")
+		registry, _ := docker.NewRegistry(docker.RegistryOptions{
+			Interval:        10 * time.Second,
+			HandlerRegistry: hr,
+		})
 		defer registry.Stop()
 
 		test.Poll(t, 100*time.Millisecond, true, func() interface{} {

--- a/probe/docker/registry.go
+++ b/probe/docker/registry.go
@@ -95,6 +95,7 @@ func newDockerClient(endpoint string) (Client, error) {
 	return docker_client.NewClient(endpoint)
 }
 
+// RegistryOptions are used to initialize the Registry
 type RegistryOptions struct {
 	Interval               time.Duration
 	Pipes                  controls.PipeClient

--- a/probe/docker/registry_test.go
+++ b/probe/docker/registry_test.go
@@ -22,7 +22,11 @@ import (
 
 func testRegistry() docker.Registry {
 	hr := controls.NewDefaultHandlerRegistry()
-	registry, _ := docker.NewRegistry(10*time.Second, nil, true, "", hr, "")
+	registry, _ := docker.NewRegistry(docker.RegistryOptions{
+		Interval:        10 * time.Second,
+		CollectStats:    true,
+		HandlerRegistry: hr,
+	})
 	return registry
 }
 
@@ -203,6 +207,10 @@ var (
 		ID:    "ping",
 		Name:  "pong",
 		Image: "baz",
+		Path:  "ping",
+		Args: []string{
+			"foo.bar.local",
+		},
 		State: client.State{
 			Pid:       2,
 			Running:   true,
@@ -226,6 +234,9 @@ var (
 			},
 		},
 		Config: &client.Config{
+			Env: []string{
+				"FOO=secret-bar",
+			},
 			Labels: map[string]string{
 				"foo1": "bar1",
 				"foo2": "bar2",
@@ -294,7 +305,7 @@ func setupStubs(mdc *mockDockerClient, f func()) {
 		return mdc, nil
 	}
 
-	docker.NewContainerStub = func(c *client.Container, _ string) docker.Container {
+	docker.NewContainerStub = func(c *client.Container, _ string, _ bool, _ bool) docker.Container {
 		return &mockContainer{c}
 	}
 

--- a/probe/process/reporter_test.go
+++ b/probe/process/reporter_test.go
@@ -21,93 +21,116 @@ func (m *mockWalker) Walk(f func(process.Process, process.Process)) error {
 	return nil
 }
 
-func TestReporter(t *testing.T) {
-	processes := []process.Process{
-		{PID: 1, PPID: 0, Name: "init"},
-		{PID: 2, PPID: 1, Name: "bash"},
-		{PID: 3, PPID: 1, Name: "apache", Threads: 2},
-		{PID: 4, PPID: 2, Name: "ping", Cmdline: "ping foo.bar.local"},
-		{PID: 5, PPID: 1, Cmdline: "tail -f /var/log/syslog"},
-	}
+var processes = []process.Process{
+	{PID: 1, PPID: 0, Name: "init"},
+	{PID: 2, PPID: 1, Name: "bash"},
+	{PID: 3, PPID: 1, Name: "apache", Threads: 2},
+	{PID: 4, PPID: 2, Name: "ping", Cmdline: "ping foo.bar.local"},
+	{PID: 5, PPID: 1, Cmdline: "tail -f /var/log/syslog"},
+}
+
+func testReporter(t *testing.T, noCommandLineArguments bool, test func(report.Report)) {
 	walker := &mockWalker{processes: processes}
 	getDeltaTotalJiffies := func() (uint64, float64, error) { return 0, 0., nil }
 	now := time.Now()
 	mtime.NowForce(now)
 	defer mtime.NowReset()
 
-	rpt, err := process.NewReporter(walker, "", getDeltaTotalJiffies, false).Report()
+	rpt, err := process.NewReporter(walker, "", getDeltaTotalJiffies, noCommandLineArguments).Report()
 	if err != nil {
 		t.Error(err)
 	}
+	test(rpt)
+}
 
-	// It reports the init process
-	node, ok := rpt.Process.Nodes[report.MakeProcessNodeID("", "1")]
-	if !ok {
-		t.Errorf("Expected report to include the pid 1 init")
+func TestInit(t *testing.T) {
+	test := func(rpt report.Report) {
+		node, ok := rpt.Process.Nodes[report.MakeProcessNodeID("", "1")]
+		if !ok {
+			t.Errorf("Expected report to include the pid 1 init")
+		}
+		if name, ok := node.Latest.Lookup(process.Name); !ok || name != processes[0].Name {
+			t.Errorf("Expected %q got %q", processes[0].Name, name)
+		}
 	}
-	if name, ok := node.Latest.Lookup(process.Name); !ok || name != processes[0].Name {
-		t.Errorf("Expected %q got %q", processes[0].Name, name)
-	}
+	testReporter(t, false, test)
+}
 
-	// It reports plain processes (with parent pid, and metrics)
-	node, ok = rpt.Process.Nodes[report.MakeProcessNodeID("", "2")]
-	if !ok {
-		t.Errorf("Expected report to include the pid 2 bash")
-	}
-	if name, ok := node.Latest.Lookup(process.Name); !ok || name != processes[1].Name {
-		t.Errorf("Expected %q got %q", processes[1].Name, name)
-	}
-	if ppid, ok := node.Latest.Lookup(process.PPID); !ok || ppid != fmt.Sprint(processes[1].PPID) {
-		t.Errorf("Expected %d got %q", processes[1].PPID, ppid)
-	}
-	if memoryUsage, ok := node.Metrics[process.MemoryUsage]; !ok {
-		t.Errorf("Expected memory usage metric, but not found")
-	} else if sample, ok := memoryUsage.LastSample(); !ok {
-		t.Errorf("Expected memory usage metric to have a sample, but there were none")
-	} else if sample.Value != 0. {
-		t.Errorf("Expected memory usage metric sample %f, got %f", 0., sample.Value)
-	}
-
-	// It reports thread-counts
-	node, ok = rpt.Process.Nodes[report.MakeProcessNodeID("", "3")]
-	if !ok {
-		t.Errorf("Expected report to include the pid 3 apache")
-	}
-	if threads, ok := node.Latest.Lookup(process.Threads); !ok || threads != fmt.Sprint(processes[2].Threads) {
-		t.Errorf("Expected %d got %q", processes[2].Threads, threads)
-	}
-
-	// It reports the Cmdline
-	node, ok = rpt.Process.Nodes[report.MakeProcessNodeID("", "4")]
-	if !ok {
-		t.Errorf("Expected report to include the pid 4 ping")
-	}
-	if cmdline, ok := node.Latest.Lookup(process.Cmdline); !ok || cmdline != fmt.Sprint(processes[3].Cmdline) {
-		t.Errorf("Expected %q got %q", processes[3].Cmdline, cmdline)
+func TestProcesses(t *testing.T) {
+	test := func(rpt report.Report) {
+		node, ok := rpt.Process.Nodes[report.MakeProcessNodeID("", "2")]
+		if !ok {
+			t.Errorf("Expected report to include the pid 2 bash")
+		}
+		if name, ok := node.Latest.Lookup(process.Name); !ok || name != processes[1].Name {
+			t.Errorf("Expected %q got %q", processes[1].Name, name)
+		}
+		if ppid, ok := node.Latest.Lookup(process.PPID); !ok || ppid != fmt.Sprint(processes[1].PPID) {
+			t.Errorf("Expected %d got %q", processes[1].PPID, ppid)
+		}
+		if memoryUsage, ok := node.Metrics[process.MemoryUsage]; !ok {
+			t.Errorf("Expected memory usage metric, but not found")
+		} else if sample, ok := memoryUsage.LastSample(); !ok {
+			t.Errorf("Expected memory usage metric to have a sample, but there were none")
+		} else if sample.Value != 0. {
+			t.Errorf("Expected memory usage metric sample %f, got %f", 0., sample.Value)
+		}
 	}
 
-	// It reports processes without a Name
-	node, ok = rpt.Process.Nodes[report.MakeProcessNodeID("", "5")]
-	if !ok {
-		t.Errorf("Expected report to include the pid 5 tail")
-	}
-	if name, ok := node.Latest.Lookup(process.Name); ok {
-		t.Errorf("Expected no name, but got %q", name)
-	}
-	if cmdline, ok := node.Latest.Lookup(process.Cmdline); !ok || cmdline != fmt.Sprint(processes[4].Cmdline) {
-		t.Errorf("Expected %q got %q", processes[4].Cmdline, cmdline)
-	}
+	testReporter(t, false, test)
+}
 
-	// It doesn't report Cmdline args when asked not to
-	rpt, err = process.NewReporter(walker, "", getDeltaTotalJiffies, true).Report()
-	if err != nil {
-		t.Error(err)
+func TestThreadCounts(t *testing.T) {
+	test := func(rpt report.Report) {
+		node, ok := rpt.Process.Nodes[report.MakeProcessNodeID("", "3")]
+		if !ok {
+			t.Errorf("Expected report to include the pid 3 apache")
+		}
+		if threads, ok := node.Latest.Lookup(process.Threads); !ok || threads != fmt.Sprint(processes[2].Threads) {
+			t.Errorf("Expected %d got %q", processes[2].Threads, threads)
+		}
 	}
-	node, ok = rpt.Process.Nodes[report.MakeProcessNodeID("", "4")]
-	if !ok {
-		t.Errorf("Expected report to include the pid 4 ping")
+	testReporter(t, false, test)
+}
+
+func TestCmdline(t *testing.T) {
+	test := func(rpt report.Report) {
+		node, ok := rpt.Process.Nodes[report.MakeProcessNodeID("", "4")]
+		if !ok {
+			t.Errorf("Expected report to include the pid 4 ping")
+		}
+		if cmdline, ok := node.Latest.Lookup(process.Cmdline); !ok || cmdline != fmt.Sprint(processes[3].Cmdline) {
+			t.Errorf("Expected %q got %q", processes[3].Cmdline, cmdline)
+		}
 	}
-	if cmdline, ok := node.Latest.Lookup(process.Cmdline); !ok || cmdline != fmt.Sprint("ping") {
-		t.Errorf("Expected %q got %q", "ping", cmdline)
+	testReporter(t, false, test)
+}
+
+func TestAnonymous(t *testing.T) {
+	test := func(rpt report.Report) {
+		node, ok := rpt.Process.Nodes[report.MakeProcessNodeID("", "5")]
+		if !ok {
+			t.Errorf("Expected report to include the pid 5 tail")
+		}
+		if name, ok := node.Latest.Lookup(process.Name); ok {
+			t.Errorf("Expected no name, but got %q", name)
+		}
+		if cmdline, ok := node.Latest.Lookup(process.Cmdline); !ok || cmdline != fmt.Sprint(processes[4].Cmdline) {
+			t.Errorf("Expected %q got %q", processes[4].Cmdline, cmdline)
+		}
 	}
+	testReporter(t, false, test)
+}
+
+func TestCmdlineRemoval(t *testing.T) {
+	test := func(rpt report.Report) {
+		node, ok := rpt.Process.Nodes[report.MakeProcessNodeID("", "4")]
+		if !ok {
+			t.Errorf("Expected report to include the pid 4 ping")
+		}
+		if cmdline, ok := node.Latest.Lookup(process.Cmdline); !ok || cmdline != fmt.Sprint("ping") {
+			t.Errorf("Expected %q got %q", "ping", cmdline)
+		}
+	}
+	testReporter(t, true, test)
 }

--- a/probe/process/reporter_test.go
+++ b/probe/process/reporter_test.go
@@ -35,7 +35,7 @@ func TestReporter(t *testing.T) {
 	mtime.NowForce(now)
 	defer mtime.NowReset()
 
-	rpt, err := process.NewReporter(walker, "", getDeltaTotalJiffies).Report()
+	rpt, err := process.NewReporter(walker, "", getDeltaTotalJiffies, false).Report()
 	if err != nil {
 		t.Error(err)
 	}
@@ -96,5 +96,18 @@ func TestReporter(t *testing.T) {
 	}
 	if cmdline, ok := node.Latest.Lookup(process.Cmdline); !ok || cmdline != fmt.Sprint(processes[4].Cmdline) {
 		t.Errorf("Expected %q got %q", processes[4].Cmdline, cmdline)
+	}
+
+	// It doesn't report Cmdline args when asked not to
+	rpt, err = process.NewReporter(walker, "", getDeltaTotalJiffies, true).Report()
+	if err != nil {
+		t.Error(err)
+	}
+	node, ok = rpt.Process.Nodes[report.MakeProcessNodeID("", "4")]
+	if !ok {
+		t.Errorf("Expected report to include the pid 4 ping")
+	}
+	if cmdline, ok := node.Latest.Lookup(process.Cmdline); !ok || cmdline != fmt.Sprint("ping") {
+		t.Errorf("Expected %q got %q", "ping", cmdline)
 	}
 }

--- a/prog/main.go
+++ b/prog/main.go
@@ -80,17 +80,19 @@ type flags struct {
 }
 
 type probeFlags struct {
-	token           string
-	httpListen      string
-	publishInterval time.Duration
-	spyInterval     time.Duration
-	pluginsRoot     string
-	insecure        bool
-	logPrefix       string
-	logLevel        string
-	resolver        string
-	noApp           bool
-	noControls      bool
+	token                  string
+	httpListen             string
+	publishInterval        time.Duration
+	spyInterval            time.Duration
+	pluginsRoot            string
+	insecure               bool
+	logPrefix              string
+	logLevel               string
+	resolver               string
+	noApp                  bool
+	noControls             bool
+	noCommandLineArguments bool
+	noEnvironmentVariables bool
 
 	useConntrack        bool // Use conntrack for endpoint topo
 	conntrackBufferSize int  // Sie of kernel buffer for conntrack
@@ -266,6 +268,8 @@ func main() {
 	flag.DurationVar(&flags.probe.spyInterval, "probe.spy.interval", time.Second, "spy (scan) interval")
 	flag.StringVar(&flags.probe.pluginsRoot, "probe.plugins.root", "/var/run/scope/plugins", "Root directory to search for plugins")
 	flag.BoolVar(&flags.probe.noControls, "probe.no-controls", false, "Disable controls (e.g. start/stop containers, terminals, logs ...)")
+	flag.BoolVar(&flags.probe.noCommandLineArguments, "probe.omit.cmd-args", false, "Disable collection of command-line arguments")
+	flag.BoolVar(&flags.probe.noEnvironmentVariables, "probe.omit.env-vars", false, "Disable collection of environment variables")
 
 	flag.BoolVar(&flags.probe.insecure, "probe.insecure", false, "(SSL) explicitly allow \"insecure\" SSL connections and transfers")
 	flag.StringVar(&flags.probe.resolver, "probe.resolver", "", "IP address & port of resolver to use.  Default is to use system resolver.")


### PR DESCRIPTION
Re-includes #2306 , which failed because we don't run integration tests for external contributors :( (we really need #2192 )

