### PR TITLE
Use Node 8.4 for builds

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,5 +1,4 @@
-FROM node:6.9.0
-RUN npm install -g yarn
+FROM node:8.4.0
 WORKDIR /home/weave
 COPY package.json yarn.lock /home/weave/
 ENV NPM_CONFIG_LOGLEVEL=warn NPM_CONFIG_PROGRESS=false

--- a/client/package.json
+++ b/client/package.json
@@ -46,7 +46,7 @@
     "reqwest": "2.0.5",
     "reselect": "3.0.0",
     "reselect-map": "1.0.1",
-    "weaveworks-ui-components": "git+https://github.com/weaveworks/ui-components.git#v0.1.20",
+    "weaveworks-ui-components": "git+https://github.com/weaveworks/ui-components.git#v0.1.28",
     "whatwg-fetch": "2.0.3",
     "xterm": "2.5.0"
   },
@@ -128,6 +128,6 @@
     ]
   },
   "engines": {
-    "node": "^6.9.0"
+    "node": "^8.4.0"
   }
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6207,9 +6207,9 @@ wd@^0.4.0:
     underscore.string "~3.0.3"
     vargs "~0.1.0"
 
-"weaveworks-ui-components@git+https://github.com/weaveworks/ui-components.git#v0.1.20":
-  version "0.1.20"
-  resolved "git+https://github.com/weaveworks/ui-components.git#46e6165f39defe8a720b59a9db69c93514960e00"
+"weaveworks-ui-components@git+https://github.com/weaveworks/ui-components.git#v0.1.28":
+  version "0.1.28"
+  resolved "git+https://github.com/weaveworks/ui-components.git#164a0d2770ee5c2318b2f1ab1948fb6046059909"
   dependencies:
     babel-cli "^6.18.0"
     babel-plugin-transform-export-extensions "6.8.0"


### PR DESCRIPTION
Related to https://github.com/weaveworks/service-ui/issues/930

Builds should be a little faster. It may also be possible to turn off some transpiling features, since Node supports new ES syntax.