### PR TITLE
Consisten spacing in Markdown headings

### DIFF
--- a/site/features.md
+++ b/site/features.md
@@ -15,13 +15,13 @@ Browse the current feature set for Scope with links to relevant indepth topics:
  * [Generate Custom Metrics using the Plugin API](#custom-plugins)
  
 
-##<a name="topology-mapping"></a>Topology Mapping
+## <a name="topology-mapping"></a>Topology Mapping
 
 Scope builds logical topologies of your application and infrastructure.  A topology is a collection of nodes and edges, where nodes represent objects like processes, container or hosts.  In Scope, edges indicate TCP connections between nodes.  Different node types can be filtered on and viewed and specific microservices can be drilled down on and inspected. Nodes are presented in a particular order with the clients above servers. As a general rule, you can read a Weave Scope view by going from top to bottom.
 
 !['Automatic Topology Mapping in Graph Mode'](images/topology-map.png)
 
-##<a name="views"></a>Views in Scope
+## <a name="views"></a>Views in Scope
 
 Views in Scope can be thought of as high-level filters on your containerized microservices as they run in the cloud. They are categorized into: Processes, Containers, Orchestrators, and Hosts. The Orchestrator view is context-sensitive, and as a result, if an app is running in Kubernetes, then Scope displays Pods, Replica Sets, Deployments, and Services that allow you to drilldown on Kubernetes clusters. 
 
@@ -37,31 +37,31 @@ For information on how to install Scope on the AWS EC2 Container Service see, "[
 
 Under the hosts view, and if you are running Weave Net for container networking, a specific Weave Net view appears. This view is useful for troubleshooting any networking problems you may be having. This view displays a number of Weave Net specific attributes such as whether quorum has been reached, the IP addresses used, whether fast datapath is enabled, or if encryption is running and many other useful attributes. See [Weave Net User Guide](https://www.weave.works/docs/net/latest/features/) for more information. 
 
-##<a name="mode"></a>Graphic or Table Mode
+## <a name="mode"></a>Graphic or Table Mode
 
 In addition to these views, nodes can be presented either in graphical or in table mode. The graphical mode is practical for obtaining a quick visual overview of your app, its infrastructure and connections between all of the nodes. And when you switch to table mode, nodes are presented in a convenient list that displays the resources being consumed by processes, containers, and hosts by dynamically shifting the resource heavy nodes to the top of the table, much like the UNIX `top` command does. 
 
 !['Table Mode Displaying Nodes by resource usage'](images/table-mode.png)
 
-##<a name="flexible-filtering"></a>Flexible Filtering
+## <a name="flexible-filtering"></a>Flexible Filtering
 
 In the left-hand corner of the UI are other filtering and other options. Nodes can be filtered by CPU and Memory so that you can easily find containers using the most resources. In the container view, options are available to filter by system, application or to show all of the containers and if you are running an app in Kubernetes then your app can be filtered by namespace and by container state whether running or stopped or contained and uncontained. 
 
 !['CPU usage indicator in Weave Scope'](images/hosts-cpu.png)
 
-##<a name="powerful-search"></a> Powerful Search
+## <a name="powerful-search"></a> Powerful Search
 
 Use Search to quickly find node types, containers and processes by name, label or even path.  The search functionality supports simple operands so that you can for example, find processes consuming a certain amount memory or nodes using too much CPU. Search terms may also be stacked to create custom, complex search criterion. See the online help within the product for a full list of allowable operands.
 
 !['Powerful Search'](images/search.png)
 
-##<a name="real-time-app-and-container-metrics"></a>Real-time App and Container Metrics
+## <a name="real-time-app-and-container-metrics"></a>Real-time App and Container Metrics
 
 View contextual metrics, tags and metadata for your containers by clicking on a node to display its details panel. Drilldown on processes inside your container to the hosts that your containers run on, arranged in expandable, sortable tables.
 
 Choose an overview of your container infrastructure, or focus on a specific microservice. Identify and correct issues to ensure the stability and performance of your containerized applications.
 
-##<a name="interact-with-and-manage-containers"></a>Troubleshoot and Manage Containers
+## <a name="interact-with-and-manage-containers"></a>Troubleshoot and Manage Containers
 
 Click on a container, pod or host to view the controls that allow you to: pause, restart, stop and delete without having to leave the Scope browser window. Logs of selected containers or pods (if you are running Kubernetes) can also be displayed by clicking the terminal icon.
 
@@ -69,7 +69,7 @@ And if further troubleshooting is required, terminal windows can be launched fro
 
 !['Terminal for container interaction'](images/terminal-view.png)
 
-##<a name="custom-plugins"></a>Generate Custom Metrics using the Plugin API
+## <a name="custom-plugins"></a>Generate Custom Metrics using the Plugin API
 
 Scope includes a Plugin API, so that custom metrics may be generated and integrated with the Scope UI.
 

--- a/site/how-it-works.md
+++ b/site/how-it-works.md
@@ -26,7 +26,7 @@ Weave Scope consists of two components: the app and the probe. The components ar
     |  +-----------------+  |
     +-----------------------+
 
-##<a name="stand-alone-mode"></a>Standalone Mode
+## <a name="stand-alone-mode"></a>Standalone Mode
 
 When running Scope in a cluster, each probe sends its reports to a dedicated app. The app merges the reports from its probe into a comprehensive report that is sent to the browser.  To visualize your entire infrastructure and apps running on that infrastructure, Scope must be launched on to every machine you are using.
 
@@ -74,7 +74,7 @@ The cloud token is accessible from the settings page after you've clicked 'Explo
 
 ![Weave Cloud Token](images/weave-cloud-token.png)
 
-##<a name="disable"></a>Disabling Automatic Updates
+## <a name="disable"></a>Disabling Automatic Updates
 
 Scope periodically checks with our servers to see if a new version is available. You can disable this by setting:
 

--- a/site/installing.md
+++ b/site/installing.md
@@ -28,7 +28,7 @@ The following topics are discussed:
  * [Installing Scope on minimesos](#minimesos)
  * [Installing Scope on Mesosphere DC/OS](#dcos)
 
-##<a name="docker"></a>Installing Scope on Docker
+## <a name="docker"></a>Installing Scope on Docker
 
 To install Scope in stand-alone mode, run the following commands:
 
@@ -48,7 +48,7 @@ Where,
 
 >>**Note:** Scope allows anyone with access to the user interface, control over your containers. As such, the Scope app endpoint (port 4040) should not be made accessible on the Internet.  Also traffic between the app and the probe is insecure and should not traverse the Internet. This means that you should either use the private / internal IP addresses of your nodes when setting it up, or route this traffic through Weave Net.  Put Scope behind a password, by using somthing like [Caddy](https://github.com/mholt/caddy) to protect the endpoint and make port 4040 available to localhost with Caddy proxying it. Or you can skip these steps, and just use Weave Cloud to manage the security for you.
 
-###<a name="docker-weave-cloud"></a>Using Weave Cloud
+### <a name="docker-weave-cloud"></a>Using Weave Cloud
 
 First, obtain a Weave Cloud token by signing up at [https://cloud.weave.works](https://cloud.weave.works/).
 
@@ -69,7 +69,7 @@ This script downloads and runs a recent Scope Docker image from the Docker Hub. 
 Open your web browser to [https://cloud.weave.works](https://cloud.weave.works) and login. Click 'View Instance' to see the Scope user interface.
 
 
-###<a name="cluster-no-net"></a>Installing Scope on a Local Cluster Without Weave Net
+### <a name="cluster-no-net"></a>Installing Scope on a Local Cluster Without Weave Net
 
 This example assumes a local cluster that is not networked with Weave Net, and also has no special hostnames or DNS settings. You will launch Scope with the IP addresses of all of the nodes in the cluster.
 
@@ -99,7 +99,7 @@ Using the above IP addresses, you will manually peer each node with all of the o
     scope launch 192.168.100.17 192.198.100.19 192.168.100.20
 
 
-###<a name="net-scope"></a> Weave Net and Scope
+### <a name="net-scope"></a> Weave Net and Scope
 
 If Scope is running on the same machine as the Weave Network, then the probe uses weaveDNS to automatically discover any other apps on the network. Scope does this by registering itself under the address `scope.weave.local`.
 
@@ -111,7 +111,7 @@ If you don’t want to use weaveDNS, then Scope can be instructed to cluster wit
 
 Hostnames will be regularly resolved as A records, and each answer used as a target.
 
-###<a name="docker-compose"></a>Using Docker Compose
+### <a name="docker-compose"></a>Using Docker Compose
 
 To install Scope on your local Docker machine in Standalone Mode using Docker Compose, run the following commands using one of the two fragments below.
 
@@ -153,7 +153,7 @@ After it’s been launched, open your browser to `http://localhost:4040`.
 
 Version 2 of this YAML file supports networks and volumes as defined by any plugins you might be using. See [Compose File Reference](https://docs.docker.com/compose/compose-file/) for more information.
 
-###<a name="docker-compose-cloud"></a>Using Docker Compose with Weave Cloud
+### <a name="docker-compose-cloud"></a>Using Docker Compose with Weave Cloud
 
 **1.** First, obtain a Cloud token from Weave Cloud by signing up at [https://cloud.weave.works](https://cloud.weave.works/).
 
@@ -207,9 +207,9 @@ Note that you will need to launch Scope onto every node that you want to monitor
 
 **4.** Go to [https://cloud.weave.works](https://cloud.weave.works) and click 'View Instance'.
 
-##<a name="k8s"></a>Installing Scope on Kubernetes
+## <a name="k8s"></a>Installing Scope on Kubernetes
 
-###<a name="k8s-weave-cloud"></a>With Weave Cloud (recommended)
+### <a name="k8s-weave-cloud"></a>With Weave Cloud (recommended)
 
 Weave Cloud hosts the Scope UI for you, provides secure access control for your team and saves resources such as CPU or memory usage.
 
@@ -219,7 +219,7 @@ Sign up for a [Weave Cloud account](https://cloud.weave.works/) and obtain a tok
 
 **SECURITY NOTE: This allows control of your Kubernetes cluster from Weave Cloud, which is a hosted service.**
 
-###<a name="k8s-standalone"></a>Without Weave Cloud (run Scope in standalone mode)
+### <a name="k8s-standalone"></a>Without Weave Cloud (run Scope in standalone mode)
 
 The simplest way to get the latest release of Scope deployed onto a Kubernetes cluster is by running the following:
 
@@ -244,7 +244,7 @@ To download and read the Scope manifest run:
 The URL is: http://localhost:4040.
 
 <!-- uncomment once https://github.com/weaveworks/scope/issues/2258 is fixed
-##<a name="ose"></a>Installing Scope on OpenShift
+## <a name="ose"></a>Installing Scope on OpenShift
 
 To install Weave Scope on OpenShift, you first need to login as `system:admin` user with the following command:
 
@@ -270,7 +270,7 @@ And if you are to deploy Scope in standalone mode run:
 To access standalone Scope app from the browser, please refer to Kubernetes instructions above.
 -->
 
-##<a name="ecs"></a>Installing Scope on Amazon ECS
+## <a name="ecs"></a>Installing Scope on Amazon ECS
 
 There are currently three options for launching Weave Scope in ECS:
 
@@ -295,7 +295,7 @@ The link below will launch a sample app using a Cloudformation template, but you
 
 For step by step instructions on how to configure the stack, see: [Install Weave to AWS with One-Click](https://www.weave.works/deploy-weave-aws-cloudformation-template/)
 
-##<a name="minimesos"></a>Installing Scope on minimesos
+## <a name="minimesos"></a>Installing Scope on minimesos
 
 The [minimesos](https://github.com/ContainerSolutions/minimesos) project enables you to run an Apache Mesos cluster on a single machine, which makes it very easy to develop Mesos frameworks.
 
@@ -307,7 +307,7 @@ If Weave Scope is removed from your minimesos cluster, you can add it back with 
 minimesos install --marathonFile https://raw.githubusercontent.com/weaveworks/scope/master/examples/mesos/minimesos.json
 ```
 
-##<a name="dcos"></a>Installing Scope as a DC/OS Package
+## <a name="dcos"></a>Installing Scope as a DC/OS Package
 
 Scope can be installed as a DC/OS Package through the open Universe.
 

--- a/site/introducing.md
+++ b/site/introducing.md
@@ -14,13 +14,13 @@ To install Scope on your local Docker machine, run the following commands:
 
 Scope can be used in standalone mode, where you deploy it locally onto your hosts, or you can use Weave Scope in [Weave Cloud](https://cloud.weave.works).  Scope can be deployed to Kubernetes, DCOS and ECS clusters.  See [Installing Weave Scope](/site/installing.md) for more information.
 
-##Getting Microservices Under Control
+## Getting Microservices Under Control
 
 Microservices-based architecture poses significant challenges when deployed to Docker containers in the cloud. Microservices tend to be dynamic with many distributed components, which can make monitoring difficult. But with Weave Scope, visualizing network bottlenecks, troubleshooting CPU consumption and memory leaks is simplified. With Views, you can quickly examine various metrics about your containerized app.
 
 !['Microservices Under Control'](images/microservices-under-control.png)
 
-##Automatic Topologies and Intelligent Grouping
+## Automatic Topologies and Intelligent Grouping
 
 Weave Scope generates a map of your processes, containers and hosts, so that you can understand, monitor, and control your applications.
 
@@ -32,7 +32,7 @@ Information collected by Weave Scope’s probes is used to build a topology of t
 
 Intelligently group nodes to help diagnose problems in your app as well as to clarify and model its infrastructure set up.  For example, you can use the Docker ‘containers-grouped-by-hostname’ view to identify and dedupe replicas of containers that back multiple services, and show which services within your Docker infrastructure are in communication.
 
-##Developer Friendly: Contextual Details and Metrics
+## Developer Friendly: Contextual Details and Metrics
 
 Drill down on nodes in any topology, and view contextual details for your containers, hosts and processes.  Metrics have been brought front and center, the tags and metadata user interface redefined with the children of your container/host arranged in expandable, sortable tables.  For example, the container consuming the most CPU or memory on a given host can be determined quickly with just a few clicks.
 
@@ -44,14 +44,14 @@ You can drill up and down between the various topologies that Scope natively und
 
 Scope can display metrics from Weave Net, Docker Containers, and the Linux Kernel.
 
-##Real-time Container Monitoring
+## Real-time Container Monitoring
 
 With Weave Scope you can control the entire container lifecycle across your cluster hosts from a single UI.  Start, stop, pause and restart containers from the details panel, and toggle filters for stopped containers in the containers view.
 
 Controlling Scope containers goes beyond simple lifecycle operations. Scope can also attach and exec. Attach executes a Docker attach against the container and lets you interact with it live.  Exec runs a shell in the container so that you can debug your running app in real-time.
 
 
-##Orchestrator Aware and Cloud Integrations
+## Orchestrator Aware and Cloud Integrations
 
 Weave Scope can visualize your app within:
 


### PR DESCRIPTION
Jekyll doesn't tolerate this, and it's generally cosidered a cleaner
style, we've had a bit of mixed style and this makes it consistent.