### PR TITLE
Set package.json version to 0.0.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weave-scope",
-  "version": "1.5.1",
+  "version": "0.0.0",
   "description": "SPA JS app for Weave Scope visualising the application network.",
   "repository": "weaveworks/scope",
   "license": "Apache-2.0",


### PR DESCRIPTION
The package version is irrelevant for the build process
and is not read anywhere.

The package is not published and causes confusion if the
bump is forgotten.