### PR TITLE
Remove whitespace from empty connection lists

### DIFF
--- a/client/app/scripts/components/node-details.js
+++ b/client/app/scripts/components/node-details.js
@@ -206,8 +206,8 @@ class NodeDetails extends React.Component {
             <NodeDetailsInfo rows={details.metadata} matches={nodeMatches.get('metadata')} />
           </div>}
 
-          {details.connections && details.connections.map(connections => (
-            <div className="node-details-content-section" key={connections.id}>
+          {details.connections && details.connections.filter(cs => cs.connections.length > 0)
+            .map(connections => (<div className="node-details-content-section" key={connections.id}>
               <NodeDetailsTable
                 {...connections}
                 nodes={connections.connections}


### PR DESCRIPTION
Removes empty container that introduce unnecessary margin
![scope-details-whitespace](https://user-images.githubusercontent.com/32963/29270432-add628b4-80ee-11e7-83f6-caeac4c8633a.png)

