### PR TITLE
Fix the click origin of the details panel in the table mode

### DIFF
--- a/client/app/scripts/charts/nodes-grid.js
+++ b/client/app/scripts/charts/nodes-grid.js
@@ -84,12 +84,12 @@ class NodesGrid extends React.Component {
     this.onSortChange = this.onSortChange.bind(this);
   }
 
-  onClickRow(ev, node, el) {
+  onClickRow(ev, node) {
     // TODO: do this better
     if (ev.target.className === 'node-details-table-node-link') {
       return;
     }
-    this.props.clickNode(node.id, node.label, el.getBoundingClientRect());
+    this.props.clickNode(node.id, node.label, ev.target.getBoundingClientRect());
   }
 
   onSortChange(sortedBy, sortedDesc) {

--- a/client/app/scripts/components/node-details/node-details-table-row.js
+++ b/client/app/scripts/components/node-details/node-details-table-row.js
@@ -79,15 +79,10 @@ export default class NodeDetailsTableRow extends React.Component {
     this.state = { focused: false };
     this.mouseDragOrigin = [0, 0];
 
-    this.saveLabelElementRef = this.saveLabelElementRef.bind(this);
     this.onMouseDown = this.onMouseDown.bind(this);
     this.onMouseUp = this.onMouseUp.bind(this);
     this.onMouseEnter = this.onMouseEnter.bind(this);
     this.onMouseLeave = this.onMouseLeave.bind(this);
-  }
-
-  saveLabelElementRef(ref) {
-    this.labelElement = ref;
   }
 
   onMouseEnter() {
@@ -121,8 +116,7 @@ export default class NodeDetailsTableRow extends React.Component {
       return;
     }
 
-    const { node, onClick } = this.props;
-    onClick(ev, node, this.labelElement);
+    this.props.onClick(ev, this.props.node);
   }
 
   render() {
@@ -143,9 +137,7 @@ export default class NodeDetailsTableRow extends React.Component {
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
         className={className}>
-        <td
-          className="node-details-table-node-label truncate"
-          ref={this.saveLabelElementRef} style={firstColumnStyle}>
+        <td className="node-details-table-node-label truncate" style={firstColumnStyle}>
           {this.props.renderIdCell(Object.assign(node, {topologyId, nodeId}))}
         </td>
         {values}


### PR DESCRIPTION
Fixes #1754.

The click event target is now used instead of the row DOM element.
