### PR TITLE
Adjust header menu vertical position

### DIFF
--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -155,9 +155,8 @@
   pointer-events: none;
 
   position: absolute;
-  top: 32px;
+  top: 15px;
   width: 100%;
-  height: 80px;
   z-index: 20;
   display: flex;
 


### PR DESCRIPTION
To make the header menu aligned with the `CONFIGURE` button again after https://github.com/weaveworks/service-ui/pull/624 is merged, I have moved the `.header` div 17px up.

IMO this still looks good (if not better, given the current footer margins) and helps us a bit with issues like #2565, since the vertical space is becoming a problem.
