### PR TITLE
lint: Fix 2 sites failing a recently introduced golint check

### DIFF
--- a/app/multitenant/consul_client.go
+++ b/app/multitenant/consul_client.go
@@ -66,10 +66,7 @@ func (c *consulClient) Get(key string, out interface{}) error {
 	if kvp == nil {
 		return ErrNotFound
 	}
-	if err := json.NewDecoder(bytes.NewReader(kvp.Value)).Decode(out); err != nil {
-		return err
-	}
-	return nil
+	return json.NewDecoder(bytes.NewReader(kvp.Value)).Decode(out)
 }
 
 // CAS atomically modify a value in a callback.

--- a/report/marshal.go
+++ b/report/marshal.go
@@ -185,12 +185,7 @@ func (rep *Report) WriteToFile(path string, compressionLevel int) error {
 		w = gzwriter
 	}
 
-	if err = codec.NewEncoder(w, handle).Encode(rep); err != nil {
-		return err
-	}
-
-	return nil
-
+	return codec.NewEncoder(w, handle).Encode(rep)
 }
 
 func handlerFromFileType(path string) (codec.Handle, bool, error) {


### PR DESCRIPTION
golint has gained a new check and we don't freeze the golint version so CI was
failing on unrelated PRs:

app/multitenant/consul_client.go:69:2: redundant if ...; err != nil check, just return error instead.
report/marshal.go:188:2: redundant if ...; err != nil check, just return error instead.

Fix those!