### PR TITLE
don't use eBPF in a couple of tests

### DIFF
--- a/integration/330_process_edge_test.sh
+++ b/integration/330_process_edge_test.sh
@@ -6,7 +6,7 @@
 start_suite "Test long connections (procspy) between processes"
 
 weave_on "$HOST1" launch
-scope_on "$HOST1" launch --probe.conntrack=false
+scope_on "$HOST1" launch --probe.ebpf.connections=false --probe.conntrack=false
 
 server_on "$HOST1"
 weave_proxy_on "$HOST1" run -dti --name client alpine /bin/sh -c "while true; do \

--- a/integration/340_process_edge_across_host_2_test.sh
+++ b/integration/340_process_edge_across_host_2_test.sh
@@ -8,8 +8,8 @@ start_suite "Test long connections (procspy) between processes on different host
 weave_on "$HOST1" launch "$HOST1" "$HOST2"
 weave_on "$HOST2" launch "$HOST1" "$HOST2"
 
-scope_on "$HOST1" launch --probe.conntrack=false
-scope_on "$HOST2" launch --probe.conntrack=false
+scope_on "$HOST1" launch --probe.ebpf.connections=false --probe.conntrack=false
+scope_on "$HOST2" launch --probe.ebpf.connections=false --probe.conntrack=false
 
 server_on "$HOST1"
 weave_proxy_on "$HOST2" run -dti --name client alpine /bin/sh -c "while true; do \


### PR DESCRIPTION
There really should be two variants - with and without eBPF - but the latter is broken due to #2689.