### PR TITLE
render: In minor labels, display '0 things' instead of blank if zero things present

### DIFF
--- a/render/detailed/summary.go
+++ b/render/detailed/summary.go
@@ -344,13 +344,14 @@ func groupNodeSummary(base NodeSummary, r report.Report, n report.Node) (NodeSum
 }
 
 func pluralize(counters report.Counters, key, singular, plural string) string {
-	if c, ok := counters.Lookup(key); ok {
-		if c == 1 {
-			return fmt.Sprintf("%d %s", c, singular)
-		}
-		return fmt.Sprintf("%d %s", c, plural)
+	c, ok := counters.Lookup(key)
+	if !ok {
+		c = 0
 	}
-	return ""
+	if c == 1 {
+		return fmt.Sprintf("%d %s", c, singular)
+	}
+	return fmt.Sprintf("%d %s", c, plural)
 }
 
 type nodeSummariesByID []NodeSummary


### PR DESCRIPTION
This also fixes a bug where k8s controller nodes would show up as 'Deployment of' without any number

Fixes #2722
![screenshot](https://user-images.githubusercontent.com/570052/28334951-9af569a0-6bb1-11e7-93c9-0a0a3ce94200.png)

