### PR TITLE
ebpf connection tracker: perf map fixes

### DIFF
--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -82,7 +82,7 @@ func newEbpfTracker() (eventTracker, error) {
 		return nil, fmt.Errorf("kernel not supported: %v", err)
 	}
 
-	t, err := tracer.NewTracer(tcpEventCbV4, tcpEventCbV6)
+	t, err := tracer.NewTracer(tcpEventCbV4, tcpEventCbV6, lostCb)
 	if err != nil {
 		return nil, err
 	}
@@ -117,6 +117,12 @@ func tcpEventCbV4(e tracer.TcpV4) {
 
 func tcpEventCbV6(e tracer.TcpV6) {
 	// TODO: IPv6 not supported in Scope
+}
+
+func lostCb(count uint64) {
+	log.Errorf("tcp tracer lost %d events. Stopping the eBPF tracker", count)
+	ebpfTracker.dead = true
+	ebpfTracker.stop()
 }
 
 func (t *EbpfTracker) handleConnection(ev tracer.EventType, tuple fourTuple, pid int, networkNamespace string) {

--- a/vendor/github.com/iovisor/gobpf/elf/elf_unsupported.go
+++ b/vendor/github.com/iovisor/gobpf/elf/elf_unsupported.go
@@ -6,12 +6,13 @@ import (
 	"fmt"
 )
 
-func (b *Module) Load() error {
-	return fmt.Errorf("not supported")
-}
-
 // not supported; dummy struct
 type BPFKProbePerf struct{}
+type SectionParams struct{}
+
+func (b *Module) Load(parameters map[string]SectionParams) error {
+	return fmt.Errorf("not supported")
+}
 
 func NewBpfPerfEvent(fileName string) *BPFKProbePerf {
 	// not supported
@@ -22,7 +23,7 @@ func (b *BPFKProbePerf) Load() error {
 	return fmt.Errorf("not supported")
 }
 
-func (b *BPFKProbePerf) PollStart(mapName string, receiverChan chan []byte) {
+func (b *BPFKProbePerf) PollStart(mapName string, receiverChan chan []byte, lostChan chan uint64) {
 	// not supported
 	return
 }

--- a/vendor/github.com/iovisor/gobpf/elf/table.go
+++ b/vendor/github.com/iovisor/gobpf/elf/table.go
@@ -106,3 +106,28 @@ func (b *Module) LookupElement(mp *Map, key, value unsafe.Pointer) error {
 
 	return nil
 }
+
+// DeleteElement deletes the given key in the the map stored in mp.
+// The key is stored in the key unsafe.Pointer.
+func (b *Module) DeleteElement(mp *Map, key unsafe.Pointer) error {
+	uba := C.union_bpf_attr{}
+	value := unsafe.Pointer(nil)
+	C.create_bpf_lookup_elem(
+		C.int(mp.m.fd),
+		key,
+		value,
+		unsafe.Pointer(&uba),
+	)
+	ret, _, err := syscall.Syscall(
+		C.__NR_bpf,
+		C.BPF_MAP_DELETE_ELEM,
+		uintptr(unsafe.Pointer(&uba)),
+		unsafe.Sizeof(uba),
+	)
+
+	if ret != 0 || err != 0 {
+		return fmt.Errorf("unable to delete element: %s", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/weaveworks/tcptracer-bpf/pkg/tracer/tracer_unsupported.go
+++ b/vendor/github.com/weaveworks/tcptracer-bpf/pkg/tracer/tracer_unsupported.go
@@ -12,7 +12,7 @@ func TracerAsset() ([]byte, error) {
 	return nil, fmt.Errorf("not supported on non-Linux systems")
 }
 
-func NewTracer(tcpEventCbV4 func(TcpV4), tcpEventCbV6 func(TcpV6)) (*Tracer, error) {
+func NewTracer(tcpEventCbV4 func(TcpV4), tcpEventCbV6 func(TcpV6), lostCb func(lost uint64)) (*Tracer, error) {
 	return nil, fmt.Errorf("not supported on non-Linux systems")
 }
 

--- a/vendor/github.com/weaveworks/tcptracer-bpf/tests/tracer.go
+++ b/vendor/github.com/weaveworks/tcptracer-bpf/tests/tracer.go
@@ -35,13 +35,18 @@ func tcpEventCbV6(e tracer.TcpV6) {
 	lastTimestampV6 = e.Timestamp
 }
 
+func lostCb(count uint64) {
+	fmt.Printf("ERROR: lost %d events!\n", count)
+	os.Exit(1)
+}
+
 func main() {
 	if len(os.Args) != 1 {
 		fmt.Fprintf(os.Stderr, "Usage: %s\n", os.Args[0])
 		os.Exit(1)
 	}
 
-	t, err := tracer.NewTracer(tcpEventCbV4, tcpEventCbV6)
+	t, err := tracer.NewTracer(tcpEventCbV4, tcpEventCbV6, lostCb)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -1020,7 +1020,7 @@
 			"importpath": "github.com/iovisor/gobpf/elf",
 			"repository": "https://github.com/iovisor/gobpf",
 			"vcs": "git",
-			"revision": "65e4048660d6c4339ebae113ac55b1af6f01305d",
+			"revision": "23f7ee81c1cc244d16ddc8110c2ec8b8a09d0448",
 			"branch": "master",
 			"path": "/elf",
 			"notests": true
@@ -1462,7 +1462,7 @@
 			"importpath": "github.com/weaveworks/tcptracer-bpf",
 			"repository": "https://github.com/weaveworks/tcptracer-bpf",
 			"vcs": "git",
-			"revision": "b715a3b635b8d9c4a096bbd6009826b57fe64c38",
+			"revision": "a82fffdbfee2ffe2c469279dbfeb3734cf7de1f2",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
This adds fixes in the perf map that receives the tcp events from the ebpf probes:
- gobpf: use the correct timestamp function instead of assuming the timestamp is at offset zero in the struct
- gobpf: fix loop on events that could drop events
- gobpf: add a go channel to notify lost events
- gobpf: make the size of the ring buffers configurable instead of using 8 page (32KB)
- tcptracer-bpf: change the size of the ring buffer "maps/tcp_event_ipv4" to 256 pages (1MB)
- tcptracer-bpf: use the go channel to notify lost events
- scope: add a callback on lost events: log the error and stop the ebpf tracker correctly. So if it ever happens, we will know about it.

This is to address the address the following failure that happened a few weeks ago:
```
<probe> ERRO: 2017/04/13 07:34:17.299127 tcp tracer received event with timestamp 677884430530033 even though the last timestamp was 677884430530738. Stopping the eBPF tracker.
<probe> WARN: 2017/04/13 07:34:17.337241 ebpf tracker died, gently falling back to proc scanning
```

-----

This is a "work in progress" because this is vendoring unmerged branches in gobpf and tcptracer-bpf.
- [x] https://github.com/iovisor/gobpf/pull/43
- [x] https://github.com/iovisor/gobpf/pull/44
- [x] https://github.com/weaveworks/tcptracer-bpf/pull/37

-----

I tried to reduce the size of the perf ring buffers to one page (4KB) in order to test it. I made lots of connections in parallel in 4 terminals (but on the same cpu to stress one perf ring buffer):

```
for i in $(seq 1 10000) ; do echo -n "$i " ; taskset --cpu-list 2 wget -O /dev/null http://172.17.0.2 2>/dev/null; done
```

Then, I checked that the fallback worked correctly:
```
<probe> ERRO: 2017/05/09 09:17:40.798823 tcp tracer lost 7 events. Stopping the eBPF tracker
<probe> WARN: 2017/05/09 09:17:41.701317 ebpf tracker died, gently falling back to proc scanning
```

-----

/cc @iaguis @2opremio 