### PR TITLE
Fix node highlight for all shapes

### DIFF
--- a/client/app/scripts/charts/node-shape-stack.js
+++ b/client/app/scripts/charts/node-shape-stack.js
@@ -2,27 +2,17 @@ import React from 'react';
 
 import { NODE_BASE_SIZE } from '../constants/styles';
 
-
 export default function NodeShapeStack(props) {
-  const shift = props.contrastMode ? 0.15 : 0.1;
-  const highlightScale = [1, 1 + shift];
-  const dy = NODE_BASE_SIZE * shift;
-
+  const dx = NODE_BASE_SIZE * (props.contrastMode ? 0.06 : 0.05);
+  const dy = NODE_BASE_SIZE * (props.contrastMode ? 0.12 : 0.1);
+  const translateAlongAxis = t => `translate(${t * dx}, ${t * dy})`;
   const Shape = props.shape;
+
   return (
-    <g transform={`translate(0, ${dy * -2.5})`} className="stack">
-      <g transform={`scale(${highlightScale}) translate(0, ${dy})`} className="highlight">
-        <Shape {...props} />
-      </g>
-      <g transform={`translate(0, ${dy * 2})`}>
-        <Shape {...props} />
-      </g>
-      <g transform={`translate(0, ${dy * 1})`}>
-        <Shape {...props} />
-      </g>
-      <g className="only-metrics">
-        <Shape {...props} />
-      </g>
+    <g transform={translateAlongAxis(-2.5)} className="stack">
+      <g transform={translateAlongAxis(2)}><Shape {...props} /></g>
+      <g transform={translateAlongAxis(1)}><Shape {...props} highlighted={false} /></g>
+      <g transform={translateAlongAxis(0)}><Shape {...props} highlighted={false} /></g>
     </g>
   );
 }

--- a/client/app/scripts/charts/node-shape-stack.js
+++ b/client/app/scripts/charts/node-shape-stack.js
@@ -3,16 +3,22 @@ import React from 'react';
 import { NODE_BASE_SIZE } from '../constants/styles';
 
 export default function NodeShapeStack(props) {
-  const dx = NODE_BASE_SIZE * (props.contrastMode ? 0.06 : 0.05);
-  const dy = NODE_BASE_SIZE * (props.contrastMode ? 0.12 : 0.1);
-  const translateAlongAxis = t => `translate(${t * dx}, ${t * dy})`;
+  const verticalDistance = NODE_BASE_SIZE * (props.contrastMode ? 0.12 : 0.1);
+  const verticalTranslate = t => `translate(0, ${t * verticalDistance})`;
   const Shape = props.shape;
 
+  // Stack three shapes on top of one another pretending they are never highlighted.
+  // Instead, fake the highlight of the whole stack with a vertically stretched shape
+  // drawn in the background. This seems to give a good approximation of the stack
+  // highlight and prevents us from needing to do some render-heavy SVG clipping magic.
   return (
-    <g transform={translateAlongAxis(-2.5)} className="stack">
-      <g transform={translateAlongAxis(2)}><Shape {...props} /></g>
-      <g transform={translateAlongAxis(1)}><Shape {...props} highlighted={false} /></g>
-      <g transform={translateAlongAxis(0)}><Shape {...props} highlighted={false} /></g>
+    <g transform={verticalTranslate(-2.5)} className="stack">
+      <g transform={`${verticalTranslate(1)} scale(1, 1.14)`}>
+        <Shape className="highlight-only" {...props} />
+      </g>
+      <g transform={verticalTranslate(2)}><Shape {...props} highlighted={false} /></g>
+      <g transform={verticalTranslate(1)}><Shape {...props} highlighted={false} /></g>
+      <g transform={verticalTranslate(0)}><Shape {...props} highlighted={false} /></g>
     </g>
   );
 }

