### PR TITLE
fix ebpf init race segfault

### DIFF
--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -97,6 +97,9 @@ func newEbpfTracker() (eventTracker, error) {
 	}
 
 	ebpfTracker = tracker
+
+	t.Start()
+
 	return tracker, nil
 }
 

--- a/probe/endpoint/ebpf_test.go
+++ b/probe/endpoint/ebpf_test.go
@@ -209,13 +209,12 @@ func TestInvalidTimeStampDead(t *testing.T) {
 		dead:            false,
 		openConnections: map[string]ebpfConnection{},
 	}
-	ebpfTracker = mockEbpfTracker
 	event.Timestamp = 0
-	tcpEventCbV4(event)
+	mockEbpfTracker.tcpEventCbV4(event)
 	event2 := event
 	event2.SPort = 1
 	event2.Timestamp = 2
-	tcpEventCbV4(event2)
+	mockEbpfTracker.tcpEventCbV4(event2)
 	mockEbpfTracker.walkConnections(func(e ebpfConnection) {
 		cnt++
 	})
@@ -227,7 +226,7 @@ func TestInvalidTimeStampDead(t *testing.T) {
 	}
 	cnt = 0
 	event.Timestamp = 1
-	tcpEventCbV4(event)
+	mockEbpfTracker.tcpEventCbV4(event)
 	mockEbpfTracker.walkConnections(func(e ebpfConnection) {
 		cnt++
 	})

--- a/vendor/github.com/weaveworks/tcptracer-bpf/pkg/tracer/tracer.go
+++ b/vendor/github.com/weaveworks/tcptracer-bpf/pkg/tracer/tracer.go
@@ -101,15 +101,17 @@ func NewTracer(tcpEventCbV4 func(TcpV4), tcpEventCbV6 func(TcpV6), lostCb func(l
 		}
 	}()
 
-	perfMapIPV4.PollStart()
-	perfMapIPV6.PollStart()
-
 	return &Tracer{
 		m:           m,
 		perfMapIPV4: perfMapIPV4,
 		perfMapIPV6: perfMapIPV6,
 		stopChan:    stopChan,
 	}, nil
+}
+
+func (t *Tracer) Start() {
+	t.perfMapIPV4.PollStart()
+	t.perfMapIPV6.PollStart()
 }
 
 func (t *Tracer) AddFdInstallWatcher(pid uint32) (err error) {

--- a/vendor/github.com/weaveworks/tcptracer-bpf/pkg/tracer/tracer_unsupported.go
+++ b/vendor/github.com/weaveworks/tcptracer-bpf/pkg/tracer/tracer_unsupported.go
@@ -15,12 +15,13 @@ func TracerAsset() ([]byte, error) {
 func NewTracer(tcpEventCbV4 func(TcpV4), tcpEventCbV6 func(TcpV6), lostCb func(lost uint64)) (*Tracer, error) {
 	return nil, fmt.Errorf("not supported on non-Linux systems")
 }
+func (t *Tracer) Start() {
+}
 func (t *Tracer) AddFdInstallWatcher(pid uint32) (err error) {
 	return fmt.Errorf("not supported on non-Linux systems")
 }
 func (t *Tracer) RemoveFdInstallWatcher(pid uint32) (err error) {
 	return fmt.Errorf("not supported on non-Linux systems")
 }
-
 func (t *Tracer) Stop() {
 }

--- a/vendor/github.com/weaveworks/tcptracer-bpf/tcptracer-bpf.c
+++ b/vendor/github.com/weaveworks/tcptracer-bpf/tcptracer-bpf.c
@@ -11,6 +11,7 @@
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wtautological-compare"
+#pragma clang diagnostic ignored "-Wgnu-variable-sized-type-not-at-end"
 #include <net/sock.h>
 #pragma clang diagnostic pop
 #include <net/inet_sock.h>

--- a/vendor/github.com/weaveworks/tcptracer-bpf/tests/tracer.go
+++ b/vendor/github.com/weaveworks/tcptracer-bpf/tests/tracer.go
@@ -67,6 +67,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	t.Start()
+
 	for _, p := range strings.Split(watchFdInstallPids, ",") {
 		if p == "" {
 			continue

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -1038,7 +1038,7 @@
 			"importpath": "github.com/weaveworks/tcptracer-bpf",
 			"repository": "https://github.com/weaveworks/tcptracer-bpf",
 			"vcs": "git",
-			"revision": "a616ebc6c5ac196af743e5dfc621a52fce030f87",
+			"revision": "fc80d1659bf07dabebbb42c5507578440103d66f",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
We defer starting the ebpf tracer until we've set the global var which is referenced by the callback functions. Previously the var could be unset when the callbacks are invoked, resulting in a segfault.

...and then we eliminate the global var altogether :)

Fixes #2687.