### PR TITLE
integration: disable tests with internet edge

### DIFF
--- a/integration/300_internet_edge_test.sh
+++ b/integration/300_internet_edge_test.sh
@@ -3,24 +3,28 @@
 # shellcheck disable=SC1091
 . ./config.sh
 
-start_suite "Test short lived connections from the Internet"
+start_suite "Test short lived connections from the Internet [DISABLED]"
 
 weave_on "$HOST1" launch
 scope_on "$HOST1" launch
-docker_on "$HOST1" run -d -p 80:80 --name nginx nginx
 
-do_connections() {
-    while true; do
-        curl -s "http://$HOST1:80/" >/dev/null || true
-        sleep 1
-    done
-}
-do_connections &
+## Test disabled: it is currently flaky
+## https://github.com/weaveworks/scope/issues/2308
 
-wait_for_containers "$HOST1" 60 nginx "The Internet"
-
-has_connection_by_id containers "$HOST1" "in-theinternet" "$(node_id containers "$HOST1" nginx)"
-
-kill %do_connections
+# docker_on "$HOST1" run -d -p 80:80 --name nginx nginx
+#
+# do_connections() {
+#     while true; do
+#         curl -s "http://$HOST1:80/" >/dev/null || true
+#         sleep 1
+#     done
+# }
+# do_connections &
+#
+# wait_for_containers "$HOST1" 60 nginx "The Internet"
+#
+# has_connection_by_id containers "$HOST1" "in-theinternet" "$(node_id containers "$HOST1" nginx)"
+#
+# kill %do_connections
 
 scope_end_suite

--- a/integration/301_internet_edge_with_ebpf_test.sh
+++ b/integration/301_internet_edge_with_ebpf_test.sh
@@ -3,26 +3,30 @@
 # shellcheck disable=SC1091
 . ./config.sh
 
-start_suite "Test short lived connections from the Internet"
+start_suite "Test short lived connections from the Internet [DISABLED]"
 
 weave_on "$HOST1" launch
 scope_on "$HOST1" launch --probe.ebpf.connections=true
-docker_on "$HOST1" run -d -p 80:80 --name nginx nginx
 
-do_connections() {
-    while true; do
-        curl -s "http://$HOST1:80/" >/dev/null || true
-        sleep 1
-    done
-}
-do_connections &
+## Test disabled: it is currently flaky
+## https://github.com/weaveworks/scope/issues/2308
 
-wait_for_containers "$HOST1" 60 nginx "The Internet"
-
-has_connection_by_id containers "$HOST1" "in-theinternet" "$(node_id containers "$HOST1" nginx)"
-
-endpoints_have_ebpf "$HOST1"
-
-kill %do_connections
+# docker_on "$HOST1" run -d -p 80:80 --name nginx nginx
+#
+# do_connections() {
+#     while true; do
+#         curl -s "http://$HOST1:80/" >/dev/null || true
+#         sleep 1
+#     done
+# }
+# do_connections &
+#
+# wait_for_containers "$HOST1" 60 nginx "The Internet"
+#
+# has_connection_by_id containers "$HOST1" "in-theinternet" "$(node_id containers "$HOST1" nginx)"
+#
+# endpoints_have_ebpf "$HOST1"
+#
+# kill %do_connections
 
 scope_end_suite


### PR DESCRIPTION
They are currently flaky.

See https://github.com/weaveworks/scope/issues/2308

/cc @2opremio 