--- a/client/app/scripts/charts/node-shapes.js
+++ b/client/app/scripts/charts/node-shapes.js
@@ -28,8 +28,13 @@ function NodeShape(shapeType, shapeElement, shapeProps, { id, highlighted, color
   return (
     <g className={className}>
       {highlighted && shapeElement({
-        className: 'highlight',
-        transform: `scale(${NODE_BASE_SIZE * 0.7})`,
+        className: 'highlight-border',
+        transform: `scale(${NODE_BASE_SIZE * 0.5})`,
+        ...shapeProps,
+      })}
+      {highlighted && shapeElement({
+        className: 'highlight-shadow',
+        transform: `scale(${NODE_BASE_SIZE * 0.5})`,
         ...shapeProps,
       })}
       {shapeElement({

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -425,6 +425,13 @@
     }
   }
 
+  .stack .highlight-only {
+    .background { display: none; }
+    .shadow { display: none; }
+    .border { display: none; }
+    .node { display: none; }
+  }
+
   .stack .shape .metric-fill {
     display: none;
   }

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -425,17 +425,6 @@
     }
   }
 
-  .stack .shape .highlight {
-    display: none;
-  }
-
-  .stack .highlight .shape  {
-    .border { display: none; }
-    .shadow { display: none; }
-    .node { display: none; }
-    .highlight { display: inline; }
-  }
-
   .stack .shape .metric-fill {
     display: none;
   }
@@ -444,12 +433,18 @@
     transform: scale(1);
     cursor: pointer;
 
-    .highlight {
-      fill: $weave-blue;
-      fill-opacity: $node-highlight-fill-opacity;
+    .highlight-border {
+      fill: none;
       stroke: $weave-blue;
-      stroke-width: $node-highlight-stroke-width;
+      stroke-width: 0.7 + $node-highlight-stroke-width * 2;
       stroke-opacity: $node-highlight-stroke-opacity;
+    }
+
+    .highlight-shadow {
+      fill: none;
+      stroke: white;
+      stroke-width: 0.7;
+      stroke-opacity: $node-highlight-shadow-opacity;
     }
 
     .background {

--- a/client/app/styles/_contrast-overrides.scss
+++ b/client/app/styles/_contrast-overrides.scss
@@ -12,7 +12,7 @@ $text-darker-color: darken($text-color, 20%);
 $white: white;
 $edge-color: black;
 
-$node-highlight-fill-opacity: 0.3;
+$node-highlight-shadow-opacity: 0.4;
 $node-highlight-stroke-opacity: 0.5;
 $node-highlight-stroke-width: 0.16;
 $node-border-stroke-width: 0.2;

--- a/client/app/styles/_variables.scss
+++ b/client/app/styles/_variables.scss
@@ -30,7 +30,7 @@ $border-radius: 4px;
 
 $terminal-header-height: 44px;
 
-$node-highlight-fill-opacity: 0.1;
+$node-highlight-shadow-opacity: 0.5;
 $node-highlight-stroke-opacity: 0.4;
 $node-highlight-stroke-width: 0.04;
 $node-border-stroke-width: 0.12;


### PR DESCRIPTION
Fixes #2429.

##### Clouds

Instead of drawing one shape with both fill and stroke for the highlight, the same shape is rendered twice with slightly different radii, no fill and a very thick stroke which ensures uniform highlight thickness around the shape. It's a slightly hacky solution (especially with adjusting the colors & opacities), but it seems to work well. Thanks @foot for the idea!

![cloud-fix2](https://cloud.githubusercontent.com/assets/1216874/24806775/3a49bae8-1bb6-11e7-8727-722be2402afb.png)

##### Stacks

~~Instead of a stretched highlight shape, a regular highlight is drawn around the bottommost layer of the stack. On top of that, the whole stack is slightly skewed to the left for a more 3D feel - not sure if we want that change though, my initial motivation was to make the highlight look better, but now I think the whole stack looks better when skewed (even when not highlighted).~~

Turns out that using the border trick also made the stack highlight look better. Drawing an extra fake shape just for the highlight is still not ideal, but the alternative would be to use some heavy SVG masks/clipping which might give an even heaver load on rendering (and certainly be harder to implement).

![stack-fixed2](https://cloud.githubusercontent.com/assets/1216874/24806801/4b7ba8da-1bb6-11e7-87a3-d87705afda8c.png)
