### PR TITLE
Allow the user to view multiple Kubernetes namespaces at once

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -50,7 +50,7 @@ var (
 // kubernetesFilters generates the current kubernetes filters based on the
 // available k8s topologies.
 func kubernetesFilters(namespaces ...string) APITopologyOptionGroup {
-	options := APITopologyOptionGroup{ID: "namespace", Default: "all"}
+	options := APITopologyOptionGroup{ID: "namespace", Default: "all", SelectType: "union"}
 	for _, namespace := range namespaces {
 		if namespace == "default" {
 			options.Default = namespace

--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -50,7 +50,7 @@ var (
 // kubernetesFilters generates the current kubernetes filters based on the
 // available k8s topologies.
 func kubernetesFilters(namespaces ...string) APITopologyOptionGroup {
-	options := APITopologyOptionGroup{ID: "namespace", Default: "all", SelectType: "union"}
+	options := APITopologyOptionGroup{ID: "namespace", Default: "", SelectType: "union", NoneLabel: "All Namespaces"}
 	for _, namespace := range namespaces {
 		if namespace == "default" {
 			options.Default = namespace
@@ -59,7 +59,6 @@ func kubernetesFilters(namespaces ...string) APITopologyOptionGroup {
 			Value: namespace, Label: namespace, filter: render.IsNamespace(namespace), filterPseudo: false,
 		})
 	}
-	options.Options = append(options.Options, APITopologyOption{Value: "all", Label: "All Namespaces", filter: nil, filterPseudo: false})
 	return options
 }
 
@@ -294,22 +293,22 @@ func (a byName) Less(i, j int) bool { return a[i].Name < a[j].Name }
 
 // APITopologyOptionGroup describes a group of APITopologyOptions
 type APITopologyOptionGroup struct {
-	ID      string              `json:"id"`
+	ID string `json:"id"`
+	// Default value for the UI to adopt. NOT used as the default if the value is omitted, allowing "" as a distinct value.
 	Default string              `json:"defaultValue,omitempty"`
 	Options []APITopologyOption `json:"options,omitempty"`
 	// SelectType describes how options can be picked. Currently defined values:
 	//   "one": Default if empty. Exactly one option may be picked from the list.
 	//   "union": Any number of options may be picked. Nodes matching any option filter selected are displayed.
-	//           Value and Default should be a ","-seperated list.
+	//           Value and Default should be a ","-separated list.
 	SelectType string `json:"selectType,omitempty"`
+	// For "union" type, this is the label the UI should use to represent the case where nothing is selected
+	NoneLabel string `json:"noneLabel,omitempty"`
 }
 
 // Get the render filters to use for this option group as a Decorator, if any.
 // If second arg is false, no decorator was needed.
 func (g APITopologyOptionGroup) getFilterDecorator(value string) (render.Decorator, bool) {
-	if value == "" {
-		value = g.Default
-	}
 	selectType := g.SelectType
 	if selectType == "" {
 		selectType = "one"

--- a/app/api_topologies_test.go
+++ b/app/api_topologies_test.go
@@ -106,6 +106,8 @@ func TestRendererForTopologyWithFiltering(t *testing.T) {
 
 	urlvalues := url.Values{}
 	urlvalues.Set(systemGroupID, customAPITopologyOptionFilterID)
+	urlvalues.Set("stopped", "running")
+	urlvalues.Set("pseudo", "hide")
 	renderer, decorator, err := topologyRegistry.RendererForTopology("containers", urlvalues, fixture.Report)
 	if err != nil {
 		t.Fatalf("Topology Registry Report error: %s", err)
@@ -135,6 +137,8 @@ func TestRendererForTopologyNoFiltering(t *testing.T) {
 
 	urlvalues := url.Values{}
 	urlvalues.Set(systemGroupID, customAPITopologyOptionFilterID)
+	urlvalues.Set("stopped", "running")
+	urlvalues.Set("pseudo", "hide")
 	renderer, decorator, err := topologyRegistry.RendererForTopology("containers", urlvalues, fixture.Report)
 	if err != nil {
 		t.Fatalf("Topology Registry Report error: %s", err)
@@ -171,6 +175,8 @@ func getTestContainerLabelFilterTopologySummary(t *testing.T, exclude bool) (det
 
 	urlvalues := url.Values{}
 	urlvalues.Set(systemGroupID, customAPITopologyOptionFilterID)
+	urlvalues.Set("stopped", "running")
+	urlvalues.Set("pseudo", "hide")
 	renderer, decorator, err := topologyRegistry.RendererForTopology("containers", urlvalues, fixture.Report)
 	if err != nil {
 		return nil, err

--- a/client/app/scripts/actions/app-actions.js
+++ b/client/app/scripts/actions/app-actions.js
@@ -174,13 +174,14 @@ export function blurSearch() {
   return { type: ActionTypes.BLUR_SEARCH };
 }
 
-export function changeTopologyOption(option, value, topologyId) {
+export function changeTopologyOption(option, value, topologyId, addOrRemove) {
   return (dispatch, getState) => {
     dispatch({
       type: ActionTypes.CHANGE_TOPOLOGY_OPTION,
       topologyId,
       option,
-      value
+      value,
+      addOrRemove
     });
     updateRoute(getState);
     // update all request workers with new options

--- a/client/app/scripts/components/topology-option-action.js
+++ b/client/app/scripts/components/topology-option-action.js
@@ -1,9 +1,6 @@
 import React from 'react';
-import { connect } from 'react-redux';
 
-import { changeTopologyOption } from '../actions/app-actions';
-
-class TopologyOptionAction extends React.Component {
+export default class TopologyOptionAction extends React.Component {
 
   constructor(props, context) {
     super(props, context);
@@ -13,13 +10,14 @@ class TopologyOptionAction extends React.Component {
   onClick(ev) {
     ev.preventDefault();
     const { optionId, topologyId, item } = this.props;
-    this.props.changeTopologyOption(optionId, item.get('value'), topologyId);
+    this.props.onClick(optionId, item.get('value'), topologyId);
   }
 
   render() {
     const { activeValue, item } = this.props;
-    const className = activeValue === item.get('value')
-      ? 'topology-option-action topology-option-action-selected' : 'topology-option-action';
+    const className = activeValue.includes(item.get('value'))
+      ? 'topology-option-action topology-option-action-selected'
+      : 'topology-option-action';
     return (
       <div className={className} onClick={this.onClick}>
         {item.get('label')}
@@ -27,8 +25,3 @@ class TopologyOptionAction extends React.Component {
     );
   }
 }
-
-export default connect(
-  null,
-  { changeTopologyOption }
-)(TopologyOptionAction);

--- a/client/app/scripts/components/topology-options.js
+++ b/client/app/scripts/components/topology-options.js
@@ -14,7 +14,20 @@ class TopologyOptions extends React.Component {
   }
 
   handleOptionClick(optionId, value, topologyId) {
-    this.props.changeTopologyOption(optionId, value, topologyId);
+    const { activeOptions, options } = this.props;
+    const selectedOption = options.find(o => o.get('id') === optionId);
+
+    if (selectedOption.get('selectType') === 'union') {
+      if (activeOptions.get(selectedOption.get('id')).includes(value)) {
+        // Option already exists; user is de-selecting
+        console.log('TODO! removeOption action');
+      } else {
+        // Option does not exist; user is enabling.
+        console.log('TODO! addOption action');
+      }
+    } else {
+      this.props.changeTopologyOption(optionId, value, topologyId);
+    }
   }
 
   renderOption(option) {

--- a/client/app/scripts/components/topology-options.js
+++ b/client/app/scripts/components/topology-options.js
@@ -11,14 +11,21 @@ class TopologyOptions extends React.Component {
     const { activeOptions, topologyId } = this.props;
     const optionId = option.get('id');
     const activeValue = activeOptions && activeOptions.has(optionId)
-      ? activeOptions.get(optionId) : option.get('defaultValue');
+      ? activeOptions.get(optionId)
+      : option.get('defaultValue');
 
     return (
       <div className="topology-option" key={optionId}>
         <div className="topology-option-wrapper">
-          {option.get('options').map(item => <TopologyOptionAction
-            optionId={optionId} topologyId={topologyId} key={item.get('value')}
-            activeValue={activeValue} item={item} />)}
+          {option.get('options').map(item => (
+            <TopologyOptionAction
+              optionId={optionId}
+              topologyId={topologyId}
+              key={item.get('value')}
+              activeValue={activeValue}
+              item={item}
+            />
+          ))}
         </div>
       </div>
     );

--- a/client/app/scripts/components/topology-options.js
+++ b/client/app/scripts/components/topology-options.js
@@ -36,8 +36,13 @@ class TopologyOptions extends React.Component {
         // Add it to the array if it's not selected
         nextOptions = opts[selected].concat(value);
       }
-      // Since the user is clicking an option, remove the highlighting from the 'none' option.
-      nextOptions = nextOptions.filter(o => o !== 'none');
+      // Since the user is clicking an option, remove the highlighting from the 'none' option,
+      // unless they are removing the last option. In that case, default to the 'none' label.
+      if (nextOptions.length === 0) {
+        nextOptions = ['none'];
+      } else {
+        nextOptions = nextOptions.filter(o => o !== 'none');
+      }
     }
     this.props.changeTopologyOption(optionId, nextOptions, topologyId);
   }

--- a/client/app/scripts/components/topology-options.js
+++ b/client/app/scripts/components/topology-options.js
@@ -18,13 +18,9 @@ class TopologyOptions extends React.Component {
     const selectedOption = options.find(o => o.get('id') === optionId);
 
     if (selectedOption.get('selectType') === 'union') {
-      if (activeOptions.get(selectedOption.get('id')).includes(value)) {
-        // Option already exists; user is de-selecting
-        console.log('TODO! removeOption action');
-      } else {
-        // Option does not exist; user is enabling.
-        console.log('TODO! addOption action');
-      }
+      const isSelectedAlready = activeOptions.get(selectedOption.get('id')).includes(value);
+      const addOrRemove = isSelectedAlready ? 'remove' : 'add';
+      this.props.changeTopologyOption(optionId, value, topologyId, addOrRemove);
     } else {
       this.props.changeTopologyOption(optionId, value, topologyId);
     }

--- a/client/app/scripts/components/topology-options.js
+++ b/client/app/scripts/components/topology-options.js
@@ -4,8 +4,18 @@ import { connect } from 'react-redux';
 import { getCurrentTopologyOptions } from '../utils/topology-utils';
 import { activeTopologyOptionsSelector } from '../selectors/topology';
 import TopologyOptionAction from './topology-option-action';
+import { changeTopologyOption } from '../actions/app-actions';
 
 class TopologyOptions extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+
+    this.handleOptionClick = this.handleOptionClick.bind(this);
+  }
+
+  handleOptionClick(optionId, value, topologyId) {
+    this.props.changeTopologyOption(optionId, value, topologyId);
+  }
 
   renderOption(option) {
     const { activeOptions, topologyId } = this.props;
@@ -19,6 +29,7 @@ class TopologyOptions extends React.Component {
         <div className="topology-option-wrapper">
           {option.get('options').map(item => (
             <TopologyOptionAction
+              onClick={this.handleOptionClick}
               optionId={optionId}
               topologyId={topologyId}
               key={item.get('value')}
@@ -32,9 +43,10 @@ class TopologyOptions extends React.Component {
   }
 
   render() {
+    const { options } = this.props;
     return (
       <div className="topology-options">
-        {this.props.options && this.props.options.toIndexedSeq().map(
+        {options && options.toIndexedSeq().map(
           option => this.renderOption(option))}
       </div>
     );
@@ -50,5 +62,6 @@ function mapStateToProps(state) {
 }
 
 export default connect(
-  mapStateToProps
+  mapStateToProps,
+  { changeTopologyOption }
 )(TopologyOptions);

--- a/client/app/scripts/reducers/__tests__/root-test.js
+++ b/client/app/scripts/reducers/__tests__/root-test.js
@@ -167,14 +167,14 @@ describe('RootReducer', () => {
     type: ActionTypes.CHANGE_TOPOLOGY_OPTION,
     topologyId: 'topo1',
     option: 'option1',
-    value: 'on'
+    value: ['on']
   };
 
   const ChangeTopologyOptionAction2 = {
     type: ActionTypes.CHANGE_TOPOLOGY_OPTION,
     topologyId: 'topo1',
     option: 'option1',
-    value: 'off'
+    value: ['off']
   };
 
   const ClickNodeAction = {
@@ -371,15 +371,13 @@ describe('RootReducer', () => {
       type: ActionTypes.CHANGE_TOPOLOGY_OPTION,
       topologyId: 'services',
       option: 'namespace',
-      value: 'scope',
-      addOrRemove: 'add'
+      value: ['default', 'scope'],
     };
     const removeAction = {
       type: ActionTypes.CHANGE_TOPOLOGY_OPTION,
       topologyId: 'services',
       option: 'namespace',
-      value: 'scope',
-      addOrRemove: 'remove'
+      value: ['default']
     };
     let nextState = initialState;
     nextState = reducer(nextState, { type: ActionTypes.RECEIVE_TOPOLOGIES, topologies});

--- a/client/app/scripts/reducers/__tests__/root-test.js
+++ b/client/app/scripts/reducers/__tests__/root-test.js
@@ -368,22 +368,32 @@ describe('RootReducer', () => {
 
   it('adds/removes a topology option', () => {
     const addAction = {
-      type: ActionTypes.ADD_TOPOLOGY_OPTION,
+      type: ActionTypes.CHANGE_TOPOLOGY_OPTION,
       topologyId: 'services',
       option: 'namespace',
-      value: 'scope'
+      value: 'scope',
+      addOrRemove: 'add'
     };
     const removeAction = {
-      type: ActionTypes.REMOVE_TOPOLOGY_OPTION,
+      type: ActionTypes.CHANGE_TOPOLOGY_OPTION,
       topologyId: 'services',
       option: 'namespace',
-      value: 'scope'
+      value: 'scope',
+      addOrRemove: 'remove'
     };
     let nextState = initialState;
     nextState = reducer(nextState, { type: ActionTypes.RECEIVE_TOPOLOGIES, topologies});
     nextState = reducer(nextState, { type: ActionTypes.CLICK_TOPOLOGY, topologyId: 'services' });
-
     nextState = reducer(nextState, addAction);
+    expect(activeTopologyOptionsSelector(nextState).toJS()).toEqual({
+      namespace: ['default', 'scope'],
+      pseudo: ['hide']
+    });
+    nextState = reducer(nextState, removeAction);
+    expect(activeTopologyOptionsSelector(nextState).toJS()).toEqual({
+      namespace: ['default'],
+      pseudo: ['hide']
+    });
   });
 
   it('sets topology options from route', () => {

--- a/client/app/scripts/reducers/__tests__/root-test.js
+++ b/client/app/scripts/reducers/__tests__/root-test.js
@@ -46,33 +46,118 @@ describe('RootReducer', () => {
     }
   };
 
-  const topologies = [{
-    hide_if_empty: true,
-    name: 'Processes',
-    rank: 1,
-    sub_topologies: [],
-    url: '/api/topology/processes',
-    fullName: 'Processes',
-    id: 'processes',
-    options: [
-      {
-        defaultValue: 'hide',
-        id: 'unconnected',
-        options: [
-          {
-            label: 'Unconnected nodes hidden',
-            value: 'hide'
-          }
-        ]
+  const topologies = [
+    {
+      hide_if_empty: true,
+      name: 'Processes',
+      rank: 1,
+      sub_topologies: [],
+      url: '/api/topology/processes',
+      fullName: 'Processes',
+      id: 'processes',
+      options: [
+        {
+          defaultValue: 'hide',
+          id: 'unconnected',
+          selectType: 'one',
+          options: [
+            {
+              label: 'Unconnected nodes hidden',
+              value: 'hide'
+            }
+          ]
+        }
+      ],
+      stats: {
+        edge_count: 379,
+        filtered_nodes: 214,
+        node_count: 320,
+        nonpseudo_node_count: 320
       }
-    ],
-    stats: {
-      edge_count: 379,
-      filtered_nodes: 214,
-      node_count: 320,
-      nonpseudo_node_count: 320
+    },
+    {
+      hide_if_empty: true,
+      name: 'Pods',
+      options: [
+        {
+          defaultValue: 'default',
+          id: 'namespace',
+          selectType: 'many',
+          options: [
+            {
+              label: 'monitoring',
+              value: 'monitoring'
+            },
+            {
+              label: 'scope',
+              value: 'scope'
+            },
+            {
+              label: 'All Namespaces',
+              value: 'all'
+            }
+          ]
+        },
+        {
+          defaultValue: 'hide',
+          id: 'pseudo',
+          options: [
+            {
+              label: 'Show Unmanaged',
+              value: 'show'
+            },
+            {
+              label: 'Hide Unmanaged',
+              value: 'hide'
+            }
+          ]
+        }
+      ],
+      rank: 3,
+      stats: {
+        edge_count: 15,
+        filtered_nodes: 16,
+        node_count: 32,
+        nonpseudo_node_count: 27
+      },
+      sub_topologies: [
+        {
+          hide_if_empty: true,
+          name: 'services',
+          options: [
+            {
+              defaultValue: 'default',
+              id: 'namespace',
+              selectType: 'many',
+              options: [
+                {
+                  label: 'monitoring',
+                  value: 'monitoring'
+                },
+                {
+                  label: 'scope',
+                  value: 'scope'
+                },
+                {
+                  label: 'All Namespaces',
+                  value: 'all'
+                }
+              ]
+            }
+          ],
+          rank: 0,
+          stats: {
+            edge_count: 14,
+            filtered_nodes: 16,
+            node_count: 159,
+            nonpseudo_node_count: 154
+          },
+          url: '/api/topology/services'
+        }
+      ],
+      url: '/api/topology/pods'
     }
-  }];
+  ];
 
   // actions
 
@@ -267,6 +352,29 @@ describe('RootReducer', () => {
     nextState = reducer(nextState, ClickTopology2Action);
     expect(activeTopologyOptionsSelector(nextState)).toBeUndefined();
     expect(getUrlState(nextState).topologyOptions.topo1.option1).toBe('off');
+  });
+  it('changes topologyOptions for selectType "many"', () => {
+    const action = {
+      type: ActionTypes.CHANGE_TOPOLOGY_OPTION,
+      topologyId: 'services',
+      option: 'namespace',
+      value: ['scope', 'monitoring']
+    };
+    let nextState = initialState;
+    nextState = reducer(nextState, {
+      type: ActionTypes.RECEIVE_TOPOLOGIES,
+      topologies
+    });
+    nextState = reducer(nextState, {
+      type: ActionTypes.CLICK_TOPOLOGY,
+      topologyId: 'services'
+    });
+
+    nextState = reducer(nextState, action);
+    expect(activeTopologyOptionsSelector(nextState).toJS()).toEqual({
+      namespace: ['scope', 'monitoring'],
+      pseudo: 'hide'
+    });
   });
 
   it('sets topology options from route', () => {

--- a/client/app/scripts/reducers/root.js
+++ b/client/app/scripts/reducers/root.js
@@ -194,7 +194,6 @@ export function rootReducer(state = initialState, action) {
       // set option on parent topology
       const topology = findTopologyById(state.get('topologies'), action.topologyId);
       if (topology) {
-        let values = [action.value];
         const topologyId = topology.get('parentId') || topology.get('id');
         const optionKey = ['topologyOptions', topologyId, action.option];
         const currentOption = state.getIn(['topologyOptions', topologyId, action.option]);
@@ -203,12 +202,7 @@ export function rootReducer(state = initialState, action) {
           state = clearNodes(state);
         }
 
-        if (action.addOrRemove === 'add') {
-          values = state.getIn(optionKey).concat(values);
-        } else if (action.addOrRemove === 'remove') {
-          values = state.getIn(optionKey).filter(o => !values.includes(o));
-        }
-        state = state.setIn(optionKey, values);
+        state = state.setIn(optionKey, action.value);
       }
       return state;
     }

--- a/client/app/scripts/reducers/root.js
+++ b/client/app/scripts/reducers/root.js
@@ -179,7 +179,8 @@ export function rootReducer(state = initialState, action) {
       const topology = findTopologyById(state.get('topologies'), action.topologyId);
       if (topology) {
         const topologyId = topology.get('parentId') || topology.get('id');
-        if (state.getIn(['topologyOptions', topologyId, action.option]) !== action.value) {
+        const currentOption = state.getIn(['topologyOptions', topologyId, action.option]);
+        if (currentOption !== action.value) {
           state = clearNodes(state);
         }
         state = state.setIn(

--- a/client/app/scripts/reducers/root.js
+++ b/client/app/scripts/reducers/root.js
@@ -87,15 +87,32 @@ export const initialState = makeMap({
   zoomCache: makeMap(),
 });
 
+function calcSelectType(topology) {
+  const result = {
+    ...topology,
+    options: topology.options && topology.options.map((option) => {
+      // Server doesn't return the `selectType` key unless the option is something other than `one`.
+      // Default to `one` if undefined, so the component doesn't have to handle this.
+      option.selectType = option.selectType || 'one';
+      return option;
+    })
+  };
+
+  if (topology.sub_topologies) {
+    result.sub_topologies = topology.sub_topologies.map(calcSelectType);
+  }
+  return result;
+}
+
 // adds ID field to topology (based on last part of URL path) and save urls in
 // map for easy lookup
 function processTopologies(state, nextTopologies) {
   // filter out hidden topos
   const visibleTopologies = filterHiddenTopologies(nextTopologies);
-
+  // set `selectType` field for topology and sub_topologies options (recursive).
+  const topologiesWithSelectType = visibleTopologies.map(calcSelectType);
   // add IDs to topology objects in-place
-  const topologiesWithId = updateTopologyIds(visibleTopologies);
-
+  const topologiesWithId = updateTopologyIds(topologiesWithSelectType);
   // cache URLs by ID
   state = state.set('topologyUrlsById',
     setTopologyUrlsById(state.get('topologyUrlsById'), topologiesWithId));
@@ -106,8 +123,7 @@ function processTopologies(state, nextTopologies) {
 }
 
 function setTopology(state, topologyId) {
-  state = state.set('currentTopology', findTopologyById(
-    state.get('topologies'), topologyId));
+  state = state.set('currentTopology', findTopologyById(state.get('topologies'), topologyId));
   return state.set('currentTopologyId', topologyId);
 }
 
@@ -118,7 +134,7 @@ function setDefaultTopologyOptions(state, topologyList) {
       topology.get('options').forEach((option) => {
         const optionId = option.get('id');
         const defaultValue = option.get('defaultValue');
-        defaultOptions = defaultOptions.set(optionId, defaultValue);
+        defaultOptions = defaultOptions.set(optionId, [defaultValue]);
       });
     }
 
@@ -185,7 +201,7 @@ export function rootReducer(state = initialState, action) {
         }
         state = state.setIn(
           ['topologyOptions', topologyId, action.option],
-          action.value
+          [action.value]
         );
       }
       return state;

--- a/client/app/scripts/utils/web-api-utils.js
+++ b/client/app/scripts/utils/web-api-utils.js
@@ -1,7 +1,7 @@
 import debug from 'debug';
 import reqwest from 'reqwest';
 import defaults from 'lodash/defaults';
-import { Map as makeMap } from 'immutable';
+import { Map as makeMap, List } from 'immutable';
 
 import { blurSearch, clearControlError, closeWebsocket, openWebsocket, receiveError,
   receiveApiDetails, receiveNodesDelta, receiveNodeDetails, receiveControlError,
@@ -45,7 +45,12 @@ let continuePolling = true;
 
 export function buildOptionsQuery(options) {
   if (options) {
-    return options.map((value, param) => `${param}=${value}`).join('&');
+    return options.map((value, param) => {
+      if (List.isList(value)) {
+        value = value.join(',');
+      }
+      return `${param}=${value}`;
+    }).join('&');
   }
   return '';
 }

--- a/render/filters.go
+++ b/render/filters.go
@@ -321,6 +321,12 @@ func IsNotPseudo(n report.Node) bool {
 	return n.Topology != Pseudo || strings.HasSuffix(n.ID, TheInternetID) || strings.HasPrefix(n.ID, ServiceNodeIDPrefix)
 }
 
+// IsPseudoTopology returns true if the node is in a pseudo topology,
+// mimicing the check performed by MakeFilter() instead of the more complex check in IsNotPseudo()
+func IsPseudoTopology(n report.Node) bool {
+	return n.Topology == Pseudo
+}
+
 // IsNamespace checks if the node is a pod/service in the specified namespace
 func IsNamespace(namespace string) FilterFunc {
 	return func(n report.Node) bool {


### PR DESCRIPTION
Implements #1421 

Exposes a new Topology option field: `selectType`. A `selectType` value of `'union'` will allow for a group of topology options to be selected at once. The use case for this was allowing users to see multiple Kubernetes namespaces on the same topology:
![screen shot 2017-03-27 at 12 45 35 pm](https://cloud.githubusercontent.com/assets/2802257/24374886/5344d812-12eb-11e7-8c62-6021c31ecd4f.png)

Topology options with `selectType: 'union'` must also provide a `noneLabel` field. In the example above the `noneLabel` value is 'All Namespaces';
 