### PR TITLE
Fix typo when disabling scope in ECS AMI

### DIFF
--- a/site/ami.md
+++ b/site/ami.md
@@ -136,7 +136,7 @@ the
 of the instance.
 
 ~~~bash
-echo manual > /etc/weave/scope.override
+echo manual > /etc/init/scope.override
 ~~~
 
 ### <a name="running-weave-scope-in-standalone-mode"></a>Running `Weave Scope` in Standalone Mode


### PR DESCRIPTION
See https://weaveworks.slack.com/archives/C0CGALD7B/p1491834062765690