### PR TITLE
[RFC] probe: kubernetes: remove WatchPods (dead code)

### DIFF
--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -114,7 +114,6 @@ func NewReporter(client Client, pipes controls.PipeClient, probeID string, hostI
 		kubeletPort:     kubeletPort,
 	}
 	reporter.registerControls()
-	client.WatchPods(reporter.podEvent)
 	return reporter
 }
 
@@ -125,26 +124,6 @@ func (r *Reporter) Stop() {
 
 // Name of this reporter, for metrics gathering
 func (Reporter) Name() string { return "K8s" }
-
-func (r *Reporter) podEvent(e Event, pod Pod) {
-	switch e {
-	case ADD:
-		rpt := report.MakeReport()
-		rpt.Shortcut = true
-		rpt.Pod.AddNode(pod.GetNode(r.probeID))
-		r.probe.Publish(rpt)
-	case DELETE:
-		rpt := report.MakeReport()
-		rpt.Shortcut = true
-		rpt.Pod.AddNode(
-			report.MakeNodeWith(
-				report.MakePodNodeID(pod.UID()),
-				map[string]string{State: StateDeleted},
-			),
-		)
-		r.probe.Publish(rpt)
-	}
-}
 
 // IsPauseImageName indicates whether an image name corresponds to a
 // kubernetes pause container image.

--- a/probe/kubernetes/reporter_test.go
+++ b/probe/kubernetes/reporter_test.go
@@ -148,7 +148,6 @@ func (c *mockClient) WalkReplicationControllers(f func(kubernetes.ReplicationCon
 func (*mockClient) WalkNodes(f func(*api.Node) error) error {
 	return nil
 }
-func (*mockClient) WatchPods(func(kubernetes.Event, kubernetes.Pod)) {}
 func (c *mockClient) GetLogs(namespaceID, podName string) (io.ReadCloser, error) {
 	r, ok := c.logs[namespaceID+";"+podName]
 	if !ok {


### PR DESCRIPTION
triggerPodWatches() and related code is not called anywhere, so it was
dead code.

This code was initially added for push shortcut reports with k8s pods:
https://github.com/weaveworks/scope/pull/1368/commits/cb52acbc468e97b078db5913bcfcdca3309402d4

Then this was disabled here:
https://github.com/weaveworks/scope/pull/1436/commits/541699d193ca882ad8c2787c2ae7029e3f2a5410

-----

Should we make shortcut reports work again, or just delete the code?

Found while looking at the code for https://github.com/weaveworks/scope/issues/2245

/cc @schu @tomwilkie @paulbellamy