### PR TITLE
Enable eBPF tracking by default

### DIFF
--- a/integration/301_internet_edge_without_ebpf_test.sh
+++ b/integration/301_internet_edge_without_ebpf_test.sh
@@ -3,10 +3,10 @@
 # shellcheck disable=SC1091
 . ./config.sh
 
-start_suite "Test short lived connections from the Internet [DISABLED]"
+start_suite "Test short lived connections from the Internet without ebpf [DISABLED]"
 
 weave_on "$HOST1" launch
-scope_on "$HOST1" launch --probe.ebpf.connections=true
+scope_on "$HOST1" launch --probe.ebpf.connections=false
 
 ## Test disabled: it is currently flaky
 ## https://github.com/weaveworks/scope/issues/2308

--- a/integration/310_container_to_container_edge_test.sh
+++ b/integration/310_container_to_container_edge_test.sh
@@ -17,6 +17,11 @@ wait_for_containers "$HOST1" 60 nginx client
 
 has_container "$HOST1" nginx
 has_container "$HOST1" client
+
+list_containers "$HOST1"
+list_connections "$HOST1"
+
 has_connection containers "$HOST1" client nginx
+endpoints_have_ebpf "$HOST1"
 
 scope_end_suite

--- a/integration/311_container_to_container_edge_without_ebpf_test.sh
+++ b/integration/311_container_to_container_edge_without_ebpf_test.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC1091
 . ./config.sh
 
-start_suite "Test short lived connections between containers, without ebpf connection tracking enabled"
+start_suite "Test short lived connections between containers, without ebpf connection tracking disabled"
 
 weave_on "$HOST1" launch
 scope_on "$HOST1" launch --probe.ebpf.connections=false
@@ -22,7 +22,5 @@ list_containers "$HOST1"
 list_connections "$HOST1"
 
 has_connection containers "$HOST1" client nginx
-
-endpoints_have_ebpf "$HOST1"
 
 scope_end_suite

--- a/integration/311_container_to_container_edge_without_ebpf_test.sh
+++ b/integration/311_container_to_container_edge_without_ebpf_test.sh
@@ -3,10 +3,10 @@
 # shellcheck disable=SC1091
 . ./config.sh
 
-start_suite "Test short lived connections between containers, with ebpf connection tracking enabled"
+start_suite "Test short lived connections between containers, without ebpf connection tracking enabled"
 
 weave_on "$HOST1" launch
-scope_on "$HOST1" launch --probe.ebpf.connections=true
+scope_on "$HOST1" launch --probe.ebpf.connections=false
 weave_on "$HOST1" run -d --name nginx nginx
 weave_on "$HOST1" run -d --name client alpine /bin/sh -c "while true; do \
 	wget http://nginx.weave.local:80/ -O - >/dev/null || true; \

--- a/integration/312_container_to_container_edge_same_netns_test.sh
+++ b/integration/312_container_to_container_edge_same_netns_test.sh
@@ -3,9 +3,9 @@
 # shellcheck disable=SC1091
 . ./config.sh
 
-start_suite "Test short lived connection between containers in same network namespace, with ebpf connection tracking enabled"
+start_suite "Test short lived connection between containers in same network namespace"
 
-scope_on "$HOST1" launch --probe.ebpf.connections=true
+scope_on "$HOST1" launch
 docker_on "$HOST1" run -d --name nginx nginx
 docker_on "$HOST1" run -d --net=container:nginx --name client albanc/dialer /go/bin/dialer connectshortlived localhost:80
 

--- a/integration/313_container_to_container_edge_with_ebpf_proc_fallback_test.sh
+++ b/integration/313_container_to_container_edge_with_ebpf_proc_fallback_test.sh
@@ -11,7 +11,7 @@ weave_on "$HOST1" launch
 # to make ebpf fail and test the proc fallback.
 DOCKER_HOST=tcp://${HOST1}:${DOCKER_PORT} CHECKPOINT_DISABLE=true \
     WEAVESCOPE_DOCKER_ARGS="-v /tmp:/sys/kernel/debug/tracing:ro" \
-    "${SCOPE}" launch --probe.ebpf.connections=true
+    "${SCOPE}" launch
 weave_on "$HOST1" run -d --name nginx nginx
 weave_on "$HOST1" run -d --name client alpine /bin/sh -c "while true; do \
 	wget http://nginx.weave.local:80/ -O - >/dev/null || true; \

--- a/integration/314_container_accept_before_kretprobe_test.sh
+++ b/integration/314_container_accept_before_kretprobe_test.sh
@@ -15,7 +15,7 @@ weave_on "$HOST1" run -d --name server busybox /bin/sh -c "while true; do \
 		sleep 1 ;
 	done | nc -l -p 8080"
 
-scope_on "$HOST1" launch --probe.ebpf.connections=true
+scope_on "$HOST1" launch
 wait_for_containers "$HOST1" 60 server
 has_container "$HOST1" server
 

--- a/prog/main.go
+++ b/prog/main.go
@@ -289,7 +289,7 @@ func main() {
 	flag.BoolVar(&flags.probe.spyProcs, "probe.proc.spy", true, "associate endpoints with processes (needs root)")
 	flag.StringVar(&flags.probe.procRoot, "probe.proc.root", "/proc", "location of the proc filesystem")
 	flag.BoolVar(&flags.probe.procEnabled, "probe.processes", true, "produce process topology & include procspied connections")
-	flag.BoolVar(&flags.probe.useEbpfConn, "probe.ebpf.connections", false, "enable connection tracking with eBPF")
+	flag.BoolVar(&flags.probe.useEbpfConn, "probe.ebpf.connections", true, "enable connection tracking with eBPF")
 
 	// Docker
 	flag.BoolVar(&flags.probe.dockerEnabled, "probe.docker", false, "collect Docker-related attributes for processes")


### PR DESCRIPTION
Fixes #2441

We already had an integration test for the proc fallback (313), so I just adjusted the ebpf flag according to its default value and changed tests explicitly testing ebpf-tracking to explicitly test tracking without ebpf.