### PR TITLE
Add daemonsets

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -29,6 +29,7 @@ const (
 	podsID                 = "pods"
 	replicaSetsID          = "replica-sets"
 	deploymentsID          = "deployments"
+	daemonsetsID           = "daemonsets"
 	servicesID             = "services"
 	hostsID                = "hosts"
 	weaveID                = "weave"
@@ -118,7 +119,7 @@ func updateKubeFilters(rpt report.Report, topologies []APITopologyDesc) []APITop
 	sort.Strings(ns)
 	topologies = append([]APITopologyDesc{}, topologies...) // Make a copy so we can make changes safely
 	for i, t := range topologies {
-		if t.id == containersID || t.id == podsID || t.id == servicesID || t.id == deploymentsID || t.id == replicaSetsID {
+		if t.id == containersID || t.id == podsID || t.id == servicesID || t.id == deploymentsID || t.id == replicaSetsID || t.id == daemonsetsID {
 			topologies[i] = mergeTopologyFilters(t, []APITopologyOptionGroup{
 				namespaceFilters(ns, "All Namespaces"),
 			})
@@ -255,6 +256,14 @@ func MakeRegistry() *Registry {
 			parent:      podsID,
 			renderer:    render.DeploymentRenderer,
 			Name:        "deployments",
+			Options:     []APITopologyOptionGroup{unmanagedFilter},
+			HideIfEmpty: true,
+		},
+		APITopologyDesc{
+			id:          daemonsetsID,
+			parent:      podsID,
+			renderer:    render.DaemonSetRenderer,
+			Name:        "daemonsets",
 			Options:     []APITopologyOptionGroup{unmanagedFilter},
 			HideIfEmpty: true,
 		},

--- a/probe/kubernetes/daemonset.go
+++ b/probe/kubernetes/daemonset.go
@@ -18,7 +18,7 @@ const (
 // DaemonSet represents a Kubernetes daemonset
 type DaemonSet interface {
 	Meta
-	Selector() labels.Selector
+	Selector() (labels.Selector, error)
 	GetNode() report.Node
 }
 
@@ -35,13 +35,12 @@ func NewDaemonSet(d *extensions.DaemonSet) DaemonSet {
 	}
 }
 
-func (d *daemonSet) Selector() labels.Selector {
+func (d *daemonSet) Selector() (labels.Selector, error) {
 	selector, err := unversioned.LabelSelectorAsSelector(d.Spec.Selector)
 	if err != nil {
-		// TODO(paulbellamy): Remove the panic!
-		panic(err)
+		return nil, err
 	}
-	return selector
+	return selector, nil
 }
 
 func (d *daemonSet) GetNode() report.Node {

--- a/probe/kubernetes/daemonset.go
+++ b/probe/kubernetes/daemonset.go
@@ -1,0 +1,53 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/labels"
+
+	"github.com/weaveworks/scope/report"
+)
+
+// These constants are keys used in node metadata
+const (
+	MisscheduledReplicas = "kubernetes_misscheduled_replicas"
+)
+
+// DaemonSet represents a Kubernetes daemonset
+type DaemonSet interface {
+	Meta
+	Selector() labels.Selector
+	GetNode() report.Node
+}
+
+type daemonSet struct {
+	*extensions.DaemonSet
+	Meta
+}
+
+// NewDaemonSet creates a new daemonset
+func NewDaemonSet(d *extensions.DaemonSet) DaemonSet {
+	return &daemonSet{
+		DaemonSet: d,
+		Meta:      meta{d.ObjectMeta},
+	}
+}
+
+func (d *daemonSet) Selector() labels.Selector {
+	selector, err := unversioned.LabelSelectorAsSelector(d.Spec.Selector)
+	if err != nil {
+		// TODO(paulbellamy): Remove the panic!
+		panic(err)
+	}
+	return selector
+}
+
+func (d *daemonSet) GetNode() report.Node {
+	return d.MetaNode(report.MakeDaemonSetNodeID(d.UID())).WithLatests(map[string]string{
+		DesiredReplicas:      fmt.Sprint(d.Status.DesiredNumberScheduled),
+		Replicas:             fmt.Sprint(d.Status.CurrentNumberScheduled),
+		MisscheduledReplicas: fmt.Sprint(d.Status.NumberMisscheduled),
+	})
+}

--- a/probe/kubernetes/deployment.go
+++ b/probe/kubernetes/deployment.go
@@ -21,7 +21,7 @@ const (
 // Deployment represents a Kubernetes deployment
 type Deployment interface {
 	Meta
-	Selector() labels.Selector
+	Selector() (labels.Selector, error)
 	GetNode(probeID string) report.Node
 }
 
@@ -36,13 +36,12 @@ func NewDeployment(d *extensions.Deployment) Deployment {
 	return &deployment{Deployment: d, Meta: meta{d.ObjectMeta}}
 }
 
-func (d *deployment) Selector() labels.Selector {
+func (d *deployment) Selector() (labels.Selector, error) {
 	selector, err := unversioned.LabelSelectorAsSelector(d.Spec.Selector)
 	if err != nil {
-		// TODO(paulbellamy): Remove the panic!
-		panic(err)
+		return nil, err
 	}
-	return selector
+	return selector, nil
 }
 
 func (d *deployment) GetNode(probeID string) report.Node {

--- a/probe/kubernetes/replica_set.go
+++ b/probe/kubernetes/replica_set.go
@@ -18,7 +18,7 @@ const (
 // ReplicaSet represents a Kubernetes replica set
 type ReplicaSet interface {
 	Meta
-	Selector() labels.Selector
+	Selector() (labels.Selector, error)
 	AddParent(topology, id string)
 	GetNode(probeID string) report.Node
 }
@@ -39,13 +39,12 @@ func NewReplicaSet(r *extensions.ReplicaSet) ReplicaSet {
 	}
 }
 
-func (r *replicaSet) Selector() labels.Selector {
+func (r *replicaSet) Selector() (labels.Selector, error) {
 	selector, err := unversioned.LabelSelectorAsSelector(r.Spec.Selector)
 	if err != nil {
-		// TODO(paulbellamy): Remove the panic!
-		panic(err)
+		return nil, err
 	}
-	return selector
+	return selector, nil
 }
 
 func (r *replicaSet) AddParent(topology, id string) {

--- a/probe/kubernetes/replication_controller.go
+++ b/probe/kubernetes/replication_controller.go
@@ -11,11 +11,12 @@ import (
 // ReplicationController represents a Kubernetes replication controller
 type ReplicationController interface {
 	Meta
-	Selector() labels.Selector
+	Selector() (labels.Selector, error)
 	AddParent(topology, id string)
 	GetNode(probeID string) report.Node
 }
 
+// replicationController implements both ReplicationController and ReplicaSet
 type replicationController struct {
 	*api.ReplicationController
 	Meta
@@ -32,11 +33,11 @@ func NewReplicationController(r *api.ReplicationController) ReplicationControlle
 	}
 }
 
-func (r *replicationController) Selector() labels.Selector {
+func (r *replicationController) Selector() (labels.Selector, error) {
 	if r.Spec.Selector == nil {
-		return labels.Nothing()
+		return labels.Nothing(), nil
 	}
-	return labels.SelectorFromSet(labels.Set(r.Spec.Selector))
+	return labels.SelectorFromSet(labels.Set(r.Spec.Selector)), nil
 }
 
 func (r *replicationController) AddParent(topology, id string) {

--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -317,9 +317,14 @@ func (r *Reporter) replicaSetTopology(probeID string, deployments []Deployment) 
 	result.Controls.AddControls(ScalingControls)
 
 	for _, deployment := range deployments {
+		selector, err := deployment.Selector()
+		if err != nil {
+			return result, replicaSets, err
+		}
+
 		selectors = append(selectors, match(
 			deployment.Namespace(),
-			deployment.Selector(),
+			selector,
 			report.Deployment,
 			report.MakeDeploymentNodeID(deployment.UID()),
 		))
@@ -392,17 +397,25 @@ func (r *Reporter) podTopology(services []Service, replicaSets []ReplicaSet, dae
 		))
 	}
 	for _, replicaSet := range replicaSets {
+		selector, err := replicaSet.Selector()
+		if err != nil {
+			return pods, err
+		}
 		selectors = append(selectors, match(
 			replicaSet.Namespace(),
-			replicaSet.Selector(),
+			selector,
 			report.ReplicaSet,
 			report.MakeReplicaSetNodeID(replicaSet.UID()),
 		))
 	}
 	for _, daemonSet := range daemonSets {
+		selector, err := daemonSet.Selector()
+		if err != nil {
+			return pods, err
+		}
 		selectors = append(selectors, match(
 			daemonSet.Namespace(),
-			daemonSet.Selector(),
+			selector,
 			report.DaemonSet,
 			report.MakeDaemonSetNodeID(daemonSet.UID()),
 		))

--- a/probe/kubernetes/reporter_test.go
+++ b/probe/kubernetes/reporter_test.go
@@ -136,6 +136,9 @@ func (c *mockClient) WalkServices(f func(kubernetes.Service) error) error {
 	}
 	return nil
 }
+func (c *mockClient) WalkDaemonSets(f func(kubernetes.DaemonSet) error) error {
+	return nil
+}
 func (c *mockClient) WalkDeployments(f func(kubernetes.Deployment) error) error {
 	return nil
 }

--- a/render/detailed/parents.go
+++ b/render/detailed/parents.go
@@ -25,6 +25,7 @@ var (
 		report.Pod:            kubernetesParentLabel,
 		report.ReplicaSet:     kubernetesParentLabel,
 		report.Deployment:     kubernetesParentLabel,
+		report.DaemonSet:      kubernetesParentLabel,
 		report.Service:        kubernetesParentLabel,
 		report.ECSTask:        latestLookup(awsecs.TaskFamily),
 		report.ECSService:     ecsServiceParentLabel,

--- a/render/detailed/summary.go
+++ b/render/detailed/summary.go
@@ -68,6 +68,7 @@ var renderers = map[string]func(NodeSummary, report.Node) (NodeSummary, bool){
 	report.Pod:            podNodeSummary,
 	report.Service:        podGroupNodeSummary,
 	report.Deployment:     podGroupNodeSummary,
+	report.DaemonSet:      podGroupNodeSummary,
 	report.ReplicaSet:     podGroupNodeSummary,
 	report.ECSTask:        ecsTaskNodeSummary,
 	report.ECSService:     ecsServiceNodeSummary,

--- a/render/detailed/summary.go
+++ b/render/detailed/summary.go
@@ -92,6 +92,7 @@ var primaryAPITopology = map[string]string{
 	report.Pod:            "pods",
 	report.ReplicaSet:     "replica-sets",
 	report.Deployment:     "deployments",
+	report.DaemonSet:      "daemonsets",
 	report.Service:        "services",
 	report.ECSTask:        "ecs-tasks",
 	report.ECSService:     "ecs-services",

--- a/render/pod.go
+++ b/render/pod.go
@@ -96,6 +96,21 @@ var ReplicaSetRenderer = ConditionalRenderer(renderKubernetesTopologies,
 	),
 )
 
+// DaemonSetRenderer is a Renderer which produces a renderable kubernetes daemonsets
+// graph by merging the pods graph and the daemonsets topology.
+var DaemonSetRenderer = ConditionalRenderer(renderKubernetesTopologies,
+	MakeMap(
+		PropagateSingleMetrics(report.Pod),
+		MakeReduce(
+			MakeMap(
+				Map2Parent(report.DaemonSet, "", nil),
+				PodRenderer,
+			),
+			SelectDaemonSet,
+		),
+	),
+)
+
 func mapPodCounts(parent, original report.Node) report.Node {
 	// When mapping ReplicaSets to Deployments, we want to propagate the Pods counter
 	if count, ok := original.Counters.Lookup(report.Pod); ok {

--- a/render/selectors.go
+++ b/render/selectors.go
@@ -30,6 +30,7 @@ var (
 	SelectPod            = TopologySelector(report.Pod)
 	SelectService        = TopologySelector(report.Service)
 	SelectDeployment     = TopologySelector(report.Deployment)
+	SelectDaemonSet      = TopologySelector(report.DaemonSet)
 	SelectReplicaSet     = TopologySelector(report.ReplicaSet)
 	SelectECSTask        = TopologySelector(report.ECSTask)
 	SelectECSService     = TopologySelector(report.ECSService)

--- a/report/id.go
+++ b/report/id.go
@@ -125,6 +125,12 @@ var (
 	// ParseReplicaSetNodeID parses a replica set node ID
 	ParseReplicaSetNodeID = parseSingleComponentID("replica_set")
 
+	// MakeDaemonSetNodeID produces a replica set node ID from its composite parts.
+	MakeDaemonSetNodeID = makeSingleComponentID("daemonset")
+
+	// ParseDaemonSetNodeID parses a daemon set node ID
+	ParseDaemonSetNodeID = parseSingleComponentID("daemonset")
+
 	// MakeECSTaskNodeID produces a replica set node ID from its composite parts.
 	MakeECSTaskNodeID = makeSingleComponentID("ecs_task")
 

--- a/report/report.go
+++ b/report/report.go
@@ -19,6 +19,7 @@ const (
 	Service        = "service"
 	Deployment     = "deployment"
 	ReplicaSet     = "replica_set"
+	DaemonSet      = "daemon_set"
 	ContainerImage = "container_image"
 	Host           = "host"
 	Overlay        = "overlay"
@@ -73,6 +74,11 @@ type Report struct {
 	// Metadata includes things like ReplicaSet id, name etc. Edges are not
 	// present.
 	ReplicaSet Topology
+
+	// DaemonSet nodes represent all Kubernetes DaemonSets running on hosts running probes.
+	// Metadata includes things like DaemonSet id, name etc. Edges are not
+	// present.
+	DaemonSet Topology
 
 	// ContainerImages nodes represent all Docker containers images on
 	// hosts running probes. Metadata includes things like image id, name etc.
@@ -164,6 +170,10 @@ func MakeReport() Report {
 			WithShape(Heptagon).
 			WithLabel("replica set", "replica sets"),
 
+		DaemonSet: MakeTopology().
+			WithShape(Heptagon).
+			WithLabel("daemonset", "daemonsets"),
+
 		Overlay: MakeTopology().
 			WithShape(Circle).
 			WithLabel("peer", "peers"),
@@ -198,6 +208,7 @@ func (r *Report) TopologyMap() map[string]*Topology {
 		Service:        &r.Service,
 		Deployment:     &r.Deployment,
 		ReplicaSet:     &r.ReplicaSet,
+		DaemonSet:      &r.DaemonSet,
 		Host:           &r.Host,
 		Overlay:        &r.Overlay,
 		ECSTask:        &r.ECSTask,
@@ -260,6 +271,7 @@ func (r *Report) WalkPairedTopologies(o *Report, f func(*Topology, *Topology)) {
 	f(&r.Service, &o.Service)
 	f(&r.Deployment, &o.Deployment)
 	f(&r.ReplicaSet, &o.ReplicaSet)
+	f(&r.DaemonSet, &o.DaemonSet)
 	f(&r.Host, &o.Host)
 	f(&r.Overlay, &o.Overlay)
 	f(&r.ECSTask, &o.ECSTask)


### PR DESCRIPTION
Fixes https://github.com/weaveworks/scope/issues/1444

This adds collection of daemonset info to the probe,
and two new views to the app. One showing only daemonsets,
one showing deployments + daemonsets.

This is too many views (see discussion in #1444), but was useful for initial debugging - we can remove the daemonsets view before merging.

We need to decide how we are going to present this new 'combined view' to the user in a way that makes it obvious what's going on. For now I've labelled it 'Replica groups' but that's not good enough.