### PR TITLE
Adds ECS Cluster Region option

### DIFF
--- a/probe/awsecs/reporter.go
+++ b/probe/awsecs/reporter.go
@@ -87,16 +87,18 @@ type Reporter struct {
 	ClientsByCluster map[string]EcsClient // Exported for test
 	cacheSize        int
 	cacheExpiry      time.Duration
+	clusterRegion    string
 	handlerRegistry  *controls.HandlerRegistry
 	probeID          string
 }
 
 // Make creates a new Reporter
-func Make(cacheSize int, cacheExpiry time.Duration, handlerRegistry *controls.HandlerRegistry, probeID string) Reporter {
+func Make(cacheSize int, cacheExpiry time.Duration, clusterRegion string, handlerRegistry *controls.HandlerRegistry, probeID string) Reporter {
 	r := Reporter{
 		ClientsByCluster: map[string]EcsClient{},
 		cacheSize:        cacheSize,
 		cacheExpiry:      cacheExpiry,
+		clusterRegion:    clusterRegion,
 		handlerRegistry:  handlerRegistry,
 		probeID:          probeID,
 	}
@@ -114,7 +116,7 @@ func (r Reporter) getClient(cluster string) (EcsClient, error) {
 	if !ok {
 		log.Debugf("Creating new ECS client")
 		var err error
-		client, err = newClient(cluster, r.cacheSize, r.cacheExpiry)
+		client, err = newClient(cluster, r.cacheSize, r.cacheExpiry, r.clusterRegion)
 		if err != nil {
 			return nil, err
 		}

--- a/prog/main.go
+++ b/prog/main.go
@@ -124,9 +124,10 @@ type probeFlags struct {
 	kubernetesClientConfig kubernetes.ClientConfig
 	kubernetesKubeletPort  uint
 
-	ecsEnabled     bool
-	ecsCacheSize   int
-	ecsCacheExpiry time.Duration
+	ecsEnabled       bool
+	ecsCacheSize     int
+	ecsCacheExpiry   time.Duration
+	ecsClusterRegion string
 
 	weaveEnabled  bool
 	weaveAddr     string
@@ -323,6 +324,7 @@ func setupFlags(flags *flags) {
 	flag.BoolVar(&flags.probe.ecsEnabled, "probe.ecs", false, "Collect ecs-related attributes for containers on this node")
 	flag.IntVar(&flags.probe.ecsCacheSize, "probe.ecs.cache.size", 1024*1024, "Max size of cached info for each ECS cluster")
 	flag.DurationVar(&flags.probe.ecsCacheExpiry, "probe.ecs.cache.expiry", time.Hour, "How long to keep cached ECS info")
+	flag.StringVar(&flags.probe.ecsClusterRegion, "probe.ecs.cluster.region", "", "ECS Cluster Region")
 
 	// Weave
 	flag.StringVar(&flags.probe.weaveAddr, "probe.weave.addr", "127.0.0.1:6784", "IP address & port of the Weave router")

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -226,7 +226,7 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 	}
 
 	if flags.ecsEnabled {
-		reporter := awsecs.Make(flags.ecsCacheSize, flags.ecsCacheExpiry, handlerRegistry, probeID)
+		reporter := awsecs.Make(flags.ecsCacheSize, flags.ecsCacheExpiry, flags.ecsClusterRegion, handlerRegistry, probeID)
 		defer reporter.Stop()
 		p.AddReporter(reporter)
 		p.AddTagger(reporter)


### PR DESCRIPTION
### Propourse

As talked with @ekimekim [on slack](https://weave-community.slack.com/archives/C2ND76PAA/p1505756045000138), this PR adds an ECS Cluster Region option.

### Usage
``` bash
./scope -probe.ecs.cluster.region us-east-1
```

The default behaviour is to get the region from the instance metadata.

