### PR TITLE
Fixed view mode switching keyboard shortcuts

### DIFF
--- a/client/app/scripts/components/app.js
+++ b/client/app/scripts/components/app.js
@@ -12,8 +12,20 @@ import Status from './status';
 import Topologies from './topologies';
 import TopologyOptions from './topology-options';
 import { getApiDetails, getTopologies } from '../utils/web-api-utils';
-import { focusSearch, pinNextMetric, hitBackspace, hitEnter, hitEsc, unpinMetric,
-  selectMetric, toggleHelp, toggleGridMode, shutdown } from '../actions/app-actions';
+import {
+  focusSearch,
+  pinNextMetric,
+  hitBackspace,
+  hitEnter,
+  hitEsc,
+  unpinMetric,
+  selectMetric,
+  toggleHelp,
+  setGraphView,
+  setTableView,
+  setResourceView,
+  shutdown
+} from '../actions/app-actions';
 import Details from './details';
 import Nodes from './nodes';
 import ViewModeSelector from './view-mode-selector';
@@ -92,8 +104,12 @@ class App extends React.Component {
         dispatch(pinNextMetric(-1));
       } else if (char === '>') {
         dispatch(pinNextMetric(1));
-      } else if (char === 't' || char === 'g') {
-        dispatch(toggleGridMode());
+      } else if (char === 'g') {
+        dispatch(setGraphView());
+      } else if (char === 't') {
+        dispatch(setTableView());
+      } else if (char === 'r') {
+        dispatch(setResourceView());
       } else if (char === 'q') {
         dispatch(unpinMetric());
         dispatch(selectMetric(null));

--- a/client/app/scripts/components/help-panel.js
+++ b/client/app/scripts/components/help-panel.js
@@ -10,8 +10,9 @@ const GENERAL_SHORTCUTS = [
   {key: 'esc', label: 'Close active panel'},
   {key: '/', label: 'Activate search field'},
   {key: '?', label: 'Toggle shortcut menu'},
-  {key: 't', label: 'Toggle Table mode'},
-  {key: 'g', label: 'Toggle Graph mode'},
+  {key: 'g', label: 'Switch to Graph view'},
+  {key: 't', label: 'Switch to Table view'},
+  {key: 'r', label: 'Switch to Resources view'},
 ];
 
 

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -1638,7 +1638,7 @@
         box-shadow: inset 0 -1px 0 #bbb;
       }
       div.key {
-        width: 80px;
+        width: 60px;
         display: inline-block;
       }
       div.label {


### PR DESCRIPTION
Fixes #2470 and introduces the following keyboard shortcuts:

<kbd>g</kbd> - switch to graph layout
<kbd>t</kbd> - switch to table layout
<kbd>r</kbd> - switch to resource layout

All of them do nothing if we're already in that layout (as toggling doesn't make sense now that there are 3 different modes).
