### PR TITLE
Add job to trigger service-ui build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,10 @@ ui-pkg-upload: tmp/weave-scope.tgz
 	AWS_SECRET_ACCESS_KEY=$$UI_BUCKET_KEY_SECRET \
 	aws s3 cp tmp/weave-scope.tgz s3://weaveworks-js-modules/weave-scope/weave-scope.tgz
 
+trigger-service-ui-build:
+	curl -H "Content-Type: application/json" -X POST \
+	https://circleci.com/api/v1.1/project/github/weaveworks/service-ui/tree/master?circle-token=$$CIRCLE_API_TOKEN
+
 clean:
 	$(GO) clean ./...
 # Don't actually rmi the build images - rm'ing the .uptodate files is enough to ensure

--- a/circle.yml
+++ b/circle.yml
@@ -86,7 +86,7 @@ deployment:
             docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/$IMAGE &&
             docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/$IMAGE:$(./tools/image-tag)
           done
-          (test -z "${UI_BUCKET_KEY_ID}" || (cd $SRCDIR && make ui-upload && make ui-pkg-upload))
+          (test -z "${UI_BUCKET_KEY_ID}" || (cd $SRCDIR && make ui-upload && make ui-pkg-upload && make trigger-service-ui-build))
         )
       - |
         test -z "${QUAY_USER}" || (


### PR DESCRIPTION
Needed for https://github.com/weaveworks/service-ui/pull/358

Does a `curl` to trigger a `service-ui` build. API token was added via CircleCI env variable.