### PR TITLE
only lint files in git ls-files, not .git/*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ tests: $(SCOPE_BACKEND_BUILD_UPTODATE) $(CODECGEN_TARGETS)
 	./tools/test -no-go-get
 
 lint: $(SCOPE_BACKEND_BUILD_UPTODATE)
-	./tools/lint -ignorespelling "agre " -ignorespelling "AGRE " .
+	./tools/lint
 	./tools/shell-lint tools
 
 prog/staticui/staticui.go: $(SCOPE_BACKEND_BUILD_UPTODATE)


### PR DESCRIPTION
Fixes #2269 ("inspired" by https://github.com/weaveworks/service-conf/pull/796 )