### PR TITLE
drop addr and port from Endpoint.Latest map

### DIFF
--- a/probe/endpoint/connection_tracker.go
+++ b/probe/endpoint/connection_tracker.go
@@ -223,9 +223,7 @@ func (t *connectionTracker) addConnection(rpt *report.Report, ft fourTuple, name
 
 func (t *connectionTracker) makeEndpointNode(namespaceID string, addr string, port uint16, extra map[string]string) report.Node {
 	portStr := strconv.Itoa(int(port))
-	node := report.MakeNodeWith(
-		report.MakeEndpointNodeID(t.conf.HostID, namespaceID, addr, portStr),
-		map[string]string{Addr: addr, Port: portStr})
+	node := report.MakeNodeWith(report.MakeEndpointNodeID(t.conf.HostID, namespaceID, addr, portStr), nil)
 	if names := t.conf.DNSSnooper.CachedNamesForIP(addr); len(names) > 0 {
 		node = node.WithSet(SnoopedDNSNames, report.MakeStringSet(names...))
 	}

--- a/probe/endpoint/nat.go
+++ b/probe/endpoint/nat.go
@@ -63,8 +63,6 @@ func (n natMapper) applyNAT(rpt report.Report, scope string) {
 		}
 
 		rpt.Endpoint.AddNode(node.WithID(copyEndpointID).WithLatests(map[string]string{
-			Addr:      mapping.rewrittenIP,
-			Port:      copyEndpointPort,
 			"copy_of": realEndpointID,
 		}))
 	})

