### PR TITLE
optimise: don't sort in NodeSet.ForEach

### DIFF
--- a/report/node_set.go
+++ b/report/node_set.go
@@ -92,13 +92,12 @@ func (n NodeSet) Size() int {
 	return n.psMap.Size()
 }
 
-// ForEach executes f for each node in the set. Nodes are traversed in sorted
-// order.
+// ForEach executes f for each node in the set.
 func (n NodeSet) ForEach(f func(Node)) {
-	for _, key := range mapKeys(n.psMap) {
-		if val, ok := n.psMap.Lookup(key); ok {
+	if n.psMap != nil {
+		n.psMap.ForEach(func(_ string, val interface{}) {
 			f(val.(Node))
-		}
+		})
 	}
 }
 

--- a/report/node_set_test.go
+++ b/report/node_set_test.go
@@ -2,6 +2,7 @@ package report_test
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/weaveworks/scope/report"
@@ -40,6 +41,7 @@ func TestMakeNodeSet(t *testing.T) {
 		set := report.MakeNodeSet(inputs...)
 		var have []string
 		set.ForEach(func(node report.Node) { have = append(have, node.ID) })
+		sort.Strings(have)
 		if !reflect.DeepEqual(testcase.wants, have) {
 			t.Errorf("%#v: want %#v, have %#v", testcase.inputs, testcase.wants, have)
 		}


### PR DESCRIPTION
It's unnecessary, and none of the other ps.Map derived structures do it.

I have tested this locally by looping through 30s of production reports - I couldn't spot any abnormalities in the UI.