### PR TITLE
Fetch resource view topologies on first topologies load

### DIFF
--- a/client/app/scripts/actions/app-actions.js
+++ b/client/app/scripts/actions/app-actions.js
@@ -618,9 +618,13 @@ export function receiveTopologies(topologies) {
       state.get('nodeDetails'),
       dispatch
     );
-    // populate search matches on first load
+    // Populate search matches on first load
     if (firstLoad && state.get('searchQuery')) {
       dispatch(focusSearch());
+    }
+    // Fetch all the relevant nodes once on first load
+    if (firstLoad && isResourceViewModeSelector(state)) {
+      getResourceViewNodesSnapshot(getState, dispatch);
     }
   };
 }

--- a/client/app/scripts/utils/web-api-utils.js
+++ b/client/app/scripts/utils/web-api-utils.js
@@ -188,14 +188,11 @@ export function getAllNodes(getState, dispatch) {
 
 /**
  * One-time update of all the nodes of topologies that appear in the current resource view.
+ * TODO: Replace the one-time snapshot with periodic polling.
  */
 export function getResourceViewNodesSnapshot(getState, dispatch) {
   const topologyIds = layersTopologyIdsSelector(getState());
-  // TODO: Remove the timeout and replace it with normal polling once we figure how to make
-  // resource view dynamic (from the UI point of view, the challenge is to make it stable).
-  setTimeout(() => {
-    getNodesForTopologies(getState, dispatch, topologyIds);
-  }, 1200);
+  getNodesForTopologies(getState, dispatch, topologyIds);
 }
 
 export function getTopologies(options, dispatch, initialPoll) {


### PR DESCRIPTION
No calls for the relevant topologies in the resource view were being made because `getResourceViewNodesSnapshot` would be called before we'd get the response from `api/topology` with all the topologies' urls.

Timeout of `1200ms` made it work locally, but wasn't a proper solution for the dev. Hopefully this fixes #2391.
