### PR TITLE
Back off when writing to Dynamo and S3

### DIFF
--- a/app/multitenant/aws_collector.go
+++ b/app/multitenant/aws_collector.go
@@ -362,7 +362,7 @@ func withBackoff(f func() error) error {
 	for err != nil && retries <= 5 {
 		time.Sleep(backoff)
 		err = f()
-		retries += 1
+		retries++
 		backoff *= 2
 	}
 	return err


### PR DESCRIPTION
Fixes #2345 

I am intentionally not backing off when writing to Memcached nor NATS. The first one is an optimization and the second one is just used for shortcut reports (not essential).

I tried to use https://github.com/weaveworks/common/blob/master/backoff/backoff.go but it's not suitable for this usecase (it doesn't forward errors and doesn't accept retry limits).
