### PR TITLE
only pass WEAVESCOPE_DOCKER_ARGS to actual probe/app start

### DIFF
--- a/scope
+++ b/scope
@@ -48,8 +48,7 @@ usage() {
 		Launch options:
 	EOF
     # shellcheck disable=SC2086
-    docker run --rm -e CHECKPOINT_DISABLE --entrypoint=/home/weave/scope \
-        $WEAVESCOPE_DOCKER_ARGS "$SCOPE_IMAGE" -h >&2
+    docker run --rm -e CHECKPOINT_DISABLE --entrypoint=/home/weave/scope "$SCOPE_IMAGE" -h >&2
 }
 
 usage_and_die() {
@@ -177,14 +176,13 @@ docker_args() {
         -v /var/run/docker.sock:/var/run/docker.sock \
         -v /var/run/scope/plugins:/var/run/scope/plugins \
         -v /sys/kernel/debug:/sys/kernel/debug \
-        -e CHECKPOINT_DISABLE \
-        $WEAVESCOPE_DOCKER_ARGS
+        -e CHECKPOINT_DISABLE
 }
 
 launch_command() {
-    # shellcheck disable=SC2046
+    # shellcheck disable=SC2046,SC2086
     echo docker run -d --name="$SCOPE_CONTAINER_NAME" $(docker_args) \
-        "$SCOPE_IMAGE" --probe.docker=true
+        $WEAVESCOPE_DOCKER_ARGS "$SCOPE_IMAGE" --probe.docker=true
 }
 
 launch_docker4mac_app_command() {
@@ -237,7 +235,7 @@ case "$COMMAND" in
     version)
         # shellcheck disable=SC2086
         docker run --rm -e CHECKPOINT_DISABLE --entrypoint=/home/weave/scope \
-            $WEAVESCOPE_DOCKER_ARGS "$SCOPE_IMAGE" --mode=version
+               "$SCOPE_IMAGE" --mode=version
         ;;
 
     -h | help | -help | --help)

--- a/scope
+++ b/scope
@@ -47,7 +47,6 @@ usage() {
 
 		Launch options:
 	EOF
-    # shellcheck disable=SC2086
     docker run --rm --entrypoint=/home/weave/scope "$SCOPE_IMAGE" -h >&2
 }
 
@@ -164,14 +163,12 @@ create_plugins_dir() {
     # is not shared from OS X and does not belong to the system."
     # In any case, creating /var/run/scope/plugins on Mac OS would not work, as domain
     # sockets do not cross VM boundaries. We need this directory to exits on the VM.
-    # shellcheck disable=SC2086
     docker run $USERNS_HOST --rm --entrypoint=/bin/sh \
         -v /var/run:/var/run \
         "$SCOPE_IMAGE" -c "mkdir -p /var/run/scope/plugins"
 }
 
 docker_args() {
-    # shellcheck disable=SC2086
     echo --privileged $USERNS_HOST --net=host --pid=host \
         -v /var/run/docker.sock:/var/run/docker.sock \
         -v /var/run/scope/plugins:/var/run/scope/plugins \
@@ -233,7 +230,6 @@ case "$COMMAND" in
         ;;
 
     version)
-        # shellcheck disable=SC2086
         docker run --rm --entrypoint=/home/weave/scope "$SCOPE_IMAGE" --mode=version
         ;;
 
@@ -276,7 +272,6 @@ case "$COMMAND" in
             if check_listen_address_arg; then
                 echo "Weave Scope is reachable at the address specified with --app.http.address" >&2
             else
-                # shellcheck disable=SC2086
                 IP_ADDRS=$(docker run --rm $USERNS_HOST --net=host --entrypoint /bin/sh "$SCOPE_IMAGE" -c "$IP_ADDR_CMD")
                 # shellcheck disable=SC2086
                 print_app_endpoints $IP_ADDRS

--- a/scope
+++ b/scope
@@ -48,7 +48,7 @@ usage() {
 		Launch options:
 	EOF
     # shellcheck disable=SC2086
-    docker run --rm -e CHECKPOINT_DISABLE --entrypoint=/home/weave/scope "$SCOPE_IMAGE" -h >&2
+    docker run --rm --entrypoint=/home/weave/scope "$SCOPE_IMAGE" -h >&2
 }
 
 usage_and_die() {
@@ -234,8 +234,7 @@ case "$COMMAND" in
 
     version)
         # shellcheck disable=SC2086
-        docker run --rm -e CHECKPOINT_DISABLE --entrypoint=/home/weave/scope \
-               "$SCOPE_IMAGE" --mode=version
+        docker run --rm --entrypoint=/home/weave/scope "$SCOPE_IMAGE" --mode=version
         ;;
 
     -h | help | -help | --help)


### PR DESCRIPTION
...so it can be used to supply the likes of `--restart=...`.