### PR TITLE
Reset nodes in frontend when scope-app restarted

### DIFF
--- a/client/app/scripts/actions/app-actions.js
+++ b/client/app/scripts/actions/app-actions.js
@@ -551,7 +551,7 @@ export function receiveNodesDelta(delta) {
         dispatch({ type: ActionTypes.FINISH_TIME_TRAVEL_TRANSITION });
       }
 
-      const hasChanges = delta.add || delta.update || delta.remove;
+      const hasChanges = delta.add || delta.update || delta.remove || delta.reset;
       if (hasChanges) {
         dispatch({
           type: ActionTypes.RECEIVE_NODES_DELTA,

--- a/client/app/scripts/reducers/root.js
+++ b/client/app/scripts/reducers/root.js
@@ -582,7 +582,12 @@ export function rootReducer(state = initialState, action) {
       log('RECEIVE_NODES_DELTA',
         'remove', size(action.delta.remove),
         'update', size(action.delta.update),
-        'add', size(action.delta.add));
+        'add', size(action.delta.add),
+        'reset', action.delta.reset);
+
+      if (action.delta.reset) {
+        state = state.set('nodes', makeMap());
+      }
 
       // remove nodes that no longer exist
       each(action.delta.remove, (nodeId) => {

--- a/render/detailed/topology_diff.go
+++ b/render/detailed/topology_diff.go
@@ -10,11 +10,12 @@ type Diff struct {
 	Add    []NodeSummary `json:"add"`
 	Update []NodeSummary `json:"update"`
 	Remove []string      `json:"remove"`
+	Reset  bool          `json:"reset,omitempty"`
 }
 
 // TopoDiff gives you the diff to get from A to B.
 func TopoDiff(a, b NodeSummaries) Diff {
-	diff := Diff{}
+	diff := Diff{Reset: a == nil}
 
 	notSeen := map[string]struct{}{}
 	for k := range a {

--- a/render/detailed/topology_diff_test.go
+++ b/render/detailed/topology_diff_test.go
@@ -79,6 +79,22 @@ func TestTopoDiff(t *testing.T) {
 				Update: []detailed.NodeSummary{nodeap},
 			},
 		},
+		{
+			label: "no previous nodes",
+			have:  detailed.TopoDiff(nil, nodes(nodea)),
+			want: detailed.Diff{
+				Add:   []detailed.NodeSummary{nodea},
+				Reset: true,
+			},
+		},
+		{
+			label: "empty previous nodes",
+			have:  detailed.TopoDiff(nodes(), nodes(nodea)),
+			want: detailed.Diff{
+				Add:   []detailed.NodeSummary{nodea},
+				Reset: false,
+			},
+		},
 	} {
 		sort.Strings(c.have.Remove)
 		sort.Sort(ByID(c.have.Add))


### PR DESCRIPTION
When the scope-app restarts, it no longer has a
reference to the previous node set. Therefore,
the delta update adds *all* nodes but does not
remove legacy ones.

`reset==true` tells the frontend to start fresh.

Fixes #2708