### PR TITLE
make circleci ui-upload unconditional

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -86,7 +86,6 @@ deployment:
             docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/$IMAGE &&
             docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/$IMAGE:$(./tools/image-tag)
           done
-          (test -z "${UI_BUCKET_KEY_ID}" || (cd $SRCDIR && make ui-upload && make ui-pkg-upload))
         )
       - |
         test -z "${QUAY_USER}" || (
@@ -94,6 +93,7 @@ deployment:
           docker tag weaveworks/scope:$(./tools/image-tag) "quay.io/${QUAY_ORGANIZATION}/scope:$(./tools/image-tag)" &&
           docker push "quay.io/${QUAY_ORGANIZATION}/scope:$(./tools/image-tag)"
         )
+      - test -z "${UI_BUCKET_KEY_ID}" || (cd $SRCDIR && make ui-upload && make ui-pkg-upload))
   hub-dev:
     branch: /^((?!master).)*$/  # not the master branch
     commands:


### PR DESCRIPTION
It doesn't depend on `$DOCKER_USER`. Also, because it was tagged on without a `&&`, it was masking errors in the dockerhub image uploads.