### PR TITLE
Don't display the empty message when nodes are displayed

### DIFF
--- a/client/app/scripts/components/nodes.js
+++ b/client/app/scripts/components/nodes.js
@@ -11,7 +11,6 @@ import { Loading, getNodeType } from './loading';
 import {
   isTopologyNodeCountZero,
   isNodesDisplayEmpty,
-  isTopologyEmpty,
 } from '../utils/topology-utils';
 import {
   isGraphViewModeSelector,
@@ -24,11 +23,12 @@ import { TOPOLOGY_LOADER_DELAY } from '../constants/timer';
 
 // TODO: The information that we already have available on the frontend should enable
 // us to determine which of these cases exactly is preventing us from seeing the nodes.
-const NODE_COUNT_ZERO_CAUSES = [
+const NODES_STATS_COUNT_ZERO_CAUSES = [
   'We haven\'t received any reports from probes recently. Are the probes properly connected?',
   'Containers view only: you\'re not running Docker, or you don\'t have any containers',
 ];
-const NODES_DISPLAY_EMPTY_CAUSES = [
+const NODES_NOT_DISPLAYED_CAUSES = [
+  'There are nodes, but they\'ve been filtered out by pinned searches in the top-left corner.',
   'There are nodes, but they\'re currently hidden. Check the view options in the bottom-left if they allow for showing hidden nodes.',
   'There are no nodes for this particular moment in time. Use the time travel feature at the bottom-right corner to explore different times.',
 ];
@@ -39,13 +39,14 @@ const renderCauses = causes => (
 
 class Nodes extends React.Component {
   renderConditionalEmptyTopologyError() {
-    const { topologyNodeCountZero, nodesDisplayEmpty, topologyEmpty } = this.props;
+    const { topologyNodeCountZero, nodesDisplayEmpty } = this.props;
 
     return (
-      <NodesError faIconClass="fa-circle-thin" hidden={!topologyEmpty}>
+      <NodesError faIconClass="fa-circle-thin" hidden={!nodesDisplayEmpty}>
         <div className="heading">Nothing to show. This can have any of these reasons:</div>
-        {topologyNodeCountZero && renderCauses(NODE_COUNT_ZERO_CAUSES)}
-        {!topologyNodeCountZero && nodesDisplayEmpty && renderCauses(NODES_DISPLAY_EMPTY_CAUSES)}
+        {topologyNodeCountZero ?
+          renderCauses(NODES_STATS_COUNT_ZERO_CAUSES) :
+          renderCauses(NODES_NOT_DISPLAYED_CAUSES)}
       </NodesError>
     );
   }
@@ -84,7 +85,6 @@ function mapStateToProps(state) {
     isResourceViewMode: isResourceViewModeSelector(state),
     topologyNodeCountZero: isTopologyNodeCountZero(state),
     nodesDisplayEmpty: isNodesDisplayEmpty(state),
-    topologyEmpty: isTopologyEmpty(state),
     websocketTransitioning: state.get('websocketTransitioning'),
     currentTopology: state.get('currentTopology'),
     nodesLoaded: state.get('nodesLoaded'),

--- a/client/app/scripts/components/search.js
+++ b/client/app/scripts/components/search.js
@@ -8,7 +8,7 @@ import { searchMatchCountByTopologySelector } from '../selectors/search';
 import { isResourceViewModeSelector } from '../selectors/topology';
 import { slugify } from '../utils/string-utils';
 import { parseQuery } from '../utils/search-utils';
-import { isTopologyEmpty } from '../utils/topology-utils';
+import { isTopologyNodeCountZero } from '../utils/topology-utils';
 import { trackMixpanelEvent } from '../utils/tracking-utils';
 import SearchItem from './search-item';
 import { ENTER_KEY_CODE } from '../constants/key-codes';
@@ -129,7 +129,7 @@ class Search extends React.Component {
     const { nodes, pinnedSearches, searchFocused, searchMatchCountByTopology,
       isResourceViewMode, searchQuery, topologiesLoaded, inputId = 'search' } = this.props;
     const hidden = !topologiesLoaded || isResourceViewMode;
-    const disabled = this.props.isTopologyEmpty && !hidden;
+    const disabled = this.props.isTopologyNodeCountZero && !hidden;
     const matchCount = searchMatchCountByTopology
       .reduce((count, topologyMatchCount) => count + topologyMatchCount, 0);
     const showPinnedSearches = pinnedSearches.size > 0;
@@ -180,7 +180,7 @@ export default connect(
     nodes: state.get('nodes'),
     topologyViewMode: state.get('topologyViewMode'),
     isResourceViewMode: isResourceViewModeSelector(state),
-    isTopologyEmpty: isTopologyEmpty(state),
+    isTopologyNodeCountZero: isTopologyNodeCountZero(state),
     currentTopology: state.get('currentTopology'),
     topologiesLoaded: state.get('topologiesLoaded'),
     pinnedSearches: state.get('pinnedSearches'),

--- a/client/app/scripts/reducers/__tests__/root-test.js
+++ b/client/app/scripts/reducers/__tests__/root-test.js
@@ -14,7 +14,8 @@ describe('RootReducer', () => {
   // TODO maybe extract those to topology-utils tests?
   const activeTopologyOptionsSelector = topologySelectors.activeTopologyOptionsSelector;
   const getAdjacentNodes = topologyUtils.getAdjacentNodes;
-  const isTopologyEmpty = topologyUtils.isTopologyEmpty;
+  const isNodesDisplayEmpty = topologyUtils.isNodesDisplayEmpty;
+  const isTopologyNodeCountZero = topologyUtils.isTopologyNodeCountZero;
   const getUrlState = require('../../utils/router-utils').getUrlState;
 
   // fixtures
@@ -532,24 +533,36 @@ describe('RootReducer', () => {
 
   // empty topology
 
-  it('detects that the topology is empty', () => {
+  it('detects that the nodes display is empty', () => {
     let nextState = initialState;
     nextState = reducer(nextState, ReceiveTopologiesAction);
     nextState = reducer(nextState, ClickTopologyAction);
-    expect(isTopologyEmpty(nextState)).toBeTruthy();
+    expect(isNodesDisplayEmpty(nextState)).toBeTruthy();
 
     nextState = reducer(nextState, ReceiveNodesDeltaAction);
-    expect(isTopologyEmpty(nextState)).toBeFalsy();
+    expect(isNodesDisplayEmpty(nextState)).toBeFalsy();
 
     nextState = reducer(nextState, ClickTopology2Action);
+    expect(isNodesDisplayEmpty(nextState)).toBeTruthy();
+
     nextState = reducer(nextState, ReceiveNodesDeltaAction);
-    expect(isTopologyEmpty(nextState)).toBeTruthy();
+    expect(isNodesDisplayEmpty(nextState)).toBeFalsy();
+  });
+
+  it('detects that the topo stats are empty', () => {
+    let nextState = initialState;
+    nextState = reducer(nextState, ReceiveTopologiesAction);
+    nextState = reducer(nextState, ClickTopologyAction);
+    expect(isTopologyNodeCountZero(nextState)).toBeFalsy();
+
+    nextState = reducer(nextState, ReceiveNodesDeltaAction);
+    expect(isTopologyNodeCountZero(nextState)).toBeFalsy();
+
+    nextState = reducer(nextState, ClickTopology2Action);
+    expect(isTopologyNodeCountZero(nextState)).toBeTruthy();
 
     nextState = reducer(nextState, ClickTopologyAction);
-    expect(isTopologyEmpty(nextState)).toBeTruthy();
-
-    nextState = reducer(nextState, ReceiveNodesDeltaAction);
-    expect(isTopologyEmpty(nextState)).toBeFalsy();
+    expect(isTopologyNodeCountZero(nextState)).toBeFalsy();
   });
 
   // selection of relatives

--- a/client/app/scripts/utils/topology-utils.js
+++ b/client/app/scripts/utils/topology-utils.js
@@ -4,6 +4,7 @@ import { Set as makeSet, List as makeList } from 'immutable';
 import { isWebsocketQueryingCurrentSelector } from '../selectors/time-travel';
 import { isResourceViewModeSelector } from '../selectors/topology';
 import { pinnedMetricSelector } from '../selectors/node-metric';
+import { shownNodesSelector } from '../selectors/node-filters';
 
 //
 // top priority first
@@ -145,11 +146,7 @@ export function isNodesDisplayEmpty(state) {
     return !pinnedMetricSelector(state);
   }
   // Otherwise (in graph and table view), we only look at the nodes content.
-  return state.get('nodes').isEmpty();
-}
-
-export function isTopologyEmpty(state) {
-  return isTopologyNodeCountZero(state) || isNodesDisplayEmpty(state);
+  return shownNodesSelector(state).isEmpty();
 }
 
 export function getAdjacentNodes(state, originNodeId) {


### PR DESCRIPTION
Fixes #2592 by making sure the nodes empty message appears only when there are actually no nodes displayed. The `shownNodesSelector` is used to determine the displayed nodes, so with this change, we also get a message when all the nodes have been filtered out by search, so I also added one message for that to the list of possible causes.
