### PR TITLE
Breaking out some Azure-based services from "The Internet" (#1876)

### DIFF
--- a/render/theinternet.go
+++ b/render/theinternet.go
@@ -17,6 +17,13 @@ var (
 		// details
 		regexp.MustCompile(`^.+\.amazonaws\.com$`),
 		regexp.MustCompile(`^.+\.googleapis\.com$`),
+		regexp.MustCompile(`^.+\.core\.windows\.net$`),	// Azure Storage - Blob, Tables, Files & Queues
+		regexp.MustCompile(`^.+\.servicebus\.windows\.net$`),// Azure Service Bus
+		regexp.MustCompile(`^.+\.azure-api\.net$`), // Azure API Management
+		regexp.MustCompile(`^.+\.onmicrosoft\.com$`), // Azure Active Directory
+		regexp.MustCompile(`^.+\.cloudapp\.azure\.com$`),	// Azure IaaS
+		regexp.MustCompile(`^.+\.database\.windows\.net$`),	// Azure SQL DB
+		regexp.MustCompile(`^.+\.documents\.azure\.com$`),	// Azure DocumentDB/CosmosDB
 	}
 
 	knownServiceExcluders = []*regexp.Regexp{

--- a/render/theinternet.go
+++ b/render/theinternet.go
@@ -17,13 +17,13 @@ var (
 		// details
 		regexp.MustCompile(`^.+\.amazonaws\.com$`),
 		regexp.MustCompile(`^.+\.googleapis\.com$`),
-		regexp.MustCompile(`^.+\.core\.windows\.net$`),	// Azure Storage - Blob, Tables, Files & Queues
+		regexp.MustCompile(`^.+\.core\.windows\.net$`),       // Azure Storage - Blob, Tables, Files & Queues
 		regexp.MustCompile(`^.+\.servicebus\.windows\.net$`), // Azure Service Bus
-		regexp.MustCompile(`^.+\.azure-api\.net$`), // Azure API Management
-		regexp.MustCompile(`^.+\.onmicrosoft\.com$`), // Azure Active Directory
-		regexp.MustCompile(`^.+\.cloudapp\.azure\.com$`),	// Azure IaaS
-		regexp.MustCompile(`^.+\.database\.windows\.net$`),	// Azure SQL DB
-		regexp.MustCompile(`^.+\.documents\.azure\.com$`),	// Azure DocumentDB/CosmosDB
+		regexp.MustCompile(`^.+\.azure-api\.net$`),           // Azure API Management
+		regexp.MustCompile(`^.+\.onmicrosoft\.com$`),         // Azure Active Directory
+		regexp.MustCompile(`^.+\.cloudapp\.azure\.com$`),     // Azure IaaS
+		regexp.MustCompile(`^.+\.database\.windows\.net$`),   // Azure SQL DB
+		regexp.MustCompile(`^.+\.documents\.azure\.com$`),    // Azure DocumentDB/CosmosDB
 	}
 
 	knownServiceExcluders = []*regexp.Regexp{

--- a/render/theinternet.go
+++ b/render/theinternet.go
@@ -18,7 +18,7 @@ var (
 		regexp.MustCompile(`^.+\.amazonaws\.com$`),
 		regexp.MustCompile(`^.+\.googleapis\.com$`),
 		regexp.MustCompile(`^.+\.core\.windows\.net$`),	// Azure Storage - Blob, Tables, Files & Queues
-		regexp.MustCompile(`^.+\.servicebus\.windows\.net$`),// Azure Service Bus
+		regexp.MustCompile(`^.+\.servicebus\.windows\.net$`), // Azure Service Bus
 		regexp.MustCompile(`^.+\.azure-api\.net$`), // Azure API Management
 		regexp.MustCompile(`^.+\.onmicrosoft\.com$`), // Azure Active Directory
 		regexp.MustCompile(`^.+\.cloudapp\.azure\.com$`),	// Azure IaaS


### PR DESCRIPTION
Currently, `The Internet` in Scope UI only excludes a couple of hostname patterns for AWS and GCE. I've added a handful of common Azure services as a temporary workaround until user-defined hostname patterns are implemented in #1876 so they don't get globbed into the `The Internet` bucket.

This is my first PR into scope, so please let me know if you'd like me to change anything!