### PR TITLE
Shrink timeline height and make years fade out

### DIFF
--- a/client/app/scripts/components/time-travel-timeline.js
+++ b/client/app/scripts/components/time-travel-timeline.js
@@ -292,11 +292,11 @@ class TimeTravelTimeline extends React.Component {
     const ticks = this.getTicksForPeriod(period, focusedTimestamp);
 
     const verticalShift = this.getVerticalShiftForPeriod(period);
-    const transform = `translate(0, ${62 - (verticalShift * 15)})`;
+    const transform = `translate(0, ${49 - (verticalShift * 16)})`;
 
     // Ticks quickly fade in from the bottom and then slowly
     // start fading out as they are being pushed to the top.
-    const opacity = verticalShift > 1 ? (6 - verticalShift) / 5 : verticalShift;
+    const opacity = verticalShift > 1 ? (5 - verticalShift) / 4 : verticalShift;
 
     return (
       <g className={period} transform={transform} style={{ opacity }}>

--- a/client/app/scripts/utils/math-utils.js
+++ b/client/app/scripts/utils/math-utils.js
@@ -39,3 +39,8 @@ export function minEuclideanDistanceBetweenPoints(points) {
   });
   return minDistance;
 }
+
+// A linear mapping [a, b] -> [0, 1] (maps value x=a into 0 and x=b into 1).
+export function linearGradientValue(x, [a, b]) {
+  return (x - a) / (b - a);
+}

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -189,7 +189,7 @@
 
   &.time-travel-open {
     .details-wrapper {
-      margin-top: 85px;
+      margin-top: $timeline-height + 15px;
     }
   }
 }
@@ -264,7 +264,7 @@
   height: 0;
 
   &.visible {
-    height: 105px;
+    height: $timeline-height + 35px;
     margin-bottom: 15px;
     margin-top: -5px;
   }
@@ -277,7 +277,7 @@
   .time-travel-timeline {
     align-items: center;
     display: flex;
-    height: 70px;
+    height: $timeline-height;
 
     svg {
       @extend .grabbable;
@@ -321,11 +321,11 @@
 
     &:before {
       top: 0;
-      height: 70px;
+      height: $timeline-height;
     }
 
     &:after {
-      top: 70px;
+      top: $timeline-height;
       height: 9px;
       opacity: 0.15;
     }

--- a/client/app/styles/_variables.scss
+++ b/client/app/styles/_variables.scss
@@ -53,6 +53,8 @@ $link-opacity-default: 0.8;
 $search-border-color: transparent;
 $search-border-width: 1px;
 
+$timeline-height: 55px;
+
 /* specific elements */
 $body-background-color: linear-gradient(30deg, $background-color 0%, $background-lighter-color 100%);
 $label-background-color: fade-out($background-average-color, .3);


### PR DESCRIPTION
Resolves #2770 by shrinking the timeline height for 15px and making the year time tags fade out as hours fade in.
