### PR TITLE
Make various anonymous fields named

### DIFF
--- a/app/multitenant/consul_client.go
+++ b/app/multitenant/consul_client.go
@@ -54,7 +54,7 @@ type kv interface {
 }
 
 type consulClient struct {
-	kv
+	kv kv
 }
 
 // Get and deserialise a JSON value from consul.

--- a/probe/endpoint/procspy/spy.go
+++ b/probe/endpoint/procspy/spy.go
@@ -23,7 +23,7 @@ type Connection struct {
 	RemoteAddress net.IP
 	RemotePort    uint16
 	inode         uint64
-	Proc
+	Proc          Proc
 }
 
 // Proc is a single process with PID and process name.

--- a/report/topology.go
+++ b/report/topology.go
@@ -10,14 +10,14 @@ import (
 // EdgeMetadatas and Nodes respectively. Edges are directional, and embedded
 // in the Node struct.
 type Topology struct {
-	Shape             string `json:"shape,omitempty"`
-	Label             string `json:"label,omitempty"`
-	LabelPlural       string `json:"label_plural,omitempty"`
-	Nodes             `json:"nodes"`
-	Controls          `json:"controls,omitempty"`
-	MetadataTemplates `json:"metadata_templates,omitempty"`
-	MetricTemplates   `json:"metric_templates,omitempty"`
-	TableTemplates    `json:"table_templates,omitempty"`
+	Shape             string            `json:"shape,omitempty"`
+	Label             string            `json:"label,omitempty"`
+	LabelPlural       string            `json:"label_plural,omitempty"`
+	Nodes             Nodes             `json:"nodes"`
+	Controls          Controls          `json:"controls,omitempty"`
+	MetadataTemplates MetadataTemplates `json:"metadata_templates,omitempty"`
+	MetricTemplates   MetricTemplates   `json:"metric_templates,omitempty"`
+	TableTemplates    TableTemplates    `json:"table_templates,omitempty"`
 }
 
 // MakeTopology gives you a Topology.


### PR DESCRIPTION
Anonymous fields make any methods on the inner object visible on the outer, so they should only be used when the outer is-a inner.

I wanted to make this change after spending several hours puzzled why the code ended up in a particular method that didn't have anything to do with what it was being called upon.

To create this PR I looked at every `struct` in the Scope codebase, apart from unit tests.  There are very few anonymous fields overall, with some such as `Mutex` correctly used.  In a couple of cases I gave the benefit of the doubt.