### PR TITLE
When k8s present, allow filtering of containers by namespace (take 2)

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -81,6 +81,7 @@ func updateFilters(rpt report.Report, topologies []APITopologyDesc) []APITopolog
 	}
 	sort.Strings(ns)
 	if len(ns) > 0 { // We only want to apply k8s filters when we have k8s-related nodes
+		topologies = append([]APITopologyDesc{}, topologies...) // Make a copy so we can make changes safely
 		for i, t := range topologies {
 			if t.id == containersID || t.id == containersByImageID || t.id == containersByHostnameID || t.id == podsID || t.id == servicesID || t.id == deploymentsID || t.id == replicaSetsID {
 				topologies[i] = mergeTopologyFilters(t, []APITopologyOptionGroup{
@@ -94,10 +95,12 @@ func updateFilters(rpt report.Report, topologies []APITopologyDesc) []APITopolog
 
 // mergeTopologyFilters recursively merges in new options on a topology description
 func mergeTopologyFilters(t APITopologyDesc, options []APITopologyOptionGroup) APITopologyDesc {
-	t.Options = append(t.Options, options...)
+	t.Options = append(append([]APITopologyOptionGroup{}, t.Options...), options...)
+	newSubTopologies := make([]APITopologyDesc, len(t.SubTopologies))
 	for i, sub := range t.SubTopologies {
-		t.SubTopologies[i] = mergeTopologyFilters(sub, options)
+		newSubTopologies[i] = mergeTopologyFilters(sub, options)
 	}
+	t.SubTopologies = newSubTopologies
 	return t
 }
 

--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -75,19 +75,22 @@ func updateFilters(rpt report.Report, topologies []APITopologyDesc) []APITopolog
 			}
 		}
 	}
-	var ns []string
+	if len(namespaces) == 0 {
+		// We only want to apply k8s filters when we have k8s-related nodes,
+		// so if we don't then return early
+		return topologies
+	}
+	ns := []string{}
 	for namespace := range namespaces {
 		ns = append(ns, namespace)
 	}
 	sort.Strings(ns)
-	if len(ns) > 0 { // We only want to apply k8s filters when we have k8s-related nodes
-		topologies = append([]APITopologyDesc{}, topologies...) // Make a copy so we can make changes safely
-		for i, t := range topologies {
-			if t.id == containersID || t.id == containersByImageID || t.id == containersByHostnameID || t.id == podsID || t.id == servicesID || t.id == deploymentsID || t.id == replicaSetsID {
-				topologies[i] = mergeTopologyFilters(t, []APITopologyOptionGroup{
-					kubernetesFilters(ns...),
-				})
-			}
+	topologies = append([]APITopologyDesc{}, topologies...) // Make a copy so we can make changes safely
+	for i, t := range topologies {
+		if t.id == containersID || t.id == containersByImageID || t.id == containersByHostnameID || t.id == podsID || t.id == servicesID || t.id == deploymentsID || t.id == replicaSetsID {
+			topologies[i] = mergeTopologyFilters(t, []APITopologyOptionGroup{
+				kubernetesFilters(ns...),
+			})
 		}
 	}
 	return topologies

--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -80,21 +80,23 @@ func updateFilters(rpt report.Report, topologies []APITopologyDesc) []APITopolog
 		ns = append(ns, namespace)
 	}
 	sort.Strings(ns)
-	for i, t := range topologies {
-		if t.id == podsID || t.id == servicesID || t.id == deploymentsID || t.id == replicaSetsID {
-			topologies[i] = updateTopologyFilters(t, []APITopologyOptionGroup{
-				kubernetesFilters(ns...), unmanagedFilter,
-			})
+	if len(ns) > 0 { // We only want to apply k8s filters when we have k8s-related nodes
+		for i, t := range topologies {
+			if t.id == containersID || t.id == containersByImageID || t.id == containersByHostnameID || t.id == podsID || t.id == servicesID || t.id == deploymentsID || t.id == replicaSetsID {
+				topologies[i] = mergeTopologyFilters(t, []APITopologyOptionGroup{
+					kubernetesFilters(ns...),
+				})
+			}
 		}
 	}
 	return topologies
 }
 
-// updateTopologyFilters recursively sets the options on a topology description
-func updateTopologyFilters(t APITopologyDesc, options []APITopologyOptionGroup) APITopologyDesc {
-	t.Options = options
+// mergeTopologyFilters recursively merges in new options on a topology description
+func mergeTopologyFilters(t APITopologyDesc, options []APITopologyOptionGroup) APITopologyDesc {
+	t.Options = append(t.Options, options...)
 	for i, sub := range t.SubTopologies {
-		t.SubTopologies[i] = updateTopologyFilters(sub, options)
+		t.SubTopologies[i] = mergeTopologyFilters(sub, options)
 	}
 	return t
 }
@@ -200,6 +202,7 @@ func MakeRegistry() *Registry {
 			renderer:    render.PodRenderer,
 			Name:        "Pods",
 			Rank:        3,
+			Options:     []APITopologyOptionGroup{unmanagedFilter},
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{
@@ -207,6 +210,7 @@ func MakeRegistry() *Registry {
 			parent:      podsID,
 			renderer:    render.ReplicaSetRenderer,
 			Name:        "replica sets",
+			Options:     []APITopologyOptionGroup{unmanagedFilter},
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{
@@ -214,6 +218,7 @@ func MakeRegistry() *Registry {
 			parent:      podsID,
 			renderer:    render.DeploymentRenderer,
 			Name:        "deployments",
+			Options:     []APITopologyOptionGroup{unmanagedFilter},
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{
@@ -221,6 +226,7 @@ func MakeRegistry() *Registry {
 			parent:      podsID,
 			renderer:    render.PodServiceRenderer,
 			Name:        "services",
+			Options:     []APITopologyOptionGroup{unmanagedFilter},
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{


### PR DESCRIPTION
Re-applies https://github.com/weaveworks/scope/pull/2285 (reverted in https://github.com/weaveworks/scope/pull/2348)
and fixes the bug(s) that prompted the revert, which turned out to be a matter of accidentially mutating
objects in a variety of ways, some of which were introduced by https://github.com/weaveworks/scope/pull/2285 but
others that weren't, but were exposed as a problem due to changing the operation from a set to an append.

Fixes https://github.com/weaveworks/scope/issues/1504