### PR TITLE
Unified zooming sensitivity

### DIFF
--- a/client/app/scripts/charts/nodes-chart.js
+++ b/client/app/scripts/charts/nodes-chart.js
@@ -6,9 +6,11 @@ import ZoomableCanvas from '../components/zoomable-canvas';
 import { transformToString } from '../utils/transform-utils';
 import { clickBackground } from '../actions/app-actions';
 import {
-  graphZoomLimitsSelector,
+  graphLimitsSelector,
   graphZoomStateSelector,
 } from '../selectors/graph-view/zoom';
+
+import { CONTENT_INCLUDED } from '../constants/naming';
 
 
 const EdgeMarkerDefinition = ({ selectedNodeId }) => {
@@ -58,7 +60,8 @@ class NodesChart extends React.Component {
       <div className="nodes-chart">
         <ZoomableCanvas
           onClick={this.handleMouseClick}
-          zoomLimitsSelector={graphZoomLimitsSelector}
+          boundContent={CONTENT_INCLUDED}
+          limitsSelector={graphLimitsSelector}
           zoomStateSelector={graphZoomStateSelector}
           disabled={this.props.selectedNodeId}>
           {transform => this.renderContent(transform)}

--- a/client/app/scripts/charts/nodes-chart.js
+++ b/client/app/scripts/charts/nodes-chart.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 
 import NodesChartElements from './nodes-chart-elements';
 import ZoomableCanvas from '../components/zoomable-canvas';
+import { transformToString } from '../utils/transform-utils';
 import { clickBackground } from '../actions/app-actions';
 import {
   graphZoomLimitsSelector,
@@ -43,17 +44,24 @@ class NodesChart extends React.Component {
     }
   }
 
+  renderContent(transform) {
+    return (
+      <g transform={transformToString(transform)}>
+        <EdgeMarkerDefinition selectedNodeId={this.props.selectedNodeId} />
+        <NodesChartElements />
+      </g>
+    );
+  }
+
   render() {
-    const { selectedNodeId } = this.props;
     return (
       <div className="nodes-chart">
         <ZoomableCanvas
           onClick={this.handleMouseClick}
           zoomLimitsSelector={graphZoomLimitsSelector}
           zoomStateSelector={graphZoomStateSelector}
-          disabled={selectedNodeId}>
-          <EdgeMarkerDefinition selectedNodeId={selectedNodeId} />
-          <NodesChartElements />
+          disabled={this.props.selectedNodeId}>
+          {transform => this.renderContent(transform)}
         </ZoomableCanvas>
       </div>
     );

--- a/client/app/scripts/components/nodes-resources.js
+++ b/client/app/scripts/components/nodes-resources.js
@@ -39,8 +39,8 @@ class NodesResources extends React.Component {
     return (
       <div className="nodes-resources">
         <ZoomableCanvas
+          bounded fixVertical
           onClick={this.handleMouseClick}
-          bounded forwardTransform fixVertical
           zoomLimitsSelector={resourcesZoomLimitsSelector}
           zoomStateSelector={resourcesZoomStateSelector}>
           {transform => this.renderLayers(transform)}

--- a/client/app/scripts/components/nodes-resources.js
+++ b/client/app/scripts/components/nodes-resources.js
@@ -5,10 +5,12 @@ import ZoomableCanvas from './zoomable-canvas';
 import NodesResourcesLayer from './nodes-resources/node-resources-layer';
 import { layersTopologyIdsSelector } from '../selectors/resource-view/layout';
 import {
-  resourcesZoomLimitsSelector,
+  resourcesLimitsSelector,
   resourcesZoomStateSelector,
 } from '../selectors/resource-view/zoom';
 import { clickBackground } from '../actions/app-actions';
+
+import { CONTENT_COVERING } from '../constants/naming';
 
 
 class NodesResources extends React.Component {
@@ -39,9 +41,9 @@ class NodesResources extends React.Component {
     return (
       <div className="nodes-resources">
         <ZoomableCanvas
-          bounded fixVertical
           onClick={this.handleMouseClick}
-          zoomLimitsSelector={resourcesZoomLimitsSelector}
+          fixVertical boundContent={CONTENT_COVERING}
+          limitsSelector={resourcesLimitsSelector}
           zoomStateSelector={resourcesZoomStateSelector}>
           {transform => this.renderLayers(transform)}
         </ZoomableCanvas>

--- a/client/app/scripts/components/time-travel-timeline.js
+++ b/client/app/scripts/components/time-travel-timeline.js
@@ -168,7 +168,7 @@ class TimeTravelTimeline extends React.Component {
   }
 
   handleZoom(ev) {
-    let durationPerPixel = scaleDuration(this.state.durationPerPixel, zoomFactor(ev));
+    let durationPerPixel = scaleDuration(this.state.durationPerPixel, 1 / zoomFactor(ev));
     if (durationPerPixel > MAX_DURATION_PER_PX) durationPerPixel = MAX_DURATION_PER_PX;
     if (durationPerPixel < MIN_DURATION_PER_PX) durationPerPixel = MIN_DURATION_PER_PX;
 

--- a/client/app/scripts/components/zoomable-canvas.js
+++ b/client/app/scripts/components/zoomable-canvas.js
@@ -162,7 +162,7 @@ class ZoomableCanvas extends React.Component {
   }
 
   handlePan() {
-    let state = { ...this.state };
+    let state = this.state;
     // Apply the translation respecting the boundaries.
     state = this.clampedTranslation({ ...state,
       translateX: this.state.translateX + d3Event.dx,
@@ -181,6 +181,7 @@ class ZoomableCanvas extends React.Component {
       };
       this.zoomAtPositionByFactor(mousePosition, zoomFactor(ev));
     }
+    ev.preventDefault();
   }
 
   clampedTranslation(state) {

--- a/client/app/scripts/constants/naming.js
+++ b/client/app/scripts/constants/naming.js
@@ -16,3 +16,6 @@ export const HIGHLIGHTED_EDGES_LAYER = 'highlighted-edges';
 export const HIGHLIGHTED_NODES_LAYER = 'highlighted-nodes';
 export const HOVERED_EDGES_LAYER = 'hovered-edges';
 export const HOVERED_NODES_LAYER = 'hovered-nodes';
+
+export const CONTENT_INCLUDED = 'content-included';
+export const CONTENT_COVERING = 'content-covering';

--- a/client/app/scripts/constants/styles.js
+++ b/client/app/scripts/constants/styles.js
@@ -38,7 +38,7 @@ export const NODE_BASE_SIZE = 100;
 export const EDGE_WAYPOINTS_CAP = 10;
 
 export const CANVAS_MARGINS = {
-  [GRAPH_VIEW_MODE]: { top: 160, left: 40, right: 40, bottom: 150 },
+  [GRAPH_VIEW_MODE]: { top: 160, left: 80, right: 80, bottom: 150 },
   [TABLE_VIEW_MODE]: { top: 220, left: 40, right: 40, bottom: 30 },
   [RESOURCE_VIEW_MODE]: { top: 140, left: 210, right: 40, bottom: 150 },
 };

--- a/client/app/scripts/selectors/graph-view/zoom.js
+++ b/client/app/scripts/selectors/graph-view/zoom.js
@@ -6,7 +6,7 @@ import { canvasMarginsSelector, canvasWidthSelector, canvasHeightSelector } from
 import { activeLayoutCachedZoomSelector } from '../zooming';
 import { graphNodesSelector } from './graph';
 
-// Nodes in the layout are always kept between 1px and 200px big.
+// Nodes in the layout are always kept between 3px and 200px big.
 const MAX_SCALE = 200 / NODE_BASE_SIZE;
 const MIN_SCALE = 3 / NODE_BASE_SIZE;
 
@@ -58,10 +58,24 @@ export const graphDefaultZoomSelector = createSelector(
   }
 );
 
-// NOTE: This constant is made into a selector to fit
-// props requirements for <ZoomableCanvas /> component.
-export const graphZoomLimitsSelector = createSelector(
-  [], () => makeMap({ minScale: MIN_SCALE, maxScale: MAX_SCALE })
+export const graphLimitsSelector = createSelector(
+  [
+    graphBoundingRectangleSelector,
+  ],
+  (boundingRectangle) => {
+    if (!boundingRectangle) return makeMap();
+
+    const { xMin, xMax, yMin, yMax } = boundingRectangle.toJS();
+
+    return makeMap({
+      minScale: MIN_SCALE,
+      maxScale: MAX_SCALE,
+      contentMinX: xMin,
+      contentMaxX: xMax,
+      contentMinY: yMin,
+      contentMaxY: yMax,
+    });
+  }
 );
 
 export const graphZoomStateSelector = createSelector(

--- a/client/app/scripts/selectors/resource-view/zoom.js
+++ b/client/app/scripts/selectors/resource-view/zoom.js
@@ -66,7 +66,7 @@ export const resourcesDefaultZoomSelector = createSelector(
   }
 );
 
-export const resourcesZoomLimitsSelector = createSelector(
+export const resourcesLimitsSelector = createSelector(
   [
     resourcesDefaultZoomSelector,
     resourceNodesBoundingRectangleSelector,
@@ -83,10 +83,10 @@ export const resourcesZoomLimitsSelector = createSelector(
       maxScale: width / minNodeWidth,
       // Minimal zoom is equivalent to the initial one, where the whole layout matches the canvas.
       minScale: defaultZoom.get('scaleX'),
-      minTranslateX: xMin,
-      maxTranslateX: xMax,
-      minTranslateY: yMin,
-      maxTranslateY: yMax,
+      contentMinX: xMin,
+      contentMaxX: xMax,
+      contentMinY: yMin,
+      contentMaxY: yMax,
     });
   }
 );

--- a/client/app/scripts/utils/transform-utils.js
+++ b/client/app/scripts/utils/transform-utils.js
@@ -4,12 +4,26 @@ const applyTranslateY = ({ scaleY = 1, translateY = 0 }, y) => (y * scaleY) + tr
 const applyScaleX = ({ scaleX = 1 }, width) => width * scaleX;
 const applyScaleY = ({ scaleY = 1 }, height) => height * scaleY;
 
-export const applyTransform = (transform, { width, height, x, y }) => ({
+export const applyTransform = (transform, { width = 0, height = 0, x, y }) => ({
   x: applyTranslateX(transform, x),
   y: applyTranslateY(transform, y),
   width: applyScaleX(transform, width),
   height: applyScaleY(transform, height),
 });
+
+
+const inverseTranslateX = ({ scaleX = 1, translateX = 0 }, x) => (x - translateX) / scaleX;
+const inverseTranslateY = ({ scaleY = 1, translateY = 0 }, y) => (y - translateY) / scaleY;
+const inverseScaleX = ({ scaleX = 1 }, width) => width / scaleX;
+const inverseScaleY = ({ scaleY = 1 }, height) => height / scaleY;
+
+export const inverseTransform = (transform, { width = 0, height = 0, x, y }) => ({
+  x: inverseTranslateX(transform, x),
+  y: inverseTranslateY(transform, y),
+  width: inverseScaleX(transform, width),
+  height: inverseScaleY(transform, height),
+});
+
 
 export const transformToString = ({ translateX = 0, translateY = 0, scaleX = 1, scaleY = 1 }) => (
   `translate(${translateX},${translateY}) scale(${scaleX},${scaleY})`

--- a/client/app/scripts/utils/zoom-utils.js
+++ b/client/app/scripts/utils/zoom-utils.js
@@ -7,7 +7,7 @@ function wheelDelta(ev) {
   // Only Firefox seems to use the line unit (which we assume to
   // be 25px), otherwise the delta is already measured in pixels.
   const unitInPixels = (ev.deltaMode === DOM_DELTA_LINE ? 25 : 1);
-  return ev.deltaY * unitInPixels * ZOOM_SENSITIVITY;
+  return -ev.deltaY * unitInPixels * ZOOM_SENSITIVITY;
 }
 
 export function zoomFactor(ev) {

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -358,6 +358,15 @@ a {
   }
 }
 
+.zoomable-canvas {
+  svg {
+    @extend .grabbable;
+    width: 100%;
+    height: 100%;
+
+    &.panning { @extend .grabbing; }
+  }
+}
 
 .topologies {
   margin: 0 4px;

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -63,6 +63,14 @@ a {
     cursor: -webkit-grabbing;
 }
 
+.fully-pannable {
+  width: 100%;
+  height: 100%;
+  @extend .grabbable;
+
+  &.panning { @extend .grabbing; }
+}
+
 .shadow-2 {
   box-shadow: 0 3px 10px rgba(0, 0, 0, 0.16), 0 3px 10px rgba(0, 0, 0, 0.23);
 }
@@ -284,15 +292,11 @@ a {
     height: $timeline-height;
 
     svg {
-      @extend .grabbable;
+      @extend .fully-pannable;
       background-color: rgba(255, 255, 255, 0.85);
       box-shadow: inset 0 0 7px #aaa;
       pointer-events: all;
       margin: 0 7px;
-      width: 100%;
-      height: 100%;
-
-      &.panning { @extend .grabbing; }
 
       .available-range {
         fill: #888;
@@ -358,14 +362,8 @@ a {
   }
 }
 
-.zoomable-canvas {
-  svg {
-    @extend .grabbable;
-    width: 100%;
-    height: 100%;
-
-    &.panning { @extend .grabbing; }
-  }
+.zoomable-canvas svg {
+  @extend .fully-pannable;
 }
 
 .topologies {

--- a/client/package.json
+++ b/client/package.json
@@ -18,8 +18,6 @@
     "d3-selection": "1.0.5",
     "d3-shape": "1.0.6",
     "d3-time-format": "2.0.5",
-    "d3-transition": "1.0.4",
-    "d3-zoom": "1.1.4",
     "dagre": "0.7.4",
     "debug": "2.6.6",
     "filesize": "3.5.9",


### PR DESCRIPTION
Replaces all `d3-zoom` code with our own handlers for zooming/panning events in order to have unified behaviour between all components and across all browsers. Having our own logic also gives us better control over the behaviour.

##### Changes

  * Use the same zooming logic in `ZoomableCanvas` as in `TimeTravelTimeline` (fixes #2787).
  * Use two modes of translation extent for the nodes canvas:
    * `CONTENT_COVERING` - the nodes content bounding box must alwas cover the viewport. This is the case with the resource view, where the content is _sticky_ so that there is never empty space to its left or right.
    * `CONTENT_INCLUDED` - this is introduced as a new mode for the nodes graph to fix #2809. Translation is bounded in such a way that a part of the nodes graph bounding box must always be in the viewport.
  * `ZoomableCanvas` now always forwards the transform instead of applying it on itself for consistency.

##### TODOs

  * Ideally, we should split `ZoomableCanvas` into the caching component and the zooming component, so that the _pure_ zooming component could also be used in `TimeTravelTimeline` and that the whole zooming logic is indeed in one place.
