### PR TITLE
Always take timestamp into account in Node Details when time travelling

### DIFF
--- a/client/app/scripts/utils/web-api-utils.js
+++ b/client/app/scripts/utils/web-api-utils.js
@@ -288,10 +288,14 @@ export function getNodeDetails(getState, dispatch) {
   if (obj && topologyUrlsById.has(obj.topologyId)) {
     const topologyUrl = topologyUrlsById.get(obj.topologyId);
     let urlComponents = [getApiPath(), topologyUrl, '/', encodeURIComponent(obj.id)];
-    if (currentTopologyId === obj.topologyId) {
-      // Only forward filters for nodes in the current topology
-      const optionsQuery = buildUrlQuery(activeTopologyOptionsSelector(state), state);
-      urlComponents = urlComponents.concat(['?', optionsQuery]);
+
+    // Only forward filters for nodes in the current topology.
+    const topologyOptions = currentTopologyId === obj.topologyId
+      ? activeTopologyOptionsSelector(state) : makeMap();
+
+    const query = buildUrlQuery(topologyOptions, state);
+    if (query) {
+      urlComponents = urlComponents.concat(['?', query]);
     }
     const url = urlComponents.join('');
 


### PR DESCRIPTION
Resolves #2769.

In Node Details requests, the query params were added only if the node belonged to the current topology - this PR keeps that logic for topology options but makes sure the timestamp is always added when time travelling, regardless of the topology context.
