### PR TITLE
Add version to Scope UI module S3 path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,11 +202,7 @@ ui-upload: client/build-external/index.html
 ui-pkg-upload: tmp/weave-scope.tgz
 	AWS_ACCESS_KEY_ID=$$UI_BUCKET_KEY_ID \
 	AWS_SECRET_ACCESS_KEY=$$UI_BUCKET_KEY_SECRET \
-	aws s3 cp tmp/weave-scope.tgz s3://weaveworks-js-modules/weave-scope/weave-scope.tgz
-
-trigger-service-ui-build:
-	curl -H "Content-Type: application/json" -X POST \
-	https://circleci.com/api/v1.1/project/github/weaveworks/service-ui/tree/master?circle-token=$$CIRCLE_API_TOKEN
+	aws s3 cp tmp/weave-scope.tgz s3://weaveworks-js-modules/weave-scope/$(shell echo $(SCOPE_VERSION))/weave-scope.tgz
 
 clean:
 	$(GO) clean ./...


### PR DESCRIPTION
Adds the Scope short commit hash to the path to module path on S3. This will require the `service-ui` app to explicitly declare which version of Scope should be installed. This introduces a (currently) manual step of changing the Scope version in `service-ui` and committing. The upside is an easy-to-understand commit log and predictable rollbacks.