### PR TITLE
synthesise k8s service network from service IPs

### DIFF
--- a/report/networks_test.go
+++ b/report/networks_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -22,4 +23,19 @@ func TestContains(t *testing.T) {
 	if !networks.Contains(net.ParseIP("10.0.0.1")) {
 		t.Errorf("10.0.0.1 in %v", networks)
 	}
+}
+
+func TestContainingIPv4Network(t *testing.T) {
+	assert.Nil(t, containingIPv4Networks([]string{}))
+	assert.Equal(t, "10.0.0.1/32", containingIPv4Networks([]string{"10.0.0.1"}).String())
+	assert.Equal(t, "10.0.0.0/17", containingIPv4Networks([]string{"10.0.0.1", "10.0.2.55", "10.0.106.48"}).String())
+	assert.Equal(t, "0.0.0.0/0", containingIPv4Networks([]string{"10.0.0.1", "192.168.0.1"}).String())
+}
+
+func containingIPv4Networks(ipstrings []string) *net.IPNet {
+	ips := make([]net.IP, len(ipstrings))
+	for i, ip := range ipstrings {
+		ips[i] = net.ParseIP(ip).To4()
+	}
+	return report.ContainingIPv4Network(ips)
 }


### PR DESCRIPTION
This prevents cluttering host.LocalNetworks with lots of /32 addresses. These were unsightly and rather distracting in the UI. They also bloated the report and slowed down server-side rendering.

Fixes #2748.