### PR TITLE
Keep topo nav visible if subnav selected

### DIFF
--- a/client/app/scripts/reducers/__tests__/root-test.js
+++ b/client/app/scripts/reducers/__tests__/root-test.js
@@ -276,7 +276,11 @@ describe('RootReducer', () => {
       name: 'Topo2',
       stats: {
         node_count: 0
-      }
+      },
+      sub_topologies: [{
+        url: '/topo2-sub',
+        name: 'topo 2 sub'
+      }]
     }]
   };
 
@@ -292,10 +296,13 @@ describe('RootReducer', () => {
       hide_if_empty: true,
       url: '/topo2',
       name: 'Topo2',
-      stats: {
-        node_count: 0,
-        filtered_nodes: 0
-      }
+      stats: { node_count: 0, filtered_nodes: 0 },
+      sub_topologies: [{
+        url: '/topo2-sub',
+        name: 'topo 2 sub',
+        hide_if_empty: true,
+        stats: { node_count: 0, filtered_nodes: 0 },
+      }]
     }]
   };
 
@@ -588,13 +595,23 @@ describe('RootReducer', () => {
 
   it('keeps hidden topology visible if selected', () => {
     let nextState = initialState;
+    nextState = reducer(nextState, ReceiveTopologiesAction);
     nextState = reducer(nextState, ClickTopology2Action);
     nextState = reducer(nextState, ReceiveTopologiesHiddenAction);
     expect(nextState.get('currentTopologyId')).toEqual('topo2');
     expect(nextState.get('topologies').toJS().length).toEqual(2);
   });
 
-  it('keeps hidden topology hidden if not selected', () => {
+  it('keeps hidden topology visible if sub_topology selected', () => {
+    let nextState = initialState;
+    nextState = reducer(nextState, ReceiveTopologiesAction);
+    nextState = reducer(nextState, { type: ActionTypes.CLICK_TOPOLOGY, topologyId: 'topo2-sub' });
+    nextState = reducer(nextState, ReceiveTopologiesHiddenAction);
+    expect(nextState.get('currentTopologyId')).toEqual('topo2-sub');
+    expect(nextState.get('topologies').toJS().length).toEqual(2);
+  });
+
+  it('hides hidden topology if not selected', () => {
     let nextState = initialState;
     nextState = reducer(nextState, ClickTopologyAction);
     nextState = reducer(nextState, ReceiveTopologiesHiddenAction);

--- a/client/app/scripts/reducers/root.js
+++ b/client/app/scripts/reducers/root.js
@@ -113,7 +113,7 @@ function processTopologies(state, nextTopologies) {
   // add IDs to topology objects in-place
   const topologiesWithId = updateTopologyIds(nextTopologies);
   // filter out hidden topos
-  const visibleTopologies = filterHiddenTopologies(topologiesWithId, state.get('currentTopologyId'));
+  const visibleTopologies = filterHiddenTopologies(topologiesWithId, state.get('currentTopology'));
   // set `selectType` field for topology and sub_topologies options (recursive).
   const topologiesWithSelectType = visibleTopologies.map(calcSelectType);
   // cache URLs by ID

--- a/client/app/scripts/utils/topology-utils.js
+++ b/client/app/scripts/utils/topology-utils.js
@@ -1,5 +1,5 @@
 import { endsWith } from 'lodash';
-import { Set as makeSet, List as makeList } from 'immutable';
+import { Set as makeSet, List as makeList, Map as makeMap } from 'immutable';
 
 import { isPausedSelector } from '../selectors/time-travel';
 import { isResourceViewModeSelector } from '../selectors/topology';
@@ -126,9 +126,11 @@ export function setTopologyUrlsById(topologyUrlsById, topologies) {
   return urlMap;
 }
 
-export function filterHiddenTopologies(topologies, currentTopologyId) {
+export function filterHiddenTopologies(topologies, currentTopology) {
+  currentTopology = currentTopology || makeMap();
   return topologies.filter(t => (!t.hide_if_empty || t.stats.node_count > 0 ||
-                               t.stats.filtered_nodes > 0 || t.id === currentTopologyId));
+                               t.stats.filtered_nodes > 0 || t.id === currentTopology.get('id') ||
+                               t.id === currentTopology.get('parentId')));
 }
 
 export function getCurrentTopologyOptions(state) {


### PR DESCRIPTION
Follow-up to 21a0093c but also displays parent topology if
an empty sub_topology is selected.