### PR TITLE
gzip: change compression level to the default

### DIFF
--- a/app/router.go
+++ b/app/router.go
@@ -150,7 +150,7 @@ func RegisterReportPostHandler(a Adder, router *mux.Router) {
 		// a.Add(..., buf) assumes buf is gzip'd msgpack
 		if !isMsgpack {
 			buf = bytes.Buffer{}
-			rpt.WriteBinary(&buf, gzip.BestCompression)
+			rpt.WriteBinary(&buf, gzip.DefaultCompression)
 		}
 
 		if err := a.Add(ctx, rpt, buf.Bytes()); err != nil {

--- a/probe/appclient/report_publisher.go
+++ b/probe/appclient/report_publisher.go
@@ -29,6 +29,6 @@ func (p *ReportPublisher) Publish(r report.Report) error {
 		})
 	}
 	buf := &bytes.Buffer{}
-	r.WriteBinary(buf, gzip.BestCompression)
+	r.WriteBinary(buf, gzip.DefaultCompression)
 	return p.publisher.Publish(buf)
 }

--- a/report/marshal_test.go
+++ b/report/marshal_test.go
@@ -12,7 +12,7 @@ import (
 func TestRoundtrip(t *testing.T) {
 	var buf bytes.Buffer
 	r1 := report.MakeReport()
-	r1.WriteBinary(&buf, gzip.BestCompression)
+	r1.WriteBinary(&buf, gzip.DefaultCompression)
 	bytes := append([]byte{}, buf.Bytes()...) // copy the contents for later
 	r2, err := report.MakeFromBinary(&buf)
 	if err != nil {
@@ -49,7 +49,7 @@ func TestMoreCompressionMeansSmaller(t *testing.T) {
 	// Make sure that 0 level compression actually does compress less.
 	var buf1, buf2 bytes.Buffer
 	r := report.MakeReport()
-	r.WriteBinary(&buf1, gzip.BestCompression)
+	r.WriteBinary(&buf1, gzip.DefaultCompression)
 	r.WriteBinary(&buf2, 0)
 	if buf1.Len() >= buf2.Len() {
 		t.Errorf("Compression doesn't change size: %v >= %v", buf1.Len(), buf2.Len())


### PR DESCRIPTION
We want the middle ground between a small compression size, a fast
compression time and a fast decompression time.

Tests suggest that the default compression level is better than the
maximum compression level: although the reports are 4% bigger and
decompress slower, they compress 33% faster.

See discussion on https://github.com/weaveworks/scope/issues/1457#issuecomment-293288682