### PR TITLE
log sqs messages at 'debug' rather than 'info' level

### DIFF
--- a/app/multitenant/sqs_control_router.go
+++ b/app/multitenant/sqs_control_router.go
@@ -194,7 +194,7 @@ func (cr *sqsControlRouter) sendMessage(ctx context.Context, queueURL *string, m
 	if err := json.NewEncoder(&buf).Encode(message); err != nil {
 		return err
 	}
-	log.Infof("sendMessage to %s: %s", *queueURL, buf.String())
+	log.Debugf("sendMessage to %s: %s", *queueURL, buf.String())
 
 	return instrument.TimeRequestHistogram(ctx, "SQS.SendMessage", sqsRequestDuration, func(_ context.Context) error {
 		_, err := cr.service.SendMessage(&sqs.SendMessageInput{


### PR DESCRIPTION
Fixes #2790.