### PR TITLE
Hide Service UI Configure button only in Scope

### DIFF
--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -9,8 +9,8 @@
     url("../../node_modules/materialize-css/fonts/roboto/Roboto-Regular.ttf");
 }
 
-// TODO: Remove this line once the configure button stops being added to Scope.
-.setup-nav-button { display: none; }
+// TODO: Remove this line once Service UI CONFIGURE button stops being added to Scope.
+.scope-wrapper .setup-nav-button { display: none; }
 
 .browsehappy {
   margin: 0.2em 0;


### PR DESCRIPTION
By mistake, #2703 introduced a change that made *CONFIGURE* button disappear from all the pages in Weave Cloud, instead of just hidding it in configured Scope.

I'm pretty sure @rade wrote somewhere he thinks it's ok to hide the button in Scope to make room for the timeline, but I couldn't find the source to quote him :)
