### PR TITLE
Avoid null dereferences in ECS client (encore)

### DIFF
--- a/probe/awsecs/client.go
+++ b/probe/awsecs/client.go
@@ -209,7 +209,9 @@ func (c ecsClientImpl) describeServicesBatch(names []string) {
 	}
 
 	for _, service := range resp.Services {
-		c.serviceCache.Set(*service.ServiceName, newECSService(service))
+		if service != nil {
+			c.serviceCache.Set(*service.ServiceName, newECSService(service))
+		}
 	}
 }
 


### PR DESCRIPTION
Leftover from #2514 

Part of #2508 