### PR TITLE
integration tests: list containers for debugging

### DIFF
--- a/integration/311_container_to_container_edge_with_ebpf_test.sh
+++ b/integration/311_container_to_container_edge_with_ebpf_test.sh
@@ -17,6 +17,10 @@ wait_for_containers "$HOST1" 60 nginx client
 
 has_container "$HOST1" nginx
 has_container "$HOST1" client
+
+list_containers "$HOST1"
+list_connections "$HOST1"
+
 has_connection containers "$HOST1" client nginx
 
 endpoints_have_ebpf "$HOST1"

--- a/integration/312_container_to_container_edge_same_netns_with_ebpf_test.sh
+++ b/integration/312_container_to_container_edge_same_netns_with_ebpf_test.sh
@@ -13,6 +13,10 @@ wait_for_containers "$HOST1" 60 nginx client
 
 has_container "$HOST1" nginx
 has_container "$HOST1" client
+
+list_containers "$HOST1"
+list_connections "$HOST1"
+
 has_connection containers "$HOST1" client nginx
 
 endpoints_have_ebpf "$HOST1"

--- a/integration/config.sh
+++ b/integration/config.sh
@@ -40,6 +40,19 @@ scope_end_suite() {
     done
 }
 
+list_containers() {
+    local host=$1
+    echo "Listing containers on ${host}:"
+    curl -s "http://${host}:4040/api/topology/containers?system=show" | jq -r '.nodes[] | select(has("metadata")) | .metadata[] | select(.id == "docker_image_name") | .value'
+}
+
+list_connections() {
+    local host=$1
+    echo "Listing connections on ${host}:"
+    curl -s "http://${host}:4040/api/topology/containers?system=show" | jq -r '.nodes[] | select(has("adjacency")) | { "from": .id, "to": .adjacency[]} | .from + " -> " + .to'
+
+}
+
 # this checks we have a named node in the given view
 has() {
     local view=$1
@@ -111,6 +124,8 @@ endpoints_have_ebpf() {
     done
 
     echo "Only ${have_ebpf} endpoints of ${number_of_endpoints} have ebpf enabled, should be equal"
+    echo "Example of one endpoint:"
+    echo "${report}" | jq -r '[.Endpoint.nodes[]][0]'
     assert "echo '$have_ebpf" "$number_of_endpoints"
 }
 


### PR DESCRIPTION
Integration test "311_container_to_container_edge_with_ebpf_test.sh" sometimes fails with the following error:
```
>>> Test ./311_container_to_container_edge_with_ebpf_test.sh finished after 125.0 secs with error: exit status 1
host1-weaveworks-scope-6767-1.us-central1-a.scope-integration-tests> weave
Test short lived connections between containers, with ebpf connection tracking enabled
8c6e4b72edf6fb359e084b061611aa3259071ee5cedefc2198575b741be0426e
Scope probe started
Weave Scope is reachable at the following URL(s):
  * http://10.128.0.12:4040/
4c715954314eaf6194fe9de4a528c6591340e7fe07c5702ff72cae82c0bf7e29
d8d88a8786aab13141d6b6a16f748552c7f4c43b0b0568654d6f456a7bd26b46
Found 2 nodes after 4 secs
Found edge client -> nginx after 7 secs
Only 0 endpoints of 23 have ebpf enabled, should be equal
test #4 "echo '0" failed:
	expected "23"
	got nothing
1 of 4 tests failed in 112.869s.
Failed to remove container (d8d88a8786aa
4c715954314e
8c6e4b72edf6
7afc794bd808
6a88bc7549c4
6cafb3356378
c932e22c2b68
5abcc2e7093c): Error response from daemon: {"message":"page not found"}
host1-weaveworks-scope-6767-1.us-central1-a.scope-integration-tests> docker stop/waiting
host1-weaveworks-scope-6767-1.us-central1-a.scope-integration-tests> docker start/running, process 11432

>>> Ran 11 tests, 1 failed
>>> Fail ./311_container_to_container_edge_with_ebpf_test.sh
```
See https://circleci.com/gh/weaveworks/scope/6767

I am trying to add more debug messages.