### PR TITLE
docker: Close pipe when the docker API call fails

### DIFF
--- a/probe/docker/controls.go
+++ b/probe/docker/controls.go
@@ -86,6 +86,7 @@ func (r *registry) attachContainer(containerID string, req xfer.Request) xfer.Re
 		ErrorStream:  local,
 	})
 	if err != nil {
+		pipe.Close()
 		return xfer.ResponseError(err)
 	}
 	pipe.OnClose(func() {
@@ -133,6 +134,7 @@ func (r *registry) execContainer(containerID string, req xfer.Request) xfer.Resp
 		ErrorStream:  local,
 	})
 	if err != nil {
+		pipe.Close()
 		return xfer.ResponseError(err)
 	}
 


### PR DESCRIPTION
This hasn't been found in the wild but by code inspection. If we fail the
docker API call, the pipe is never closed. Close it before returning.