### PR TITLE
api_topologies: Don't put namespace filters on containers-by-dns/image

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -89,7 +89,7 @@ func updateSwarmFilters(rpt report.Report, topologies []APITopologyDesc) []APITo
 	}
 	topologies = append([]APITopologyDesc{}, topologies...) // Make a copy so we can make changes safely
 	for i, t := range topologies {
-		if t.id == containersID || t.id == containersByImageID || t.id == containersByHostnameID || t.id == swarmServicesID {
+		if t.id == containersID || t.id == swarmServicesID {
 			topologies[i] = mergeTopologyFilters(t, []APITopologyOptionGroup{
 				namespaceFilters(ns, docker.DefaultNamespace, "All Stacks"),
 			})
@@ -122,7 +122,7 @@ func updateKubeFilters(rpt report.Report, topologies []APITopologyDesc) []APITop
 	sort.Strings(ns)
 	topologies = append([]APITopologyDesc{}, topologies...) // Make a copy so we can make changes safely
 	for i, t := range topologies {
-		if t.id == containersID || t.id == containersByImageID || t.id == containersByHostnameID || t.id == podsID || t.id == servicesID || t.id == deploymentsID || t.id == replicaSetsID {
+		if t.id == containersID || t.id == podsID || t.id == servicesID || t.id == deploymentsID || t.id == replicaSetsID {
 			topologies[i] = mergeTopologyFilters(t, []APITopologyOptionGroup{
 				namespaceFilters(ns, "default", "All Namespaces"),
 			})


### PR DESCRIPTION
This should never have been added. The IsNamespace filter will always return false for these nodes.
It isn't even clear what this filter would mean, even if implemented, since those nodes don't map to a single
container and therefore not to a single namespace.

This bug was introduced in https://github.com/weaveworks/scope/pull/2285 and is very problematic
because it means the default view on those topologies is blank if the 'default' k8s namespace is present.