### PR TITLE
Release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,64 @@
+## Release 1.4.1
+
+Highlights:
+- More accurate and cheaper connection tracking with eBPF, which now is enabled by default.
+- Bug fixes and performance improvements.
+
+New features and enhancements:
+- Enable eBPF tracking by default
+	[#2535](https://github.com/weaveworks/scope/pull/2535)
+- Elide url passwords in cli arguments
+	[#2568](https://github.com/weaveworks/scope/pull/2568)
+
+Performance improvements:
+- drop addr and port from Endpoint.Latest map
+	[#2581](https://github.com/weaveworks/scope/pull/2581)
+- parallel reduce
+	[#2561](https://github.com/weaveworks/scope/pull/2561)
+- don't read all of /proc when probe.proc.spy=false
+	[#2557](https://github.com/weaveworks/scope/pull/2557)
+- optimise: don't sort in NodeSet.ForEach
+	[#2548](https://github.com/weaveworks/scope/pull/2548)
+- encode empty ps.Maps as nil
+	[#2547](https://github.com/weaveworks/scope/pull/2547)
+
+Bug fixes:
+- re-target app clients when name resolution changes
+	[#2579](https://github.com/weaveworks/scope/pull/2579)
+- correct type for "Observed Gen."
+	[#2572](https://github.com/weaveworks/scope/pull/2572)
+- Back off upon errored kubernetes api requests
+	[#2562](https://github.com/weaveworks/scope/pull/2562)
+- Close eBPF tracker cleanly
+	[#2541](https://github.com/weaveworks/scope/pull/2541)
+- Simplify connection tracker init and fix procfs scan fallback
+	[#2539](https://github.com/weaveworks/scope/pull/2539)
+- Guard against null DaemonSet store
+	[#2538](https://github.com/weaveworks/scope/pull/2538)
+
+Internal improvements and cleanup:
+- es6ify server.js and include in eslint
+	[#2560](https://github.com/weaveworks/scope/pull/2560)
+- Fix prog/main_test.go
+	[#2567](https://github.com/weaveworks/scope/pull/2567)
+- Fix incomplete dependencies for `make scope/prog`
+	[#2563](https://github.com/weaveworks/scope/pull/2563)
+- bump package.json version to current scope version
+	[#2555](https://github.com/weaveworks/scope/pull/2555)
+- simplify connection join
+	[#2559](https://github.com/weaveworks/scope/pull/2559)
+- Use map helpers
+	[#2546](https://github.com/weaveworks/scope/pull/2546)
+- add copyreport utility
+	[#2542](https://github.com/weaveworks/scope/pull/2542)
+
+Weave Cloud related changes:
+- Time travel control
+	[#2524](https://github.com/weaveworks/scope/pull/2524)
+- Add app capabilities to /api endpoint
+	[#2575](https://github.com/weaveworks/scope/pull/2575)
+
+
 ## Release 1.4.0
 
 Highlights:


### PR DESCRIPTION
@rndstr @fbarl @davkal @foot @ekimekim @bowenli @jpellizzari @abuehrle @pidster @errordeveloper @rade Please chip in by testing this release branch in the scenarios below and tick off what you tested afterwards (including your name at the end). Have a look at the CHANGELOG to prioritize your testing.

To make things easier to test I have pushed the image `weaveworks/scope:release-1.4-68b7217`:

- [ ] Start a 2 node cluster and leave a UI connected, watch for performance regression
- [ ] Run a Scope cluster on ECS
- [ ] Run Scope on https://github.com/microservices-demo/microservices-demo/
- [ ] Run Scope on Docker For Mac
- [ ] Start and stop Scope in standalone mode
  - [ ] Linux
  - [ ] docker-machine
- [ ] Connect probes from release candidate to Weave Cloud
  - [ ] Local scope in probe-only mode connects to Weave Cloud and renders correctly
    - [ ] dev
    - [ ] prod
  - [ ] Controls appear for containers and function correctly
    - [ ] dev
    - [ ] prod
  - [ ] No new errors in logging or telemetry
    - [ ] dev
    - [ ] prod
- [ ] UI integration
  - [ ] Hot-reloading `cd client && npm i && npm start` and open http://localhost:4042
  - [ ] UI under prefix path  `cd client && npm run build && npm start-production` and open http://localhost:4043/scoped/
  - [ ] URL parameters: Run previous release and click around, keep UI open, start new release, reload page
- [ ] UI features
  (To test: clone [microservices demo](https://github.com/microservices-demo/microservices-demo) and run `cd deploy/docker-compose && docker-compose up`)
  - [ ] General: switch between topologies, see nodes and edges, details panel
  - [ ] Zoom and pan, switch between topologies
  - [ ] Topology filters: namespaces, system containers, etc.
  - [ ] Metrics on canvas, try pinning/unpinning
  - [ ] Search
    - [ ] by container name
    - [ ] by usage `cpu < 2%`
  - [ ] Terminal
    - [ ] Attach to container to see logs
    - [ ] Exec to container and type `ls`
    - [ ] Pop out terminal
  - [ ] Contrast mode
  - [ ] Download report
  - [ ] Pause button

## Things to think about
- ECS Integration
- Kubernetes Integration
- CPU and memory usage