### PR TITLE
scope script: Allow 'user' part of image name to be given by DOCKERHUB_USER env var

### DIFF
--- a/scope
+++ b/scope
@@ -10,7 +10,8 @@ else
     IMAGE_VERSION="$SCRIPT_VERSION"
 fi
 IMAGE_VERSION=${VERSION:-$IMAGE_VERSION}
-SCOPE_IMAGE_NAME=weaveworks/scope
+DOCKERHUB_USER=${DOCKERHUB_USER:-weaveworks}
+SCOPE_IMAGE_NAME="$DOCKERHUB_USER/scope"
 SCOPE_IMAGE="$SCOPE_IMAGE_NAME:$IMAGE_VERSION"
 # Careful: it's easy to operate on (e.g. stop) the wrong scope instance
 # when SCOPE{_APP,}_CONTAINER_NAME values differ between runs. Handle


### PR DESCRIPTION
This allows alternate scope images to be used, and mirrors the option available for weave net.