### PR TITLE
Let conntrack track non-NATed short-lived connections

### DIFF
--- a/integration/350_container_to_container_edge_no_weave_test.sh
+++ b/integration/350_container_to_container_edge_no_weave_test.sh
@@ -3,8 +3,6 @@
 # shellcheck disable=SC1091
 . ./config.sh
 
-set -x
-
 start_suite "Test short lived connections between containers without Weave (no NAT)"
 
 scope_on "$HOST1" launch

--- a/integration/350_container_to_container_edge_no_weave_test.sh
+++ b/integration/350_container_to_container_edge_no_weave_test.sh
@@ -1,0 +1,24 @@
+#! /bin/bash
+
+# shellcheck disable=SC1091
+. ./config.sh
+
+set -x
+
+start_suite "Test short lived connections between containers without Weave (no NAT)"
+
+scope_on "$HOST1" launch
+docker_on "$HOST1" run -d --name nginx nginx
+wait_for_containers "$HOST1" 60 nginx
+nginx_ip="$(docker_on "$HOST1" inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' nginx)"
+docker_on "$HOST1" run -d --name client alpine /bin/sh -c "while true; do \
+	wget $nginx_ip:80/ -O - >/dev/null || true; \
+	sleep 1; \
+done"
+wait_for_containers "$HOST1" 60 client
+
+has_container "$HOST1" nginx
+has_container "$HOST1" client
+has_connection containers "$HOST1" client nginx
+
+scope_end_suite

--- a/probe/endpoint/connection_tracker.go
+++ b/probe/endpoint/connection_tracker.go
@@ -37,7 +37,7 @@ func newProcfsConnectionTracker(conf connectionTrackerConfig) connectionTracker 
 	}
 	return connectionTracker{
 		conf:            conf,
-		flowWalker:      newConntrackFlowWalker(conf.UseConntrack, conf.ProcRoot, conf.BufferSize, "--any-nat"),
+		flowWalker:      newConntrackFlowWalker(conf.UseConntrack, conf.ProcRoot, conf.BufferSize),
 		ebpfTracker:     nil,
 		reverseResolver: newReverseResolver(),
 	}


### PR DESCRIPTION
Fixes #2494 

Regression introduced by https://github.com/weaveworks/scope/pull/2135

- [ ] Add integration test