### PR TITLE
Added mixpanel tracking for some basic events

### DIFF
--- a/client/app/scripts/actions/app-actions.js
+++ b/client/app/scripts/actions/app-actions.js
@@ -31,6 +31,7 @@ import {
 import {
   activeTopologyOptionsSelector,
   isResourceViewModeSelector,
+  resourceViewAvailableSelector,
 } from '../selectors/topology';
 import {
   GRAPH_VIEW_MODE,
@@ -321,18 +322,20 @@ export function setTableView() {
 
 export function setResourceView() {
   return (dispatch, getState) => {
-    dispatch({
-      type: ActionTypes.SET_VIEW_MODE,
-      viewMode: RESOURCE_VIEW_MODE,
-    });
-    // Pin the first metric if none of the visible ones is pinned.
-    const state = getState();
-    if (!pinnedMetricSelector(state)) {
-      const firstAvailableMetricType = availableMetricTypesSelector(state).first();
-      dispatch(pinMetric(firstAvailableMetricType));
+    if (resourceViewAvailableSelector(getState())) {
+      dispatch({
+        type: ActionTypes.SET_VIEW_MODE,
+        viewMode: RESOURCE_VIEW_MODE,
+      });
+      // Pin the first metric if none of the visible ones is pinned.
+      const state = getState();
+      if (!pinnedMetricSelector(state)) {
+        const firstAvailableMetricType = availableMetricTypesSelector(state).first();
+        dispatch(pinMetric(firstAvailableMetricType));
+      }
+      getResourceViewNodesSnapshot(getState, dispatch);
+      updateRoute(getState);
     }
-    getResourceViewNodesSnapshot(getState, dispatch);
-    updateRoute(getState);
   };
 }
 

--- a/client/app/scripts/actions/app-actions.js
+++ b/client/app/scripts/actions/app-actions.js
@@ -24,6 +24,7 @@ import {
 import { getCurrentTopologyUrl } from '../utils/topology-utils';
 import { storageSet } from '../utils/storage-utils';
 import { loadTheme } from '../utils/contrast-utils';
+import { trackMixpanelEvent } from '../utils/tracking-utils';
 import {
   availableMetricTypesSelector,
   selectedMetricTypeSelector,
@@ -200,6 +201,13 @@ export function changeTopologyOption(option, value, topologyId, addOrRemove) {
     // update all request workers with new options
     resetUpdateBuffer();
     const state = getState();
+    trackMixpanelEvent('scope.topology.option.click', {
+      option,
+      value,
+      layout: state.get('topologyViewMode'),
+      topologyId: state.getIn(['currentTopology', 'id']),
+      parentTopologyId: state.getIn(['currentTopology', 'parentId']),
+    });
     getTopologies(activeTopologyOptionsSelector(state), dispatch);
     getNodesDelta(
       getCurrentTopologyUrl(state),
@@ -257,7 +265,11 @@ export function clickDownloadGraph() {
 }
 
 export function clickForceRelayout() {
-  return (dispatch) => {
+  return (dispatch, getState) => {
+    const state = getState();
+    trackMixpanelEvent('scope.layout.refresh.click', {
+      layout: state.get('topologyViewMode'),
+    });
     dispatch({
       type: ActionTypes.CLICK_FORCE_RELAYOUT,
       forceRelayout: true
@@ -335,6 +347,11 @@ export function clickNode(nodeId, label, origin) {
     });
     updateRoute(getState);
     const state = getState();
+    trackMixpanelEvent('scope.node.click', {
+      layout: state.get('topologyViewMode'),
+      topologyId: state.getIn(['currentTopology', 'id']),
+      parentTopologyId: state.getIn(['currentTopology', 'parentId']),
+    });
     getNodeDetails(
       state.get('topologyUrlsById'),
       state.get('currentTopologyId'),
@@ -362,6 +379,11 @@ export function clickRelative(nodeId, topologyId, label, origin) {
     });
     updateRoute(getState);
     const state = getState();
+    trackMixpanelEvent('scope.node.relative.click', {
+      layout: state.get('topologyViewMode'),
+      topologyId: state.getIn(['currentTopology', 'id']),
+      parentTopologyId: state.getIn(['currentTopology', 'parentId']),
+    });
     getNodeDetails(
       state.get('topologyUrlsById'),
       state.get('currentTopologyId'),
@@ -511,6 +533,12 @@ export function hitEnter() {
     if (state.get('searchFocused')) {
       const query = state.get('searchQuery');
       if (query && parseQuery(query)) {
+        trackMixpanelEvent('scope.search.query.pin', {
+          query,
+          layout: state.get('topologyViewMode'),
+          topologyId: state.getIn(['currentTopology', 'id']),
+          parentTopologyId: state.getIn(['currentTopology', 'parentId']),
+        });
         dispatch({
           type: ActionTypes.PIN_SEARCH,
           query

--- a/client/app/scripts/actions/app-actions.js
+++ b/client/app/scripts/actions/app-actions.js
@@ -23,7 +23,6 @@ import {
 import { getCurrentTopologyUrl } from '../utils/topology-utils';
 import { storageSet } from '../utils/storage-utils';
 import { loadTheme } from '../utils/contrast-utils';
-import { trackMixpanelEvent } from '../utils/tracking-utils';
 import {
   availableMetricTypesSelector,
   selectedMetricTypeSelector,
@@ -210,13 +209,6 @@ export function changeTopologyOption(option, value, topologyId, addOrRemove) {
     // update all request workers with new options
     resetUpdateBuffer();
     const state = getState();
-    trackMixpanelEvent('scope.topology.option.click', {
-      option,
-      value,
-      layout: state.get('topologyViewMode'),
-      topologyId: state.getIn(['currentTopology', 'id']),
-      parentTopologyId: state.getIn(['currentTopology', 'parentId']),
-    });
     getTopologies(activeTopologyOptionsSelector(state), dispatch);
     getNodesDelta(
       getCurrentTopologyUrl(state),
@@ -274,11 +266,7 @@ export function clickDownloadGraph() {
 }
 
 export function clickForceRelayout() {
-  return (dispatch, getState) => {
-    const state = getState();
-    trackMixpanelEvent('scope.layout.refresh.click', {
-      layout: state.get('topologyViewMode'),
-    });
+  return (dispatch) => {
     dispatch({
       type: ActionTypes.CLICK_FORCE_RELAYOUT,
       forceRelayout: true
@@ -356,11 +344,6 @@ export function clickNode(nodeId, label, origin) {
     });
     updateRoute(getState);
     const state = getState();
-    trackMixpanelEvent('scope.node.click', {
-      layout: state.get('topologyViewMode'),
-      topologyId: state.getIn(['currentTopology', 'id']),
-      parentTopologyId: state.getIn(['currentTopology', 'parentId']),
-    });
     getNodeDetails(
       state.get('topologyUrlsById'),
       state.get('currentTopologyId'),
@@ -388,11 +371,6 @@ export function clickRelative(nodeId, topologyId, label, origin) {
     });
     updateRoute(getState);
     const state = getState();
-    trackMixpanelEvent('scope.node.relative.click', {
-      layout: state.get('topologyViewMode'),
-      topologyId: state.getIn(['currentTopology', 'id']),
-      parentTopologyId: state.getIn(['currentTopology', 'parentId']),
-    });
     getNodeDetails(
       state.get('topologyUrlsById'),
       state.get('currentTopologyId'),

--- a/client/app/scripts/actions/app-actions.js
+++ b/client/app/scripts/actions/app-actions.js
@@ -4,7 +4,6 @@ import ActionTypes from '../constants/action-types';
 import { saveGraph } from '../utils/file-utils';
 import { modulo } from '../utils/math-utils';
 import { updateRoute } from '../utils/router-utils';
-import { parseQuery } from '../utils/search-utils';
 import {
   bufferDeltaUpdate,
   resumeUpdate,
@@ -171,6 +170,16 @@ export function pinNextMetric(delta) {
     const nextMetricType = metricTypes.get(nextIndex);
 
     dispatch(pinMetric(nextMetricType));
+  };
+}
+
+export function pinSearch() {
+  return (dispatch, getState) => {
+    dispatch({
+      type: ActionTypes.PIN_SEARCH,
+      query: getState().get('searchQuery'),
+    });
+    updateRoute(getState);
   };
 }
 
@@ -518,29 +527,6 @@ export function hitBackspace() {
       if (query) {
         dispatch({
           type: ActionTypes.UNPIN_SEARCH,
-          query
-        });
-        updateRoute(getState);
-      }
-    }
-  };
-}
-
-export function hitEnter() {
-  return (dispatch, getState) => {
-    const state = getState();
-    // pin query based on current search field
-    if (state.get('searchFocused')) {
-      const query = state.get('searchQuery');
-      if (query && parseQuery(query)) {
-        trackMixpanelEvent('scope.search.query.pin', {
-          query,
-          layout: state.get('topologyViewMode'),
-          topologyId: state.getIn(['currentTopology', 'id']),
-          parentTopologyId: state.getIn(['currentTopology', 'parentId']),
-        });
-        dispatch({
-          type: ActionTypes.PIN_SEARCH,
           query
         });
         updateRoute(getState);

--- a/client/app/scripts/actions/app-actions.js
+++ b/client/app/scripts/actions/app-actions.js
@@ -2,7 +2,6 @@ import debug from 'debug';
 
 import ActionTypes from '../constants/action-types';
 import { saveGraph } from '../utils/file-utils';
-import { modulo } from '../utils/math-utils';
 import { updateRoute } from '../utils/router-utils';
 import {
   bufferDeltaUpdate,
@@ -25,7 +24,8 @@ import { storageSet } from '../utils/storage-utils';
 import { loadTheme } from '../utils/contrast-utils';
 import {
   availableMetricTypesSelector,
-  selectedMetricTypeSelector,
+  nextPinnedMetricTypeSelector,
+  previousPinnedMetricTypeSelector,
   pinnedMetricSelector,
 } from '../selectors/node-metric';
 import {
@@ -160,15 +160,17 @@ export function unpinMetric() {
   };
 }
 
-export function pinNextMetric(delta) {
+export function pinNextMetric() {
   return (dispatch, getState) => {
-    const state = getState();
-    const metricTypes = availableMetricTypesSelector(state);
-    const currentIndex = metricTypes.indexOf(selectedMetricTypeSelector(state));
-    const nextIndex = modulo(currentIndex + delta, metricTypes.count());
-    const nextMetricType = metricTypes.get(nextIndex);
+    const nextPinnedMetricType = nextPinnedMetricTypeSelector(getState());
+    dispatch(pinMetric(nextPinnedMetricType));
+  };
+}
 
-    dispatch(pinMetric(nextMetricType));
+export function pinPreviousMetric() {
+  return (dispatch, getState) => {
+    const previousPinnedMetricType = previousPinnedMetricTypeSelector(getState());
+    dispatch(pinMetric(previousPinnedMetricType));
   };
 }
 

--- a/client/app/scripts/charts/node.js
+++ b/client/app/scripts/charts/node.js
@@ -7,6 +7,8 @@ import { clickNode, enterNode, leaveNode } from '../actions/app-actions';
 import { getNodeColor } from '../utils/color-utils';
 import MatchedText from '../components/matched-text';
 import MatchedResults from '../components/matched-results';
+import { trackMixpanelEvent } from '../utils/tracking-utils';
+import { GRAPH_VIEW_MODE } from '../constants/naming';
 import { NODE_BASE_SIZE } from '../constants/styles';
 
 import NodeShapeStack from './node-shape-stack';
@@ -141,6 +143,11 @@ class Node extends React.Component {
 
   handleMouseClick(ev) {
     ev.stopPropagation();
+    trackMixpanelEvent('scope.node.click', {
+      layout: GRAPH_VIEW_MODE,
+      topologyId: this.props.currentTopology.get('id'),
+      parentTopologyId: this.props.currentTopology.get('parentId'),
+    });
     this.props.clickNode(this.props.id, this.props.label, this.shapeRef.getBoundingClientRect());
   }
 
@@ -159,7 +166,8 @@ function mapStateToProps(state) {
   return {
     exportingGraph: state.get('exportingGraph'),
     showingNetworks: state.get('showingNetworks'),
-    contrastMode: state.get('contrastMode')
+    currentTopology: state.get('currentTopology'),
+    contrastMode: state.get('contrastMode'),
   };
 }
 

--- a/client/app/scripts/charts/nodes-grid.js
+++ b/client/app/scripts/charts/nodes-grid.js
@@ -1,11 +1,13 @@
 /* eslint react/jsx-no-bind: "off", no-multi-comp: "off" */
-
 import React from 'react';
 import { connect } from 'react-redux';
 import { List as makeList, Map as makeMap } from 'immutable';
+
 import NodeDetailsTable from '../components/node-details/node-details-table';
 import { clickNode, sortOrderChanged } from '../actions/app-actions';
 import { shownNodesSelector } from '../selectors/node-filters';
+import { trackMixpanelEvent } from '../utils/tracking-utils';
+import { TABLE_VIEW_MODE } from '../constants/naming';
 
 import { canvasMarginsSelector, canvasHeightSelector } from '../selectors/canvas';
 import { searchNodeMatchesSelector } from '../selectors/search';
@@ -89,6 +91,11 @@ class NodesGrid extends React.Component {
     if (ev.target.className === 'node-details-table-node-link') {
       return;
     }
+    trackMixpanelEvent('scope.node.click', {
+      layout: TABLE_VIEW_MODE,
+      topologyId: this.props.currentTopology.get('id'),
+      parentTopologyId: this.props.currentTopology.get('parentId'),
+    });
     this.props.clickNode(node.id, node.label, ev.target.getBoundingClientRect());
   }
 

--- a/client/app/scripts/components/app.js
+++ b/client/app/scripts/components/app.js
@@ -16,7 +16,6 @@ import {
   focusSearch,
   pinNextMetric,
   hitBackspace,
-  hitEnter,
   hitEsc,
   unpinMetric,
   toggleHelp,
@@ -38,11 +37,11 @@ import {
   isTableViewModeSelector,
   isGraphViewModeSelector,
 } from '../selectors/topology';
+import {
+  BACKSPACE_KEY_CODE,
+  ESC_KEY_CODE,
+} from '../constants/key-codes';
 
-
-const BACKSPACE_KEY_CODE = 8;
-const ENTER_KEY_CODE = 13;
-const ESC_KEY_CODE = 27;
 const keyPressLog = debug('scope:app-key-press');
 
 class App extends React.Component {
@@ -79,8 +78,6 @@ class App extends React.Component {
     // don't get esc in onKeyPress
     if (ev.keyCode === ESC_KEY_CODE) {
       this.props.dispatch(hitEsc());
-    } else if (ev.keyCode === ENTER_KEY_CODE) {
-      this.props.dispatch(hitEnter());
     } else if (ev.keyCode === BACKSPACE_KEY_CODE) {
       this.props.dispatch(hitBackspace());
     } else if (ev.code === 'KeyD' && ev.ctrlKey && !showingTerminal) {

--- a/client/app/scripts/components/footer.js
+++ b/client/app/scripts/components/footer.js
@@ -4,19 +4,39 @@ import moment from 'moment';
 
 import Plugins from './plugins';
 import { getUpdateBufferSize } from '../utils/update-buffer-utils';
-import { clickDownloadGraph, clickForceRelayout, clickPauseUpdate,
-  clickResumeUpdate, toggleHelp, toggleTroubleshootingMenu, setContrastMode } from '../actions/app-actions';
+import { trackMixpanelEvent } from '../utils/tracking-utils';
+import {
+  clickDownloadGraph,
+  clickForceRelayout,
+  clickPauseUpdate,
+  clickResumeUpdate,
+  toggleHelp,
+  toggleTroubleshootingMenu,
+  setContrastMode
+} from '../actions/app-actions';
+
 
 class Footer extends React.Component {
   constructor(props, context) {
     super(props, context);
 
     this.handleContrastClick = this.handleContrastClick.bind(this);
+    this.handleRelayoutClick = this.handleRelayoutClick.bind(this);
   }
-  handleContrastClick(e) {
-    e.preventDefault();
+
+  handleContrastClick(ev) {
+    ev.preventDefault();
     this.props.setContrastMode(!this.props.contrastMode);
   }
+
+  handleRelayoutClick(ev) {
+    ev.preventDefault();
+    trackMixpanelEvent('scope.layout.refresh.click', {
+      layout: this.props.topologyViewMode,
+    });
+    this.props.clickForceRelayout();
+  }
+
   render() {
     const { hostname, updatePausedAt, version, versionUpdate, contrastMode } = this.props;
 
@@ -75,7 +95,7 @@ class Footer extends React.Component {
           </a>
           <a
             className="footer-icon"
-            onClick={this.props.clickForceRelayout}
+            onClick={this.handleRelayoutClick}
             title={forceRelayoutTitle}>
             <span className="fa fa-refresh" />
           </a>
@@ -103,9 +123,10 @@ function mapStateToProps(state) {
   return {
     hostname: state.get('hostname'),
     updatePausedAt: state.get('updatePausedAt'),
+    topologyViewMode: state.get('topologyViewMode'),
     version: state.get('version'),
     versionUpdate: state.get('versionUpdate'),
-    contrastMode: state.get('contrastMode')
+    contrastMode: state.get('contrastMode'),
   };
 }
 

--- a/client/app/scripts/components/metric-selector-item.js
+++ b/client/app/scripts/components/metric-selector-item.js
@@ -34,10 +34,10 @@ class MetricSelectorItem extends React.Component {
     const pinnedMetricType = this.props.pinnedMetricType;
 
     if (metricType !== pinnedMetricType) {
-      this.trackEvent('scope.metric.resource.pin');
+      this.trackEvent('scope.metric.selector.pin.click');
       this.props.pinMetric(metricType);
     } else {
-      this.trackEvent('scope.metric.resource.unpin');
+      this.trackEvent('scope.metric.selector.unpin.click');
       this.props.unpinMetric();
     }
   }

--- a/client/app/scripts/components/metric-selector-item.js
+++ b/client/app/scripts/components/metric-selector-item.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 
 import { hoverMetric, pinMetric, unpinMetric } from '../actions/app-actions';
 import { selectedMetricTypeSelector } from '../selectors/node-metric';
+import { trackMixpanelEvent } from '../utils/tracking-utils';
 
 
 class MetricSelectorItem extends React.Component {
@@ -24,8 +25,20 @@ class MetricSelectorItem extends React.Component {
     const pinnedMetricType = this.props.pinnedMetricType;
 
     if (metricType !== pinnedMetricType) {
+      trackMixpanelEvent('scope.metric.resource.pin', {
+        metricType,
+        layout: this.props.topologyViewMode,
+        topologyId: this.props.currentTopology.get('id'),
+        parentTopologyId: this.props.currentTopology.get('parentId'),
+      });
       this.props.pinMetric(metricType);
     } else {
+      trackMixpanelEvent('scope.metric.resource.unpin', {
+        metricType,
+        layout: this.props.topologyViewMode,
+        topologyId: this.props.currentTopology.get('id'),
+        parentTopologyId: this.props.currentTopology.get('parentId'),
+      });
       this.props.unpinMetric();
     }
   }
@@ -54,8 +67,10 @@ class MetricSelectorItem extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    selectedMetricType: selectedMetricTypeSelector(state),
+    topologyViewMode: state.get('topologyViewMode'),
+    currentTopology: state.get('currentTopology'),
     pinnedMetricType: state.get('pinnedMetricType'),
+    selectedMetricType: selectedMetricTypeSelector(state),
   };
 }
 

--- a/client/app/scripts/components/metric-selector-item.js
+++ b/client/app/scripts/components/metric-selector-item.js
@@ -15,6 +15,15 @@ class MetricSelectorItem extends React.Component {
     this.onMouseClick = this.onMouseClick.bind(this);
   }
 
+  trackEvent(eventName) {
+    trackMixpanelEvent(eventName, {
+      metricType: this.props.metric.get('label'),
+      layout: this.props.topologyViewMode,
+      topologyId: this.props.currentTopology.get('id'),
+      parentTopologyId: this.props.currentTopology.get('parentId'),
+    });
+  }
+
   onMouseOver() {
     const metricType = this.props.metric.get('label');
     this.props.hoverMetric(metricType);
@@ -25,20 +34,10 @@ class MetricSelectorItem extends React.Component {
     const pinnedMetricType = this.props.pinnedMetricType;
 
     if (metricType !== pinnedMetricType) {
-      trackMixpanelEvent('scope.metric.resource.pin', {
-        metricType,
-        layout: this.props.topologyViewMode,
-        topologyId: this.props.currentTopology.get('id'),
-        parentTopologyId: this.props.currentTopology.get('parentId'),
-      });
+      this.trackEvent('scope.metric.resource.pin');
       this.props.pinMetric(metricType);
     } else {
-      trackMixpanelEvent('scope.metric.resource.unpin', {
-        metricType,
-        layout: this.props.topologyViewMode,
-        topologyId: this.props.currentTopology.get('id'),
-        parentTopologyId: this.props.currentTopology.get('parentId'),
-      });
+      this.trackEvent('scope.metric.resource.unpin');
       this.props.unpinMetric();
     }
   }

--- a/client/app/scripts/components/node-details/node-details-relatives-link.js
+++ b/client/app/scripts/components/node-details/node-details-relatives-link.js
@@ -2,17 +2,23 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { clickRelative } from '../../actions/app-actions';
+import { trackMixpanelEvent } from '../../utils/tracking-utils';
 import MatchedText from '../matched-text';
+
 
 class NodeDetailsRelativesLink extends React.Component {
   constructor(props, context) {
     super(props, context);
+
     this.handleClick = this.handleClick.bind(this);
     this.saveNodeRef = this.saveNodeRef.bind(this);
   }
 
   handleClick(ev) {
     ev.preventDefault();
+    trackMixpanelEvent('scope.node.relative.click', {
+      topologyId: this.props.topologyId,
+    });
     this.props.dispatch(clickRelative(
       this.props.id,
       this.props.topologyId,

--- a/client/app/scripts/components/node-details/node-details-table-node-link.js
+++ b/client/app/scripts/components/node-details/node-details-table-node-link.js
@@ -2,16 +2,22 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { clickRelative } from '../../actions/app-actions';
+import { trackMixpanelEvent } from '../../utils/tracking-utils';
+
 
 class NodeDetailsTableNodeLink extends React.Component {
   constructor(props, context) {
     super(props, context);
+
     this.handleClick = this.handleClick.bind(this);
     this.saveNodeRef = this.saveNodeRef.bind(this);
   }
 
   handleClick(ev) {
     ev.preventDefault();
+    trackMixpanelEvent('scope.node.relative.click', {
+      topologyId: this.props.topologyId,
+    });
     this.props.dispatch(clickRelative(
       this.props.nodeId,
       this.props.topologyId,

--- a/client/app/scripts/components/search.js
+++ b/client/app/scripts/components/search.js
@@ -83,7 +83,6 @@ class Search extends React.Component {
     // If the search query is parsable, pin it when ENTER key is hit.
     if (ev.keyCode === ENTER_KEY_CODE && parseQuery(this.props.searchQuery)) {
       trackMixpanelEvent('scope.search.query.pin', {
-        query: this.props.searchQuery,
         layout: this.props.topologyViewMode,
         topologyId: this.props.currentTopology.get('id'),
         parentTopologyId: this.props.currentTopology.get('parentId'),
@@ -99,7 +98,6 @@ class Search extends React.Component {
   doSearch(value) {
     if (value !== '') {
       trackMixpanelEvent('scope.search.query.change', {
-        query: value,
         layout: this.props.topologyViewMode,
         topologyId: this.props.currentTopology.get('id'),
         parentTopologyId: this.props.currentTopology.get('parentId'),

--- a/client/app/scripts/components/search.js
+++ b/client/app/scripts/components/search.js
@@ -8,6 +8,7 @@ import { searchMatchCountByTopologySelector } from '../selectors/search';
 import { isResourceViewModeSelector } from '../selectors/topology';
 import { slugify } from '../utils/string-utils';
 import { isTopologyEmpty } from '../utils/topology-utils';
+import { trackMixpanelEvent } from '../utils/tracking-utils';
 import SearchItem from './search-item';
 
 
@@ -71,7 +72,7 @@ class Search extends React.Component {
     if (this.state.value && value === '') {
       value = null;
     }
-    this.setState({value});
+    this.setState({ value });
     this.doSearch(inputValue);
   }
 
@@ -80,6 +81,14 @@ class Search extends React.Component {
   }
 
   doSearch(value) {
+    if (value !== '') {
+      trackMixpanelEvent('scope.search.query.change', {
+        query: value,
+        layout: this.props.topologyViewMode,
+        topologyId: this.props.currentTopology.get('id'),
+        parentTopologyId: this.props.currentTopology.get('parentId'),
+      });
+    }
     this.props.doSearch(value);
   }
 
@@ -155,8 +164,10 @@ class Search extends React.Component {
 export default connect(
   state => ({
     nodes: state.get('nodes'),
+    topologyViewMode: state.get('topologyViewMode'),
     isResourceViewMode: isResourceViewModeSelector(state),
     isTopologyEmpty: isTopologyEmpty(state),
+    currentTopology: state.get('currentTopology'),
     topologiesLoaded: state.get('topologiesLoaded'),
     pinnedSearches: state.get('pinnedSearches'),
     searchFocused: state.get('searchFocused'),

--- a/client/app/scripts/components/topologies.js
+++ b/client/app/scripts/components/topologies.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 
+import { trackMixpanelEvent } from '../utils/tracking-utils';
 import { searchMatchCountByTopologySelector } from '../selectors/search';
 import { isResourceViewModeSelector } from '../selectors/topology';
 import { clickTopology } from '../actions/app-actions';
@@ -25,8 +26,12 @@ class Topologies extends React.Component {
     this.onTopologyClick = this.onTopologyClick.bind(this);
   }
 
-  onTopologyClick(ev) {
+  onTopologyClick(ev, topology) {
     ev.preventDefault();
+    trackMixpanelEvent('scope.topology.selector.click', {
+      topologyId: topology.get('id'),
+      parentTopologyId: topology.get('parentId'),
+    });
     this.props.clickTopology(ev.currentTarget.getAttribute('rel'));
   }
 
@@ -44,7 +49,7 @@ class Topologies extends React.Component {
     return (
       <div
         className={className} title={title} key={topologyId} rel={topologyId}
-        onClick={this.onTopologyClick}>
+        onClick={ev => this.onTopologyClick(ev, subTopology)}>
         <div className="topologies-sub-item-label">
           {subTopology.get('name')}
         </div>
@@ -65,7 +70,9 @@ class Topologies extends React.Component {
 
     return (
       <div className="topologies-item" key={topologyId}>
-        <div className={className} title={title} rel={topologyId} onClick={this.onTopologyClick}>
+        <div
+          className={className} title={title} rel={topologyId}
+          onClick={ev => this.onTopologyClick(ev, topology)}>
           <div className="topologies-item-label">
             {topology.get('name')}
           </div>

--- a/client/app/scripts/components/view-mode-selector.js
+++ b/client/app/scripts/components/view-mode-selector.js
@@ -5,9 +5,11 @@ import classNames from 'classnames';
 import MetricSelector from './metric-selector';
 import { trackMixpanelEvent } from '../utils/tracking-utils';
 import { setGraphView, setTableView, setResourceView } from '../actions/app-actions';
-import { layersTopologyIdsSelector } from '../selectors/resource-view/layout';
 import { availableMetricsSelector } from '../selectors/node-metric';
-import { isResourceViewModeSelector } from '../selectors/topology';
+import {
+  isResourceViewModeSelector,
+  resourceViewAvailableSelector,
+} from '../selectors/topology';
 import {
   GRAPH_VIEW_MODE,
   TABLE_VIEW_MODE,
@@ -68,7 +70,7 @@ class ViewModeSelector extends React.Component {
 function mapStateToProps(state) {
   return {
     isResourceViewMode: isResourceViewModeSelector(state),
-    hasResourceView: !layersTopologyIdsSelector(state).isEmpty(),
+    hasResourceView: resourceViewAvailableSelector(state),
     showingMetricsSelector: availableMetricsSelector(state).count() > 0,
     topologyViewMode: state.get('topologyViewMode'),
     currentTopology: state.get('currentTopology'),

--- a/client/app/scripts/components/view-mode-selector.js
+++ b/client/app/scripts/components/view-mode-selector.js
@@ -3,31 +3,17 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 
 import MetricSelector from './metric-selector';
+import { trackMixpanelEvent } from '../utils/tracking-utils';
 import { setGraphView, setTableView, setResourceView } from '../actions/app-actions';
 import { layersTopologyIdsSelector } from '../selectors/resource-view/layout';
 import { availableMetricsSelector } from '../selectors/node-metric';
+import { isResourceViewModeSelector } from '../selectors/topology';
 import {
-  isGraphViewModeSelector,
-  isTableViewModeSelector,
-  isResourceViewModeSelector,
-} from '../selectors/topology';
+  GRAPH_VIEW_MODE,
+  TABLE_VIEW_MODE,
+  RESOURCE_VIEW_MODE,
+} from '../constants/naming';
 
-
-const Item = (icons, label, isSelected, onClick, isEnabled = true) => {
-  const className = classNames('view-mode-selector-action', {
-    'view-mode-selector-action-selected': isSelected,
-  });
-  return (
-    <div
-      className={className}
-      disabled={!isEnabled}
-      onClick={isEnabled && onClick}
-      title={`View ${label.toLowerCase()}`}>
-      <span className={icons} style={{fontSize: 12}} />
-      <span className="label">{label}</span>
-    </div>
-  );
-};
 
 class ViewModeSelector extends React.Component {
   componentWillReceiveProps(nextProps) {
@@ -36,16 +22,42 @@ class ViewModeSelector extends React.Component {
     }
   }
 
+  renderItem(icons, label, viewMode, setViewModeAction, isEnabled = true) {
+    const isSelected = (this.props.topologyViewMode === viewMode);
+    const className = classNames('view-mode-selector-action', {
+      'view-mode-selector-action-selected': isSelected,
+    });
+    const onClick = () => {
+      trackMixpanelEvent('scope.layout.selector.click', {
+        layout: viewMode,
+        topologyId: this.props.currentTopology.get('id'),
+        parentTopologyId: this.props.currentTopology.get('parentId'),
+      });
+      setViewModeAction();
+    };
+
+    return (
+      <div
+        className={className}
+        disabled={!isEnabled}
+        onClick={isEnabled && onClick}
+        title={`View ${label.toLowerCase()}`}>
+        <span className={icons} style={{ fontSize: 12 }} />
+        <span className="label">{label}</span>
+      </div>
+    );
+  }
+
   render() {
-    const { isGraphViewMode, isTableViewMode, isResourceViewMode, hasResourceView } = this.props;
+    const { hasResourceView } = this.props;
 
     return (
       <div className="view-mode-selector">
         <div className="view-mode-selector-wrapper">
-          {Item('fa fa-share-alt', 'Graph', isGraphViewMode, this.props.setGraphView)}
-          {Item('fa fa-table', 'Table', isTableViewMode, this.props.setTableView)}
-          {Item('fa fa-bar-chart', 'Resources', isResourceViewMode, this.props.setResourceView,
-            hasResourceView)}
+          {this.renderItem('fa fa-share-alt', 'Graph', GRAPH_VIEW_MODE, this.props.setGraphView)}
+          {this.renderItem('fa fa-table', 'Table', TABLE_VIEW_MODE, this.props.setTableView)}
+          {this.renderItem('fa fa-bar-chart', 'Resources', RESOURCE_VIEW_MODE,
+            this.props.setResourceView, hasResourceView)}
         </div>
         <MetricSelector />
       </div>
@@ -55,11 +67,11 @@ class ViewModeSelector extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    isGraphViewMode: isGraphViewModeSelector(state),
-    isTableViewMode: isTableViewModeSelector(state),
     isResourceViewMode: isResourceViewModeSelector(state),
     hasResourceView: !layersTopologyIdsSelector(state).isEmpty(),
     showingMetricsSelector: availableMetricsSelector(state).count() > 0,
+    topologyViewMode: state.get('topologyViewMode'),
+    currentTopology: state.get('currentTopology'),
   };
 }
 

--- a/client/app/scripts/constants/key-codes.js
+++ b/client/app/scripts/constants/key-codes.js
@@ -1,0 +1,4 @@
+
+export const BACKSPACE_KEY_CODE = 8;
+export const ENTER_KEY_CODE = 13;
+export const ESC_KEY_CODE = 27;

--- a/client/app/scripts/selectors/node-metric.js
+++ b/client/app/scripts/selectors/node-metric.js
@@ -2,6 +2,7 @@ import { createSelector } from 'reselect';
 import { createMapSelector, createListSelector } from 'reselect-map';
 import { fromJS, Map as makeMap, List as makeList } from 'immutable';
 
+import { modulo } from '../utils/math-utils';
 import { isGraphViewModeSelector, isResourceViewModeSelector } from '../selectors/topology';
 import { RESOURCE_VIEW_METRICS } from '../constants/resources';
 
@@ -52,6 +53,30 @@ export const pinnedMetricSelector = createSelector(
     state => state.get('pinnedMetricType'),
   ],
   (availableMetrics, metricType) => availableMetrics.find(m => m.get('label') === metricType)
+);
+
+export const nextPinnedMetricTypeSelector = createSelector(
+  [
+    availableMetricTypesSelector,
+    state => state.get('pinnedMetricType'),
+  ],
+  (metricTypes, pinnedMetricType) => {
+    const currentIndex = metricTypes.indexOf(pinnedMetricType);
+    const nextIndex = modulo(currentIndex + 1, metricTypes.count());
+    return metricTypes.get(pinnedMetricType ? nextIndex : 0);
+  }
+);
+
+export const previousPinnedMetricTypeSelector = createSelector(
+  [
+    availableMetricTypesSelector,
+    state => state.get('pinnedMetricType'),
+  ],
+  (metricTypes, pinnedMetricType) => {
+    const currentIndex = metricTypes.indexOf(pinnedMetricType);
+    const previousIndex = modulo(currentIndex - 1, metricTypes.count());
+    return metricTypes.get(pinnedMetricType ? previousIndex : 0);
+  }
 );
 
 export const selectedMetricTypeSelector = createSelector(

--- a/client/app/scripts/selectors/topology.js
+++ b/client/app/scripts/selectors/topology.js
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 
+import { layersTopologyIdsSelector } from './resource-view/layout';
 import {
   RESOURCE_VIEW_MODE,
   GRAPH_VIEW_MODE,
@@ -28,6 +29,13 @@ export const isResourceViewModeSelector = createSelector(
     state => state.get('topologyViewMode'),
   ],
   viewMode => viewMode === RESOURCE_VIEW_MODE
+);
+
+export const resourceViewAvailableSelector = createSelector(
+  [
+    layersTopologyIdsSelector
+  ],
+  layersTopologyIds => !layersTopologyIds.isEmpty()
 );
 
 // Checks if graph complexity is high. Used to trigger

--- a/client/app/scripts/utils/tracking-utils.js
+++ b/client/app/scripts/utils/tracking-utils.js
@@ -1,0 +1,13 @@
+import debug from 'debug';
+
+const log = debug('service:tracking');
+
+// Track mixpanel events only if Scope is running inside of Weave Cloud.
+export function trackMixpanelEvent(name, props) {
+  if (window.mixpanel && process.env.WEAVE_CLOUD) {
+    window.mixpanel.track(name, props);
+    log('trackMixpanelEvent', name, props);
+  } else {
+    log('trackMixpanelEvent', name, props);
+  }
+}

--- a/client/app/scripts/utils/tracking-utils.js
+++ b/client/app/scripts/utils/tracking-utils.js
@@ -6,7 +6,6 @@ const log = debug('service:tracking');
 export function trackMixpanelEvent(name, props) {
   if (window.mixpanel && process.env.WEAVE_CLOUD) {
     window.mixpanel.track(name, props);
-    log('trackMixpanelEvent', name, props);
   } else {
     log('trackMixpanelEvent', name, props);
   }


### PR DESCRIPTION
Addresses #2460 by making use of Service UI's configured `window.mixpanel` variable directly.

##### Tracked events

* `scope.layout.refresh.click`
* `scope.layout.selector.click`
* `scope.layout.selector.keypress`
* `scope.metric.selector.pin.click`
* `scope.metric.selector.pin.next.keypress`
* `scope.metric.selector.pin.previous.keypress`
* `scope.metric.selector.unpin.click`
* `scope.metric.selector.unpin.keypress`
* `scope.node.click`
* `scope.node.relative.click`
* `scope.search.query.change`
* `scope.search.query.pin`
* `scope.topology.option.click`
* `scope.topology.selector.click`

Most of them have the active topology and view mode (layout) props attached to them to have some context of where the events are coming from. I checked it on the mixpanel dashboard and it seems to work nicely!

##### Other changes

* Replaced the `hitEnter` action with `pinSearch` which gets called directly from the `search.js`, since we only need to handle the *ENTER* key press from the search bar.
* Disable <kbd>r</kbd> shortcut when the resource view is disabled.
