### PR TITLE
performance: only color connected once

### DIFF
--- a/render/container.go
+++ b/render/container.go
@@ -34,7 +34,7 @@ var ContainerRenderer = MakeFilter(
 	MakeReduce(
 		MakeMap(
 			MapProcess2Container,
-			ProcessRenderer,
+			ColorConnectedProcessRenderer,
 		),
 
 		// This mapper brings in connections by joining with container

--- a/render/host.go
+++ b/render/host.go
@@ -13,7 +13,7 @@ var HostRenderer = MakeReduce(
 	),
 	MakeMap(
 		MapX2Host,
-		ProcessRenderer,
+		ColorConnectedProcessRenderer,
 	),
 	MakeMap(
 		MapX2Host,

--- a/render/process.go
+++ b/render/process.go
@@ -27,14 +27,20 @@ var EndpointRenderer = FilterProcspiedOrEBPF(SelectEndpoint)
 // ProcessRenderer is a Renderer which produces a renderable process
 // graph by merging the endpoint graph and the process topology.
 var ProcessRenderer = ConditionalRenderer(renderProcesses,
-	ColorConnected(MakeReduce(
+	MakeReduce(
 		MakeMap(
 			MapEndpoint2Process,
 			EndpointRenderer,
 		),
 		SelectProcess,
-	)),
+	),
 )
+
+// ColorConnectedProcessRenderer colors connected nodes from
+// ProcessRenderer. Since the process topology views only show
+// connected processes, we need this info to determine whether
+// processes appearing in a details panel are linkable.
+var ColorConnectedProcessRenderer = ColorConnected(ProcessRenderer)
 
 // processWithContainerNameRenderer is a Renderer which produces a process
 // graph enriched with container names where appropriate


### PR DESCRIPTION
`ProcessRenderer` was coloring connected nodes because we need that info for rendering details panels. However, the main process topology view renderers depending on `ProcessRenderer` were also doing coloring themselves. For the 'processes' topology that was literally duplicating work. For the 'processes-by-name' topology that was throwing away the process coloring, and then coloring at the name level.

Solution: remove the coloring from the `ProcessRenderer`, thus eliminating the duplicate/thrown-away work, and introduce a `ColorConnectedProcessRenderer` which is only used in places that
populate details panels.

The performance improvement from this is tiny, but the change is worth it for improved clarity alone.