### PR TITLE
Msgpack perf: write psMap out directly

### DIFF
--- a/app/api_topologies_test.go
+++ b/app/api_topologies_test.go
@@ -225,7 +225,7 @@ func TestAPITopologyAddsKubernetes(t *testing.T) {
 	buf := &bytes.Buffer{}
 	encoder := codec.NewEncoder(buf, &codec.MsgpackHandle{})
 	if err := encoder.Encode(rpt); err != nil {
-		t.Fatalf("GOB encoding error: %s", err)
+		t.Fatalf("Msgpack encoding error: %s", err)
 	}
 	checkRequest(t, ts, "POST", "/api/report", buf.Bytes())
 

--- a/common/xfer/plugin_spec.go
+++ b/common/xfer/plugin_spec.go
@@ -2,7 +2,6 @@ package xfer
 
 import (
 	"bytes"
-	"encoding/gob"
 	"fmt"
 	"sort"
 
@@ -207,23 +206,6 @@ func (PluginSpecs) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON shouldn't be used, use CodecDecodeSelf instead
 func (*PluginSpecs) UnmarshalJSON(b []byte) error {
 	panic("UnmarshalJSON shouldn't be used, use CodecDecodeSelf instead")
-}
-
-// GobEncode implements gob.Marshaller
-func (n PluginSpecs) GobEncode() ([]byte, error) {
-	buf := bytes.Buffer{}
-	err := gob.NewEncoder(&buf).Encode(n.toIntermediate())
-	return buf.Bytes(), err
-}
-
-// GobDecode implements gob.Unmarshaller
-func (n *PluginSpecs) GobDecode(input []byte) error {
-	in := []PluginSpec{}
-	if err := gob.NewDecoder(bytes.NewBuffer(input)).Decode(&in); err != nil {
-		return err
-	}
-	*n = PluginSpecs{}.fromIntermediate(in)
-	return nil
 }
 
 // PluginSpecsByID implements sort.Interface, so we can sort the specs by the

--- a/extras/generate_latest_map
+++ b/extras/generate_latest_map
@@ -155,23 +155,11 @@ function generate_latest_map() {
         })
     }
 
-    func (m ${latest_map_type}) toIntermediate() map[string]${entry_type} {
-        intermediate := make(map[string]${entry_type}, m.Size())
-        if m.Map != nil {
-	        m.Map.ForEach(func(key string, val interface{}) {
-		        intermediate[key] = *val.(*${entry_type})
-	        })
-        }
-        return intermediate
-    }
-
     // CodecEncodeSelf implements codec.Selfer.
     func (m *${latest_map_type}) CodecEncodeSelf(encoder *codec.Encoder) {
-        if m.Map != nil {
-	        encoder.Encode(m.toIntermediate())
-        } else {
-	        encoder.Encode(nil)
-        }
+        mapWrite(m.Map, encoder, func(encoder *codec.Encoder, val interface{}) {
+            val.(*${entry_type}).CodecEncodeSelf(encoder)
+        })
     }
 
     // CodecDecodeSelf implements codec.Selfer.

