### PR TITLE
Please Review: added search type variable

### DIFF
--- a/site/.project
+++ b/site/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Scope-Docs</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/site/ami.md
+++ b/site/ami.md
@@ -1,6 +1,7 @@
 ---
 title: Weaveworks ECS AMIs
 menu_order: 25
+search_type: Documentation
 ---
 
 

--- a/site/building.md
+++ b/site/building.md
@@ -1,6 +1,7 @@
 ---
 title: Developing and Debugging
 menu_order: 90
+search_type: Documentation
 ---
 
 The following topics are discussed:

--- a/site/features.md
+++ b/site/features.md
@@ -1,6 +1,7 @@
 ---
 title: Feature Overview
 menu_order: 15
+search_type: Documentation
 ---
 
 Browse the current feature set for Scope with links to relevant indepth topics:

--- a/site/how-it-works.md
+++ b/site/how-it-works.md
@@ -1,6 +1,7 @@
 ---
 title: Understanding Weave Scope
 menu_order: 70
+search_type: Documentation
 ---
 
 The following topics are discussed:

--- a/site/installing.md
+++ b/site/installing.md
@@ -1,6 +1,7 @@
 ---
 title: Installing Weave Scope
 menu_order: 20
+search_type: Documentation
 ---
 
 

--- a/site/introducing.md
+++ b/site/introducing.md
@@ -1,6 +1,7 @@
 ---
 title: Introducing Weave Scope
 menu_order: 10
+search_type: Documentation
 ---
 
 

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -1,6 +1,7 @@
 ---
 title: Generating Custom Metrics with Plugins
 menu_order: 80
+search_type: Documentation
 ---
 
 The following topics are discussed:


### PR DESCRIPTION
Added `search_type: Documentation` as a first step for search in the new site.  This variable groups all documentation type content together. 

@2opremio please check that I haven't gaffe'ed anything.  