### PR TITLE
ensure connections from /proc/net/tcp{,6} get the right pid

### DIFF
--- a/probe/endpoint/procspy/spy_linux.go
+++ b/probe/endpoint/procspy/spy_linux.go
@@ -28,6 +28,11 @@ func (c *pnConnIter) Next() *Connection {
 	}
 	if proc, ok := c.procs[n.Inode]; ok {
 		n.Proc = *proc
+	} else {
+		// ProcNet.Next() always returns a pointer to the same
+		// struct. We therefore must clear any garbage left over from
+		// the previous call.
+		n.Proc = Proc{}
 	}
 	return n
 }


### PR DESCRIPTION
`ProcNet.Next` does not allocate `Connection` structs, for efficiency. Instead it always returns a `*Connection` pointing to the same instance. As a result, any mutations by the caller to struct elements that aren't actually set by `ProcNet.Next`, in particular `Connection.Proc`, are carried across to subsequent calls.

This had hilarious consequences: connections referencing an inode which we hadn't come across during proc walking would be associated with the process corresponding to the last successfully looked up inode.

The fix is to clear out the garbage left over from previous calls.

Fixes #2638.