### PR TITLE
new full reports are more important than old and shortcut reports

### DIFF
--- a/probe/appclient/multi_client_test.go
+++ b/probe/appclient/multi_client_test.go
@@ -37,7 +37,7 @@ func (c *mockClient) Stop() {
 	c.stopped++
 }
 
-func (c *mockClient) Publish(io.Reader) error {
+func (c *mockClient) Publish(io.Reader, bool) error {
 	c.publish++
 	return nil
 }
@@ -106,7 +106,7 @@ func TestMultiClientPublish(t *testing.T) {
 	mp.Set("b", []url.URL{{Host: "b2"}, {Host: "b3"}})
 
 	for i := 1; i < 10; i++ {
-		if err := mp.Publish(&bytes.Buffer{}); err != nil {
+		if err := mp.Publish(&bytes.Buffer{}, false); err != nil {
 			t.Error(err)
 		}
 		if want, have := 3*i, sum(); want != have {

--- a/probe/appclient/report_publisher.go
+++ b/probe/appclient/report_publisher.go
@@ -30,5 +30,5 @@ func (p *ReportPublisher) Publish(r report.Report) error {
 	}
 	buf := &bytes.Buffer{}
 	r.WriteBinary(buf, gzip.DefaultCompression)
-	return p.publisher.Publish(buf)
+	return p.publisher.Publish(buf, r.Shortcut)
 }

--- a/probe/probe_internal_test.go
+++ b/probe/probe_internal_test.go
@@ -53,7 +53,7 @@ type mockPublisher struct {
 	have chan report.Report
 }
 
-func (m mockPublisher) Publish(in io.Reader) error {
+func (m mockPublisher) Publish(in io.Reader, shortcut bool) error {
 	var r report.Report
 	if reader, err := gzip.NewReader(in); err != nil {
 		return err


### PR DESCRIPTION
so when there is backpressure in publishing reports, drop shortcut reports in preference to full reports, and drop old full reports in preference to new full reports.

Fixes #2738.