### PR TITLE
Honor DOCKER_* env variables in probe and app

### DIFF
--- a/app/weave.go
+++ b/app/weave.go
@@ -12,10 +12,9 @@ import (
 
 // Default values for weave app integration
 const (
-	DefaultHostname       = "scope.weave.local."
-	DefaultWeaveURL       = "http://127.0.0.1:6784"
-	DefaultContainerName  = "weavescope"
-	DefaultDockerEndpoint = "unix:///var/run/docker.sock"
+	DefaultHostname      = "scope.weave.local."
+	DefaultWeaveURL      = "http://127.0.0.1:6784"
+	DefaultContainerName = "weavescope"
 )
 
 // WeavePublisher is a thing which periodically registers this app with WeaveDNS.

--- a/probe/docker/registry.go
+++ b/probe/docker/registry.go
@@ -92,6 +92,9 @@ type Client interface {
 }
 
 func newDockerClient(endpoint string) (Client, error) {
+	if endpoint == "" {
+		return docker_client.NewClientFromEnv()
+	}
 	return docker_client.NewClient(endpoint)
 }
 

--- a/probe/overlay/weave.go
+++ b/probe/overlay/weave.go
@@ -152,8 +152,8 @@ type DockerClient interface {
 	InspectContainer(id string) (*docker_client.Container, error)
 }
 
-func newDockerClient(endpoint string) (DockerClient, error) {
-	return docker_client.NewClient(endpoint)
+func newDockerClient() (DockerClient, error) {
+	return docker_client.NewClientFromEnv()
 }
 
 // Weave represents a single Weave router, presumably on the same host
@@ -181,8 +181,8 @@ type Weave struct {
 
 // NewWeave returns a new Weave tagger based on the Weave router at
 // address. The address should be an IP or FQDN, no port.
-func NewWeave(hostID string, client weave.Client, dockerEndpoint string) (*Weave, error) {
-	dockerClient, err := NewDockerClientStub(dockerEndpoint)
+func NewWeave(hostID string, client weave.Client) (*Weave, error) {
+	dockerClient, err := NewDockerClientStub()
 	if err != nil {
 		return nil, err
 	}

--- a/probe/overlay/weave_test.go
+++ b/probe/overlay/weave_test.go
@@ -64,12 +64,12 @@ var mockWeaveContainers = map[string]*docker_client.Container{
 func runTest(t *testing.T, f func(*overlay.Weave)) {
 	// Place and restore docker client
 	origNewDockerClientStub := overlay.NewDockerClientStub
-	overlay.NewDockerClientStub = func(string) (overlay.DockerClient, error) {
+	overlay.NewDockerClientStub = func() (overlay.DockerClient, error) {
 		return &mockDockerClient{containers: mockWeaveContainers}, nil
 	}
 	defer func() { overlay.NewDockerClientStub = origNewDockerClientStub }()
 
-	w, err := overlay.NewWeave(mockHostID, weave.MockClient{}, "")
+	w, err := overlay.NewWeave(mockHostID, weave.MockClient{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/prog/main.go
+++ b/prog/main.go
@@ -337,7 +337,7 @@ func setupFlags(flags *flags) {
 	flag.StringVar(&flags.app.weaveAddr, "app.weave.addr", app.DefaultWeaveURL, "Address on which to contact WeaveDNS")
 	flag.StringVar(&flags.app.weaveHostname, "app.weave.hostname", "", "Hostname to advertise in WeaveDNS")
 	flag.StringVar(&flags.app.containerName, "app.container.name", app.DefaultContainerName, "Name of this container (to lookup container ID)")
-	flag.StringVar(&flags.app.dockerEndpoint, "app.docker", app.DefaultDockerEndpoint, "Location of docker endpoint (to lookup container ID)")
+	flag.StringVar(&flags.app.dockerEndpoint, "app.docker", "", "Overwrite location of docker endpoint (to lookup container ID) (default \"$DOCKER_HOST\")")
 	flag.Var(&flags.containerLabelFilterFlags, "app.container-label-filter", "Add container label-based view filter, specified as title:label. Multiple flags are accepted. Example: --app.container-label-filter='Database Containers:role=db'")
 	flag.Var(&flags.containerLabelFilterFlagsExclude, "app.container-label-filter-exclude", "Add container label-based view filter that excludes containers with the given label, specified as title:label. Multiple flags are accepted. Example: --app.container-label-filter-exclude='Database Containers:role=db'")
 
@@ -394,7 +394,7 @@ func main() {
 	if flags.probe.httpListen != "" {
 		_, _, err := net.SplitHostPort(flags.probe.httpListen)
 		if err != nil {
-			log.Fatalf("Invalid value for -app.http.address: %v", err)
+			log.Fatalf("Invalid value for -probe.http.address: %v", err)
 		}
 	}
 

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -42,7 +42,6 @@ const (
 
 var (
 	pluginAPIVersion = "1"
-	dockerEndpoint   = "unix:///var/run/docker.sock"
 )
 
 func checkNewScopeVersion(flags probeFlags) {
@@ -199,7 +198,6 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 			CollectStats:           true,
 			HostID:                 hostID,
 			HandlerRegistry:        handlerRegistry,
-			DockerEndpoint:         dockerEndpoint,
 			NoCommandLineArguments: flags.noCommandLineArguments,
 			NoEnvironmentVariables: flags.noEnvironmentVariables,
 		}
@@ -236,7 +234,7 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 
 	if flags.weaveEnabled {
 		client := weave.NewClient(sanitize.URL("http://", 6784, "")(flags.weaveAddr))
-		weave, err := overlay.NewWeave(hostID, client, dockerEndpoint)
+		weave, err := overlay.NewWeave(hostID, client)
 		if err != nil {
 			log.Errorf("Weave: failed to start client: %v", err)
 		} else {


### PR DESCRIPTION
Changed default for flag `-app.docker` to use the DOCKER_* env variables
instead of hardcoded /var/run/docker.sock; uses docker's default if
no DOCKER_HOST defined, for both probe and app.

Fixes #1975

---
This is technically a breaking change (if someone had DOCKER_HOST set before and not provided an alternate location in `-app.docker`, it will now take a different location); albeit one I would assume impact is very low. Still, how do we handle this?