### PR TITLE
Add a test that checks if reports with data round-trip

### DIFF
--- a/report/marshal_test.go
+++ b/report/marshal_test.go
@@ -5,8 +5,11 @@ import (
 	"compress/gzip"
 	"reflect"
 	"testing"
+	"time"
 
+	"github.com/weaveworks/common/mtime"
 	"github.com/weaveworks/scope/report"
+	s_reflect "github.com/weaveworks/scope/test/reflect"
 )
 
 func TestRoundtrip(t *testing.T) {
@@ -27,6 +30,59 @@ func TestRoundtrip(t *testing.T) {
 	}
 	if !reflect.DeepEqual(r1, *r3) {
 		t.Errorf("%v != %v", r1, *r3)
+	}
+}
+
+// Create a Report for test purposes that contains about one of
+// everything interesting.  Not more than one, to avoid different
+// ordering comparing unequal
+func makeTestReport() report.Report {
+	// Note: why doesn't Scope generally force all times to UTC?
+	nowTime := time.Date(2016, 12, 25, 7, 37, 0, 0, time.UTC)
+	t1 := nowTime.Add(-time.Minute)
+	t2 := t1.Add(time.Second)
+	mtime.NowForce(nowTime)
+	r := report.MakeReport()
+	r.ID = "3894069658342253419"
+	r.Endpoint.AddNode(report.MakeNode(";172.20.1.168;41582").
+		WithTopology("endpoint").
+		WithSet("snooped_dns_names", report.MakeStringSet("ip-172-20-1-168.ec2.internal")).
+		WithControls("docker_remove_container").
+		WithLatestActiveControls("docker_pause_container").
+		WithLatest("addr", t1, "127.0.0.1"),
+	)
+	r.Process.WithShape("square").WithLabel("process", "processes").
+		AddNode(report.MakeNode("ip-172-20-1-168;10446").
+			WithTopology("process").
+			WithParents(report.MakeSets().Add("host", report.MakeStringSet("ip-172-20-1-168;<host>"))).
+			WithLatest("pid", t1, "10446").
+			WithMetrics(report.Metrics{"process_cpu_usage_percent": report.MakeMetric([]report.Sample{{Timestamp: t1, Value: 0.1}, {Timestamp: t2, Value: 0.2}})}))
+	r.Pod.WithShape("heptagon").WithLabel("pod", "pods").
+		AddNode(report.MakeNode("fceef9592ec3cf1a8e1d178fdd0de41a;<pod>").
+			WithTopology("pod").
+			WithControls("kubernetes_delete_pod").
+			WithLatestControls(map[string]report.NodeControlData{"kubernetes_get_logs": {Dead: true}}).
+			WithLatest("host_node_id", t1, "ip-172-20-1-168;<host>"))
+	r.Overlay.WithMetadataTemplates(report.MetadataTemplates{
+		"weave_encryption": report.MetadataTemplate{ID: "weave_encryption", Label: "Encryption", Priority: 4, From: "latest"},
+	}).
+		AddNode(report.MakeNode("#docker_peer_ip-172-20-1-168").
+			WithTopology("overlay").
+			WithSet("local_networks", report.MakeStringSet("172.18.0.0/16")))
+	mtime.NowReset()
+	return r
+}
+
+func TestBiggerRoundtrip(t *testing.T) {
+	var buf bytes.Buffer
+	r1 := makeTestReport()
+	r1.WriteBinary(&buf, gzip.BestCompression)
+	r2, err := report.MakeFromBinary(&buf)
+	if err != nil {
+		t.Error(err)
+	}
+	if !s_reflect.DeepEqual(r1, *r2) {
+		t.Errorf("%v != %v", r1, *r2)
 	}
 }
 

--- a/report/node.go
+++ b/report/node.go
@@ -18,7 +18,7 @@ type Node struct {
 	Controls       NodeControls             `json:"controls,omitempty"`
 	LatestControls NodeControlDataLatestMap `json:"latestControls,omitempty"`
 	Latest         StringLatestMap          `json:"latest,omitempty"`
-	Metrics        Metrics                  `json:"metrics,omitempty"`
+	Metrics        Metrics                  `json:"metrics,omitempty" deepequal:"nil==empty"`
 	Parents        Sets                     `json:"parents,omitempty"`
 	Children       NodeSet                  `json:"children,omitempty"`
 }

--- a/report/topology.go
+++ b/report/topology.go
@@ -13,7 +13,7 @@ type Topology struct {
 	Label             string            `json:"label,omitempty"`
 	LabelPlural       string            `json:"label_plural,omitempty"`
 	Nodes             Nodes             `json:"nodes"`
-	Controls          Controls          `json:"controls,omitempty"`
+	Controls          Controls          `json:"controls,omitempty" deepequal:"nil==empty"`
 	MetadataTemplates MetadataTemplates `json:"metadata_templates,omitempty"`
 	MetricTemplates   MetricTemplates   `json:"metric_templates,omitempty"`
 	TableTemplates    TableTemplates    `json:"table_templates,omitempty"`

--- a/test/reflect/deepequal.go
+++ b/test/reflect/deepequal.go
@@ -146,6 +146,11 @@ func structEq(v1, v2 reflect.Value, visited map[visit]bool, depth int) bool {
 		if v1.Type().Field(i).Tag.Get("deepequal") == "skip" {
 			continue
 		}
+		if v1.Type().Field(i).Tag.Get("deepequal") == "nil==empty" {
+			if v1.Field(i).IsNil() && v2.Field(i).Len() == 0 || v2.Field(i).IsNil() && v1.Field(i).Len() == 0 {
+				continue
+			}
+		}
 		if !deepValueEqual(v1.Field(i), v2.Field(i), visited, depth+1) {
 			return false
 		}


### PR DESCRIPTION
Previously the only roundtrip test was for an empty report. This test has fake data similar to that found in real reports.

`Node.Metrics` does not round-trip exactly: it is tagged with `omitempty` so when decoded an empty map turns into the zero value.  A `DeepEqual` workaround is added so the test passes.
Perhaps it would be better to adjust the decode so the field is not nil after decoding.

This PR is a precursor to tests which check backwards compatibility: for instance that the binary data encoded by version 1.2 still decodes to the expected structure.