### PR TITLE
add 'realclean' make target to clear out container images

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -88,7 +88,7 @@ build() {
     ## Inject the version numbers and build the distributables
     ## (library versions?)
     sed -i.tmp "s/SCRIPT_VERSION=\"[^\"]*\"/SCRIPT_VERSION=\"$VERSION\"/" ./scope
-    make SUDO="$SUDO" SCOPE_VERSION="$VERSION" DOCKERHUB_USER="$DOCKERHUB_USER"
+    make SUDO="$SUDO" SCOPE_VERSION="$VERSION" DOCKERHUB_USER="$DOCKERHUB_USER" realclean all
 
     if make tests SUDO="$SUDO"; then
         echo -e '\u2713 Tests pass'


### PR DESCRIPTION
...and use that in bin/release, so that we don't build releases with ancient images.