### PR TITLE
Fix incomplete dependencies for `make scope/prog`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ $(SCOPE_EXPORT): docker/Dockerfile.scope $(CLOUD_AGENT_EXPORT) docker/$(RUNSVINI
 
 $(RUNSVINIT): vendor/runsvinit/*.go
 
-$(SCOPE_EXE): $(shell find ./ -path ./vendor -prune -o -type f -name *.go) prog/staticui/staticui.go prog/externalui/externalui.go $(CODECGEN_TARGETS)
+$(SCOPE_EXE): $(shell find ./ -path ./vendor -prune -o -type f -name '*.go') prog/staticui/staticui.go prog/externalui/externalui.go $(CODECGEN_TARGETS)
 
 report/report.codecgen.go: $(call GET_CODECGEN_DEPS,report/)
 render/render.codecgen.go: $(call GET_CODECGEN_DEPS,render/)


### PR DESCRIPTION
It seems that on my OS the passed param to find gets expanded early and
thus the command

    $(shell find ./ -path ./vendor -prune -o -type f -name *.go)

results in

        ./test.go ./vendor

instead of including all the go files from subdirs. Quoting helps.