### PR TITLE
Try to prevent zooming NaN errors

### DIFF
--- a/client/app/scripts/actions/app-actions.js
+++ b/client/app/scripts/actions/app-actions.js
@@ -405,7 +405,8 @@ export function clickTopology(topologyId) {
 export function cacheZoomState(zoomState) {
   return {
     type: ActionTypes.CACHE_ZOOM_STATE,
-    zoomState
+    // Make sure only proper numerical values are cached.
+    zoomState: zoomState.filter(value => !window.isNaN(value)),
   };
 }
 

--- a/client/app/scripts/reducers/root.js
+++ b/client/app/scripts/reducers/root.js
@@ -88,7 +88,8 @@ export const initialState = makeMap({
   topologyViewMode: GRAPH_VIEW_MODE,
   version: '...',
   versionUpdate: null,
-  viewport: makeMap(),
+  // Set some initial numerical values to prevent NaN in case of edgy race conditions.
+  viewport: makeMap({ width: 0, height: 0 }),
   websocketClosed: false,
   zoomCache: makeMap(),
   serviceImages: makeMap()


### PR DESCRIPTION
Should fix #2858.

Although I couldn't find the exact cause (the problem is not really reproducible, there seems to be a ~0.5% chance of running into a race condition), I believe that one of the two measures will make it vanish:

##### Changes

* Set initial viewport `(width, height)` to `(0, 0)` in the global state. That one gets set to proper values once `App` component mounts, but we want to make sure it's a numerical value (vs. `undefined`) before in case the zooming selectors which depend on it pick it up before the app is mounted.
* Make sure `NaN` values are never cached. That means that even if we hit the same race condition, it should fix itself in the next render loop because the default zoom values will be used again instead of the cached `NaN`. So if this error does happen again, I expect it would just be thrown once and then the zooming and panning would work normally again.
