### PR TITLE
rename 'report_persistence' capability to 'historic_reports'

### DIFF
--- a/app/collector.go
+++ b/app/collector.go
@@ -29,6 +29,7 @@ const reportQuantisationInterval = 3 * time.Second
 // interface for parts of the app, and several experimental components.
 type Reporter interface {
 	Report(context.Context, time.Time) (report.Report, error)
+	HasHistoricReports() bool
 	WaitOn(context.Context, chan struct{})
 	UnWait(context.Context, chan struct{})
 }
@@ -139,6 +140,12 @@ func (c *collector) Report(_ context.Context, timestamp time.Time) (report.Repor
 	return rpt, nil
 }
 
+// HasHistoricReports indicates whether the collector contains reports
+// older than now-app.window.
+func (c *collector) HasHistoricReports() bool {
+	return false
+}
+
 // remove reports older than the app.window
 func (c *collector) clean() {
 	var (
@@ -193,6 +200,12 @@ type StaticCollector report.Report
 // Reporter.
 func (c StaticCollector) Report(context.Context, time.Time) (report.Report, error) {
 	return report.Report(c), nil
+}
+
+// HasHistoricReports indicates whether the collector contains reports
+// older than now-app.window.
+func (c StaticCollector) HasHistoricReports() bool {
+	return false
 }
 
 // Add adds a report to the collector's internal state. It implements Adder.

--- a/app/multitenant/aws_collector.go
+++ b/app/multitenant/aws_collector.go
@@ -340,6 +340,10 @@ func (c *awsCollector) Report(ctx context.Context, timestamp time.Time) (report.
 	return c.merger.Merge(reports).Upgrade(), nil
 }
 
+func (c *awsCollector) HasHistoricReports() bool {
+	return true
+}
+
 // calculateDynamoKeys generates the row & column keys for Dynamo.
 func calculateDynamoKeys(userid string, now time.Time) (string, string) {
 	rowKey := fmt.Sprintf("%s-%s", userid, strconv.FormatInt(now.UnixNano()/time.Hour.Nanoseconds(), 10))

--- a/common/xfer/constants.go
+++ b/common/xfer/constants.go
@@ -14,9 +14,9 @@ const (
 	ScopeProbeVersionHeader = "X-Scope-Probe-Version"
 )
 
-// ReportPersistenceCapability indicates whether probe reports end up in a
-// long-term storage and can be retrieved.
-const ReportPersistenceCapability = "report_persistence"
+// HistoricReportsCapability indicates whether reports older than the
+// current time (-app.window) can be retrieved.
+const HistoricReportsCapability = "historic_reports"
 
 // Details are some generic details that can be fetched from /api
 type Details struct {

--- a/prog/app.go
+++ b/prog/app.go
@@ -295,7 +295,7 @@ func appMain(flags appFlags) {
 	}
 
 	capabilities := map[string]bool{
-		xfer.HistoricReportsCapability: flags.s3URL != "local",
+		xfer.HistoricReportsCapability: collector.HasHistoricReports(),
 	}
 	handler := router(collector, controlRouter, pipeRouter, flags.externalUI, capabilities)
 	if flags.logHTTP {

--- a/prog/app.go
+++ b/prog/app.go
@@ -295,7 +295,7 @@ func appMain(flags appFlags) {
 	}
 
 	capabilities := map[string]bool{
-		xfer.ReportPersistenceCapability: flags.s3URL != "local",
+		xfer.HistoricReportsCapability: flags.s3URL != "local",
 	}
 	handler := router(collector, controlRouter, pipeRouter, flags.externalUI, capabilities)
 	if flags.logHTTP {


### PR DESCRIPTION
since that better captures the intent - the UI doesn't care about reports get stored, but what reports it can retrieve.

Part of #2607.