### PR TITLE
maximize report publishing timeout

### DIFF
--- a/probe/appclient/app_client.go
+++ b/probe/appclient/app_client.go
@@ -318,7 +318,7 @@ func (c *appClient) Publish(r io.Reader, shortcut bool) error {
 	select {
 	case c.readers <- r:
 	default:
-		log.Errorf("Dropping report to %s", c.hostname)
+		log.Warnf("Dropping report to %s", c.hostname)
 		if shortcut {
 			return nil
 		}

--- a/probe/appclient/app_client.go
+++ b/probe/appclient/app_client.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	httpClientTimeout = 4 * time.Second
+	httpClientTimeout = 12 * time.Second // a bit less than default app.window
 	initialBackoff    = 1 * time.Second
 	maxBackoff        = 60 * time.Second
 )


### PR DESCRIPTION
If the app really does take a long time to process reports, it is better not to time out and send it more reports. However, we do want to send at least one report per app.window, otherwise the scope UI
will go blank.

Fixes #2464 (as much as is practically possible)

Note that the timeout also applies to pipe and control traffic. I believe it's a reasonable value for that too.