### PR TITLE
Fix arrow heads positioning

### DIFF
--- a/client/app/scripts/charts/edge-container.js
+++ b/client/app/scripts/charts/edge-container.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Motion, spring } from 'react-motion';
 import { Map as makeMap } from 'immutable';
 import { line, curveBasis } from 'd3-shape';
-import { each, omit, times } from 'lodash';
+import { each, omit, times, constant } from 'lodash';
 
 import { NODES_SPRING_ANIMATION_CONFIG } from '../constants/animation';
 import { EDGE_WAYPOINTS_CAP } from '../constants/styles';
@@ -18,17 +18,27 @@ const transformedEdge = (props, path) => (
   <Edge {...props} path={spline(path)} />
 );
 
-// Converts a waypoints map of the format {x0: 11, y0: 22, x1: 33, y1: 44}
+// Converts a waypoints map of the format { x0: 11, y0: 22, x1: 33, y1: 44 }
 // that is used by Motion to an array of waypoints in the format
-// [{x: 11, y: 22}, {x: 33, y: 44}] that can be used by D3.
+// [{ x: 11, y: 22 }, { x: 33, y: 44 }] that can be used by D3.
 const waypointsMapToArray = (waypointsMap) => {
-  const waypointsCount = Object.keys(waypointsMap).length / 2;
-  const waypointsArray = times(waypointsCount, () => ({ x: 0, y: 0 }));
+  const waypointsArray = times(EDGE_WAYPOINTS_CAP, () => ({}));
   each(waypointsMap, (value, key) => {
     const [axis, index] = [key[0], key.slice(1)];
     waypointsArray[index][axis] = value;
   });
   return waypointsArray;
+};
+
+// Converts a waypoints array of the input format [{ x: 11, y: 22 }, { x: 33, y: 44 }]
+// to an array of waypoints that is used by Motion in the format { x0: 11, y0: 22, x1: 33, y1: 44 }.
+const waypointsArrayToMap = (waypointsArray) => {
+  let waypointsMap = makeMap();
+  waypointsArray.forEach((point, index) => {
+    waypointsMap = waypointsMap.set(`x${index}`, spring(point.x, NODES_SPRING_ANIMATION_CONFIG));
+    waypointsMap = waypointsMap.set(`y${index}`, spring(point.y, NODES_SPRING_ANIMATION_CONFIG));
+  });
+  return waypointsMap;
 };
 
 
@@ -61,24 +71,24 @@ export default class EdgeContainer extends React.PureComponent {
 
     return (
       // For the Motion interpolation to work, the waypoints need to be in a map format like
-      // {x0: 11, y0: 22, x1: 33, y1: 44} that we convert to the array format when rendering.
+      // { x0: 11, y0: 22, x1: 33, y1: 44 } that we convert to the array format when rendering.
       <Motion style={this.state.waypointsMap.toJS()}>
         {interpolated => transformedEdge(forwardedProps, waypointsMapToArray(interpolated))}
       </Motion>
     );
   }
 
-  prepareWaypointsForMotion(nextWaypoints) {
-    while (nextWaypoints.size < EDGE_WAYPOINTS_CAP) {
-      nextWaypoints = nextWaypoints.insert(0, nextWaypoints.first());
+  prepareWaypointsForMotion(waypoints) {
+    waypoints = waypoints.toJS();
+
+    // The Motion library requires the number of waypoints to be constant, so we fill in for
+    // the missing ones by reusing the edge source point, which doesn't affect the edge shape
+    // because of how the curveBasis interpolation is done.
+    const waypointsMissing = EDGE_WAYPOINTS_CAP - waypoints.length;
+    if (waypointsMissing > 0) {
+      waypoints = times(waypointsMissing, constant(waypoints[0])).concat(waypoints);
     }
 
-    let { waypointsMap } = this.state;
-    nextWaypoints.toJS().forEach((point, index) => {
-      waypointsMap = waypointsMap.set(`x${index}`, spring(point.x, NODES_SPRING_ANIMATION_CONFIG));
-      waypointsMap = waypointsMap.set(`y${index}`, spring(point.y, NODES_SPRING_ANIMATION_CONFIG));
-    });
-
-    this.setState({ waypointsMap });
+    this.setState({ waypointsMap: waypointsArrayToMap(waypoints) });
   }
 }

--- a/client/app/scripts/constants/styles.js
+++ b/client/app/scripts/constants/styles.js
@@ -31,6 +31,11 @@ export const UNIT_CLOUD_PATH = 'M-1.25 0.233Q-1.25 0.44-1.104 0.587-0.957 0.733-
 //      are given on a small unit scale as foreign objects in SVG.
 export const NODE_BASE_SIZE = 100;
 
+// Tweak this value for the number of control
+// points along the edge curve, e.g. values:
+//   * 2 -> edges are simply straight lines
+//   * 4 -> minimal value for loops to look ok
+export const EDGE_WAYPOINTS_CAP = 10;
 
 export const CANVAS_MARGINS = {
   [GRAPH_VIEW_MODE]: { top: 160, left: 40, right: 40, bottom: 150 },

--- a/client/app/scripts/constants/styles.js
+++ b/client/app/scripts/constants/styles.js
@@ -31,10 +31,10 @@ export const UNIT_CLOUD_PATH = 'M-1.25 0.233Q-1.25 0.44-1.104 0.587-0.957 0.733-
 //      are given on a small unit scale as foreign objects in SVG.
 export const NODE_BASE_SIZE = 100;
 
-// Tweak this value for the number of control
-// points along the edge curve, e.g. values:
-//   * 2 -> edges are simply straight lines
-//   * 4 -> minimal value for loops to look ok
+// This value represents the upper bound on the number of control points along the graph edge
+// curve. Any integer value >= 6 should result in valid edges, but generally the greater this
+// value is, the nicer the edge bundling will be. On the other hand, big values would result
+// in slower rendering of the graph.
 export const EDGE_WAYPOINTS_CAP = 10;
 
 export const CANVAS_MARGINS = {


### PR DESCRIPTION
Fixes #2328 in two steps:

* For edges that are not loops, we're now adding two new endpoints instead of overriding the existing ones, so that the edges enter the nodes in a more *tangential* manner as opposed to having a high curvature.
* Also increased the layout engine's perceived `NODE_SIZE_FACTOR` slightly to the same effect.

Before:
![arr-prev](https://cloud.githubusercontent.com/assets/1216874/25813023/70815a74-3418-11e7-946a-afea6a67e848.png)

Now:
![arr-now](https://cloud.githubusercontent.com/assets/1216874/25813003/62048de0-3418-11e7-96fe-c0856f3a61bc.png)
