### PR TITLE
Last line of defense against overlapping nodes in graph layout

### DIFF
--- a/client/app/scripts/charts/__tests__/node-layout-test.js
+++ b/client/app/scripts/charts/__tests__/node-layout-test.js
@@ -407,4 +407,35 @@ describe('NodesLayout', () => {
     expect(nodes.n6.x).toBeGreaterThan(nodes.n3.x);
     expect(nodes.n6.y).toEqual(nodes.n3.y);
   });
+
+  it('rerenders the nodes completely after the coordinates have been messed up', () => {
+    // Take an initial setting
+    let result = NodesLayout.doLayout(
+      nodeSets.rank4.nodes,
+      nodeSets.rank4.edges,
+    );
+
+    // Cache the result layout
+    options.cachedLayout = result;
+    options.nodeCache = options.nodeCache.merge(result.nodes);
+    options.edgeCache = options.edgeCache.merge(result.edge);
+
+    // Shrink the coordinates of all the notes 2x to make them closer to one another
+    options.nodeCache = options.nodeCache.update(cache => cache.map(node => node.merge({
+      x: node.get('x') / 2,
+      y: node.get('y') / 2,
+    })));
+
+    // Rerun the initial layout to get a trivial diff and skip all the advanced layouting logic.
+    result = NodesLayout.doLayout(
+      nodeSets.rank4.nodes,
+      nodeSets.rank4.edges,
+      options
+    );
+
+    // The layout should have updated by running into our last 'integration testing' criterion
+    coords = getNodeCoordinates(options.nodeCache);
+    resultCoords = getNodeCoordinates(result.nodes);
+    expect(resultCoords).not.toEqual(coords);
+  });
 });

--- a/client/app/scripts/charts/nodes-layout.js
+++ b/client/app/scripts/charts/nodes-layout.js
@@ -4,6 +4,7 @@ import { fromJS, Map as makeMap, Set as ImmSet } from 'immutable';
 
 import { NODE_BASE_SIZE, EDGE_WAYPOINTS_CAP } from '../constants/styles';
 import { EDGE_ID_SEPARATOR } from '../constants/naming';
+import { trackMixpanelEvent } from '../utils/tracking-utils';
 import { featureIsEnabledAny } from '../utils/feature-utils';
 import { buildTopologyCacheId, updateNodeDegrees } from '../utils/topology-utils';
 import { minEuclideanDistanceBetweenPoints } from '../utils/math-utils';
@@ -481,6 +482,7 @@ export function doLayout(immNodes, immEdges, opts) {
     // Last line of defense - re-render everything if two nodes are too close to one another.
     if (minEuclideanDistanceBetweenPoints(layout.nodes) < NODE_CENTERS_SEPARATION_FACTOR) {
       layout = runLayoutEngine(cache.graph, nodesWithDegrees, immEdges, opts);
+      trackMixpanelEvent('scope.layout.graph.overlap');
     }
 
     // cache results

--- a/client/app/scripts/utils/__tests__/math-utils-test.js
+++ b/client/app/scripts/utils/__tests__/math-utils-test.js
@@ -1,3 +1,5 @@
+import { fromJS } from 'immutable';
+
 
 describe('MathUtils', () => {
   const MathUtils = require('../math-utils');
@@ -17,6 +19,27 @@ describe('MathUtils', () => {
       expect(f(-3, 5)).toBe(2);
       expect(f(-4, 5)).toBe(1);
       expect(f(-5, 5)).toBe(0);
+    });
+  });
+
+  describe('minEuclideanDistanceBetweenPoints', () => {
+    const f = MathUtils.minEuclideanDistanceBetweenPoints;
+    const entryA = { pointA: { x: 0, y: 0 } };
+    const entryB = { pointB: { x: 30, y: 0 } };
+    const entryC = { pointC: { x: 0, y: -40 } };
+    const entryD = { pointD: { x: -1000, y: 567 } };
+    const entryE = { pointE: { x: -999, y: 567 } };
+    const entryF = { pointF: { x: 30, y: 0 } };
+
+    it('it should return the minimal distance between any two points in the collection', () => {
+      expect(f(fromJS({}))).toBe(0);
+      expect(f(fromJS({...entryA}))).toBe(0);
+      expect(f(fromJS({...entryA, ...entryB}))).toBe(30);
+      expect(f(fromJS({...entryA, ...entryC}))).toBe(40);
+      expect(f(fromJS({...entryB, ...entryC}))).toBe(50);
+      expect(f(fromJS({...entryA, ...entryB, ...entryC, ...entryD}))).toBe(30);
+      expect(f(fromJS({...entryA, ...entryB, ...entryC, ...entryD, ...entryE}))).toBe(1);
+      expect(f(fromJS({...entryA, ...entryB, ...entryC, ...entryD, ...entryF}))).toBe(0);
     });
   });
 });

--- a/client/app/scripts/utils/math-utils.js
+++ b/client/app/scripts/utils/math-utils.js
@@ -18,3 +18,26 @@
 export function modulo(i, n) {
   return ((i % n) + n) % n;
 }
+
+function euclideanDistance(pointA, pointB) {
+  const dx = pointA.get('x') - pointB.get('x');
+  const dy = pointA.get('y') - pointB.get('y');
+  return Math.sqrt((dx * dx) + (dy * dy));
+}
+
+// This could be solved in O(N log N) (see https://en.wikipedia.org/wiki/Closest_pair_of_points_problem),
+// but this brute-force O(N^2) should be good enough for a reasonable number of nodes.
+export function minEuclideanDistanceBetweenPoints(points) {
+  let minDistance = 0;
+  let foundPair = false;
+  points.forEach((pointA, idA) => {
+    points.forEach((pointB, idB) => {
+      const distance = euclideanDistance(pointA, pointB);
+      if (idA !== idB && (distance < minDistance || !foundPair)) {
+        minDistance = distance;
+        foundPair = true;
+      }
+    });
+  });
+  return minDistance;
+}


### PR DESCRIPTION
Fixes #2261 by introducing an additional test at the end of the layout function to see if any the nodes would overlap - if they would, the whole layout is refreshed by calling the render engine with a clean cache.

*Note*: The `layoutSingleNodes` has just been moved to the top, nothing was changed there.
