### PR TITLE
Avoid object creation when scanning DNS names

### DIFF
--- a/render/detailed/connections.go
+++ b/render/detailed/connections.go
@@ -113,10 +113,10 @@ func internetAddr(node report.Node, ep report.Node) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	if names := render.DNSNames(ep); len(names) > 0 {
+	if name, found := render.DNSFirstMatch(ep, func(string) bool { return true }); found {
 		// we show the "most important" name only, since we don't have
 		// space for more
-		addr = fmt.Sprintf("%s (%s)", names[0], addr)
+		addr = fmt.Sprintf("%s (%s)", name, addr)
 	}
 	return addr, true
 }


### PR DESCRIPTION
Since we do this a lot, scanning the lists in-place saves work.

Also we don't need to sort them since StringSet is implemented as a sorted set of strings

It's actually benchmarking a little slower, when the best of five runs is taken, but with reduced memory allocation.  The timing of this benchmark is highly variable on my VM; the new benchmarks in #2920 are more reliably faster with this change.

Before
```
BenchmarkTopologyList-2   	       1	1479321809 ns/op	351308800 B/op	 2913864 allocs/op
```

After
```
BenchmarkTopologyList-2   	       1	1511797615 ns/op	347651256 B/op	 2753226 allocs/op
```
