### PR TITLE
Fix zoom for `npm start`

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,8 @@
     "d3-selection": "1.0.5",
     "d3-shape": "1.0.6",
     "d3-time-format": "2.0.5",
+    "d3-transition": "1.0.4",
+    "d3-drag": "1.0.4",
     "d3-zoom": "1.1.4",
     "dagre": "0.7.4",
     "debug": "2.6.6",


### PR DESCRIPTION
Pins d3-transition and d3-drag dependencies which were previously
pulled in as deps from d3zoom as version 1.1.0 each. This broke
the zoom feature for `npm start`.

Fixes #2545