### PR TITLE
Use a context sensitive route for the popped out terminal.html

### DIFF
--- a/client/app/scripts/components/terminal.js
+++ b/client/app/scripts/components/terminal.js
@@ -9,7 +9,7 @@ import Term from 'xterm';
 import { clickCloseTerminal } from '../actions/app-actions';
 import { getNeutralColor } from '../utils/color-utils';
 import { setDocumentTitle } from '../utils/title-utils';
-import { getPipeStatus, doResizeTty, getWebsocketUrl, getApiPath } from '../utils/web-api-utils';
+import { getPipeStatus, doResizeTty, getWebsocketUrl, basePath } from '../utils/web-api-utils';
 
 const log = debug('scope:terminal');
 
@@ -243,7 +243,7 @@ class Terminal extends React.Component {
 
     const bcr = this.node.getBoundingClientRect();
     const minWidth = (this.state.characterWidth * 80) + (8 * 2);
-    openNewWindow(`${getApiPath()}/terminal.html#!/state/${paramString}`, bcr, minWidth);
+    openNewWindow(`${basePath(window.location.pathname)}/terminal.html#!/state/${paramString}`, bcr, minWidth);
   }
 
   handleResize() {

--- a/client/app/scripts/index.js
+++ b/client/app/scripts/index.js
@@ -1,3 +1,4 @@
 exports.reducer = require('./reducers/root').default;
 exports.Scope = require('./components/app').default;
 exports.actions = require('./actions/app-actions');
+exports.TerminalApp = require('./components/terminal-app').default;


### PR DESCRIPTION
- Service-ui has learned a new route which corresponds to the existing
  scope terminal.html route. Both standalone and service-ui scope can now
  respond to terminal.html:
  - If using standalone scope path/to/scope/ -> path/to/scope/terminal.html will be used.
  - If using service-ui app/instanceid -> app/instanceId/terminal.html