### PR TITLE
Small memory-allocation reduction

### DIFF
--- a/report/metrics.go
+++ b/report/metrics.go
@@ -238,6 +238,9 @@ func renderTime(t time.Time) string {
 }
 
 func parseTime(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
 	t, _ := time.Parse(time.RFC3339Nano, s)
 	return t
 }


### PR DESCRIPTION
When decoding a report with `Metrics` containing the zero timestamp, which we encode as an empty string, we are causing `time.Parse` to return an error. That error object is created on the heap.

Benchmarks (best time of five runs in each case):
Current master 46c5fca7ce21e12624622234ca32513cb02250e1:
```
BenchmarkDecode-2   	     100	  15286633 ns/op	 4213446 B/op	   75126 allocs/op
```

After 9322b54b68e5b314b742c5981afd3b3f85b6aa28:
```
BenchmarkDecode-2   	     100	  14763561 ns/op	 4156811 B/op	   74416 allocs/op
```
