### PR TITLE
Hide 'Save canvas as SVG' button in Table View

### DIFF
--- a/client/app/scripts/components/troubleshooting-menu.js
+++ b/client/app/scripts/components/troubleshooting-menu.js
@@ -38,7 +38,7 @@ class DebugMenu extends React.Component {
                 </span>
               </a>
             </div>
-            <div className="troubleshooting-menu-item">
+            {!this.props.gridMode && <div className="troubleshooting-menu-item">
               <a
                 href=""
                 className="footer-icon"
@@ -50,7 +50,7 @@ class DebugMenu extends React.Component {
                   Save canvas as SVG (does not include search highlighting)
                 </span>
               </a>
-            </div>
+            </div>}
             <div className="troubleshooting-menu-item">
               <a
                 href=""
@@ -86,7 +86,13 @@ class DebugMenu extends React.Component {
   }
 }
 
-export default connect(null, {
+function mapStateToProps(state) {
+  return {
+    gridMode: state.get('gridMode'),
+  };
+}
+
+export default connect(mapStateToProps, {
   toggleTroubleshootingMenu,
   resetLocalViewState,
   clickDownloadGraph


### PR DESCRIPTION
Fixes #2354.
