### PR TITLE
ignore endpoints with >1 adjacency in process rendering

### DIFF
--- a/render/process.go
+++ b/render/process.go
@@ -123,6 +123,13 @@ func MapEndpoint2Process(n report.Node, local report.Networks) report.Nodes {
 		return report.Nodes{}
 	}
 
+	if len(n.Adjacency) > 1 {
+		// We cannot be sure that the pid is associated with all the
+		// connections. It is better to drop such an endpoint than
+		// risk rendering bogus connections.
+		return report.Nodes{}
+	}
+
 	id := report.MakeProcessNodeID(report.ExtractHostID(n), pid)
 	node := NewDerivedNode(id, n).WithTopology(report.Process)
 	node.Latest = node.Latest.Set(process.PID, timestamp, pid)


### PR DESCRIPTION
This eliminates the worst effects of #2665.

It is imperfect because it
- simply drops all connections that originate from the same endpoint, if there is more than one. Not only will this eliminate the problematic connections (i.e. those where it is indeed the case that the same source ip+port was used by different processes), but also those where the source ip+port was used multiple times by the same process. That is unlikely for ephemeral ports (the odds of the *same* process getting given a particular ephemeral port more than once in a short period of time are much lower than the odds of *any two* processes getting given a particular ephemeral port in a short period of time, which is the problematic case we are wanting to eliminate here), but a dead certainty when the process is specifically choosing a source port, which is unusual but possible.
- does not eliminate incorrect process attribution when *destination* ip+ports are used by different processes. The most common case for that is pre-forking in the likes of apache. In that scenario, all the processes are "siblings". Incorrect attribution is not that bad here; yes, things will be wrong at the process level, but not in a "talking to some completely random process" sort of way, and higher level topologies are unaffected.

I have checked the effects of this change on recent Weave Cloud dev topologies, and it makes them look sane, while not obviously removing any edges that should be there.