### PR TITLE
Remove zoom on double-click

### DIFF
--- a/client/app/scripts/components/zoom-wrapper.js
+++ b/client/app/scripts/components/zoom-wrapper.js
@@ -94,7 +94,9 @@ class ZoomWrapper extends React.Component {
 
   setZoomTriggers(zoomingEnabled) {
     if (zoomingEnabled) {
-      this.svg.call(this.zoom);
+      // use d3-zoom defaults but exclude double clicks
+      this.svg.call(this.zoom)
+        .on('dblclick.zoom', null);
     } else {
       this.svg.on('.zoom', null);
     }


### PR DESCRIPTION
This was confusing in demos at KubeCon and DockerCon this year, as
clicking on nodes kept the UI zooming in.
Plus, when asked, users had no idea that double-click meant zoom in.

Fixes weaveworks/service-ui#453