### PR TITLE
k8s: Use 'DaemonSet', 'StatefulSet' etc instead of 'Daemon Set', 'Stateful Set'

### DIFF
--- a/probe/kubernetes/cronjob.go
+++ b/probe/kubernetes/cronjob.go
@@ -64,7 +64,7 @@ func (cj *cronJob) Selectors() ([]labels.Selector, error) {
 
 func (cj *cronJob) GetNode() report.Node {
 	return cj.MetaNode(report.MakeCronJobNodeID(cj.UID())).WithLatests(map[string]string{
-		NodeType:      "Cron Job",
+		NodeType:      "CronJob",
 		Schedule:      cj.Spec.Schedule,
 		Suspended:     fmt.Sprint(cj.Spec.Suspend != nil && *cj.Spec.Suspend), // nil -> false
 		LastScheduled: cj.Status.LastScheduleTime.Format(time.RFC3339Nano),

--- a/probe/kubernetes/daemonset.go
+++ b/probe/kubernetes/daemonset.go
@@ -48,6 +48,6 @@ func (d *daemonSet) GetNode() report.Node {
 		DesiredReplicas:      fmt.Sprint(d.Status.DesiredNumberScheduled),
 		Replicas:             fmt.Sprint(d.Status.CurrentNumberScheduled),
 		MisscheduledReplicas: fmt.Sprint(d.Status.NumberMisscheduled),
-		NodeType:             "Daemon Set",
+		NodeType:             "DaemonSet",
 	})
 }

--- a/probe/kubernetes/statefulset.go
+++ b/probe/kubernetes/statefulset.go
@@ -44,7 +44,7 @@ func (s *statefulSet) GetNode() report.Node {
 		desiredReplicas = int(*s.Spec.Replicas)
 	}
 	latests := map[string]string{
-		NodeType:        "Stateful Set",
+		NodeType:        "StatefulSet",
 		DesiredReplicas: fmt.Sprint(desiredReplicas),
 		Replicas:        fmt.Sprint(s.Status.Replicas),
 	}

--- a/render/detailed/summary.go
+++ b/render/detailed/summary.go
@@ -261,9 +261,9 @@ func podNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
 
 var podGroupNodeTypeName = map[string]string{
 	report.Deployment:  "Deployment",
-	report.DaemonSet:   "Daemon Set",
-	report.StatefulSet: "Stateful Set",
-	report.CronJob:     "Cron Job",
+	report.DaemonSet:   "DaemonSet",
+	report.StatefulSet: "StatefulSet",
+	report.CronJob:     "CronJob",
 }
 
 func podGroupNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {


### PR DESCRIPTION
We can't search for terms with spaces.

Fixes #2752 