### PR TITLE
Add default values for edge waypoints

### DIFF
--- a/client/app/scripts/charts/edge-container.js
+++ b/client/app/scripts/charts/edge-container.js
@@ -27,7 +27,7 @@ const transformedEdge = (props, path) => (
 // that is used by Motion to an array of waypoints in the format
 // [{x: 11, y: 22}, {x: 33, y: 44}] that can be used by D3.
 const waypointsMapToArray = (waypointsMap) => {
-  const waypointsArray = times(WAYPOINTS_COUNT, () => ({}));
+  const waypointsArray = times(WAYPOINTS_COUNT, () => ({ x: 0, y: 0}));
   each(waypointsMap, (value, key) => {
     const [axis, index] = [key[0], key.slice(1)];
     waypointsArray[index][axis] = value;


### PR DESCRIPTION
Fixes #2378 

Adds default values to ensure that `<path />` edge elements don't receive a `NaN`.