### PR TITLE
Check whether tableContent ref is present

### DIFF
--- a/client/app/scripts/components/node-details/node-details-table.js
+++ b/client/app/scripts/components/node-details/node-details-table.js
@@ -173,7 +173,7 @@ class NodeDetailsTable extends React.Component {
     this.focusState = {
       focusedNode: node,
       focusedRowIndex: rowIndex,
-      tableContentMinHeightConstraint: this.tableContent.scrollHeight,
+      tableContentMinHeightConstraint: this.tableContent && this.tableContent.scrollHeight,
     };
   }
 


### PR DESCRIPTION
Fix #2898.

The `tableContent` ref is only set after the first render, so if we would immediatelly focus on a row in the first render cycle, the race conditions would sometimes cause this error.

Ignoring the height if `tableContent` is not there is fine as the height defaults to `0`, which is always fine before the second render (when a row might be removed from the table so that value becomes relevant).
