### PR TITLE
Update topologies and namespaces when time travelling

### DIFF
--- a/client/app/scripts/components/topology-options.js
+++ b/client/app/scripts/components/topology-options.js
@@ -83,6 +83,7 @@ class TopologyOptions extends React.Component {
     // TODO: This logic should probably be made consistent with how topology
     // selection is handled when time travelling, especially when the name-
     // spaces are brought under category selection.
+    // TODO: Consider extracting this into a global selector.
     let activeValue = option.get('defaultValue');
     if (activeOptions && activeOptions.has(optionId)) {
       const activeSelection = makeSet(activeOptions.get(optionId));

--- a/client/app/scripts/components/topology-options.js
+++ b/client/app/scripts/components/topology-options.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Map as makeMap } from 'immutable';
+import { Set as makeSet, Map as makeMap } from 'immutable';
 import includes from 'lodash/includes';
 
 import { trackMixpanelEvent } from '../utils/tracking-utils';
@@ -73,9 +73,26 @@ class TopologyOptions extends React.Component {
   renderOption(option) {
     const { activeOptions, currentTopologyId } = this.props;
     const optionId = option.get('id');
-    const activeValue = activeOptions && activeOptions.has(optionId)
-      ? activeOptions.get(optionId)
-      : option.get('defaultValue');
+
+    // Make the active value be the intersection of the available options
+    // and the active selection and use the default value if there is no
+    // overlap. It seems intuitive that active selection would always be a
+    // subset of available option, but the exception can happen when going
+    // back in time (making available options change, while not touching
+    // the selection).
+    // TODO: This logic should probably be made consistent with how topology
+    // selection is handled when time travelling, especially when the name-
+    // spaces are brought under category selection.
+    let activeValue = option.get('defaultValue');
+    if (activeOptions && activeOptions.has(optionId)) {
+      const activeSelection = makeSet(activeOptions.get(optionId));
+      const availableOptions = makeSet(option.get('options').map(o => o.get('value')));
+      const intersection = activeSelection.intersect(availableOptions);
+      if (!intersection.isEmpty()) {
+        activeValue = intersection.toJS();
+      }
+    }
+
     const noneItem = makeMap({
       value: '',
       label: option.get('noneLabel')

--- a/client/app/scripts/reducers/root.js
+++ b/client/app/scripts/reducers/root.js
@@ -223,7 +223,7 @@ export function rootReducer(state = initialState, action) {
       if (topology) {
         const topologyId = topology.get('parentId') || topology.get('id');
         const optionKey = ['topologyOptions', topologyId, action.option];
-        const currentOption = state.getIn(['topologyOptions', topologyId, action.option]);
+        const currentOption = state.getIn(optionKey);
 
         if (!isEqual(currentOption, action.value)) {
           state = clearNodes(state);


### PR DESCRIPTION
Resolves #2802.

##### Changes

* Unblock the calls to topology when time travelling, triggering updates of both *topology selector* and *topology options*. Disappearance of the selected option is handled a bit differently between the two:
  * The topology selection never changes over time, meaning that e.g. if we select *Processes* and go back in time to the point when that topology wasn't there, we'd still keep it selected but show it as empty. This is to avoid confusion with context switching and also because not sure which one we should default to.
  * The namespace selection is taken as an intersection of the full selection and the currently available options. If the intersection is empty, we default to the default option (in case of namespaces, that's the _All namespaces_ option). Here we use the fact that we have somewhere to default to, but in a long run, this logic should probably be consistent with how topologies selection is handled.
