### PR TITLE
Time Travel: unmount in the shutdown() action

### DIFF
--- a/client/app/scripts/actions/app-actions.js
+++ b/client/app/scripts/actions/app-actions.js
@@ -798,10 +798,16 @@ export function changeInstance() {
 }
 
 export function shutdown() {
-  stopPolling();
-  teardownWebsockets();
-  return {
-    type: ActionTypes.SHUTDOWN
+  return (dispatch) => {
+    stopPolling();
+    teardownWebsockets();
+    // Exit the time travel mode before unmounting the app.
+    dispatch({
+      type: ActionTypes.RESUME_TIME
+    });
+    dispatch({
+      type: ActionTypes.SHUTDOWN
+    });
   };
 }
 

--- a/client/app/scripts/actions/app-actions.js
+++ b/client/app/scripts/actions/app-actions.js
@@ -574,14 +574,16 @@ export function receiveNodesDelta(delta) {
 
 export function resumeTime() {
   return (dispatch, getState) => {
-    dispatch({
-      type: ActionTypes.RESUME_TIME
-    });
-    // After unpausing, all of the following calls will re-activate polling.
-    getTopologies(getState, dispatch);
-    getNodes(getState, dispatch, true);
-    if (isResourceViewModeSelector(getState())) {
-      getResourceViewNodesSnapshot(getState(), dispatch);
+    if (isPausedSelector(getState())) {
+      dispatch({
+        type: ActionTypes.RESUME_TIME
+      });
+      // After unpausing, all of the following calls will re-activate polling.
+      getTopologies(getState, dispatch);
+      getNodes(getState, dispatch, true);
+      if (isResourceViewModeSelector(getState())) {
+        getResourceViewNodesSnapshot(getState(), dispatch);
+      }
     }
   };
 }

--- a/client/app/scripts/components/time-travel.js
+++ b/client/app/scripts/components/time-travel.js
@@ -47,11 +47,6 @@ class TimeTravel extends React.Component {
     this.setState(getTimestampStates(props.pausedAt));
   }
 
-  componentWillUnmount() {
-    // TODO: Get rid of this somehow. See: https://github.com/weaveworks/service-ui/issues/814
-    this.props.resumeTime();
-  }
-
   handleInputChange(ev) {
     const timestamp = moment(ev.target.value);
     this.setState({ inputValue: ev.target.value });


### PR DESCRIPTION
Resolves https://github.com/weaveworks/service-ui/issues/814 by making timeline deconstruction part of the `shutdown()` action, avoiding the attempt to establish new connections.

Also, triggering `resumeTime` action only if previously paused.