### PR TITLE
Fixes loading of viewState from localStorage into URL

### DIFF
--- a/client/app/scripts/utils/router-utils.js
+++ b/client/app/scripts/utils/router-utils.js
@@ -119,7 +119,7 @@ export function getRouter(dispatch, initialState) {
       } else {
         const mergedState = Object.assign(initialState, parsedState);
         // push storage state to URL
-        window.location.hash = `!/state/${mergedState}`;
+        window.location.hash = `!/state/${JSON.stringify(mergedState)}`;
         dispatch(route(mergedState));
       }
     } else {


### PR DESCRIPTION
Needed another serialization to avoid "[Object object]" in the url.

Fixes #2408 