### PR TITLE
[WIP] Minor repositioning of controls

### DIFF
--- a/client/app/scripts/components/app.js
+++ b/client/app/scripts/components/app.js
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { debounce } from 'lodash';
 
-import Logo from './logo';
 import Footer from './footer';
 import Sidebar from './sidebar';
 import HelpPanel from './help-panel';
@@ -172,7 +171,6 @@ class App extends React.Component {
       timeTravelTransitioning, showingTimeTravel } = this.props;
 
     const className = classNames('scope-app', { 'time-travel-open': showingTimeTravel });
-    const isIframe = window !== window.top;
 
     return (
       <div className={className} ref={this.saveAppRef}>
@@ -187,12 +185,6 @@ class App extends React.Component {
         <div className="header">
           <TimeTravel />
           <div className="selectors">
-            <div className="logo">
-              {!isIframe && <svg width="100%" height="100%" viewBox="0 0 1089 217">
-                <Logo />
-              </svg>}
-            </div>
-            <Search />
             <Topologies />
             <ViewModeSelector />
             <TimeControl />
@@ -205,6 +197,7 @@ class App extends React.Component {
           {showingNetworkSelector && isGraphViewMode && <NetworkSelector />}
           {!isResourceViewMode && <Status />}
           {!isResourceViewMode && <TopologyOptions />}
+          {!isResourceViewMode && <Search />}
         </Sidebar>
 
         <Footer />

--- a/client/app/scripts/components/footer.js
+++ b/client/app/scripts/components/footer.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
+import Logo from './logo';
 import Plugins from './plugins';
 import { trackMixpanelEvent } from '../utils/tracking-utils';
 import {
@@ -46,6 +47,12 @@ class Footer extends React.Component {
 
     return (
       <div className="footer">
+        <span className="logo">
+          <svg width="110px" viewBox="0 0 1089 217">
+            <Logo />
+          </svg>
+        </span>
+
         <div className="footer-status">
           {versionUpdate && <a
             className="footer-versionupdate"

--- a/client/app/scripts/components/search.js
+++ b/client/app/scripts/components/search.js
@@ -5,7 +5,6 @@ import { debounce } from 'lodash';
 
 import { blurSearch, doSearch, focusSearch, pinSearch, toggleHelp } from '../actions/app-actions';
 import { searchMatchCountByTopologySelector } from '../selectors/search';
-import { isResourceViewModeSelector } from '../selectors/topology';
 import { slugify } from '../utils/string-utils';
 import { parseQuery } from '../utils/search-utils';
 import { isTopologyNodeCountZero } from '../utils/topology-utils';
@@ -127,16 +126,14 @@ class Search extends React.Component {
 
   render() {
     const { nodes, pinnedSearches, searchFocused, searchMatchCountByTopology,
-      isResourceViewMode, searchQuery, topologiesLoaded, inputId = 'search' } = this.props;
-    const hidden = !topologiesLoaded || isResourceViewMode;
-    const disabled = this.props.isTopologyNodeCountZero && !hidden;
+      searchQuery, topologiesLoaded, inputId = 'search' } = this.props;
+    const disabled = !topologiesLoaded || this.props.isTopologyNodeCountZero;
     const matchCount = searchMatchCountByTopology
       .reduce((count, topologyMatchCount) => count + topologyMatchCount, 0);
     const showPinnedSearches = pinnedSearches.size > 0;
     // manual clear (null) has priority, then props, then state
     const value = this.state.value === null ? '' : this.state.value || searchQuery || '';
-    const classNames = classnames('search', 'hideable', {
-      hide: hidden,
+    const classNames = classnames('search', {
       'search-pinned': showPinnedSearches,
       'search-matched': matchCount,
       'search-filled': value,
@@ -179,7 +176,6 @@ export default connect(
   state => ({
     nodes: state.get('nodes'),
     topologyViewMode: state.get('topologyViewMode'),
-    isResourceViewMode: isResourceViewModeSelector(state),
     isTopologyNodeCountZero: isTopologyNodeCountZero(state),
     currentTopology: state.get('currentTopology'),
     topologiesLoaded: state.get('topologiesLoaded'),

--- a/client/app/scripts/components/topology-options.js
+++ b/client/app/scripts/components/topology-options.js
@@ -109,10 +109,12 @@ class TopologyOptions extends React.Component {
 
   render() {
     const { options } = this.props;
+
+    if (!options) return null;
+
     return (
       <div className="topology-options">
-        {options && options.toIndexedSeq().map(
-          option => this.renderOption(option))}
+        {options.toIndexedSeq().map(option => this.renderOption(option))}
       </div>
     );
   }

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -9,6 +9,9 @@
     url("../../node_modules/materialize-css/fonts/roboto/Roboto-Regular.ttf");
 }
 
+// TODO: Remove this when the CONFIGURE button is removed from Scope in Weave Cloud.
+.setup-nav-button { display: none; }
+
 .browsehappy {
   margin: 0.2em 0;
   background: #ccc;
@@ -179,7 +182,7 @@
 }
 
 .header {
-  margin-top: 38px;
+  margin-top: 15px;
   pointer-events: none;
   width: 100%;
 
@@ -209,6 +212,11 @@
 .footer {
   @extend .overlay-wrapper;
   right: 43px;
+
+  .logo {
+    margin-right: 8px;
+    margin-bottom: -6px;
+  }
 
   &-status {
     margin-right: 1em;
@@ -326,11 +334,12 @@
 
 
 .topologies {
-  margin: 0 4px;
+  position: absolute;
   display: flex;
+  left: 25px;
 
   .topologies-item {
-    margin: 0px 8px;
+    margin-right: 16px;
 
     &-label {
       font-size: .8rem;
@@ -1379,7 +1388,8 @@
 
 .status {
   text-transform: uppercase;
-  padding: 2px 12px;
+  padding: 2px;
+  margin: 8px 0;
   border-radius: $border-radius;
   color: $text-secondary-color;
   display: inline-block;
@@ -1448,8 +1458,12 @@
   margin-top: 6px;
 }
 
+.view-mode-selector {
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .view-mode-selector, .time-control {
-  margin-left: 20px;
   min-width: 161px;
 
   &-wrapper {
@@ -1481,6 +1495,7 @@
 
 .time-control {
   position: absolute;
+  margin-left: 20px;
   right: 36px;
 
   &-controls {
@@ -1569,17 +1584,22 @@
 .sidebar {
   position: fixed;
   bottom: 11px;
-  left: 11px;
+  left: 25px;
   padding: 5px;
   font-size: .7rem;
   border-radius: 8px;
   border: 1px solid transparent;
   pointer-events: none;
+
+  .topology-options {
+    margin-bottom: 15px;
+  }
 }
 
 .sidebar-gridmode {
   background-color: #e9e9f1;
   border-color: $background-darker-color;
+  padding: 5px 10px;
   opacity: 0.9;
 }
 
@@ -1588,13 +1608,11 @@
 
   display: inline-block;
   position: relative;
-  width: 10em;
+  width: 150px;
   transition: width 0.3s 0s $base-ease;
 
   &-wrapper {
-    flex: 0 1 20%;
-    margin: 0 8px;
-    text-align: right;
+    margin-bottom: 20px;
   }
 
   &-disabled {
@@ -1695,7 +1713,7 @@
   &-focused,
   &-filled,
   &-pinned {
-    width: 100%;
+    width: 550px;
   }
 
   &-matched &-input {


### PR DESCRIPTION
Moved around some controls as preparation for #2677 (see [latest mockups](https://www.dropbox.com/sh/45hq01047u7zfir/AABQugkx5FjhOOpIGilBB0pBa?dl=0&preview=170710timelineSketch2.png)) and addressed https://github.com/weaveworks/service-ui/issues/746 in the context of Scope.

##### Semantic grouping

* *Topologies* - top left
* *View selectors* (view mode, resource metrics) - top center
* *Time control* - top right
* *Filters* (topology options, search) - bottom left
* *Footer* (version, help, misc controls, zooming) - bottom right

##### Specific changes

* Moved the *Search bar* to the bottom left corner as it belongs to filters semantically.
* Moved the *Scope logo* down to the footer (next to version) and made it much smaller.
* Moved *Topologies* selector to the freed up space on the left and split it from the *View mode* selector.
* Centered *View mode* selector horizontally.
* Hidding the *CONFIGURE* button for Scope.

##### Notes

* We should consider moving the *Networks* button together with the view selectors (as is the case with resource metrics).