--- a/report/counters.go
+++ b/report/counters.go
@@ -2,7 +2,6 @@ package report
 
 import (
 	"bytes"
-	"encoding/gob"
 	"fmt"
 	"reflect"
 	"sort"
@@ -137,14 +136,6 @@ func (c Counters) DeepEqual(d Counters) bool {
 	return equal
 }
 
-func (c Counters) toIntermediate() map[string]int {
-	intermediate := map[string]int{}
-	c.ForEach(func(key string, val int) {
-		intermediate[key] = val
-	})
-	return intermediate
-}
-
 func (c Counters) fromIntermediate(in map[string]int) Counters {
 	out := ps.NewMap()
 	for k, v := range in {
@@ -181,21 +172,4 @@ func (Counters) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON shouldn't be used, use CodecDecodeSelf instead
 func (*Counters) UnmarshalJSON(b []byte) error {
 	panic("UnmarshalJSON shouldn't be used, use CodecDecodeSelf instead")
-}
-
-// GobEncode implements gob.Marshaller
-func (c Counters) GobEncode() ([]byte, error) {
-	buf := bytes.Buffer{}
-	err := gob.NewEncoder(&buf).Encode(c.toIntermediate())
-	return buf.Bytes(), err
-}
-
-// GobDecode implements gob.Unmarshaller
-func (c *Counters) GobDecode(input []byte) error {
-	in := map[string]int{}
-	if err := gob.NewDecoder(bytes.NewBuffer(input)).Decode(&in); err != nil {
-		return err
-	}
-	*c = Counters{}.fromIntermediate(in)
-	return nil
 }

--- a/report/counters.go
+++ b/report/counters.go
@@ -155,7 +155,10 @@ func (c Counters) fromIntermediate(in map[string]int) Counters {
 
 // CodecEncodeSelf implements codec.Selfer
 func (c *Counters) CodecEncodeSelf(encoder *codec.Encoder) {
-	encoder.Encode(c.toIntermediate())
+	mapWrite(c.psMap, encoder, func(encoder *codec.Encoder, val interface{}) {
+		i := val.(int)
+		encoder.Encode(i)
+	})
 }
 
 // CodecDecodeSelf implements codec.Selfer

--- a/report/counters_internal_test.go
+++ b/report/counters_internal_test.go
@@ -102,18 +102,6 @@ func TestCountersEncoding(t *testing.T) {
 		Add("bar", 2)
 
 	{
-		gobs, err := want.GobEncode()
-		if err != nil {
-			t.Fatal(err)
-		}
-		have := EmptyCounters
-		have.GobDecode(gobs)
-		if !reflect.DeepEqual(want, have) {
-			t.Error(test.Diff(want, have))
-		}
-	}
-
-	{
 
 		for _, h := range []codec.Handle{
 			codec.Handle(&codec.MsgpackHandle{}),

--- a/report/edge_metadatas.go
+++ b/report/edge_metadatas.go
@@ -168,11 +168,10 @@ func (c EdgeMetadatas) fromIntermediate(in map[string]EdgeMetadata) EdgeMetadata
 
 // CodecEncodeSelf implements codec.Selfer
 func (c *EdgeMetadatas) CodecEncodeSelf(encoder *codec.Encoder) {
-	if c.psMap != nil {
-		encoder.Encode(c.toIntermediate())
-	} else {
-		encoder.Encode(nil)
-	}
+	mapWrite(c.psMap, encoder, func(encoder *codec.Encoder, val interface{}) {
+		e := val.(EdgeMetadata)
+		(&e).CodecEncodeSelf(encoder)
+	})
 }
 
 // CodecDecodeSelf implements codec.Selfer

--- a/report/edge_metadatas.go
+++ b/report/edge_metadatas.go
@@ -2,7 +2,6 @@ package report
 
 import (
 	"bytes"
-	"encoding/gob"
 	"fmt"
 	"reflect"
 	"sort"
@@ -148,24 +147,6 @@ func (c EdgeMetadatas) DeepEqual(d EdgeMetadatas) bool {
 	return equal
 }
 
-func (c EdgeMetadatas) toIntermediate() map[string]EdgeMetadata {
-	intermediate := map[string]EdgeMetadata{}
-	if c.psMap != nil {
-		c.psMap.ForEach(func(key string, val interface{}) {
-			intermediate[key] = val.(EdgeMetadata)
-		})
-	}
-	return intermediate
-}
-
-func (c EdgeMetadatas) fromIntermediate(in map[string]EdgeMetadata) EdgeMetadatas {
-	out := ps.NewMap()
-	for k, v := range in {
-		out = out.Set(k, v)
-	}
-	return EdgeMetadatas{out}
-}
-
 // CodecEncodeSelf implements codec.Selfer
 func (c *EdgeMetadatas) CodecEncodeSelf(encoder *codec.Encoder) {
 	mapWrite(c.psMap, encoder, func(encoder *codec.Encoder, val interface{}) {
@@ -194,23 +175,6 @@ func (EdgeMetadatas) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON shouldn't be used, use CodecDecodeSelf instead
 func (*EdgeMetadatas) UnmarshalJSON(b []byte) error {
 	panic("UnmarshalJSON shouldn't be used, use CodecDecodeSelf instead")
-}
-
-// GobEncode implements gob.Marshaller
-func (c EdgeMetadatas) GobEncode() ([]byte, error) {
-	buf := bytes.Buffer{}
-	err := gob.NewEncoder(&buf).Encode(c.toIntermediate())
-	return buf.Bytes(), err
-}
-
-// GobDecode implements gob.Unmarshaller
-func (c *EdgeMetadatas) GobDecode(input []byte) error {
-	in := map[string]EdgeMetadata{}
-	if err := gob.NewDecoder(bytes.NewBuffer(input)).Decode(&in); err != nil {
-		return err
-	}
-	*c = EdgeMetadatas{}.fromIntermediate(in)
-	return nil
 }
 
 // EdgeMetadata describes a superset of the metadata that probes can possibly

--- a/report/edge_metadatas_internal_test.go
+++ b/report/edge_metadatas_internal_test.go
@@ -215,18 +215,6 @@ func TestEdgeMetadatasEncoding(t *testing.T) {
 		})
 
 	{
-		gobs, err := want.GobEncode()
-		if err != nil {
-			t.Fatal(err)
-		}
-		have := EmptyEdgeMetadatas
-		have.GobDecode(gobs)
-		if !reflect.DeepEqual(want, have) {
-			t.Error(test.Diff(want, have))
-		}
-	}
-
-	{
 		for _, h := range []codec.Handle{
 			codec.Handle(&codec.MsgpackHandle{}),
 			codec.Handle(&codec.JsonHandle{}),
@@ -246,18 +234,6 @@ func TestEdgeMetadatasEncoding(t *testing.T) {
 
 func TestEdgeMetadatasEncodingNil(t *testing.T) {
 	want := EdgeMetadatas{}
-
-	{
-		gobs, err := want.GobEncode()
-		if err != nil {
-			t.Fatal(err)
-		}
-		have := EmptyEdgeMetadatas
-		have.GobDecode(gobs)
-		if have.psMap == nil {
-			t.Error("needed to get back a non-nil psMap for EdgeMetadata")
-		}
-	}
 
 	{
 

--- a/report/latest_map_generated.go
+++ b/report/latest_map_generated.go
@@ -122,23 +122,11 @@ func (m StringLatestMap) DeepEqual(n StringLatestMap) bool {
 	})
 }
 
-func (m StringLatestMap) toIntermediate() map[string]stringLatestEntry {
-	intermediate := make(map[string]stringLatestEntry, m.Size())
-	if m.Map != nil {
-		m.Map.ForEach(func(key string, val interface{}) {
-			intermediate[key] = *val.(*stringLatestEntry)
-		})
-	}
-	return intermediate
-}
-
 // CodecEncodeSelf implements codec.Selfer.
 func (m *StringLatestMap) CodecEncodeSelf(encoder *codec.Encoder) {
-	if m.Map != nil {
-		encoder.Encode(m.toIntermediate())
-	} else {
-		encoder.Encode(nil)
-	}
+	mapWrite(m.Map, encoder, func(encoder *codec.Encoder, val interface{}) {
+		val.(*stringLatestEntry).CodecEncodeSelf(encoder)
+	})
 }
 
 // CodecDecodeSelf implements codec.Selfer.
@@ -274,23 +262,11 @@ func (m NodeControlDataLatestMap) DeepEqual(n NodeControlDataLatestMap) bool {
 	})
 }
 
-func (m NodeControlDataLatestMap) toIntermediate() map[string]nodeControlDataLatestEntry {
-	intermediate := make(map[string]nodeControlDataLatestEntry, m.Size())
-	if m.Map != nil {
-		m.Map.ForEach(func(key string, val interface{}) {
-			intermediate[key] = *val.(*nodeControlDataLatestEntry)
-		})
-	}
-	return intermediate
-}
-
 // CodecEncodeSelf implements codec.Selfer.
 func (m *NodeControlDataLatestMap) CodecEncodeSelf(encoder *codec.Encoder) {
-	if m.Map != nil {
-		encoder.Encode(m.toIntermediate())
-	} else {
-		encoder.Encode(nil)
-	}
+	mapWrite(m.Map, encoder, func(encoder *codec.Encoder, val interface{}) {
+		val.(*nodeControlDataLatestEntry).CodecEncodeSelf(encoder)
+	})
 }
 
 // CodecDecodeSelf implements codec.Selfer.

--- a/report/marshal.go
+++ b/report/marshal.go
@@ -17,6 +17,10 @@ func (s *dummySelfer) CodecDecodeSelf(decoder *codec.Decoder) {
 	panic("This shouldn't happen: perhaps something has gone wrong in code generation?")
 }
 
+func (s *dummySelfer) CodecEncodeSelf(encoder *codec.Encoder) {
+	panic("This shouldn't happen: perhaps something has gone wrong in code generation?")
+}
+
 // WriteBinary writes a Report as a gzipped msgpack.
 func (rep Report) WriteBinary(w io.Writer, compressionLevel int) error {
 	gzwriter, err := gzip.NewWriterLevel(w, compressionLevel)

--- a/report/node_set.go
+++ b/report/node_set.go
@@ -2,7 +2,6 @@ package report
 
 import (
 	"bytes"
-	"encoding/gob"
 	"fmt"
 	"sort"
 
@@ -205,21 +204,4 @@ func (NodeSet) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON shouldn't be used, use CodecDecodeSelf instead
 func (*NodeSet) UnmarshalJSON(b []byte) error {
 	panic("UnmarshalJSON shouldn't be used, use CodecDecodeSelf instead")
-}
-
-// GobEncode implements gob.Marshaller
-func (n NodeSet) GobEncode() ([]byte, error) {
-	buf := bytes.Buffer{}
-	err := gob.NewEncoder(&buf).Encode(n.toIntermediate())
-	return buf.Bytes(), err
-}
-
-// GobDecode implements gob.Unmarshaller
-func (n *NodeSet) GobDecode(input []byte) error {
-	in := []Node{}
-	if err := gob.NewDecoder(bytes.NewBuffer(input)).Decode(&in); err != nil {
-		return err
-	}
-	*n = NodeSet{}.fromIntermediate(in)
-	return nil
 }

--- a/report/sets.go
+++ b/report/sets.go
@@ -168,11 +168,9 @@ func (s Sets) fromIntermediate(in map[string]StringSet) Sets {
 
 // CodecEncodeSelf implements codec.Selfer
 func (s *Sets) CodecEncodeSelf(encoder *codec.Encoder) {
-	if s.psMap != nil {
-		encoder.Encode(s.toIntermediate())
-	} else {
-		encoder.Encode(nil)
-	}
+	mapWrite(s.psMap, encoder, func(encoder *codec.Encoder, val interface{}) {
+		encoder.Encode(val.(StringSet))
+	})
 }
 
 // CodecDecodeSelf implements codec.Selfer

--- a/report/sets.go
+++ b/report/sets.go
@@ -2,7 +2,6 @@ package report
 
 import (
 	"bytes"
-	"encoding/gob"
 	"fmt"
 	"reflect"
 	"sort"
@@ -148,24 +147,6 @@ func (s Sets) DeepEqual(t Sets) bool {
 	return equal
 }
 
-func (s Sets) toIntermediate() map[string]StringSet {
-	intermediate := map[string]StringSet{}
-	if s.psMap != nil {
-		s.psMap.ForEach(func(key string, val interface{}) {
-			intermediate[key] = val.(StringSet)
-		})
-	}
-	return intermediate
-}
-
-func (s Sets) fromIntermediate(in map[string]StringSet) Sets {
-	out := ps.NewMap()
-	for k, v := range in {
-		out = out.Set(k, v)
-	}
-	return Sets{out}
-}
-
 // CodecEncodeSelf implements codec.Selfer
 func (s *Sets) CodecEncodeSelf(encoder *codec.Encoder) {
 	mapWrite(s.psMap, encoder, func(encoder *codec.Encoder, val interface{}) {
@@ -193,21 +174,4 @@ func (Sets) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON shouldn't be used, use CodecDecodeSelf instead
 func (*Sets) UnmarshalJSON(b []byte) error {
 	panic("UnmarshalJSON shouldn't be used, use CodecDecodeSelf instead")
-}
-
-// GobEncode implements gob.Marshaller
-func (s Sets) GobEncode() ([]byte, error) {
-	buf := bytes.Buffer{}
-	err := gob.NewEncoder(&buf).Encode(s.toIntermediate())
-	return buf.Bytes(), err
-}
-
-// GobDecode implements gob.Unmarshaller
-func (s *Sets) GobDecode(input []byte) error {
-	in := map[string]StringSet{}
-	if err := gob.NewDecoder(bytes.NewBuffer(input)).Decode(&in); err != nil {
-		return err
-	}
-	*s = Sets{}.fromIntermediate(in)
-	return nil
 }


### PR DESCRIPTION
There is a big performance improvement from sending the data directly rather than creating an intermediate data structure.

Before:
```
vagrant-ubuntu-wily-64:~/.../weaveworks/scope/report$ go test -cpu=1 -run=EncodeSpeed
ok  	github.com/weaveworks/scope/report	3.978s
ok  	github.com/weaveworks/scope/report	4.035s
ok  	github.com/weaveworks/scope/report	3.945s
ok  	github.com/weaveworks/scope/report	4.184s
```
After:
```
ok  	github.com/weaveworks/scope/report	1.951s
ok  	github.com/weaveworks/scope/report	1.934s
ok  	github.com/weaveworks/scope/report	1.971s
ok  	github.com/weaveworks/scope/report	1.970s
```

1.934/3.945=49%

Test program:

```
func TestEncodeSpeed(t *testing.T) {
	b, _ := ioutil.ReadFile("fixed.msgpack")
	r := Report{}
	d := codec.NewDecoderBytes(b, &codec.MsgpackHandle{})
	d.Decode(&r)
	for i := 0; i < 100; i++ {
		buf := &bytes.Buffer{}
		codec.NewEncoder(buf, &codec.MsgpackHandle{}).Encode(&r)
	}
}
```

