### PR TITLE
es6ify server.js and include in eslint

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -2,7 +2,7 @@
 
 ## Getting Started (using local node)
 
-- You need nodejs 4.2.2 and a running `weavescope` container
+- You need at least Node.js 6.9.0 and a running `weavescope` container
 - Setup: `npm install`
 - Develop: `BACKEND_HOST=<dockerhost-ip> npm start` and then open `http://localhost:4042/`
 

--- a/client/package.json
+++ b/client/package.json
@@ -103,7 +103,7 @@
     "start-production": "NODE_ENV=production node server.js",
     "test": "jest",
     "coveralls": "cat coverage/lcov.info | coveralls",
-    "lint": "eslint app",
+    "lint": "eslint app server.js",
     "clean": "rm build/app.js",
     "noprobe": "../scope stop && ../scope launch --no-probe --app.window 8760h",
     "loadreport": "npm run noprobe && sleep 1 && curl -X POST -H \"Content-Type: application/json\" http://$BACKEND_HOST/api/report -d"

--- a/client/server.js
+++ b/client/server.js
@@ -67,7 +67,7 @@ if (process.env.NODE_ENV !== 'production') {
  *****************/
 
 const port = process.env.PORT || 4042;
-const server = app.listen(port, () => {
+const server = app.listen(port, 'localhost', () => {
   const host = server.address().address;
 
   console.log('Scope UI listening at http://%s:%s', host, port);
@@ -98,7 +98,7 @@ const proxyPathServer = http.createServer((req, res) => {
     return res.end('No rules matched! Check out /scoped/');
   }
   return pathProxy.web(req, res, {target});
-}).listen(pathProxyPort, () => {
+}).listen(pathProxyPort, 'localhost', () => {
   const pathProxyHost = proxyPathServer.address().address;
   console.log('Scope Proxy Path UI listening at http://%s:%s/scoped/',
     pathProxyHost, pathProxyPort);


### PR DESCRIPTION
also updated documentation for minimum Node.js version required.

Edit: also explicitly set hosts to `localhost` for expressjs servers to make it easier to click on the logged links in case of ipv6 default address.