### PR TITLE
Allows to skip client build when doing make prog/scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,19 +144,19 @@ ifeq ($(BUILD_IN_CONTAINER),true)
 
 client/build/index.html: $(shell find client/app -type f) $(SCOPE_UI_BUILD_UPTODATE)
 	mkdir -p client/build
-	test "true" = "$(SCOPE_SKIP_UI_ASSETS)" || { \
+	if test "true" != "$(SCOPE_SKIP_UI_ASSETS)"; then \
 		$(SUDO) docker run $(RM) $(RUN_FLAGS) -v $(shell pwd)/client/app:/home/weave/app \
 			-v $(shell pwd)/client/build:/home/weave/build \
 			$(SCOPE_UI_BUILD_IMAGE) yarn run build; \
-	}
+	fi
 
 client/build-external/index.html: $(shell find client/app -type f) $(SCOPE_UI_BUILD_UPTODATE)
 	mkdir -p client/build-external
-	test "true" = "$(SCOPE_SKIP_UI_ASSETS)" || { \
+	if test "true" != "$(SCOPE_SKIP_UI_ASSETS)"; then \
 		$(SUDO) docker run $(RM) $(RUN_FLAGS) -v $(shell pwd)/client/app:/home/weave/app \
 			-v $(shell pwd)/client/build-external:/home/weave/build-external \
 			$(SCOPE_UI_BUILD_IMAGE) yarn run build-external; \
-	}
+	fi
 
 client-test: $(shell find client/app/scripts -type f) $(SCOPE_UI_BUILD_UPTODATE)
 	$(SUDO) docker run $(RM) $(RUN_FLAGS) -v $(shell pwd)/client/app:/home/weave/app \
@@ -184,11 +184,11 @@ else
 
 client/build/index.html:
 	mkdir -p client/build
-	test "true" = "$(SCOPE_SKIP_UI_ASSETS)" || { cd client && yarn run build; }
+	if test "true" != "$(SCOPE_SKIP_UI_ASSETS)"; then cd client && yarn run build; fi
 
 client/build-external/index.html:
 	mkdir -p client/build-external
-	test "true" = "$(SCOPE_SKIP_UI_ASSETS)" || { cd client && yarn run build-external; }
+	if test "true" != "$(SCOPE_SKIP_UI_ASSETS)"; then cd client && yarn run build-external; fi
 
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -144,15 +144,19 @@ ifeq ($(BUILD_IN_CONTAINER),true)
 
 client/build/index.html: $(shell find client/app -type f) $(SCOPE_UI_BUILD_UPTODATE)
 	mkdir -p client/build
-	$(SUDO) docker run $(RM) $(RUN_FLAGS) -v $(shell pwd)/client/app:/home/weave/app \
-		-v $(shell pwd)/client/build:/home/weave/build \
-		$(SCOPE_UI_BUILD_IMAGE) yarn run build
+	test "true" = "$(SCOPE_SKIP_UI_ASSETS)" || { \
+		$(SUDO) docker run $(RM) $(RUN_FLAGS) -v $(shell pwd)/client/app:/home/weave/app \
+			-v $(shell pwd)/client/build:/home/weave/build \
+			$(SCOPE_UI_BUILD_IMAGE) yarn run build; \
+	}
 
 client/build-external/index.html: $(shell find client/app -type f) $(SCOPE_UI_BUILD_UPTODATE)
-	mkdir -p client/build
-	$(SUDO) docker run $(RM) $(RUN_FLAGS) -v $(shell pwd)/client/app:/home/weave/app \
-		-v $(shell pwd)/client/build-external:/home/weave/build-external \
-		$(SCOPE_UI_BUILD_IMAGE) yarn run build-external
+	mkdir -p client/build-external
+	test "true" = "$(SCOPE_SKIP_UI_ASSETS)" || { \
+		$(SUDO) docker run $(RM) $(RUN_FLAGS) -v $(shell pwd)/client/app:/home/weave/app \
+			-v $(shell pwd)/client/build-external:/home/weave/build-external \
+			$(SCOPE_UI_BUILD_IMAGE) yarn run build-external; \
+	}
 
 client-test: $(shell find client/app/scripts -type f) $(SCOPE_UI_BUILD_UPTODATE)
 	$(SUDO) docker run $(RM) $(RUN_FLAGS) -v $(shell pwd)/client/app:/home/weave/app \
@@ -179,12 +183,12 @@ tmp/weave-scope.tgz: $(shell find client/app -type f) $(SCOPE_UI_BUILD_UPTODATE)
 else
 
 client/build/index.html:
-	test "true" = "$(SCOPE_SKIP_UI_ASSETS)" && mkdir -p client/build || \
-		{ cd client && yarn run build; }
+	mkdir -p client/build
+	test "true" = "$(SCOPE_SKIP_UI_ASSETS)" || { cd client && yarn run build; }
 
 client/build-external/index.html:
-	test "true" = "$(SCOPE_SKIP_UI_ASSETS)" && mkdir -p client/build-external || \
-		{ cd client && yarn run build-external; }
+	mkdir -p client/build-external
+	test "true" = "$(SCOPE_SKIP_UI_ASSETS)" || { cd client && yarn run build-external; }
 
 endif
 


### PR DESCRIPTION
When you run the client locally with `yarn start` and modify the
app/probe code you don't want to compile the client on `make prog/scope`.

This allows you to do `SCOPE_SKIP_UI_ASSETS=true make prog/scope` to
only build the scope binary.

---
Is there a place I should document this?