### PR TITLE
Add app capabilities to /api endpoint

### DIFF
--- a/app/api_report_test.go
+++ b/app/api_report_test.go
@@ -14,7 +14,7 @@ import (
 
 func topologyServer() *httptest.Server {
 	router := mux.NewRouter().SkipClean(true)
-	app.RegisterTopologyRoutes(router, app.StaticCollector(fixture.Report))
+	app.RegisterTopologyRoutes(router, app.StaticCollector(fixture.Report), map[string]bool{"foo_capability": true})
 	return httptest.NewServer(router)
 }
 

--- a/app/api_topologies_test.go
+++ b/app/api_topologies_test.go
@@ -189,7 +189,7 @@ func TestAPITopologyAddsKubernetes(t *testing.T) {
 	router := mux.NewRouter()
 	c := app.NewCollector(1 * time.Minute)
 	app.RegisterReportPostHandler(c, router)
-	app.RegisterTopologyRoutes(router, c)
+	app.RegisterTopologyRoutes(router, c, map[string]bool{"foo_capability": true})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 

--- a/common/xfer/constants.go
+++ b/common/xfer/constants.go
@@ -14,6 +14,8 @@ const (
 	ScopeProbeVersionHeader = "X-Scope-Probe-Version"
 )
 
+// ReportPersistenceCapability indicates whether probe reports end up in a
+// long-term storage and can be retrieved.
 const ReportPersistenceCapability = "report_persistence"
 
 // Details are some generic details that can be fetched from /api

--- a/common/xfer/constants.go
+++ b/common/xfer/constants.go
@@ -14,12 +14,15 @@ const (
 	ScopeProbeVersionHeader = "X-Scope-Probe-Version"
 )
 
+const ReportPersistenceCapability = "report_persistence"
+
 // Details are some generic details that can be fetched from /api
 type Details struct {
-	ID       string      `json:"id"`
-	Version  string      `json:"version"`
-	Hostname string      `json:"hostname"`
-	Plugins  PluginSpecs `json:"plugins,omitempty"`
+	ID           string          `json:"id"`
+	Version      string          `json:"version"`
+	Hostname     string          `json:"hostname"`
+	Plugins      PluginSpecs     `json:"plugins,omitempty"`
+	Capabilities map[string]bool `json:"capabilities,omitempty"`
 
 	NewVersion *NewVersionInfo `json:"newVersion,omitempty"`
 }


### PR DESCRIPTION
The first capability is whether there is report persistence, needed to conditionally enable time controls in the UI  ( https://github.com/weaveworks/scope/pull/2524 )