### PR TITLE
don't show container count in host detail panel image list

### DIFF
--- a/render/detailed/node.go
+++ b/render/detailed/node.go
@@ -175,10 +175,8 @@ var nodeSummaryGroupSpecs = []struct {
 	{
 		topologyID: report.ContainerImage,
 		NodeSummaryGroup: NodeSummaryGroup{
-			Label: "Container Images",
-			Columns: []Column{
-				{ID: report.Container, Label: "# Containers", DefaultSort: true, Datatype: "number"},
-			},
+			Label:   "Container Images",
+			Columns: []Column{},
 		},
 	},
 }

--- a/render/detailed/node.go
+++ b/render/detailed/node.go
@@ -135,7 +135,6 @@ var nodeSummaryGroupSpecs = []struct {
 		topologyID: report.Pod,
 		NodeSummaryGroup: NodeSummaryGroup{
 			Label: "Pods",
-
 			Columns: []Column{
 				{ID: kubernetes.State, Label: "State"},
 				{ID: report.Container, Label: "# Containers", Datatype: "number"},
@@ -155,7 +154,8 @@ var nodeSummaryGroupSpecs = []struct {
 	{
 		topologyID: report.Container,
 		NodeSummaryGroup: NodeSummaryGroup{
-			Label: "Containers", Columns: []Column{
+			Label: "Containers",
+			Columns: []Column{
 				{ID: docker.CPUTotalUsage, Label: "CPU", Datatype: "number"},
 				{ID: docker.MemoryUsage, Label: "Memory", Datatype: "number"},
 			},
@@ -164,7 +164,8 @@ var nodeSummaryGroupSpecs = []struct {
 	{
 		topologyID: report.Process,
 		NodeSummaryGroup: NodeSummaryGroup{
-			Label: "Processes", Columns: []Column{
+			Label: "Processes",
+			Columns: []Column{
 				{ID: process.PID, Label: "PID", Datatype: "number"},
 				{ID: process.CPUUsage, Label: "CPU", Datatype: "number"},
 				{ID: process.MemoryUsage, Label: "Memory", Datatype: "number"},
@@ -174,8 +175,7 @@ var nodeSummaryGroupSpecs = []struct {
 	{
 		topologyID: report.ContainerImage,
 		NodeSummaryGroup: NodeSummaryGroup{
-			TopologyID: "containers-by-image",
-			Label:      "Container Images",
+			Label: "Container Images",
 			Columns: []Column{
 				{ID: report.Container, Label: "# Containers", DefaultSort: true, Datatype: "number"},
 			},

--- a/render/detailed/node_test.go
+++ b/render/detailed/node_test.go
@@ -132,10 +132,8 @@ func TestMakeDetailedHostNode(t *testing.T) {
 			{
 				Label:      "Container Images",
 				TopologyID: "containers-by-image",
-				Columns: []detailed.Column{
-					{ID: report.Container, Label: "# Containers", DefaultSort: true, Datatype: "number"},
-				},
-				Nodes: []detailed.NodeSummary{containerImageNodeSummary},
+				Columns:    []detailed.Column{},
+				Nodes:      []detailed.NodeSummary{containerImageNodeSummary},
 			},
 		},
 		Connections: []detailed.ConnectionsSummary{


### PR DESCRIPTION
The figure is inaccurate since it counts containers across all hosts. Getting the count correct is non-trivial, so it's better to not show the figure at all.

NB: the count still shows up on mouse-over of the link, but that is defensible and not (very) confusing since the link represents the image, not the image on a particular host, and it's the same count that show up as the minor label in the container images view.

Fixes #2681.