### PR TITLE
Improve Firefox performance

### DIFF
--- a/client/app/scripts/charts/edge-container.js
+++ b/client/app/scripts/charts/edge-container.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Motion, spring } from 'react-motion';
 import { Map as makeMap } from 'immutable';
 import { line, curveBasis } from 'd3-shape';
-import { each, omit, times, constant } from 'lodash';
+import { each, times, constant } from 'lodash';
 
 import { NODES_SPRING_ANIMATION_CONFIG } from '../constants/animation';
 import { NODE_BASE_SIZE, EDGE_WAYPOINTS_CAP } from '../constants/styles';
@@ -70,8 +70,7 @@ export default class EdgeContainer extends React.PureComponent {
   }
 
   render() {
-    const { isAnimated, waypoints } = this.props;
-    const forwardedProps = omit(this.props, 'isAnimated', 'waypoints', 'scale');
+    const { isAnimated, waypoints, scale, ...forwardedProps } = this.props;
 
     if (!isAnimated) {
       return transformedEdge(forwardedProps, waypoints.toJS(), this.state.thickness);

--- a/client/app/scripts/charts/edge.js
+++ b/client/app/scripts/charts/edge.js
@@ -14,9 +14,9 @@ class Edge extends React.Component {
   }
 
   render() {
-    const { id, path, highlighted, blurred, focused, thickness, source, target } = this.props;
+    const { id, path, highlighted, focused, thickness, source, target } = this.props;
     const shouldRenderMarker = (focused || highlighted) && (source !== target);
-    const className = classNames('edge', { highlighted, blurred });
+    const className = classNames('edge', { highlighted });
 
     return (
       <g

--- a/client/app/scripts/charts/node-container.js
+++ b/client/app/scripts/charts/node-container.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { omit } from 'lodash';
 import { Motion, spring } from 'react-motion';
 
 import { NODES_SPRING_ANIMATION_CONFIG } from '../constants/animation';
@@ -16,8 +15,7 @@ const transformedNode = (otherProps, { x, y, k }) => (
 
 export default class NodeContainer extends React.PureComponent {
   render() {
-    const { dx, dy, isAnimated, scale } = this.props;
-    const forwardedProps = omit(this.props, 'dx', 'dy', 'isAnimated', 'scale');
+    const { dx, dy, isAnimated, scale, ...forwardedProps } = this.props;
 
     if (!isAnimated) {
       // Show static node for optimized rendering

--- a/client/app/scripts/charts/node-container.js
+++ b/client/app/scripts/charts/node-container.js
@@ -6,24 +6,22 @@ import { NODES_SPRING_ANIMATION_CONFIG } from '../constants/animation';
 import Node from './node';
 
 
-const transformedNode = (otherProps, { x, y, k, opacity }) => (
+const transformedNode = (otherProps, { x, y, k }) => (
   // NOTE: Controlling blurring and transform from here seems to re-render
   // faster than adding a CSS class and controlling it from there.
-  <g transform={`translate(${x},${y}) scale(${k})`} style={{opacity}}>
+  <g transform={`translate(${x},${y}) scale(${k})`}>
     <Node {...otherProps} />
   </g>
 );
 
 export default class NodeContainer extends React.PureComponent {
   render() {
-    const { dx, dy, isAnimated, scale, blurred, contrastMode } = this.props;
-    const nodeBlurOpacity = contrastMode ? 0.6 : 0.25;
-    const forwardedProps = omit(this.props, 'dx', 'dy', 'isAnimated', 'scale', 'blurred');
-    const opacity = blurred ? nodeBlurOpacity : 1;
+    const { dx, dy, isAnimated, scale } = this.props;
+    const forwardedProps = omit(this.props, 'dx', 'dy', 'isAnimated', 'scale');
 
     if (!isAnimated) {
       // Show static node for optimized rendering
-      return transformedNode(forwardedProps, { x: dx, y: dy, k: scale, opacity });
+      return transformedNode(forwardedProps, { x: dx, y: dy, k: scale });
     }
 
     return (
@@ -33,7 +31,6 @@ export default class NodeContainer extends React.PureComponent {
           x: spring(dx, NODES_SPRING_ANIMATION_CONFIG),
           y: spring(dy, NODES_SPRING_ANIMATION_CONFIG),
           k: spring(scale, NODES_SPRING_ANIMATION_CONFIG),
-          opacity: spring(opacity, NODES_SPRING_ANIMATION_CONFIG),
         }}>
         {interpolated => transformedNode(forwardedProps, interpolated)}
       </Motion>

--- a/client/app/scripts/charts/nodes-chart-elements.js
+++ b/client/app/scripts/charts/nodes-chart-elements.js
@@ -222,11 +222,6 @@ class NodesChartElements extends React.Component {
       .map(this.edgeScaleDecorator)
       .groupBy(this.edgeDisplayLayer);
 
-    // const orderedElements = makeList([
-    //   edges,
-    //   nodes,
-    // ]).flatten(true);
-
     // NOTE: The elements need to be arranged into a single array outside
     // of DOM structure for React rendering engine to do smart rearrangements
     // without unnecessary re-rendering of the elements themselves. So e.g.
@@ -257,7 +252,7 @@ function mapStateToProps(state) {
     hasSelectedNode: hasSelectedNodeFn(state),
     layoutNodes: layoutNodesSelector(state),
     layoutEdges: layoutEdgesSelector(state),
-    isAnimated: false && !graphExceedsComplexityThreshSelector(state),
+    isAnimated: !graphExceedsComplexityThreshSelector(state),
     highlightedNodeIds: highlightedNodeIdsSelector(state),
     highlightedEdgeIds: highlightedEdgeIdsSelector(state),
     selectedNetworkNodesIds: selectedNetworkNodesIdsSelector(state),

--- a/client/app/scripts/charts/nodes-chart-elements.js
+++ b/client/app/scripts/charts/nodes-chart-elements.js
@@ -189,16 +189,23 @@ class NodesChartElements extends React.Component {
     );
   }
 
+  renderOverlay(element) {
+    // NOTE: This piece of code is a bit hacky - as we can't set the absolute coords for the
+    // SVG element, we set the zoom level high enough that we're sure it covers the screen.
+    const className = classNames('nodes-chart-overlay', { active: element.get('isActive') });
+    const scale = this.props.selectedScale * 100000;
+    return (
+      <rect
+        className={className} fill="#fff"
+        x={-1} y={-1} width={2} height={2}
+        transform={`scale(${scale})`}
+      />
+    );
+  }
+
   renderElement(element) {
     if (element.get('isOverlay')) {
-      const className = classNames('nodes-overlay', { active: element.get('isActive') });
-      return (
-        <rect
-          className={className}
-          x={-1} y={-1} width={2} height={2}
-          transform="scale(1000000)" fill="#fff"
-        />
-      );
+      return this.renderOverlay(element);
     }
     // This heuristics is not ideal but it works.
     return element.get('points') ? this.renderEdge(element) : this.renderNode(element);

--- a/client/app/scripts/charts/nodes-chart-elements.js
+++ b/client/app/scripts/charts/nodes-chart-elements.js
@@ -190,13 +190,13 @@ class NodesChartElements extends React.Component {
   }
 
   renderElement(element) {
-    if (element.get('overlay')) {
-      const className = classNames('nodes-overlay', { active: element.get('active') });
+    if (element.get('isOverlay')) {
+      const className = classNames('nodes-overlay', { active: element.get('isActive') });
       return (
         <rect
           className={className}
           x={-1} y={-1} width={2} height={2}
-          transform="scale(1000000)"fill="#fff"
+          transform="scale(1000000)" fill="#fff"
         />
       );
     }
@@ -229,7 +229,7 @@ class NodesChartElements extends React.Component {
     const orderedElements = makeList([
       edges.get(BLURRED_EDGES_LAYER, makeList()),
       nodes.get(BLURRED_NODES_LAYER, makeList()),
-      fromJS([{ overlay: true, active: !!nodes.get(BLURRED_NODES_LAYER) }]),
+      fromJS([{ isOverlay: true, isActive: !!nodes.get(BLURRED_NODES_LAYER) }]),
       edges.get(NORMAL_EDGES_LAYER, makeList()),
       nodes.get(NORMAL_NODES_LAYER, makeList()),
       edges.get(HIGHLIGHTED_EDGES_LAYER, makeList()),

--- a/client/app/scripts/charts/nodes-chart-elements.js
+++ b/client/app/scripts/charts/nodes-chart-elements.js
@@ -193,12 +193,12 @@ class NodesChartElements extends React.Component {
     // NOTE: This piece of code is a bit hacky - as we can't set the absolute coords for the
     // SVG element, we set the zoom level high enough that we're sure it covers the screen.
     const className = classNames('nodes-chart-overlay', { active: element.get('isActive') });
-    const scale = this.props.selectedScale * 100000;
+    const scale = (this.props.selectedScale || 1) * 100000;
     return (
       <rect
-        className={className} fill="#fff"
+        className={className} key="nodes-chart-overlay"
+        transform={`scale(${scale})`} fill="#fff"
         x={-1} y={-1} width={2} height={2}
-        transform={`scale(${scale})`}
       />
     );
   }

--- a/client/app/scripts/components/node-details.js
+++ b/client/app/scripts/components/node-details.js
@@ -151,6 +151,7 @@ class NodeDetails extends React.Component {
   }
 
   renderDetails() {
+    console.log('render details');
     const { details, nodeControlStatus, nodeMatches = makeMap() } = this.props;
     const showControls = details.controls && details.controls.length > 0;
     const nodeColor = getNodeColorDark(details.rank, details.label, details.pseudo);

--- a/client/app/scripts/components/node-details.js
+++ b/client/app/scripts/components/node-details.js
@@ -151,7 +151,6 @@ class NodeDetails extends React.Component {
   }
 
   renderDetails() {
-    console.log('render details');
     const { details, nodeControlStatus, nodeMatches = makeMap() } = this.props;
     const showControls = details.controls && details.controls.length > 0;
     const nodeColor = getNodeColorDark(details.rank, details.label, details.pseudo);

--- a/client/app/scripts/constants/animation.js
+++ b/client/app/scripts/constants/animation.js
@@ -1,3 +1,3 @@
 
-export const NODES_SPRING_ANIMATION_CONFIG = { stiffness: 80, damping: 20, precision: 0.1 };
+export const NODES_SPRING_ANIMATION_CONFIG = { stiffness: 200, damping: 25, precision: 1 };
 export const NODES_SPRING_FAST_ANIMATION_CONFIG = { stiffness: 800, damping: 50, precision: 1 };

--- a/client/app/scripts/selectors/topology.js
+++ b/client/app/scripts/selectors/topology.js
@@ -46,7 +46,7 @@ export const graphExceedsComplexityThreshSelector = createSelector(
     state => state.getIn(['currentTopology', 'stats', 'node_count']) || 0,
     state => state.getIn(['currentTopology', 'stats', 'edge_count']) || 0,
   ],
-  (nodeCount, edgeCount) => (nodeCount + (2 * edgeCount)) > 1000
+  (nodeCount, edgeCount) => (nodeCount + (2 * edgeCount)) > 500
 );
 
 // Options for current topology, sub-topologies share options with parent

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -27,15 +27,18 @@
 }
 
 .colorable {
-  transition: background-color .3s $base-ease;
+  transition: none;
+  // transition: background-color .3s $base-ease;
 }
 
 .palable {
-  transition: all .2s $base-ease;
+  transition: none;
+  // transition: all .2s $base-ease;
 }
 
 .hideable {
-  transition: opacity .5s $base-ease;
+  transition: none;
+  // transition: opacity .5s $base-ease;
 }
 
 .blinkable {
@@ -259,7 +262,7 @@
   margin-bottom: 15px;
   z-index: 2001;
 
-  transition: all .15s $base-ease;
+  // transition: all .15s $base-ease;
   overflow: hidden;
   height: 0;
 
@@ -411,6 +414,16 @@
 
 }
 
+.nodes-overlay {
+  // transition: opacity 2.5s $base-ease;
+  pointer-events: none;
+  opacity: 0;
+
+  &.active {
+    opacity: $node-elements-in-background-opacity;
+  }
+}
+
 .nodes-chart, .nodes-resources {
 
   &-error, &-loading {
@@ -439,7 +452,7 @@
   }
 
   &-loading &-error-icon-container {
-    @extend .blinkable;
+    // @extend .blinkable;
   }
 
   &-loading {
@@ -468,7 +481,7 @@
   }
 
   .nodes-chart-elements .node {
-    transition: opacity .2s $base-ease;
+    // transition: opacity .2s $base-ease;
     text-align: center;
 
     .node-label {
@@ -562,12 +575,6 @@
   }
 
   .edge {
-    transition: opacity .5s $base-ease;
-
-    &.blurred {
-      opacity: $edge-opacity-blurred;
-    }
-
     .link {
       fill: none;
       stroke: $edge-color;
@@ -628,7 +635,7 @@
       fill: none;
       stroke-opacity: 1;
       stroke-width: $node-border-stroke-width;
-      transition: stroke-opacity 0.333s $base-ease, fill 0.333s $base-ease;
+      // transition: stroke-opacity 0.333s $base-ease, fill 0.333s $base-ease;
     }
 
     &.metrics .border {
@@ -700,7 +707,7 @@
     right: $details-window-padding-left;
     top: 100px;
     bottom: 48px;
-    transition: transform 0.33333s cubic-bezier(0,0,0.21,1), margin-top .15s $base-ease;
+    // transition: transform 0.33333s cubic-bezier(0,0,0.21,1), margin-top .15s $base-ease;
   }
 }
 
@@ -848,7 +855,7 @@
       color: $white;
 
       &-icon {
-        @extend .blinkable;
+        // @extend .blinkable;
         margin-right: 0.5em;
       }
     }
@@ -1237,7 +1244,7 @@
     left: 10px;
     bottom: 10px;
     right: 0;
-    transition: transform 0.5s cubic-bezier(0.230, 1.000, 0.320, 1.000);
+    // transition: transform 0.5s cubic-bezier(0.230, 1.000, 0.320, 1.000);
     @extend .shadow-2;
   }
 
@@ -1397,7 +1404,7 @@
   }
 
   .error {
-    animation: blinking 2.0s 60 $base-ease; // blink for 2 minutes
+    // animation: blinking 2.0s 60 $base-ease; // blink for 2 minutes
     color: $text-secondary-color;
   }
 
@@ -1421,7 +1428,7 @@
   }
 
   &.status-loading {
-    animation: blinking 2.0s 150 $base-ease; // keep blinking for 5 minutes
+    // animation: blinking 2.0s 150 $base-ease; // keep blinking for 5 minutes
     text-transform: none;
     color: $text-color;
   }
@@ -1530,7 +1537,7 @@
   }
 
   &-info {
-    @extend .blinkable;
+    // @extend .blinkable;
     display: block;
     margin-top: 5px;
     text-align: right;
@@ -1618,7 +1625,7 @@
   display: inline-block;
   position: relative;
   width: 10em;
-  transition: width 0.3s 0s $base-ease;
+  // transition: width 0.3s 0s $base-ease;
 
   &-wrapper {
     flex: 0 1 20%;
@@ -1638,7 +1645,7 @@
     color: $text-tertiary-color;
     top: 0;
     opacity: 0;
-    transition: transform 0.3s 0s $base-ease, opacity 0.3s 0s $base-ease;
+    // transition: transform 0.3s 0s $base-ease, opacity 0.3s 0s $base-ease;
     text-align: left;
   }
 
@@ -1665,7 +1672,7 @@
     &-hint {
       font-size: 0.8rem;
       text-transform: uppercase;
-      transition: opacity 0.3s 0.5s $base-ease;
+      // transition: opacity 0.3s 0.5s $base-ease;
       opacity: 1;
     }
   }
@@ -1703,7 +1710,7 @@
   &-focused &-label-hint,
   &-pinned &-label-hint,
   &-filled &-label-hint {
-    transition: opacity 0.1s 0s $base-ease;
+    // transition: opacity 0.1s 0s $base-ease;
     opacity: 0;
   }
 
@@ -1712,7 +1719,7 @@
   &-pinned &-hint {
     opacity: 1;
     transform: translate3d(0, 2.75em, 0);
-    transition: transform 0.3s 0.3s $base-ease, opacity 0.3s 0.3s $base-ease;
+    // transition: transform 0.3s 0.3s $base-ease, opacity 0.3s 0.3s $base-ease;
   }
 
   &-focused &-input-field,

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -27,18 +27,15 @@
 }
 
 .colorable {
-  transition: none;
-  // transition: background-color .3s $base-ease;
+  transition: background-color .3s $base-ease;
 }
 
 .palable {
-  transition: none;
-  // transition: all .2s $base-ease;
+  transition: all .2s $base-ease;
 }
 
 .hideable {
-  transition: none;
-  // transition: opacity .5s $base-ease;
+  transition: opacity .5s $base-ease;
 }
 
 .blinkable {
@@ -262,7 +259,7 @@
   margin-bottom: 15px;
   z-index: 2001;
 
-  // transition: all .15s $base-ease;
+  transition: all .15s $base-ease;
   overflow: hidden;
   height: 0;
 
@@ -415,7 +412,7 @@
 }
 
 .nodes-overlay {
-  // transition: opacity 2.5s $base-ease;
+  transition: all .5s $base-ease;
   pointer-events: none;
   opacity: 0;
 
@@ -481,7 +478,6 @@
   }
 
   .nodes-chart-elements .node {
-    // transition: opacity .2s $base-ease;
     text-align: center;
 
     .node-label {
@@ -635,7 +631,6 @@
       fill: none;
       stroke-opacity: 1;
       stroke-width: $node-border-stroke-width;
-      // transition: stroke-opacity 0.333s $base-ease, fill 0.333s $base-ease;
     }
 
     &.metrics .border {
@@ -707,7 +702,7 @@
     right: $details-window-padding-left;
     top: 100px;
     bottom: 48px;
-    // transition: transform 0.33333s cubic-bezier(0,0,0.21,1), margin-top .15s $base-ease;
+    transition: transform 0.33333s cubic-bezier(0,0,0.21,1), margin-top .15s $base-ease;
   }
 }
 
@@ -1244,7 +1239,7 @@
     left: 10px;
     bottom: 10px;
     right: 0;
-    // transition: transform 0.5s cubic-bezier(0.230, 1.000, 0.320, 1.000);
+    transition: transform 0.5s cubic-bezier(0.230, 1.000, 0.320, 1.000);
     @extend .shadow-2;
   }
 
@@ -1625,7 +1620,7 @@
   display: inline-block;
   position: relative;
   width: 10em;
-  // transition: width 0.3s 0s $base-ease;
+  transition: width 0.3s 0s $base-ease;
 
   &-wrapper {
     flex: 0 1 20%;
@@ -1645,7 +1640,7 @@
     color: $text-tertiary-color;
     top: 0;
     opacity: 0;
-    // transition: transform 0.3s 0s $base-ease, opacity 0.3s 0s $base-ease;
+    transition: transform 0.3s 0s $base-ease, opacity 0.3s 0s $base-ease;
     text-align: left;
   }
 
@@ -1672,7 +1667,7 @@
     &-hint {
       font-size: 0.8rem;
       text-transform: uppercase;
-      // transition: opacity 0.3s 0.5s $base-ease;
+      transition: opacity 0.3s 0.5s $base-ease;
       opacity: 1;
     }
   }
@@ -1710,7 +1705,7 @@
   &-focused &-label-hint,
   &-pinned &-label-hint,
   &-filled &-label-hint {
-    // transition: opacity 0.1s 0s $base-ease;
+    transition: opacity 0.1s 0s $base-ease;
     opacity: 0;
   }
 
@@ -1719,7 +1714,7 @@
   &-pinned &-hint {
     opacity: 1;
     transform: translate3d(0, 2.75em, 0);
-    // transition: transform 0.3s 0.3s $base-ease, opacity 0.3s 0.3s $base-ease;
+    transition: transform 0.3s 0.3s $base-ease, opacity 0.3s 0.3s $base-ease;
   }
 
   &-focused &-input-field,

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -448,8 +448,9 @@
     li { padding-top: 5px; }
   }
 
-  &-loading &-error-icon-container {
-    // @extend .blinkable;
+  // Make watermarks blink only if actually shown (otherwise the FF performance decreses weirdly).
+  &-loading:not(.hide) &-error-icon-container {
+    @extend .blinkable;
   }
 
   &-loading {
@@ -850,7 +851,7 @@
       color: $white;
 
       &-icon {
-        // @extend .blinkable;
+        @extend .blinkable;
         margin-right: 0.5em;
       }
     }
@@ -1399,7 +1400,7 @@
   }
 
   .error {
-    // animation: blinking 2.0s 60 $base-ease; // blink for 2 minutes
+    animation: blinking 2.0s 60 $base-ease; // blink for 2 minutes
     color: $text-secondary-color;
   }
 
@@ -1423,7 +1424,7 @@
   }
 
   &.status-loading {
-    // animation: blinking 2.0s 150 $base-ease; // keep blinking for 5 minutes
+    animation: blinking 2.0s 150 $base-ease; // keep blinking for 5 minutes
     text-transform: none;
     color: $text-color;
   }
@@ -1532,7 +1533,7 @@
   }
 
   &-info {
-    // @extend .blinkable;
+    @extend .blinkable;
     display: block;
     margin-top: 5px;
     text-align: right;

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -411,8 +411,7 @@
 
 }
 
-.nodes-overlay {
-  transition: all .5s $base-ease;
+.nodes-chart-overlay {
   pointer-events: none;
   opacity: 0;
 

--- a/client/app/styles/_contrast-overrides.scss
+++ b/client/app/styles/_contrast-overrides.scss
@@ -12,6 +12,8 @@ $text-darker-color: darken($text-color, 20%);
 $white: white;
 $edge-color: black;
 
+$node-elements-in-background-opacity: 0.4;
+
 $node-highlight-shadow-opacity: 0.4;
 $node-highlight-stroke-opacity: 0.5;
 $node-highlight-stroke-width: 0.16;

--- a/client/app/styles/_variables.scss
+++ b/client/app/styles/_variables.scss
@@ -31,7 +31,7 @@ $border-radius: 4px;
 
 $terminal-header-height: 44px;
 
-$node-elements-in-background-opacity: 0.75;
+$node-elements-in-background-opacity: 0.7;
 
 $node-highlight-shadow-opacity: 0.5;
 $node-highlight-stroke-opacity: 0.4;

--- a/client/app/styles/_variables.scss
+++ b/client/app/styles/_variables.scss
@@ -31,6 +31,8 @@ $border-radius: 4px;
 
 $terminal-header-height: 44px;
 
+$node-elements-in-background-opacity: 0.75;
+
 $node-highlight-shadow-opacity: 0.5;
 $node-highlight-stroke-opacity: 0.4;
 $node-highlight-stroke-width: 0.04;


### PR DESCRIPTION
Improves on #2302.

##### Changes

* Added a non-reactive semi-transparent layer between background and foreground nodes and edges in the graph view, removing excessive opacity transitions for individual elements (which also fixes #2431).
* The semi-transparent layer mentioned above is now applied instantly (without a transition) to avoid the glitches and is made a bit lighter (I thought it looked better that way, but that can easily be reverted).
* Made default *spring* animation a bit faster so that it appears smoother and more reactive on Firefox.
* Decreased the graph animation treshold again to make it bearable on Firefox.
