### PR TITLE
Made view mode selector responsive

### DIFF
--- a/client/app/scripts/components/view-mode-selector.js
+++ b/client/app/scripts/components/view-mode-selector.js
@@ -21,9 +21,10 @@ const Item = (icons, label, isSelected, onClick, isEnabled = true) => {
     <div
       className={className}
       disabled={!isEnabled}
-      onClick={isEnabled && onClick}>
+      onClick={isEnabled && onClick}
+      title={`View ${label.toLowerCase()}`}>
       <span className={icons} style={{fontSize: 12}} />
-      <span>{label}</span>
+      <span className="label">{label}</span>
     </div>
   );
 };

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -227,6 +227,7 @@
     opacity: 0.9;
     margin-bottom: 3px;
     border: 1px solid transparent;
+    white-space: nowrap;
 
     &-active, &:hover {
       color: $text-color;
@@ -1229,6 +1230,7 @@
     border-radius: $border-radius;
     border: 1px solid $background-darker-color;
     display: inline-block;
+    white-space: nowrap;
   }
 
   &-action {
@@ -1296,10 +1298,12 @@
   }
 }
 
-.view-mode-selector-wrapper .fa {
-  margin-right: 4px;
-  margin-left: 0;
-  color: $text-secondary-color;
+.view-mode-selector-wrapper {
+  .label { margin-left: 4px; }
+  .fa {
+    margin-left: 0;
+    color: $text-secondary-color;
+  }
 }
 
 .network-selector-action {
@@ -1866,4 +1870,8 @@
   .fa-close {
     width: 25px;
   }
+}
+
+@media (max-width: 1330px) {
+  .view-mode-selector .label { display: none; }
 }


### PR DESCRIPTION
Fixes #2396.

* Made a bunch of selector components `white-space: nowrap` to prevent ugly wrapping
* Added a *@media* query to hide view mode selector labels when viewport is shrunk, showing only icons
* Added a tooltip info to the view mode selector, which is especially important when the labels are gone