--- a/probe/endpoint/nat_internal_test.go
+++ b/probe/endpoint/nat_internal_test.go
@@ -70,8 +70,6 @@ func TestNat(t *testing.T) {
 		have := report.MakeReport()
 		originalID := report.MakeEndpointNodeID("host1", "", "10.0.47.1", "80")
 		have.Endpoint.AddNode(report.MakeNodeWith(originalID, map[string]string{
-			Addr:      "10.0.47.1",
-			Port:      "80",
 			"foo":     "bar",
 			Procspied: "true",
 		}))
@@ -79,8 +77,6 @@ func TestNat(t *testing.T) {
 		want := have.Copy()
 		wantID := report.MakeEndpointNodeID("host1", "", "1.2.3.4", "80")
 		want.Endpoint.AddNode(report.MakeNodeWith(wantID, map[string]string{
-			Addr:      "1.2.3.4",
-			Port:      "80",
 			"copy_of": originalID,
 			"foo":     "bar",
 			Procspied: "true",
@@ -129,16 +125,12 @@ func TestNat(t *testing.T) {
 		have := report.MakeReport()
 		originalID := report.MakeEndpointNodeID("host2", "", "10.0.47.2", "22222")
 		have.Endpoint.AddNode(report.MakeNodeWith(originalID, map[string]string{
-			Addr:      "10.0.47.2",
-			Port:      "22222",
 			"foo":     "baz",
 			Procspied: "true",
 		}))
 
 		want := have.Copy()
 		want.Endpoint.AddNode(report.MakeNodeWith(report.MakeEndpointNodeID("host2", "", "2.3.4.5", "22223"), map[string]string{
-			Addr:      "2.3.4.5",
-			Port:      "22223",
 			"copy_of": originalID,
 			"foo":     "baz",
 			Procspied: "true",

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -11,8 +11,6 @@ import (
 
 // Node metadata keys.
 const (
-	Addr            = "addr" // typically IPv4
-	Port            = "port"
 	Conntracked     = "conntracked"
 	EBPF            = "eBPF"
 	Procspied       = "procspied"

--- a/render/detailed/summary.go
+++ b/render/detailed/summary.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/weaveworks/scope/probe/awsecs"
 	"github.com/weaveworks/scope/probe/docker"
-	"github.com/weaveworks/scope/probe/endpoint"
 	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/probe/kubernetes"
 	"github.com/weaveworks/scope/probe/overlay"
@@ -182,7 +181,7 @@ func pseudoNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
 	}
 
 	// try rendering it as an endpoint
-	if addr, ok := n.Latest.Lookup(endpoint.Addr); ok {
+	if _, addr, _, ok := report.ParseEndpointNodeID(n.ID); ok {
 		base.Label = addr
 		base.Shape = report.Circle
 		return base, true

--- a/render/process.go
+++ b/render/process.go
@@ -2,7 +2,6 @@ package render
 
 import (
 	"github.com/weaveworks/scope/probe/docker"
-	"github.com/weaveworks/scope/probe/endpoint"
 	"github.com/weaveworks/scope/probe/process"
 	"github.com/weaveworks/scope/report"
 )
@@ -82,7 +81,7 @@ var ProcessNameRenderer = ConditionalRenderer(renderProcesses,
 
 // MapEndpoint2Pseudo makes internet of host pesudo nodes from a endpoint node.
 func MapEndpoint2Pseudo(n report.Node, local report.Networks) report.Nodes {
-	addr, ok := n.Latest.Lookup(endpoint.Addr)
+	_, addr, _, ok := report.ParseEndpointNodeID(n.ID)
 	if !ok {
 		return report.Nodes{}
 	}

--- a/render/short_lived_connections_test.go
+++ b/render/short_lived_connections_test.go
@@ -52,29 +52,21 @@ var (
 		Endpoint: report.Topology{
 			Nodes: report.Nodes{
 				randomEndpointNodeID: report.MakeNodeWith(randomEndpointNodeID, map[string]string{
-					endpoint.Addr:        randomIP,
-					endpoint.Port:        randomPort,
 					endpoint.Conntracked: "true",
 				}).
 					WithAdjacent(serverEndpointNodeID).WithTopology(report.Endpoint),
 
 				serverEndpointNodeID: report.MakeNodeWith(serverEndpointNodeID, map[string]string{
-					endpoint.Addr:        serverIP,
-					endpoint.Port:        serverPort,
 					endpoint.Conntracked: "true",
 				}).
 					WithTopology(report.Endpoint),
 
 				container1EndpointNodeID: report.MakeNodeWith(container1EndpointNodeID, map[string]string{
-					endpoint.Addr:        container1IP,
-					endpoint.Port:        container1Port,
 					endpoint.Conntracked: "true",
 				}).
 					WithAdjacent(duplicatedEndpointNodeID).WithTopology(report.Endpoint),
 
 				duplicatedEndpointNodeID: report.MakeNodeWith(duplicatedEndpointNodeID, map[string]string{
-					endpoint.Addr:        duplicatedIP,
-					endpoint.Port:        duplicatedPort,
 					endpoint.Conntracked: "true",
 				}).
 					WithTopology(report.Endpoint),

--- a/test/fixture/report_fixture.go
+++ b/test/fixture/report_fixture.go
@@ -128,8 +128,6 @@ var (
 				// care to test into the fixture. Just be sure to include the bits
 				// that the mapping funcs extract :)
 				Client54001NodeID: report.MakeNode(Client54001NodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
-					endpoint.Addr:      ClientIP,
-					endpoint.Port:      ClientPort54001,
 					process.PID:        Client1PID,
 					report.HostNodeID:  ClientHostNodeID,
 					endpoint.Procspied: True,
@@ -139,8 +137,6 @@ var (
 				}),
 
 				Client54002NodeID: report.MakeNode(Client54002NodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
-					endpoint.Addr:      ClientIP,
-					endpoint.Port:      ClientPort54002,
 					process.PID:        Client2PID,
 					report.HostNodeID:  ClientHostNodeID,
 					endpoint.Procspied: True,
@@ -150,16 +146,12 @@ var (
 				}),
 
 				Server80NodeID: report.MakeNode(Server80NodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
-					endpoint.Addr:      ServerIP,
-					endpoint.Port:      ServerPort,
 					process.PID:        ServerPID,
 					report.HostNodeID:  ServerHostNodeID,
 					endpoint.Procspied: True,
 				}),
 
 				NonContainerNodeID: report.MakeNode(NonContainerNodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
-					endpoint.Addr:      ServerIP,
-					endpoint.Port:      NonContainerClientPort,
 					process.PID:        NonContainerPID,
 					report.HostNodeID:  ServerHostNodeID,
 					endpoint.Procspied: True,
@@ -167,8 +159,6 @@ var (
 
 				// Probe pseudo nodes
 				UnknownClient1NodeID: report.MakeNode(UnknownClient1NodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
-					endpoint.Addr:      UnknownClient1IP,
-					endpoint.Port:      UnknownClient1Port,
 					endpoint.Procspied: True,
 				}).WithEdge(Server80NodeID, report.EdgeMetadata{
 					EgressPacketCount: newu64(30),
@@ -176,8 +166,6 @@ var (
 				}),
 
 				UnknownClient2NodeID: report.MakeNode(UnknownClient2NodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
-					endpoint.Addr:      UnknownClient2IP,
-					endpoint.Port:      UnknownClient2Port,
 					endpoint.Procspied: True,
 				}).WithEdge(Server80NodeID, report.EdgeMetadata{
 					EgressPacketCount: newu64(40),
@@ -185,8 +173,6 @@ var (
 				}),
 
 				UnknownClient3NodeID: report.MakeNode(UnknownClient3NodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
-					endpoint.Addr:      UnknownClient3IP,
-					endpoint.Port:      UnknownClient3Port,
 					endpoint.Procspied: True,
 				}).WithEdge(Server80NodeID, report.EdgeMetadata{
 					EgressPacketCount: newu64(50),
@@ -194,8 +180,6 @@ var (
 				}),
 
 				RandomClientNodeID: report.MakeNode(RandomClientNodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
-					endpoint.Addr:      RandomClientIP,
-					endpoint.Port:      RandomClientPort,
 					endpoint.Procspied: True,
 				}).WithEdge(Server80NodeID, report.EdgeMetadata{
 					EgressPacketCount: newu64(60),
@@ -203,8 +187,6 @@ var (
 				}),
 
 				GoogleEndpointNodeID: report.MakeNode(GoogleEndpointNodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
-					endpoint.Addr:      GoogleIP,
-					endpoint.Port:      GooglePort,
 					endpoint.Procspied: True,
 				}),
 			},


### PR DESCRIPTION
The information is constant and already present in the id, so we can extract it from there.

That reduces the report size and improves report encoding/decoding performance. It should reduce memory usage too and improve report merging performance too.

NB: Probes with this change are incompatible with old apps.