### PR TITLE
Yarn prefixes version with `v` when packing

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weave-scope",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "SPA JS app for Weave Scope visualising the application network.",
   "repository": "weaveworks/scope",
   "license": "Apache-2.0",
@@ -101,7 +101,7 @@
     "build-external": "EXTERNAL=true webpack --config webpack.production.config.js",
     "copy-pkg-files": "cp package.json build-pkg/ && cp -R app/styles build-pkg/",
     "build-pkg": "mkdir -p build-pkg && node node_modules/.bin/babel app/scripts --ignore __tests__ --out-dir build-pkg && yarn run copy-pkg-files",
-    "bundle": "yarn run build-pkg && yarn pack ./build-pkg && mv weave-scope-$npm_package_version.tgz ./tmp/weave-scope.tgz",
+    "bundle": "yarn run build-pkg && yarn pack ./build-pkg && mv weave-scope-v$npm_package_version.tgz ./tmp/weave-scope.tgz",
     "start": "node server.js",
     "start-production": "NODE_ENV=production node server.js",
     "test": "jest",


### PR DESCRIPTION
Fixes 

```
mv: cannot stat 'weave-scope-1.5.0.tgz': No such file or directory
```