### PR TITLE
restart eBPF tracking on error

### DIFF
--- a/integration/315_ebpf_restart_test.sh
+++ b/integration/315_ebpf_restart_test.sh
@@ -1,0 +1,55 @@
+#! /bin/bash
+
+# shellcheck disable=SC1091
+. ./config.sh
+
+start_suite "Test with ebpf restarts and proc fallback"
+
+weave_on "$HOST1" launch
+# Manually start scope in order to start EbpfTracker in debug mode
+DOCKER_HOST=tcp://${HOST1}:${DOCKER_PORT} CHECKPOINT_DISABLE=true \
+    WEAVESCOPE_DOCKER_ARGS="-e SCOPE_DEBUG_BPF=1" \
+    "${SCOPE}" launch
+
+server_on "$HOST1"
+client_on "$HOST1"
+
+wait_for_containers "$HOST1" 60 nginx client
+
+has_container "$HOST1" nginx
+has_container "$HOST1" client
+has_connection containers "$HOST1" client nginx
+
+# shellcheck disable=SC2016
+run_on "$HOST1" 'echo stop | sudo tee /proc/$(pidof scope-probe)/root/var/run/scope/debug-bpf'
+sleep 5
+
+server_on "$HOST1" "nginx2"
+client_on "$HOST1" "client2" "nginx2"
+
+wait_for_containers "$HOST1" 60 nginx2 client2
+
+has_container "$HOST1" nginx2
+has_container "$HOST1" client2
+has_connection containers "$HOST1" client2 nginx2
+
+# Save stdout for debugging output
+exec 3>&1
+assert_raises "docker_on $HOST1 logs weavescope 2>&1 | grep 'ebpf tracker died, restarting it' || (docker_on $HOST1 logs weavescope 2>&3 ; false)"
+
+# shellcheck disable=SC2016
+run_on "$HOST1" 'echo stop | sudo tee /proc/$(pidof scope-probe)/root/var/run/scope/debug-bpf'
+sleep 5
+
+server_on "$HOST1" "nginx3"
+client_on "$HOST1" "client3" "nginx3"
+
+wait_for_containers "$HOST1" 60 nginx3 client3
+
+has_container "$HOST1" nginx3
+has_container "$HOST1" client3
+has_connection containers "$HOST1" client3 nginx3
+
+assert_raises "docker_on $HOST1 logs weavescope 2>&1 | grep 'ebpf tracker died again, gently falling back to proc scanning' || (docker_on $HOST1 logs weavescope 2>&3 ; false)"
+
+scope_end_suite

--- a/integration/config.sh
+++ b/integration/config.sh
@@ -36,13 +36,18 @@ weave_proxy_on() {
 }
 
 server_on() {
-    weave_proxy_on "$1" run -d --name nginx nginx
+    local host=$1
+    local name=${2:-nginx}
+    weave_proxy_on "$1" run -d --name "$name" nginx
 }
 
 client_on() {
-    weave_proxy_on "$1" run -d --name client alpine /bin/sh -c "while true; do \
-    	wget http://nginx.weave.local:80/ -O - >/dev/null || true; \
-	sleep 1; \
+    local host=$1
+    local name=${2:-client}
+    local server=${3:-nginx}
+    weave_proxy_on "$1" run -d --name "$name" alpine /bin/sh -c "while true; do \
+        wget http://$server.weave.local:80/ -O - >/dev/null || true; \
+        sleep 1; \
     done"
 }
 

--- a/probe/endpoint/ebpf_test.go
+++ b/probe/endpoint/ebpf_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/weaveworks/tcptracer-bpf/pkg/tracer"
 )
