### PR TITLE
[PROTOTYPE] Resource view - replace flame graph with a sort of tree map

### DIFF
--- a/client/app/scripts/actions/app-actions.js
+++ b/client/app/scripts/actions/app-actions.js
@@ -22,6 +22,7 @@ import {
 import { getCurrentTopologyUrl } from '../utils/topology-utils';
 import { storageSet } from '../utils/storage-utils';
 import { loadTheme } from '../utils/contrast-utils';
+import { resourceViewAvailableSelector } from '../selectors/resource-view/layout';
 import {
   availableMetricTypesSelector,
   nextPinnedMetricTypeSelector,
@@ -31,7 +32,6 @@ import {
 import {
   activeTopologyOptionsSelector,
   isResourceViewModeSelector,
-  resourceViewAvailableSelector,
 } from '../selectors/topology';
 import {
   GRAPH_VIEW_MODE,

--- a/client/app/scripts/components/nodes-resources/node-resources-layer.js
+++ b/client/app/scripts/components/nodes-resources/node-resources-layer.js
@@ -15,13 +15,13 @@ class NodesResourcesLayer extends React.Component {
     const { layerVerticalPosition, topologyId, transform, layoutNodes } = this.props;
     let height;
     if (topologyId === 'hosts') height = 400;
-    if (topologyId === 'containers') height = 335;
-    if (topologyId === 'processes') height = 270;
+    if (topologyId === 'containers') height = 355;
+    if (topologyId === 'processes') height = 310;
 
     let y;
     if (topologyId === 'hosts') y = -400;
-    if (topologyId === 'containers') y = -345;
-    if (topologyId === 'processes') y = -290;
+    if (topologyId === 'containers') y = -360;
+    if (topologyId === 'processes') y = -320;
 
     return (
       <g className="node-resources-layer">
@@ -30,6 +30,7 @@ class NodesResourcesLayer extends React.Component {
             <NodeResourcesMetricBox
               key={node.get('id')}
               color={node.get('color')}
+              fill={node.get('fill')}
               label={node.get('label')}
               metricSummary={node.get('metricSummary')}
               width={node.get('width')}

--- a/client/app/scripts/components/nodes-resources/node-resources-layer.js
+++ b/client/app/scripts/components/nodes-resources/node-resources-layer.js
@@ -4,6 +4,7 @@ import { Map as makeMap } from 'immutable';
 
 import NodeResourcesMetricBox from './node-resources-metric-box';
 import NodeResourcesLayerTopology from './node-resources-layer-topology';
+import { canvasHeightSelector } from '../../selectors/canvas';
 import {
   layerVerticalPositionByTopologyIdSelector,
   layoutNodesByTopologyIdSelector,
@@ -13,15 +14,17 @@ import {
 class NodesResourcesLayer extends React.Component {
   render() {
     const { layerVerticalPosition, topologyId, transform, layoutNodes } = this.props;
+    const c = 1150 / this.props.canvasHeight;
+
     let height;
     if (topologyId === 'hosts') height = 400;
-    if (topologyId === 'containers') height = 355;
-    if (topologyId === 'processes') height = 310;
+    if (topologyId === 'containers') height = 400 - (c * 45);
+    if (topologyId === 'processes') height = 400 - (c * 90);
 
     let y;
     if (topologyId === 'hosts') y = -400;
-    if (topologyId === 'containers') y = -360;
-    if (topologyId === 'processes') y = -320;
+    if (topologyId === 'containers') y = -400 + (c * 40);
+    if (topologyId === 'processes') y = -400 + (c * 80);
 
     return (
       <g className="node-resources-layer">
@@ -56,6 +59,7 @@ function mapStateToProps(state, props) {
   return {
     layerVerticalPosition: layerVerticalPositionByTopologyIdSelector(state).get('hosts'),
     layoutNodes: layoutNodesByTopologyIdSelector(state).get(props.topologyId, makeMap()),
+    canvasHeight: canvasHeightSelector(state),
   };
 }
 

--- a/client/app/scripts/components/nodes-resources/node-resources-layer.js
+++ b/client/app/scripts/components/nodes-resources/node-resources-layer.js
@@ -13,6 +13,15 @@ import {
 class NodesResourcesLayer extends React.Component {
   render() {
     const { layerVerticalPosition, topologyId, transform, layoutNodes } = this.props;
+    let height;
+    if (topologyId === 'hosts') height = 400;
+    if (topologyId === 'containers') height = 335;
+    if (topologyId === 'processes') height = 270;
+
+    let y;
+    if (topologyId === 'hosts') y = -400;
+    if (topologyId === 'containers') y = -345;
+    if (topologyId === 'processes') y = -290;
 
     return (
       <g className="node-resources-layer">
@@ -24,14 +33,15 @@ class NodesResourcesLayer extends React.Component {
               label={node.get('label')}
               metricSummary={node.get('metricSummary')}
               width={node.get('width')}
-              height={node.get('height')}
+              height={height}
               x={node.get('offset')}
-              y={layerVerticalPosition}
+              topId={topologyId}
+              y={y}
               transform={transform}
             />
           ))}
         </g>
-        {!layoutNodes.isEmpty() && <NodeResourcesLayerTopology
+        {!layoutNodes.isEmpty() && false && <NodeResourcesLayerTopology
           verticalPosition={layerVerticalPosition}
           transform={transform}
           topologyId={topologyId}
@@ -43,7 +53,7 @@ class NodesResourcesLayer extends React.Component {
 
 function mapStateToProps(state, props) {
   return {
-    layerVerticalPosition: layerVerticalPositionByTopologyIdSelector(state).get(props.topologyId),
+    layerVerticalPosition: layerVerticalPositionByTopologyIdSelector(state).get('hosts'),
     layoutNodes: layoutNodesByTopologyIdSelector(state).get(props.topologyId, makeMap()),
   };
 }

--- a/client/app/scripts/components/nodes-resources/node-resources-metric-box-info.js
+++ b/client/app/scripts/components/nodes-resources/node-resources-metric-box-info.js
@@ -20,11 +20,11 @@ export default class NodeResourcesMetricBoxInfo extends React.Component {
   }
 
   render() {
-    const { width, x, y } = this.props;
+    const { width, type, x, y } = this.props;
     return (
       <foreignObject x={x} y={y} width={width} height="45px">
         <div className="node-resources-metric-box-info">
-          <span className="wrapper label truncate">{this.props.label}</span>
+          <span className="wrapper label truncate">{this.props.label} <i>{type}</i></span>
           <span className="wrapper consumption truncate">{this.humanizedMetricInfo()}</span>
         </div>
       </foreignObject>

--- a/client/app/scripts/components/nodes-resources/node-resources-metric-box.js
+++ b/client/app/scripts/components/nodes-resources/node-resources-metric-box.js
@@ -70,8 +70,13 @@ class NodeResourcesMetricBox extends React.Component {
 
   render() {
     const { x, y, width } = this.state;
-    const { label, color, metricSummary } = this.props;
-    const { showCapacity, relativeConsumption, type } = metricSummary.toJS();
+    const { label, color, metricSummary, topId } = this.props;
+    const { showCapacity, type } = metricSummary.toJS();
+
+    let t;
+    if (topId === 'hosts') t = 'host';
+    if (topId === 'containers') t = 'container';
+    if (topId === 'processes') t = 'process';
 
     const showInfo = width >= RESOURCES_LABEL_MIN_SIZE;
     const showNode = width >= 1; // hide the thin nodes
@@ -87,14 +92,15 @@ class NodeResourcesMetricBox extends React.Component {
     return (
       <g className="node-resources-metric-box">
         <title>{label} - {type} usage at {resourceUsageTooltipInfo}</title>
-        {showCapacity && <rect className="frame" {...this.defaultRectProps()} />}
-        <rect className="bar" fill={color} {...this.defaultRectProps(relativeConsumption)} />
+        <rect className="frame" {...this.defaultRectProps()} />
+        <rect className="bar" fill={color} {...this.defaultRectProps(1)} />
         {showInfo && <NodeResourcesMetricBoxInfo
           label={label}
           metricSummary={metricSummary}
           width={width - (2 * RESOURCES_LABEL_PADDING)}
           x={x + RESOURCES_LABEL_PADDING}
           y={y + RESOURCES_LABEL_PADDING}
+          type={t}
         />}
       </g>
     );

--- a/client/app/scripts/components/nodes-resources/node-resources-metric-box.js
+++ b/client/app/scripts/components/nodes-resources/node-resources-metric-box.js
@@ -60,7 +60,9 @@ class NodeResourcesMetricBox extends React.Component {
     return {
       transform: `translate(0, ${translateY})`,
       opacity: this.props.contrastMode ? 1 : 0.85,
-      stroke: this.props.contrastMode ? 'black' : 'white',
+      // stroke: this.props.contrastMode ? 'black' : 'white',
+      stroke: this.props.color,
+      strokeWidth: 0.5,
       height: height * relativeHeight,
       width,
       x,
@@ -70,7 +72,7 @@ class NodeResourcesMetricBox extends React.Component {
 
   render() {
     const { x, y, width } = this.state;
-    const { label, color, metricSummary, topId } = this.props;
+    const { label, fill, metricSummary, topId } = this.props;
     const { showCapacity, type } = metricSummary.toJS();
 
     let t;
@@ -93,7 +95,7 @@ class NodeResourcesMetricBox extends React.Component {
       <g className="node-resources-metric-box">
         <title>{label} - {type} usage at {resourceUsageTooltipInfo}</title>
         <rect className="frame" {...this.defaultRectProps()} />
-        <rect className="bar" fill={color} {...this.defaultRectProps(1)} />
+        <rect className="bar" fill={fill} {...this.defaultRectProps(1)} />
         {showInfo && <NodeResourcesMetricBoxInfo
           label={label}
           metricSummary={metricSummary}

--- a/client/app/scripts/components/nodes-resources/node-resources-metric-box.js
+++ b/client/app/scripts/components/nodes-resources/node-resources-metric-box.js
@@ -60,7 +60,6 @@ class NodeResourcesMetricBox extends React.Component {
     return {
       transform: `translate(0, ${translateY})`,
       opacity: this.props.contrastMode ? 1 : 0.85,
-      // stroke: this.props.contrastMode ? 'black' : 'white',
       stroke: this.props.color,
       strokeWidth: 0.5,
       height: height * relativeHeight,

--- a/client/app/scripts/components/view-mode-selector.js
+++ b/client/app/scripts/components/view-mode-selector.js
@@ -6,10 +6,8 @@ import MetricSelector from './metric-selector';
 import { trackMixpanelEvent } from '../utils/tracking-utils';
 import { setGraphView, setTableView, setResourceView } from '../actions/app-actions';
 import { availableMetricsSelector } from '../selectors/node-metric';
-import {
-  isResourceViewModeSelector,
-  resourceViewAvailableSelector,
-} from '../selectors/topology';
+import { resourceViewAvailableSelector } from '../selectors/resource-view/layout';
+import { isResourceViewModeSelector } from '../selectors/topology';
 import {
   GRAPH_VIEW_MODE,
   TABLE_VIEW_MODE,

--- a/client/app/scripts/constants/styles.js
+++ b/client/app/scripts/constants/styles.js
@@ -10,7 +10,7 @@ export const DETAILS_PANEL_MARGINS = {
 };
 
 // Resource view
-export const RESOURCES_LAYER_TITLE_WIDTH = 200;
+export const RESOURCES_LAYER_TITLE_WIDTH = 0;
 export const RESOURCES_LAYER_HEIGHT = 150;
 export const RESOURCES_LAYER_PADDING = 10;
 export const RESOURCES_LABEL_MIN_SIZE = 50;
@@ -35,7 +35,7 @@ export const NODE_BASE_SIZE = 100;
 export const CANVAS_MARGINS = {
   [GRAPH_VIEW_MODE]: { top: 160, left: 40, right: 40, bottom: 150 },
   [TABLE_VIEW_MODE]: { top: 160, left: 40, right: 40, bottom: 30 },
-  [RESOURCE_VIEW_MODE]: { top: 160, left: 210, right: 40, bottom: 50 },
+  [RESOURCE_VIEW_MODE]: { top: 160, left: 40, right: 40, bottom: 50 },
 };
 
 // Node details table constants

--- a/client/app/scripts/decorators/node.js
+++ b/client/app/scripts/decorators/node.js
@@ -16,7 +16,7 @@ export function nodeResourceBoxDecorator(node) {
   const metricSummary = node.get('metricSummary', makeMap());
   const width = metricSummary.get('showCapacity') ?
     metricSummary.get('totalCapacity') :
-    metricSummary.get('absoluteConsumption');
+    metricSummary.get('absoluteConsumption') * 100;
   const height = RESOURCES_LAYER_HEIGHT;
 
   return node.merge(makeMap({ width, height }));

--- a/client/app/scripts/decorators/node.js
+++ b/client/app/scripts/decorators/node.js
@@ -8,7 +8,16 @@ import { RESOURCES_LAYER_HEIGHT } from '../constants/styles';
 export function nodeResourceViewColorDecorator(node) {
   // Color lightness is normally determined from the node label. However, in the resource view
   // mode, we don't want to vary the lightness so we just always forward the empty string instead.
-  return node.set('color', getNodeColor(node.get('rank'), '', node.get('pseudo')));
+  let text = 'containers';
+  if (node.get('label').substr(0, 2) === 'ip') text = 'a';
+  if (node.get('label')[0] === '/') text = 'processes';
+
+  // const text = node.get('label');
+  const subtext = node.get('rank');
+  return node.merge({
+    color: getNodeColor(text, subtext, node.get('pseudo')),
+    fill: getNodeColor(text, subtext, node.get('pseudo'), true),
+  });
 }
 
 // Decorates the resource node with dimensions taken from its metric summary.

--- a/client/app/scripts/decorators/node.js
+++ b/client/app/scripts/decorators/node.js
@@ -5,12 +5,10 @@ import { formatMetricSvg } from '../utils/string-utils';
 import { RESOURCES_LAYER_HEIGHT } from '../constants/styles';
 
 
-export function nodeResourceViewColorDecorator(node) {
+export function nodeResourceViewColorDecorator(node, cat) {
   // Color lightness is normally determined from the node label. However, in the resource view
   // mode, we don't want to vary the lightness so we just always forward the empty string instead.
-  let text = 'containers';
-  if (node.get('label').substr(0, 2) === 'ip') text = 'a';
-  if (node.get('label')[0] === '/') text = 'processes';
+  const text = (cat === 'hosts' ? 'a' : cat);
 
   // const text = node.get('label');
   const subtext = node.get('rank');

--- a/client/app/scripts/decorators/node.js
+++ b/client/app/scripts/decorators/node.js
@@ -16,7 +16,7 @@ export function nodeResourceBoxDecorator(node) {
   const metricSummary = node.get('metricSummary', makeMap());
   const width = metricSummary.get('showCapacity') ?
     metricSummary.get('totalCapacity') :
-    metricSummary.get('absoluteConsumption') * 100;
+    metricSummary.get('absoluteConsumption') * 1;
   const height = RESOURCES_LAYER_HEIGHT;
 
   return node.merge(makeMap({ width, height }));

--- a/client/app/scripts/selectors/resource-view/layout.js
+++ b/client/app/scripts/selectors/resource-view/layout.js
@@ -36,6 +36,13 @@ export const layersTopologyIdsSelector = createSelector(
   topologyId => fromJS(RESOURCE_VIEW_LAYERS[topologyId] || [])
 );
 
+export const resourceViewAvailableSelector = createSelector(
+  [
+    layersTopologyIdsSelector
+  ],
+  layersTopologyIds => !layersTopologyIds.isEmpty()
+);
+
 // Calculates the resource view layer Y-coordinate for every topology in the resource view.
 export const layerVerticalPositionByTopologyIdSelector = createSelector(
   [
@@ -144,7 +151,7 @@ export const layoutNodesByTopologyIdSelector = createSelector(
         nodesBucket.sortBy(resourceNodeConsumptionComparator).forEach((node, nodeId) => {
           const positionedNode = node.set('offset', currentOffset);
           positionedNodes = positionedNodes.set(nodeId, positionedNode);
-          currentOffset += node.get('width') + (c * 0.3);
+          currentOffset += node.get('width') + (c * 0.0);
         });
 
         // TODO: This block of code checks for the overlaps which are caused by children

--- a/client/app/scripts/selectors/resource-view/layout.js
+++ b/client/app/scripts/selectors/resource-view/layout.js
@@ -98,7 +98,7 @@ const decoratedNodesByTopologySelector = createSelector(
 
       // Color the node, deduce its anchor point, dimensions and info about its pinned metric.
       const decoratedTopologyNodes = (topologyNodes || makeMap())
-        .map(nodeResourceViewColorDecorator)
+        .map(n => nodeResourceViewColorDecorator(n, layerTopologyId))
         .map(nodeMetricSummaryDecorator)
         .map(nodeResourceBoxDecorator)
         .map(nodeParentDecorator);

--- a/client/app/scripts/selectors/resource-view/layout.js
+++ b/client/app/scripts/selectors/resource-view/layout.js
@@ -9,6 +9,7 @@ import {
   RESOURCE_VIEW_LAYERS,
   TOPOLOGIES_WITH_CAPACITY,
 } from '../../constants/resources';
+import { activeLayoutCachedZoomSelector } from '../zooming';
 import {
   nodeParentDecoratorByTopologyId,
   nodeMetricSummaryDecoratorByType,
@@ -116,8 +117,9 @@ export const layoutNodesByTopologyIdSelector = createSelector(
   [
     layersTopologyIdsSelector,
     decoratedNodesByTopologySelector,
+    activeLayoutCachedZoomSelector,
   ],
-  (layersTopologyIds, nodesByTopology) => {
+  (layersTopologyIds, nodesByTopology, cachedZoom) => {
     let layoutNodes = makeMap();
     let parentTopologyId = null;
 
@@ -135,20 +137,21 @@ export const layoutNodesByTopologyIdSelector = createSelector(
         // Set the initial offset to the offset of the parent (that has already been set).
         // If there is no offset information, i.e. we're processing the base layer, set it to 0.
         const parentNode = layoutNodes.getIn([parentTopologyId, parentNodeId], makeMap());
-        let currentOffset = parentNode.get('offset', 0);
+        const c = 10 / (cachedZoom.get('scaleX') || 1);
+        let currentOffset = parentNode.get('offset', 0) + c;
 
         // Sort the nodes in the current bucket and lay them down one after another.
         nodesBucket.sortBy(resourceNodeConsumptionComparator).forEach((node, nodeId) => {
           const positionedNode = node.set('offset', currentOffset);
           positionedNodes = positionedNodes.set(nodeId, positionedNode);
-          currentOffset += node.get('width');
+          currentOffset += node.get('width') + (c * 0.3);
         });
 
         // TODO: This block of code checks for the overlaps which are caused by children
         // consuming more resources than their parent node. This happens due to inconsistent
         // data being sent from the backend and it needs to be fixed there.
-        const parentOffset = parentNode.get('offset', 0);
-        const parentWidth = parentNode.get('width', currentOffset);
+        const parentOffset = parentNode.get('offset', 0) + c;
+        const parentWidth = parentNode.get('width', currentOffset) - (2 * c);
         const totalChildrenWidth = currentOffset - parentOffset;
         // If the total width of the children exceeds the parent node box width, we have a problem.
         // We fix it by shrinking all the children to by a factor to perfectly fit into the parent.

--- a/client/app/scripts/selectors/resource-view/zoom.js
+++ b/client/app/scripts/selectors/resource-view/zoom.js
@@ -80,7 +80,7 @@ export const resourcesZoomLimitsSelector = createSelector(
 
     return makeMap({
       // Maximal zoom is such that the smallest box takes the whole canvas.
-      maxScale: width / minNodeWidth,
+      maxScale: width / Math.max(minNodeWidth, 1),
       // Minimal zoom is equivalent to the initial one, where the whole layout matches the canvas.
       minScale: defaultZoom.get('scaleX'),
       minTranslateX: xMin,

--- a/client/app/scripts/selectors/topology.js
+++ b/client/app/scripts/selectors/topology.js
@@ -1,6 +1,5 @@
 import { createSelector } from 'reselect';
 
-import { layersTopologyIdsSelector } from './resource-view/layout';
 import {
   RESOURCE_VIEW_MODE,
   GRAPH_VIEW_MODE,
@@ -29,13 +28,6 @@ export const isResourceViewModeSelector = createSelector(
     state => state.get('topologyViewMode'),
   ],
   viewMode => viewMode === RESOURCE_VIEW_MODE
-);
-
-export const resourceViewAvailableSelector = createSelector(
-  [
-    layersTopologyIdsSelector
-  ],
-  layersTopologyIds => !layersTopologyIds.isEmpty()
 );
 
 // Checks if graph complexity is high. Used to trigger

--- a/client/app/scripts/utils/color-utils.js
+++ b/client/app/scripts/utils/color-utils.js
@@ -25,15 +25,15 @@ export function text2degree(text) {
   return hueScale(num);
 }
 
-export function colors(text, secondText) {
-  let hue = text2degree(text);
+export function colors(text, secondText, blend = false) {
+  let hue = text2degree(text) + (text2degree(secondText) * 0.2);
   // skip green and shift to the end of the color wheel
   if (hue > 70 && hue < 150) {
     hue += 80;
   }
-  const saturation = 0.6;
-  let lightness = 0.5;
-  if (secondText) {
+  const saturation = blend ? 0.5 : 0.7;
+  let lightness = blend ? 0.7 : 0.3;
+  if (secondText && false) {
     // reuse text2degree and feed degree to lightness scale
     lightness = lightnessScale(text2degree(secondText));
   }
@@ -44,11 +44,11 @@ export function getNeutralColor() {
   return PSEUDO_COLOR;
 }
 
-export function getNodeColor(text = '', secondText = '', isPseudo = false) {
+export function getNodeColor(text = '', secondText = '', isPseudo = false, blend = false) {
   if (isPseudo) {
     return PSEUDO_COLOR;
   }
-  return colors(text, secondText).toString();
+  return colors(text, secondText, blend).toString();
 }
 
 export function getNodeColorDark(text = '', secondText = '', isPseudo = false) {

--- a/client/app/scripts/utils/color-utils.js
+++ b/client/app/scripts/utils/color-utils.js
@@ -26,11 +26,12 @@ export function text2degree(text) {
 }
 
 export function colors(text, secondText, blend = false) {
-  let hue = text2degree(text) + (text2degree(secondText) * 0.2);
+  let hue = text2degree(text) + (text2degree(secondText) * 0.15) + 360;
+  while (hue >= 360) hue -= 360;
   // skip green and shift to the end of the color wheel
-  if (hue > 70 && hue < 150) {
-    hue += 80;
-  }
+  // if (hue > 70 && hue < 150) {
+  //   hue += 80;
+  // }
   const saturation = blend ? 0.5 : 0.7;
   let lightness = blend ? 0.7 : 0.3;
   if (secondText && false) {

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -948,6 +948,8 @@
   &-metric-box {
     fill: rgba(150, 150, 150, 0.4);
 
+    .bar { opacity: 0.8; }
+
     &-info {
       background-color: rgba(white, 0.6);
       border-radius: 2px;


### PR DESCRIPTION
Here's how my hacked prototype looks like:

Overview:
![tree-map-1](https://cloud.githubusercontent.com/assets/1216874/25379852/8edb497c-29ae-11e7-82ff-0bc17fa36a88.png)

Zoomed in:
![tree-map-2](https://cloud.githubusercontent.com/assets/1216874/25379847/8c81b832-29ae-11e7-874f-afebd6750505.png)
![tree-map-3](https://cloud.githubusercontent.com/assets/1216874/25381137/ebc31706-29b2-11e7-97bf-602c113223f4.png)
![tree-map-4](https://cloud.githubusercontent.com/assets/1216874/25381073/b705f4a2-29b2-11e7-9b49-4be4f896b84c.png)

@pidster @bowenli @jpellizzari @2opremio Before reading the rationale below, I'd be curious to get your fresh (and unbiased) opinion about the screenshots above. Do they seem more/less intuitive and informative to you than the current flame graph layout?

----

Following @davkal's feedback in https://github.com/weaveworks/scope/pull/2420#issuecomment-295706842, the discussion followed how the current resource view could be improved. To sum up, the concerns were:

* Inconsistent display of resource boxes between *hosts* and *containers*/*processes*
* The concern that *hosts* metrics spreading along both axis (horizontal for capacity, vertical for consumption) might at first raise more questions than it answers
* The idea of processes running *inside* containers and containers runinning *inside* hosts could be made visually more explicit
* The current view can look confusingly empty on higher zoom levels:

![zoomed-in](https://cloud.githubusercontent.com/assets/1216874/25380566/eeed3788-29b0-11e7-9358-7cacfaf8e634.png)

Now, simply dropping the vertical bar for *hosts* resource boxes addresses the first two concerns, but it also brings about the question of how not to lose the information about hosts resource consumption. As far as my intuition goes, the sum of all the children containers should give a good approximation of the resource consumption of their parent hosts. That sort of agregated approach also gets rid of current some data discrepancy between the layers. So why not simply put container boxes into their parent hosts (and then do the same for processes)? That immediatelly addresses the third point above and improves on the last point. 

As can be seen from the screenshots on the top, the *HOSTS*, *CONTAINERS*, *PROCESSES* tabs were also removed from the left and their information was appended to the node labels instead.
