### PR TITLE
Use 127.0.0.1 instead of localhost, more

### DIFF
--- a/extras/fixprobe/main.go
+++ b/extras/fixprobe/main.go
@@ -19,7 +19,7 @@ import (
 
 func main() {
 	var (
-		publish         = flag.String("publish", fmt.Sprintf("localhost:%d", xfer.AppPort), "publish target")
+		publish         = flag.String("publish", fmt.Sprintf("127.0.0.1:%d", xfer.AppPort), "publish target")
 		publishInterval = flag.Duration("publish.interval", 1*time.Second, "publish (output) interval")
 		publishToken    = flag.String("publish.token", "fixprobe", "publish token, for if we are talking to the service")
 		publishID       = flag.String("publish.id", "fixprobe", "publisher ID used to identify publishers")

--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -429,7 +429,7 @@ func (r *Reporter) podTopology(services []Service, replicaSets []ReplicaSet, dae
 	// 1. reconstructing the NodeName requires cloud provider credentials
 	// 2. inferring the NodeName out of the hostname or system uuid is unreliable
 	//    (uuids and hostnames can be duplicated across the cluster).
-	localPodUIDs, errUIDs := GetLocalPodUIDs(fmt.Sprintf("localhost:%d", r.kubeletPort))
+	localPodUIDs, errUIDs := GetLocalPodUIDs(fmt.Sprintf("127.0.0.1:%d", r.kubeletPort))
 	if errUIDs != nil {
 		log.Warnf("Cannot obtain local pods, reporting all (which may impact performance): %v", errUIDs)
 	}


### PR DESCRIPTION
We do this in case that name resolves to something else.
This was done in #2103 for one case; don't see why we wouldn't do the same everywhere.