### PR TITLE
close s3 response body to prevent leaks

### DIFF
--- a/app/multitenant/s3_client.go
+++ b/app/multitenant/s3_client.go
@@ -82,6 +82,7 @@ func (store *S3Store) fetchReport(ctx context.Context, key string) (*report.Repo
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	return report.MakeFromBinary(resp.Body)
 }
 


### PR DESCRIPTION
We do exactly this in https://github.com/weaveworks/cortex/blob/master/chunk/aws_storage_client.go#L335

Fixes #2018.