### PR TITLE
Optimisation: replace three map-reduces with Renderers

### DIFF
--- a/render/container.go
+++ b/render/container.go
@@ -83,9 +83,7 @@ func (c connectionJoin) Render(rpt report.Report, dct Decorator) report.Nodes {
 		// Nodes without a hostid may be pseudo nodes - if so, pass through to result
 		if _, ok := m.Latest.Lookup(report.HostNodeID); !ok {
 			if id, ok := externalNodeID(m, addr, local); ok {
-				addToResults(m, id, ret, mapped, func() report.Node {
-					return report.MakeNode(id).WithTopology(Pseudo)
-				})
+				addToResults(m, id, ret, mapped, newPseudoNode)
 				continue
 			}
 		}
@@ -97,7 +95,7 @@ func (c connectionJoin) Render(rpt report.Report, dct Decorator) report.Nodes {
 			id, found = ipNodes[report.MakeScopedEndpointNodeID(scope, addr, port)]
 		}
 		if found && id != "" { // not one we blanked out earlier
-			addToResults(m, id, ret, mapped, func() report.Node {
+			addToResults(m, id, ret, mapped, func(id string) report.Node {
 				return inputNodes[id]
 			})
 		}

--- a/render/host.go
+++ b/render/host.go
@@ -67,11 +67,11 @@ type endpoints2Hosts struct {
 }
 
 func (e endpoints2Hosts) Render(rpt report.Report, dct Decorator) report.Nodes {
-	ns := SelectEndpoint.Render(rpt, dct)
 	local := LocalNetworks(rpt)
+	endpoints := SelectEndpoint.Render(rpt, dct)
 	ret := newJoinResults()
 
-	for _, n := range ns {
+	for _, n := range endpoints {
 		// Nodes without a hostid are treated as pseudo nodes
 		hostNodeID, timestamp, ok := n.Latest.LookupEntry(report.HostNodeID)
 		if !ok {
@@ -88,7 +88,7 @@ func (e endpoints2Hosts) Render(rpt report.Report, dct Decorator) report.Nodes {
 			})
 		}
 	}
-	ret.fixupAdjacencies(ns)
+	ret.fixupAdjacencies(endpoints)
 	return ret.nodes
 }
 

--- a/render/host.go
+++ b/render/host.go
@@ -7,8 +7,7 @@ import (
 // HostRenderer is a Renderer which produces a renderable host
 // graph from the host topology.
 //
-// not memoised
-var HostRenderer = MakeReduce(
+var HostRenderer = Memoise(MakeReduce(
 	endpoints2Hosts{},
 	MakeMap(
 		MapX2Host,
@@ -27,7 +26,7 @@ var HostRenderer = MakeReduce(
 		PodRenderer,
 	),
 	SelectHost,
-)
+))
 
 // MapX2Host maps any Nodes to host Nodes.
 //

--- a/render/host.go
+++ b/render/host.go
@@ -104,6 +104,20 @@ func (e endpoints2Hosts) Render(rpt report.Report, dct Decorator) report.Nodes {
 	return ret
 }
 
+// Add Node M to the result set ret under id, creating a new result
+// node if not already there, and updating the old-id to new-id mapping
+// Note we do not update any counters for child topologies here
+func addToResults(m report.Node, id string, ret report.Nodes, mapped map[string]string, create func() report.Node) {
+	result, exists := ret[id]
+	if !exists {
+		result = create()
+	}
+	result.Children = result.Children.Add(m)
+	result.Children = result.Children.Merge(m.Children)
+	ret[result.ID] = result
+	mapped[m.ID] = result.ID
+}
+
 // Rewrite Adjacency for new nodes in ret, original nodes in input, and mapping old->new IDs in mapped
 func fixupAdjancencies(input, ret report.Nodes, mapped map[string]string) {
 	for _, n := range input {

--- a/render/host.go
+++ b/render/host.go
@@ -80,12 +80,10 @@ func (e endpoints2Hosts) Render(rpt report.Report, dct Decorator) report.Nodes {
 			if !ok {
 				continue
 			}
-			addToResults(n, id, ret, mapped, func() report.Node {
-				return report.MakeNode(id).WithTopology(Pseudo)
-			})
+			addToResults(n, id, ret, mapped, newPseudoNode)
 		} else {
 			id := report.MakeHostNodeID(report.ExtractHostID(n))
-			addToResults(n, id, ret, mapped, func() report.Node {
+			addToResults(n, id, ret, mapped, func(id string) report.Node {
 				return report.MakeNode(id).WithTopology(report.Host).
 					WithLatest(report.HostNodeID, timestamp, hostNodeID)
 			})
@@ -98,15 +96,15 @@ func (e endpoints2Hosts) Render(rpt report.Report, dct Decorator) report.Nodes {
 // Add Node M to the result set ret under id, creating a new result
 // node if not already there, and updating the old-id to new-id mapping
 // Note we do not update any counters for child topologies here
-func addToResults(m report.Node, id string, ret report.Nodes, mapped map[string]string, create func() report.Node) {
+func addToResults(m report.Node, id string, ret report.Nodes, mapped map[string]string, create func(string) report.Node) {
 	result, exists := ret[id]
 	if !exists {
-		result = create()
+		result = create(id)
 	}
 	result.Children = result.Children.Add(m)
 	result.Children = result.Children.Merge(m.Children)
-	ret[result.ID] = result
-	mapped[m.ID] = result.ID
+	ret[id] = result
+	mapped[m.ID] = id
 }
 
 // Rewrite Adjacency for new nodes in ret, original nodes in input, and mapping old->new IDs in mapped

--- a/render/id.go
+++ b/render/id.go
@@ -45,6 +45,21 @@ func NewDerivedExternalNode(n report.Node, addr string, local report.Networks) (
 	return NewDerivedPseudoNode(id, n), true
 }
 
+func pseudoNodeID(n report.Node, local report.Networks) (string, bool) {
+	_, addr, _, ok := report.ParseEndpointNodeID(n.ID)
+	if !ok {
+		return "", false
+	}
+
+	if id, ok := externalNodeID(n, addr, local); ok {
+		return id, ok
+	}
+
+	// due to https://github.com/weaveworks/scope/issues/1323 we are dropping
+	// all non-external pseudo nodes for now.
+	return "", false
+}
+
 // figure out if a node should be considered external and returns an ID which can be used to create a pseudo node
 func externalNodeID(n report.Node, addr string, local report.Networks) (string, bool) {
 	// First, check if it's a known service and emit a a specific node if it

--- a/render/id.go
+++ b/render/id.go
@@ -36,6 +36,10 @@ func NewDerivedPseudoNode(id string, node report.Node) report.Node {
 	return output
 }
 
+func newPseudoNode(id string) report.Node {
+	return report.MakeNode(id).WithTopology(Pseudo)
+}
+
 func pseudoNodeID(n report.Node, local report.Networks) (string, bool) {
 	_, addr, _, ok := report.ParseEndpointNodeID(n.ID)
 	if !ok {

--- a/render/id.go
+++ b/render/id.go
@@ -38,11 +38,20 @@ func NewDerivedPseudoNode(id string, node report.Node) report.Node {
 
 // NewDerivedExternalNode figures out if a node should be considered external and creates the corresponding pseudo node
 func NewDerivedExternalNode(n report.Node, addr string, local report.Networks) (report.Node, bool) {
+	id, ok := externalNodeID(n, addr, local)
+	if !ok {
+		return report.Node{}, false
+	}
+	return NewDerivedPseudoNode(id, n), true
+}
+
+// figure out if a node should be considered external and returns an ID which can be used to create a pseudo node
+func externalNodeID(n report.Node, addr string, local report.Networks) (string, bool) {
 	// First, check if it's a known service and emit a a specific node if it
 	// is. This needs to be done before checking IPs since known services can
 	// live in the same network, see https://github.com/weaveworks/scope/issues/2163
 	if hostname, found := DNSFirstMatch(n, isKnownService); found {
-		return NewDerivedPseudoNode(ServiceNodeIDPrefix+hostname, n), true
+		return ServiceNodeIDPrefix + hostname, true
 	}
 
 	// If the dstNodeAddr is not in a network local to this report, we emit an
@@ -50,13 +59,13 @@ func NewDerivedExternalNode(n report.Node, addr string, local report.Networks) (
 	if ip := net.ParseIP(addr); ip != nil && !local.Contains(ip) {
 		// emit one internet node for incoming, one for outgoing
 		if len(n.Adjacency) > 0 {
-			return NewDerivedPseudoNode(IncomingInternetID, n), true
+			return IncomingInternetID, true
 		}
-		return NewDerivedPseudoNode(OutgoingInternetID, n), true
+		return OutgoingInternetID, true
 	}
 
 	// The node is not external
-	return report.Node{}, false
+	return "", false
 }
 
 // DNSFirstMatch returns the first DNS name where match() returns

--- a/render/id.go
+++ b/render/id.go
@@ -36,15 +36,6 @@ func NewDerivedPseudoNode(id string, node report.Node) report.Node {
 	return output
 }
 
-// NewDerivedExternalNode figures out if a node should be considered external and creates the corresponding pseudo node
-func NewDerivedExternalNode(n report.Node, addr string, local report.Networks) (report.Node, bool) {
-	id, ok := externalNodeID(n, addr, local)
-	if !ok {
-		return report.Node{}, false
-	}
-	return NewDerivedPseudoNode(id, n), true
-}
-
 func pseudoNodeID(n report.Node, local report.Networks) (string, bool) {
 	_, addr, _, ok := report.ParseEndpointNodeID(n.ID)
 	if !ok {

--- a/render/process.go
+++ b/render/process.go
@@ -91,18 +91,12 @@ var ProcessNameRenderer = ConditionalRenderer(renderProcesses,
 
 // MapEndpoint2Pseudo makes internet of host pesudo nodes from a endpoint node.
 func MapEndpoint2Pseudo(n report.Node, local report.Networks) report.Nodes {
-	_, addr, _, ok := report.ParseEndpointNodeID(n.ID)
+	id, ok := pseudoNodeID(n, local)
 	if !ok {
 		return report.Nodes{}
 	}
-
-	if externalNode, ok := NewDerivedExternalNode(n, addr, local); ok {
-		return report.Nodes{externalNode.ID: externalNode}
-	}
-
-	// due to https://github.com/weaveworks/scope/issues/1323 we are dropping
-	// all non-external pseudo nodes for now.
-	return report.Nodes{}
+	externalNode := NewDerivedPseudoNode(id, n)
+	return report.Nodes{externalNode.ID: externalNode}
 }
 
 // MapEndpoint2Process maps endpoint Nodes to process

--- a/render/process.go
+++ b/render/process.go
@@ -100,9 +100,7 @@ func (e endpoints2Processes) Render(rpt report.Report, dct Decorator) report.Nod
 		// Nodes without a hostid are treated as pseudo nodes
 		if hostNodeID, ok := n.Latest.Lookup(report.HostNodeID); !ok {
 			if id, ok := pseudoNodeID(n, local); ok {
-				addToResults(n, id, ret, mapped, func() report.Node {
-					return report.MakeNode(id).WithTopology(Pseudo)
-				})
+				addToResults(n, id, ret, mapped, newPseudoNode)
 			}
 		} else {
 			pid, timestamp, ok := n.Latest.LookupEntry(process.PID)
@@ -119,7 +117,7 @@ func (e endpoints2Processes) Render(rpt report.Report, dct Decorator) report.Nod
 
 			hostID, _, _ := report.ParseNodeID(hostNodeID)
 			id := report.MakeProcessNodeID(hostID, pid)
-			addToResults(n, id, ret, mapped, func() report.Node {
+			addToResults(n, id, ret, mapped, func(id string) report.Node {
 				if processNode, found := processes[id]; found {
 					return processNode
 				}

--- a/render/process.go
+++ b/render/process.go
@@ -81,16 +81,6 @@ var ProcessNameRenderer = ConditionalRenderer(renderProcesses,
 	),
 )
 
-// MapEndpoint2Pseudo makes internet of host pesudo nodes from a endpoint node.
-func MapEndpoint2Pseudo(n report.Node, local report.Networks) report.Nodes {
-	id, ok := pseudoNodeID(n, local)
-	if !ok {
-		return report.Nodes{}
-	}
-	externalNode := NewDerivedPseudoNode(id, n)
-	return report.Nodes{externalNode.ID: externalNode}
-}
-
 // endpoints2Processes joins the endpoint topology to the process
 // topology, matching on hostID and pid.
 type endpoints2Processes struct {

--- a/render/process.go
+++ b/render/process.go
@@ -90,9 +90,9 @@ func (e endpoints2Processes) Render(rpt report.Report, dct Decorator) report.Nod
 	if len(rpt.Process.Nodes) == 0 {
 		return report.Nodes{}
 	}
+	local := LocalNetworks(rpt)
 	processes := SelectProcess.Render(rpt, dct)
 	endpoints := SelectEndpoint.Render(rpt, dct)
-	local := LocalNetworks(rpt)
 	ret := newJoinResults()
 
 	for _, n := range endpoints {


### PR DESCRIPTION
In three cases: `ConnectionJoin`, `ProcessRenderer` and `HostRenderer`, the code was running a `Map` to speculatively create `Node`s, then a `Reduce` to match them all up with something else.

If we replace those multiple operations with a single routine which does the matching directly, we save a lot of garbage.

I also added benchmark to time a single topology rendering, equivalent to hitting an endpoint like`/api/topology/hosts`. Best time of five runs; input is a 33MB report from production on Oct 15:
Before
```
$ go test -tags 'unsafe netgo' -run=x -bench=Topology -bench-report-file=prod-report1.json
BenchmarkTopologyList-2         	       1	1400508627 ns/op	352382920 B/op	 2913537 allocs/op
BenchmarkTopologyHosts-2        	       1	1124918587 ns/op	302509672 B/op	 2627937 allocs/op
BenchmarkTopologyContainers-2   	       2	 691307933 ns/op	194143244 B/op	 1723873 allocs/op
```

After
```
$ go test -tags 'unsafe netgo' -run=x -bench=Topology -bench-report-file=prod-report1.json
BenchmarkTopologyList-2         	       2	 692289010 ns/op	146370204 B/op	 1529315 allocs/op
BenchmarkTopologyHosts-2        	       3	 485628292 ns/op	95328261 B/op	 1245029 allocs/op
BenchmarkTopologyContainers-2   	      10	 208411667 ns/op	36021493 B/op	  515582 allocs/op
```

That is a 50-70% reduction in time and objects created.