### PR TITLE
Fix for incorrect report.json URL in cloud

### DIFF
--- a/client/app/scripts/components/troubleshooting-menu.js
+++ b/client/app/scripts/components/troubleshooting-menu.js
@@ -20,6 +20,9 @@ class DebugMenu extends React.Component {
   }
 
   render() {
+    const reportDownloadUrl = process.env.WEAVE_CLOUD
+      ? `${window.location.origin}/api${window.location.pathname}/api/report`
+      : 'api/report';
     return (
       <div className="troubleshooting-menu-wrapper">
         <div className="troubleshooting-menu">
@@ -28,7 +31,7 @@ class DebugMenu extends React.Component {
             <div className="troubleshooting-menu-item">
               <a
                 className="footer-icon"
-                href="api/report"
+                href={reportDownloadUrl}
                 download
                 title="Save raw data as JSON"
               >


### PR DESCRIPTION
Fix for #2402 

If the `WEAVE_CLOUD` env variable is present, serve the JSON from the `/api` path.