### PR TITLE
kubernetes: Add StatefulSets and CronJobs

### DIFF
--- a/probe/kubernetes/client.go
+++ b/probe/kubernetes/client.go
@@ -11,6 +11,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
 	apiappsv1beta1 "k8s.io/client-go/pkg/apis/apps/v1beta1"
@@ -301,10 +302,11 @@ func (c *client) WalkCronJobs(f func(CronJob) error) error {
 	if c.cronJobStore == nil {
 		return nil
 	}
-	jobs := []*apibatchv1.Job{}
+	// We index jobs by id to make lookup for each cronjob more efficient
+	jobs := map[types.UID]*apibatchv1.Job{}
 	for _, m := range c.jobStore.List() {
 		j := m.(*apibatchv1.Job)
-		jobs = append(jobs, j)
+		jobs[j.UID] = j
 	}
 	for _, m := range c.cronJobStore.List() {
 		cj := m.(*apibatchv2alpha1.CronJob)

--- a/probe/kubernetes/cronjob.go
+++ b/probe/kubernetes/cronjob.go
@@ -6,6 +6,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	batchv1 "k8s.io/client-go/pkg/apis/batch/v1"
 	batchv2alpha1 "k8s.io/client-go/pkg/apis/batch/v2alpha1"
 
@@ -35,14 +36,11 @@ type cronJob struct {
 
 // NewCronJob creates a new cron job. jobs should be all jobs, which will be filtered
 // for those matching this cron job.
-func NewCronJob(cj *batchv2alpha1.CronJob, jobs []*batchv1.Job) CronJob {
+func NewCronJob(cj *batchv2alpha1.CronJob, jobs map[types.UID]*batchv1.Job) CronJob {
 	myJobs := []*batchv1.Job{}
-	for _, j := range jobs {
-		for _, o := range cj.Status.Active {
-			if j.UID == o.UID {
-				myJobs = append(myJobs, j)
-				break
-			}
+	for _, o := range cj.Status.Active {
+		if j, ok := jobs[o.UID]; ok {
+			myJobs = append(myJobs, j)
 		}
 	}
 	return &cronJob{

--- a/probe/kubernetes/cronjob.go
+++ b/probe/kubernetes/cronjob.go
@@ -1,0 +1,75 @@
+package kubernetes
+
+import (
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	batchv1 "k8s.io/client-go/pkg/apis/batch/v1"
+	batchv2alpha1 "k8s.io/client-go/pkg/apis/batch/v2alpha1"
+
+	"github.com/weaveworks/scope/report"
+)
+
+// These constants are keys used in node metadata
+const (
+	Schedule      = "kubernetes_schedule"
+	Suspended     = "kubernetes_suspended"
+	LastScheduled = "kubernetes_last_scheduled"
+	ActiveJobs    = "kubernetes_active_jobs"
+)
+
+// CronJob represents a Kubernetes cron job
+type CronJob interface {
+	Meta
+	Selectors() ([]labels.Selector, error)
+	GetNode() report.Node
+}
+
+type cronJob struct {
+	*batchv2alpha1.CronJob
+	Meta
+	jobs []*batchv1.Job
+}
+
+// NewCronJob creates a new cron job. jobs should be all jobs, which will be filtered
+// for those matching this cron job.
+func NewCronJob(cj *batchv2alpha1.CronJob, jobs []*batchv1.Job) CronJob {
+	myJobs := []*batchv1.Job{}
+	for _, j := range jobs {
+		for _, o := range cj.Status.Active {
+			if j.UID == o.UID {
+				myJobs = append(myJobs, j)
+				break
+			}
+		}
+	}
+	return &cronJob{
+		CronJob: cj,
+		Meta:    meta{cj.ObjectMeta},
+		jobs:    myJobs,
+	}
+}
+
+func (cj *cronJob) Selectors() ([]labels.Selector, error) {
+	selectors := []labels.Selector{}
+	for _, j := range cj.jobs {
+		selector, err := metav1.LabelSelectorAsSelector(j.Spec.Selector)
+		if err != nil {
+			return nil, err
+		}
+		selectors = append(selectors, selector)
+	}
+	return selectors, nil
+}
+
+func (cj *cronJob) GetNode() report.Node {
+	return cj.MetaNode(report.MakeCronJobNodeID(cj.UID())).WithLatests(map[string]string{
+		NodeType:      "Cron Job",
+		Schedule:      cj.Spec.Schedule,
+		Suspended:     fmt.Sprint(cj.Spec.Suspend != nil && *cj.Spec.Suspend), // nil -> false
+		LastScheduled: cj.Status.LastScheduleTime.Format(time.RFC3339Nano),
+		ActiveJobs:    fmt.Sprint(len(cj.jobs)),
+	})
+}

--- a/probe/kubernetes/deployment.go
+++ b/probe/kubernetes/deployment.go
@@ -46,9 +46,14 @@ func (d *deployment) Selector() (labels.Selector, error) {
 }
 
 func (d *deployment) GetNode(probeID string) report.Node {
+	// Spec.Replicas can be omitted, and the pointer will be nil. It defaults to 1.
+	desiredReplicas := 1
+	if d.Spec.Replicas != nil {
+		desiredReplicas = int(*d.Spec.Replicas)
+	}
 	return d.MetaNode(report.MakeDeploymentNodeID(d.UID())).WithLatests(map[string]string{
 		ObservedGeneration:    fmt.Sprint(d.Status.ObservedGeneration),
-		DesiredReplicas:       fmt.Sprint(d.Spec.Replicas),
+		DesiredReplicas:       fmt.Sprint(desiredReplicas),
 		Replicas:              fmt.Sprint(d.Status.Replicas),
 		UpdatedReplicas:       fmt.Sprint(d.Status.UpdatedReplicas),
 		AvailableReplicas:     fmt.Sprint(d.Status.AvailableReplicas),

--- a/probe/kubernetes/reporter_test.go
+++ b/probe/kubernetes/reporter_test.go
@@ -136,6 +136,12 @@ func (c *mockClient) WalkServices(f func(kubernetes.Service) error) error {
 func (c *mockClient) WalkDaemonSets(f func(kubernetes.DaemonSet) error) error {
 	return nil
 }
+func (c *mockClient) WalkStatefulSets(f func(kubernetes.StatefulSet) error) error {
+	return nil
+}
+func (c *mockClient) WalkCronJobs(f func(kubernetes.CronJob) error) error {
+	return nil
+}
 func (c *mockClient) WalkDeployments(f func(kubernetes.Deployment) error) error {
 	return nil
 }

--- a/probe/kubernetes/statefulset.go
+++ b/probe/kubernetes/statefulset.go
@@ -1,0 +1,55 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/pkg/apis/apps/v1beta1"
+
+	"github.com/weaveworks/scope/report"
+)
+
+// StatefulSet represents a Kubernetes statefulset
+type StatefulSet interface {
+	Meta
+	Selector() (labels.Selector, error)
+	GetNode() report.Node
+}
+
+type statefulSet struct {
+	*v1beta1.StatefulSet
+	Meta
+}
+
+// NewStatefulSet creates a new statefulset
+func NewStatefulSet(s *v1beta1.StatefulSet) StatefulSet {
+	return &statefulSet{
+		StatefulSet: s,
+		Meta:        meta{s.ObjectMeta},
+	}
+}
+
+func (s *statefulSet) Selector() (labels.Selector, error) {
+	selector, err := metav1.LabelSelectorAsSelector(s.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+	return selector, nil
+}
+
+func (s *statefulSet) GetNode() report.Node {
+	desiredReplicas := 1
+	if s.Spec.Replicas != nil {
+		desiredReplicas = int(*s.Spec.Replicas)
+	}
+	latests := map[string]string{
+		NodeType:        "Stateful Set",
+		DesiredReplicas: fmt.Sprint(desiredReplicas),
+		Replicas:        fmt.Sprint(s.Status.Replicas),
+	}
+	if s.Status.ObservedGeneration != nil {
+		latests[ObservedGeneration] = fmt.Sprint(*s.Status.ObservedGeneration)
+	}
+	return s.MetaNode(report.MakeStatefulSetNodeID(s.UID())).WithLatests(latests)
+}

--- a/render/detailed/parents.go
+++ b/render/detailed/parents.go
@@ -25,6 +25,8 @@ var (
 		report.Pod:            kubernetesParentLabel,
 		report.Deployment:     kubernetesParentLabel,
 		report.DaemonSet:      kubernetesParentLabel,
+		report.StatefulSet:    kubernetesParentLabel,
+		report.CronJob:        kubernetesParentLabel,
 		report.Service:        kubernetesParentLabel,
 		report.ECSTask:        latestLookup(awsecs.TaskFamily),
 		report.ECSService:     ecsServiceParentLabel,

--- a/render/detailed/summary.go
+++ b/render/detailed/summary.go
@@ -68,6 +68,8 @@ var renderers = map[string]func(NodeSummary, report.Node) (NodeSummary, bool){
 	report.Service:        podGroupNodeSummary,
 	report.Deployment:     podGroupNodeSummary,
 	report.DaemonSet:      podGroupNodeSummary,
+	report.StatefulSet:    podGroupNodeSummary,
+	report.CronJob:        podGroupNodeSummary,
 	report.ECSTask:        ecsTaskNodeSummary,
 	report.ECSService:     ecsServiceNodeSummary,
 	report.SwarmService:   swarmServiceNodeSummary,
@@ -90,6 +92,8 @@ var primaryAPITopology = map[string]string{
 	report.Pod:            "pods",
 	report.Deployment:     "kube-controllers",
 	report.DaemonSet:      "kube-controllers",
+	report.StatefulSet:    "kube-controllers",
+	report.CronJob:        "kube-controllers",
 	report.Service:        "services",
 	report.ECSTask:        "ecs-tasks",
 	report.ECSService:     "ecs-services",
@@ -256,8 +260,10 @@ func podNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
 }
 
 var podGroupNodeTypeName = map[string]string{
-	report.Deployment: "Deployment",
-	report.DaemonSet:  "Daemon Set",
+	report.Deployment:  "Deployment",
+	report.DaemonSet:   "Daemon Set",
+	report.StatefulSet: "Stateful Set",
+	report.CronJob:     "Cron Job",
 }
 
 func podGroupNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {

--- a/render/pod.go
+++ b/render/pod.go
@@ -18,7 +18,21 @@ const (
 var UnmanagedIDPrefix = MakePseudoNodeID(UnmanagedID)
 
 func renderKubernetesTopologies(rpt report.Report) bool {
-	return len(rpt.Pod.Nodes)+len(rpt.Service.Nodes)+len(rpt.Deployment.Nodes)+len(rpt.DaemonSet.Nodes) >= 1
+	// Render if any k8s topology has any nodes
+	topologies := []*report.Topology{
+		&rpt.Pod,
+		&rpt.Service,
+		&rpt.Deployment,
+		&rpt.DaemonSet,
+		&rpt.StatefulSet,
+		&rpt.CronJob,
+	}
+	for _, t := range topologies {
+		if len(t.Nodes) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func isPauseContainer(n report.Node) bool {
@@ -68,7 +82,7 @@ var PodServiceRenderer = ConditionalRenderer(renderKubernetesTopologies,
 // have connections to each other.
 var KubeControllerRenderer = ConditionalRenderer(renderKubernetesTopologies,
 	renderParents(
-		report.Pod, []string{report.Deployment, report.DaemonSet}, UnmanagedID,
+		report.Pod, []string{report.Deployment, report.DaemonSet, report.StatefulSet, report.CronJob}, UnmanagedID,
 		PodRenderer,
 	),
 )

--- a/render/selectors.go
+++ b/render/selectors.go
@@ -31,6 +31,8 @@ var (
 	SelectService        = TopologySelector(report.Service)
 	SelectDeployment     = TopologySelector(report.Deployment)
 	SelectDaemonSet      = TopologySelector(report.DaemonSet)
+	SelectStatefulSet    = TopologySelector(report.StatefulSet)
+	SelectCronJob        = TopologySelector(report.CronJob)
 	SelectECSTask        = TopologySelector(report.ECSTask)
 	SelectECSService     = TopologySelector(report.ECSService)
 	SelectSwarmService   = TopologySelector(report.SwarmService)

--- a/report/id.go
+++ b/report/id.go
@@ -131,6 +131,18 @@ var (
 	// ParseDaemonSetNodeID parses a daemon set node ID
 	ParseDaemonSetNodeID = parseSingleComponentID("daemonset")
 
+	// MakeStatefulSetNodeID produces a replica set node ID from its composite parts.
+	MakeStatefulSetNodeID = makeSingleComponentID("statefulset")
+
+	// ParseStatefulSetNodeID parses a daemon set node ID
+	ParseStatefulSetNodeID = parseSingleComponentID("statefulset")
+
+	// MakeCronJobNodeID produces a replica set node ID from its composite parts.
+	MakeCronJobNodeID = makeSingleComponentID("cronjob")
+
+	// ParseCronJobNodeID parses a daemon set node ID
+	ParseCronJobNodeID = parseSingleComponentID("cronjob")
+
 	// MakeECSTaskNodeID produces a replica set node ID from its composite parts.
 	MakeECSTaskNodeID = makeSingleComponentID("ecs_task")
 

--- a/report/report.go
+++ b/report/report.go
@@ -178,7 +178,7 @@ func MakeReport() Report {
 			WithLabel("service", "services"),
 
 		Deployment: MakeTopology().
-			WithShape(Octagon).
+			WithShape(Heptagon).
 			WithLabel("deployment", "deployments"),
 
 		ReplicaSet: MakeTopology().
@@ -190,7 +190,7 @@ func MakeReport() Report {
 			WithLabel("daemonset", "daemonsets"),
 
 		StatefulSet: MakeTopology().
-			WithShape(Triangle).
+			WithShape(Octagon).
 			WithLabel("stateful set", "stateful sets"),
 
 		CronJob: MakeTopology().

--- a/report/report.go
+++ b/report/report.go
@@ -20,6 +20,8 @@ const (
 	Deployment     = "deployment"
 	ReplicaSet     = "replica_set"
 	DaemonSet      = "daemon_set"
+	StatefulSet    = "stateful_set"
+	CronJob        = "cron_job"
 	ContainerImage = "container_image"
 	Host           = "host"
 	Overlay        = "overlay"
@@ -82,6 +84,16 @@ type Report struct {
 	// Metadata includes things like DaemonSet id, name etc. Edges are not
 	// present.
 	DaemonSet Topology
+
+	// StatefulSet nodes represent all Kubernetes Stateful Sets running on hosts running probes.
+	// Metadata includes things like Stateful Set id, name, etc. Edges are not
+	// present.
+	StatefulSet Topology
+
+	// CronJob nodes represent all Kubernetes Cron Jobs running on hosts running probes.
+	// Metadata includes things like Cron Job id, name, etc. Edges are not
+	// present.
+	CronJob Topology
 
 	// ContainerImages nodes represent all Docker containers images on
 	// hosts running probes. Metadata includes things like image id, name etc.
@@ -177,6 +189,14 @@ func MakeReport() Report {
 			WithShape(Pentagon).
 			WithLabel("daemonset", "daemonsets"),
 
+		StatefulSet: MakeTopology().
+			WithShape(Triangle).
+			WithLabel("stateful set", "stateful sets"),
+
+		CronJob: MakeTopology().
+			WithShape(Triangle).
+			WithLabel("cron job", "cron jobs"),
+
 		Overlay: MakeTopology().
 			WithShape(Circle).
 			WithLabel("peer", "peers"),
@@ -212,6 +232,8 @@ func (r *Report) TopologyMap() map[string]*Topology {
 		Deployment:     &r.Deployment,
 		ReplicaSet:     &r.ReplicaSet,
 		DaemonSet:      &r.DaemonSet,
+		StatefulSet:    &r.StatefulSet,
+		CronJob:        &r.CronJob,
 		Host:           &r.Host,
 		Overlay:        &r.Overlay,
 		ECSTask:        &r.ECSTask,
@@ -275,6 +297,8 @@ func (r *Report) WalkPairedTopologies(o *Report, f func(*Topology, *Topology)) {
 	f(&r.Deployment, &o.Deployment)
 	f(&r.ReplicaSet, &o.ReplicaSet)
 	f(&r.DaemonSet, &o.DaemonSet)
+	f(&r.StatefulSet, &o.StatefulSet)
+	f(&r.CronJob, &o.CronJob)
 	f(&r.Host, &o.Host)
 	f(&r.Overlay, &o.Overlay)
 	f(&r.ECSTask, &o.ECSTask)


### PR DESCRIPTION
Fixes #2239. Fixes #2571.

Most basic info is in metadata. Future work:
* Map statefulset to its associated service (probably as a parent)
* Add a control to suspend cronjobs