### PR TITLE
Do not read tcp6 files if TCP version 6 isn't supported

### DIFF
--- a/probe/endpoint/procspy/spy_linux.go
+++ b/probe/endpoint/procspy/spy_linux.go
@@ -69,7 +69,9 @@ func (s *linuxScanner) Connections() (ConnIter, error) {
 
 	if buf.Len() == 0 {
 		readFile(procRoot+"/net/tcp", buf)
-		readFile(procRoot+"/net/tcp6", buf)
+		if ipv6IsSupported {
+			readFile(procRoot+"/net/tcp6", buf)
+		}
 	}
 
 	return &pnConnIter{


### PR DESCRIPTION
This will help with #2577 when using `/proc` parsing. Fixing the eBPF connection tracker requeres a separate PR.