### PR TITLE
Clear client polling and nodes state on dismount 

### DIFF
--- a/client/app/scripts/actions/app-actions.js
+++ b/client/app/scripts/actions/app-actions.js
@@ -17,7 +17,7 @@ import {
   getNodeDetails,
   getTopologies,
   deletePipe,
-  stopTopologyPolling,
+  stopPolling,
   teardownWebsockets,
 } from '../utils/web-api-utils';
 import { getCurrentTopologyUrl } from '../utils/topology-utils';
@@ -720,20 +720,17 @@ export function toggleTroubleshootingMenu(ev) {
 
 export function changeInstance() {
   return (dispatch, getState) => {
-    dispatch({ type: ActionTypes.CHANGE_INSTANCE });
+    dispatch({
+      type: ActionTypes.CHANGE_INSTANCE
+    });
     updateRoute(getState);
-    const state = getState();
-    getTopologies(activeTopologyOptionsSelector(state), dispatch);
-    getNodesDelta(
-      getCurrentTopologyUrl(state),
-      activeTopologyOptionsSelector(state),
-      dispatch,
-      true // forces websocket teardown and reconnect to new instance
-    );
   };
 }
 
 export function shutdown() {
-  stopTopologyPolling();
+  stopPolling();
   teardownWebsockets();
+  return {
+    type: ActionTypes.SHUTDOWN
+  };
 }

--- a/client/app/scripts/components/app.js
+++ b/client/app/scripts/components/app.js
@@ -42,9 +42,10 @@ class App extends React.Component {
     window.addEventListener('keyup', this.onKeyUp);
 
     getRouter(this.props.dispatch, this.props.urlState).start({hashbang: true});
-    if (!this.props.routeSet) {
-      // dont request topologies when already done via router
-      getTopologies(this.props.activeTopologyOptions, this.props.dispatch);
+    if (!this.props.routeSet || process.env.WEAVE_CLOUD) {
+      // dont request topologies when already done via router.
+      // If running as a component, always request topologies when the app mounts.
+      getTopologies(this.props.activeTopologyOptions, this.props.dispatch, true);
     }
     getApiDetails(this.props.dispatch);
   }
@@ -52,7 +53,7 @@ class App extends React.Component {
   componentWillUnmount() {
     window.removeEventListener('keypress', this.onKeyPress);
     window.removeEventListener('keyup', this.onKeyUp);
-    shutdown();
+    this.props.dispatch(shutdown());
   }
 
   onKeyUp(ev) {

--- a/client/app/scripts/constants/action-types.js
+++ b/client/app/scripts/constants/action-types.js
@@ -62,6 +62,7 @@ const ACTION_TYPES = [
   'SET_GRID_MODE',
   'CHANGE_INSTANCE',
   'TOGGLE_CONTRAST_MODE',
+  'SHUTDOWN'
 ];
 
 export default zipObject(ACTION_TYPES, ACTION_TYPES);

--- a/client/app/scripts/reducers/root.js
+++ b/client/app/scripts/reducers/root.js
@@ -744,6 +744,11 @@ export function rootReducer(state = initialState, action) {
       return state.set('contrastMode', action.enabled);
     }
 
+    case ActionTypes.SHUTDOWN: {
+      state = clearNodes(state);
+      return state.set('nodesLoaded', false);
+    }
+
     default: {
       return state;
     }


### PR DESCRIPTION
Needed for https://github.com/weaveworks/service-ui/pull/358

Prevents additional polling when Scope is dismounted while running as a component. Also cleans up old nodes to show the correct loading screen when mounted.