### PR TITLE
fix error when docker DAEMON is running with user namespace enabled.

### DIFF
--- a/scope
+++ b/scope
@@ -165,7 +165,8 @@ create_plugins_dir() {
     # is not shared from OS X and does not belong to the system."
     # In any case, creating /var/run/scope/plugins on Mac OS would not work, as domain
     # sockets do not cross VM boundaries. We need this directory to exits on the VM.
-    docker run --rm --entrypoint=/bin/sh \
+    # shellcheck disable=SC2086
+    docker run $USERNS_HOST --rm --entrypoint=/bin/sh \
         -v /var/run:/var/run \
         "$SCOPE_IMAGE" -c "mkdir -p /var/run/scope/plugins"
 }


### PR DESCRIPTION
Hi, i love to use weaveworks. This is pull request is almost same as https://github.com/weaveworks/scope/pull/2161

I begin to use Docker for Mac, and set daemon using user namespace map: 
<img width="492" alt="screen shot 2017-06-11 at 17 14 37" src="https://user-images.githubusercontent.com/5234060/27009434-7a207c56-4ec9-11e7-8e9e-56d208b0afd3.png">

Then `scope launch` will report error:
```
mkdir: can't create directory '/var/run/scope/': Permission denied
```

The reason is very obvious because when it internally runs
```
docker run --rm --entrypoint=/bin/sh \
        -v /var/run:/var/run \
        "$SCOPE_IMAGE" -c "mkdir -p /var/run/scope/plugins"
```
It actually is using remapped root:root(`10000:10000`), instead of normal `0:0`.

So by same way, it inserted `--userns=host` option to the above run command, then it works fine.

Hope you can merge it.

Finally, i suggest that everyone should pay more attention about user namespace enabled daemon, and use it. This really rocks, it maps non root user to root in container, maybe this will be the default daemon mode in future.
