### PR TITLE
tracking: Fix in-flight collision of two related PRs

### DIFF
--- a/client/app/scripts/components/node-details/node-details-control-button.js
+++ b/client/app/scripts/components/node-details/node-details-control-button.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { trackMixpanelEvent } from '../../utils/tracking-utils';
+import { trackAnalyticsEvent } from '../../utils/tracking-utils';
 import { doControl } from '../../actions/app-actions';
 
 class NodeDetailsControlButton extends React.Component {
@@ -23,7 +23,7 @@ class NodeDetailsControlButton extends React.Component {
   handleClick(ev) {
     ev.preventDefault();
     const { id, human } = this.props.control;
-    trackMixpanelEvent('scope.node.control.click', { id, title: human });
+    trackAnalyticsEvent('scope.node.control.click', { id, title: human });
     this.props.dispatch(doControl(this.props.nodeId, this.props.control));
   }
 }


### PR DESCRIPTION
Unfortunately, I forgot to rebase before renaming trackMixpanelEvent() and a PR
adding a new trace point was already in-flight.

More precisely:
  - https://github.com/weaveworks/scope/pull/2861 renames trackMixpanelEvent()
    to trackAnalysticsEent()
  - https://github.com/weaveworks/scope/pull/2857 add a new
    trackMixpanelEvent() call.

Each PR is fine, but with the merge of both without rebasing any, we end up
with master having a dandling call to trackMixpanelEvent().