### PR TITLE
Add docker swarm Stack selector ala k8s namespace selector

### DIFF
--- a/probe/docker/reporter.go
+++ b/probe/docker/reporter.go
@@ -23,6 +23,7 @@ const (
 	ImageTableID     = "image_table"
 	ServiceName      = "service_name"
 	StackNamespace   = "stack_namespace"
+	DefaultNamespace = "No Stack"
 )
 
 // Exposed for testing

--- a/probe/docker/tagger.go
+++ b/probe/docker/tagger.go
@@ -59,12 +59,12 @@ func (t *Tagger) Tag(r report.Report) (report.Report, error) {
 		}
 		stackNamespace, ok := container.Latest.Lookup(LabelPrefix + "com.docker.stack.namespace")
 		if !ok {
-			continue
-		}
-
-		prefix := stackNamespace + "_"
-		if strings.HasPrefix(serviceName, prefix) {
-			serviceName = serviceName[len(prefix):]
+			stackNamespace = DefaultNamespace
+		} else {
+			prefix := stackNamespace + "_"
+			if strings.HasPrefix(serviceName, prefix) {
+				serviceName = serviceName[len(prefix):]
+			}
 		}
 
 		nodeID := report.MakeSwarmServiceNodeID(serviceID)


### PR DESCRIPTION
We have to introduce the kinda hacky concept of a 'No Stack' stack
to reconcile it with the idea of a 'default' k8s namespace. This is important
because swarm services without a stack don't have the same docker labels as ones that do.
Curiously, they still have what appears to be a stack name 'prefix' on their names,
but I can't isolate that name anywhere easily so they'll just have to make do.

I basically copy-pasted updateFilters to make this work, todo go back and refactor
to not duplicate 90% of the code.