@@ -219,6 +220,14 @@ func TestInvalidTimeStampDead(t *testing.T) {
 	})
 	if cnt != 2 {
 		t.Errorf("walkConnections found %v instead of 2 connections", cnt)
+	}
+	// EbpfTracker is marked as dead asynchronously.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if mockEbpfTracker.isDead() {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
 	if !mockEbpfTracker.isDead() {
 		t.Errorf("expected ebpfTracker to be set to dead after events with wrong order")

--- a/vendor/github.com/weaveworks/tcptracer-bpf/pkg/tracer/tracer.go
+++ b/vendor/github.com/weaveworks/tcptracer-bpf/pkg/tracer/tracer.go
@@ -79,10 +79,19 @@ func NewTracer(cb Callback) (*Tracer, error) {
 		for {
 			select {
 			case <-stopChan:
+				// On stop, stopChan will be closed but the other channels will
+				// also be closed shortly after. The select{} has no priorities,
+				// therefore, the "ok" value must be checked below.
 				return
-			case data := <-channelV4:
+			case data, ok := <-channelV4:
+				if !ok {
+					return // see explanation above
+				}
 				cb.TCPEventV4(tcpV4ToGo(&data))
-			case lost := <-lostChanV4:
+			case lost, ok := <-lostChanV4:
+				if !ok {
+					return // see explanation above
+				}
 				cb.LostV4(lost)
 			}
 		}
@@ -93,9 +102,15 @@ func NewTracer(cb Callback) (*Tracer, error) {
 			select {
 			case <-stopChan:
 				return
-			case data := <-channelV6:
+			case data, ok := <-channelV6:
+				if !ok {
+					return // see explanation above
+				}
 				cb.TCPEventV6(tcpV6ToGo(&data))
-			case lost := <-lostChanV6:
+			case lost, ok := <-lostChanV6:
+				if !ok {
+					return // see explanation above
+				}
 				cb.LostV6(lost)
 			}
 		}

--- a/vendor/github.com/weaveworks/tcptracer-bpf/vendor/github.com/iovisor/gobpf/elf/elf.go
+++ b/vendor/github.com/weaveworks/tcptracer-bpf/vendor/github.com/iovisor/gobpf/elf/elf.go
@@ -515,6 +515,7 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 			isCgroupSkb := strings.HasPrefix(secName, "cgroup/skb")
 			isCgroupSock := strings.HasPrefix(secName, "cgroup/sock")
 			isSocketFilter := strings.HasPrefix(secName, "socket")
+			isTracepoint := strings.HasPrefix(secName, "tracepoint/")
 
 			var progType uint32
 			switch {
@@ -528,9 +529,11 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 				progType = uint32(C.BPF_PROG_TYPE_CGROUP_SOCK)
 			case isSocketFilter:
 				progType = uint32(C.BPF_PROG_TYPE_SOCKET_FILTER)
+			case isTracepoint:
+				progType = uint32(C.BPF_PROG_TYPE_TRACEPOINT)
 			}
 
-			if isKprobe || isKretprobe || isCgroupSkb || isCgroupSock || isSocketFilter {
+			if isKprobe || isKretprobe || isCgroupSkb || isCgroupSock || isSocketFilter || isTracepoint {
 				rdata, err := rsection.Data()
 				if err != nil {
 					return err
@@ -579,6 +582,12 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 						insns: insns,
 						fd:    int(progFd),
 					}
+				case isTracepoint:
+					b.tracepointPrograms[secName] = &TracepointProgram{
+						Name:  secName,
+						insns: insns,
+						fd:    int(progFd),
+					}
 				}
 			}
 		}
@@ -596,6 +605,7 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 		isCgroupSkb := strings.HasPrefix(secName, "cgroup/skb")
 		isCgroupSock := strings.HasPrefix(secName, "cgroup/sock")
 		isSocketFilter := strings.HasPrefix(secName, "socket")
+		isTracepoint := strings.HasPrefix(secName, "tracepoint/")
 
 		var progType uint32
 		switch {
@@ -609,9 +619,11 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 			progType = uint32(C.BPF_PROG_TYPE_CGROUP_SOCK)
 		case isSocketFilter:
 			progType = uint32(C.BPF_PROG_TYPE_SOCKET_FILTER)
+		case isTracepoint:
+			progType = uint32(C.BPF_PROG_TYPE_TRACEPOINT)
 		}
 
-		if isKprobe || isKretprobe || isCgroupSkb || isCgroupSock || isSocketFilter {
+		if isKprobe || isKretprobe || isCgroupSkb || isCgroupSock || isSocketFilter || isTracepoint {
 			data, err := section.Data()
 			if err != nil {
 				return err
@@ -651,6 +663,12 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 				}
 			case isSocketFilter:
 				b.socketFilters[secName] = &SocketFilter{
+					Name:  secName,
+					insns: insns,
+					fd:    int(progFd),
+				}
+			case isTracepoint:
+				b.tracepointPrograms[secName] = &TracepointProgram{
 					Name:  secName,
 					insns: insns,
 					fd:    int(progFd),

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -1020,7 +1020,7 @@
 			"importpath": "github.com/weaveworks/tcptracer-bpf",
 			"repository": "https://github.com/weaveworks/tcptracer-bpf",
 			"vcs": "git",
-			"revision": "53a889d82fbd8a4fc4ef3f0013a9f88a3e9f4ccc",
+			"revision": "e080bd747dc6b62d4ed3ed2b7f0be4801bef8faf",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
This is a workaround for https://github.com/weaveworks/scope/issues/2650

Tested manually the following way:

Start Scope with:
```
    sudo WEAVESCOPE_DOCKER_ARGS="-e SCOPE_DEBUG_BPF=1" ./scope launch
```    
Simulate EbpfTracker failure with:
```
    echo foo | sudo tee /proc/$(pidof scope-probe)/root/var/run/scope/debug-bpf
```

TODO:
- [x] implement guard against "flapping"
- [x] tests
- [x] ~pending on https://github.com/weaveworks/tcptracer-bpf/pull/49~
- [x] pending on https://github.com/weaveworks/tcptracer-bpf/pull/50