### PR TITLE
Revert "Merge pull request #2285 from weaveworks/mike/k8s-ns-in-container-view"

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -80,23 +80,21 @@ func updateFilters(rpt report.Report, topologies []APITopologyDesc) []APITopolog
 		ns = append(ns, namespace)
 	}
 	sort.Strings(ns)
-	if len(ns) > 0 { // We only want to apply k8s filters when we have k8s-related nodes
-		for i, t := range topologies {
-			if t.id == containersID || t.id == containersByImageID || t.id == containersByHostnameID || t.id == podsID || t.id == servicesID || t.id == deploymentsID || t.id == replicaSetsID {
-				topologies[i] = mergeTopologyFilters(t, []APITopologyOptionGroup{
-					kubernetesFilters(ns...),
-				})
-			}
+	for i, t := range topologies {
+		if t.id == podsID || t.id == servicesID || t.id == deploymentsID || t.id == replicaSetsID {
+			topologies[i] = updateTopologyFilters(t, []APITopologyOptionGroup{
+				kubernetesFilters(ns...), unmanagedFilter,
+			})
 		}
 	}
 	return topologies
 }
 
-// mergeTopologyFilters recursively merges in new options on a topology description
-func mergeTopologyFilters(t APITopologyDesc, options []APITopologyOptionGroup) APITopologyDesc {
-	t.Options = append(t.Options, options...)
+// updateTopologyFilters recursively sets the options on a topology description
+func updateTopologyFilters(t APITopologyDesc, options []APITopologyOptionGroup) APITopologyDesc {
+	t.Options = options
 	for i, sub := range t.SubTopologies {
-		t.SubTopologies[i] = mergeTopologyFilters(sub, options)
+		t.SubTopologies[i] = updateTopologyFilters(sub, options)
 	}
 	return t
 }
@@ -202,7 +200,6 @@ func MakeRegistry() *Registry {
 			renderer:    render.PodRenderer,
 			Name:        "Pods",
 			Rank:        3,
-			Options:     []APITopologyOptionGroup{unmanagedFilter},
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{
@@ -210,7 +207,6 @@ func MakeRegistry() *Registry {
 			parent:      podsID,
 			renderer:    render.ReplicaSetRenderer,
 			Name:        "replica sets",
-			Options:     []APITopologyOptionGroup{unmanagedFilter},
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{
@@ -218,7 +214,6 @@ func MakeRegistry() *Registry {
 			parent:      podsID,
 			renderer:    render.DeploymentRenderer,
 			Name:        "deployments",
-			Options:     []APITopologyOptionGroup{unmanagedFilter},
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{
@@ -226,7 +221,6 @@ func MakeRegistry() *Registry {
 			parent:      podsID,
 			renderer:    render.PodServiceRenderer,
 			Name:        "services",
-			Options:     []APITopologyOptionGroup{unmanagedFilter},
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{

--- a/render/filters.go
+++ b/render/filters.go
@@ -10,10 +10,6 @@ import (
 	"github.com/weaveworks/scope/report"
 )
 
-const (
-	k8sNamespaceLabel = "io.kubernetes.pod.namespace"
-)
-
 // PreciousNodeRenderer ensures a node is never filtered out by decorators
 type PreciousNodeRenderer struct {
 	PreciousNodeID string
@@ -285,7 +281,7 @@ func IsApplication(n report.Node) bool {
 	if roleLabel == "system" {
 		return false
 	}
-	namespace, _ := n.Latest.Lookup(docker.LabelPrefix + k8sNamespaceLabel)
+	namespace, _ := n.Latest.Lookup(docker.LabelPrefix + "io.kubernetes.pod.namespace")
 	if namespace == "kube-system" {
 		return false
 	}
@@ -324,14 +320,7 @@ func IsNotPseudo(n report.Node) bool {
 // IsNamespace checks if the node is a pod/service in the specified namespace
 func IsNamespace(namespace string) FilterFunc {
 	return func(n report.Node) bool {
-		tryKeys := []string{kubernetes.Namespace, docker.LabelPrefix + k8sNamespaceLabel}
-		gotNamespace := ""
-		for _, key := range tryKeys {
-			if value, ok := n.Latest.Lookup(key); ok {
-				gotNamespace = value
-				break
-			}
-		}
+		gotNamespace, _ := n.Latest.Lookup(kubernetes.Namespace)
 		return namespace == gotNamespace
 	}
 }


### PR DESCRIPTION
This reverts commit 76ddc75fb8180011202ab1494e722758b43d2a86, reversing
changes made to 3ade2933eb7722ef4c8f2fe66eab9a58802daea9.

We are rolling this back for now because it's causing a bug where sub-topologies
would have ~3000 repeated cases of the k8s filters, causing performance issues clientside.