### PR TITLE
Changed --dry-run command to execute after OSX setup

### DIFF
--- a/scope
+++ b/scope
@@ -203,6 +203,13 @@ print_app_endpoints() {
     done
 }
 
+dry_run() {
+    # Do a dry run of scope in the foreground, so it can parse args etc
+    # avoiding the entrypoint script in the process.
+    # shellcheck disable=SC2046
+    docker run --rm --entrypoint=/home/weave/scope $(docker_args) "$SCOPE_IMAGE" --dry-run "$@"
+}
+
 check_docker_access
 check_docker_version
 
@@ -232,11 +239,6 @@ case "$COMMAND" in
         ;;
 
     launch)
-        # Do a dry run of scope in the foreground, so it can parse args etc
-        # avoiding the entrypoint script in the process.
-        # shellcheck disable=SC2046
-        docker run --rm --entrypoint=/home/weave/scope $(docker_args) "$SCOPE_IMAGE" --dry-run "$@"
-
         if check_docker_for_mac; then
             create_plugins_dir
             if check_probe_only; then
@@ -248,6 +250,7 @@ case "$COMMAND" in
             # access to host ports of the VM.
             # - https://github.com/weaveworks/scope/issues/1411
             # - https://forums.docker.com/t/ports-in-host-network-namespace-are-not-accessible/10789
+            dry_run "$@"
             check_not_running "$SCOPE_APP_CONTAINER_NAME" "$SCOPE_IMAGE_NAME"
             check_not_running "$SCOPE_CONTAINER_NAME" "$SCOPE_IMAGE_NAME"
             docker rm -f "$SCOPE_APP_CONTAINER_NAME" >/dev/null 2>&1 || true
@@ -260,7 +263,7 @@ case "$COMMAND" in
             print_app_endpoints "localhost"
             exit
         fi
-
+        dry_run "$@"
         launch "$@"
         if ! check_probe_only; then
             # shellcheck disable=SC2086


### PR DESCRIPTION
Fix for #2357 

Moves the `--dry-run` to after OSX setup is completed.