### PR TITLE
remove unused memoisation

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -435,6 +435,7 @@ func (r *Registry) Add(ts ...APITopologyDesc) {
 	defer r.Unlock()
 	for _, t := range ts {
 		t.URL = apiTopologyURL + t.id
+		t.renderer = render.Memoise(t.renderer)
 
 		if t.parent != "" {
 			parent := r.items[t.parent]

--- a/render/container.go
+++ b/render/container.go
@@ -24,7 +24,7 @@ var UncontainedIDPrefix = MakePseudoNodeID(UncontainedID)
 // NB We only want processes in container _or_ processes with network connections
 // but we need to be careful to ensure we only include each edge once, by only
 // including the ProcessRenderer once.
-var ContainerRenderer = MakeFilter(
+var ContainerRenderer = Memoise(MakeFilter(
 	func(n report.Node) bool {
 		// Drop deleted containers
 		state, ok := n.Latest.Lookup(docker.ContainerState)
@@ -37,9 +37,9 @@ var ContainerRenderer = MakeFilter(
 		),
 		ConnectionJoin(MapContainer2IP, SelectContainer),
 	),
-)
+))
 
-var mapEndpoint2IP = MakeMap(endpoint2IP, SelectEndpoint)
+var mapEndpoint2IP = Memoise(MakeMap(endpoint2IP, SelectEndpoint))
 
 const originalNodeID = "original_node_id"
 

--- a/render/container.go
+++ b/render/container.go
@@ -182,11 +182,11 @@ func (r containerWithImageNameRenderer) Render(rpt report.Report, dct Decorator)
 
 // ContainerWithImageNameRenderer is a Renderer which produces a container
 // graph where the ranks are the image names, not their IDs
-var ContainerWithImageNameRenderer = containerWithImageNameRenderer{ContainerRenderer}
+var ContainerWithImageNameRenderer = Memoise(containerWithImageNameRenderer{ContainerRenderer})
 
 // ContainerImageRenderer is a Renderer which produces a renderable container
 // image graph by merging the container graph and the container image topology.
-var ContainerImageRenderer = FilterEmpty(report.Container,
+var ContainerImageRenderer = Memoise(FilterEmpty(report.Container,
 	MakeMap(
 		MapContainerImage2Name,
 		MakeReduce(
@@ -197,10 +197,12 @@ var ContainerImageRenderer = FilterEmpty(report.Container,
 			SelectContainerImage,
 		),
 	),
-)
+))
 
 // ContainerHostnameRenderer is a Renderer which produces a renderable container
 // by hostname graph..
+//
+// not memoised
 var ContainerHostnameRenderer = FilterEmpty(report.Container,
 	MakeReduce(
 		MakeMap(

--- a/render/ecs.go
+++ b/render/ecs.go
@@ -5,7 +5,7 @@ import (
 )
 
 // ECSTaskRenderer is a Renderer for Amazon ECS tasks.
-var ECSTaskRenderer = ConditionalRenderer(renderECSTopologies,
+var ECSTaskRenderer = Memoise(ConditionalRenderer(renderECSTopologies,
 	renderParents(
 		report.Container, []string{report.ECSTask}, UnmanagedID,
 		MakeFilter(
@@ -13,9 +13,11 @@ var ECSTaskRenderer = ConditionalRenderer(renderECSTopologies,
 			ContainerWithImageNameRenderer,
 		),
 	),
-)
+))
 
 // ECSServiceRenderer is a Renderer for Amazon ECS services.
+//
+// not memoised
 var ECSServiceRenderer = ConditionalRenderer(renderECSTopologies,
 	renderParents(
 		report.ECSTask, []string{report.ECSService}, "",

--- a/render/filters.go
+++ b/render/filters.go
@@ -114,20 +114,20 @@ type Filter struct {
 
 // MakeFilter makes a new Filter (that ignores pseudo nodes).
 func MakeFilter(f FilterFunc, r Renderer) Renderer {
-	return Memoise(&Filter{
+	return &Filter{
 		Renderer: r,
 		FilterFunc: func(n report.Node) bool {
 			return n.Topology == Pseudo || f(n)
 		},
-	})
+	}
 }
 
 // MakeFilterPseudo makes a new Filter that will not ignore pseudo nodes.
 func MakeFilterPseudo(f FilterFunc, r Renderer) Renderer {
-	return Memoise(&Filter{
+	return &Filter{
 		Renderer:   r,
 		FilterFunc: f,
-	})
+	}
 }
 
 // MakeFilterDecorator makes a decorator that filters out non-pseudo nodes

--- a/render/host.go
+++ b/render/host.go
@@ -6,6 +6,8 @@ import (
 
 // HostRenderer is a Renderer which produces a renderable host
 // graph from the host topology.
+//
+// not memoised
 var HostRenderer = MakeReduce(
 	MakeMap(
 		MapEndpoint2Host,

--- a/render/pod.go
+++ b/render/pod.go
@@ -42,7 +42,7 @@ func isPauseContainer(n report.Node) bool {
 
 // PodRenderer is a Renderer which produces a renderable kubernetes
 // graph by merging the container graph and the pods topology.
-var PodRenderer = ConditionalRenderer(renderKubernetesTopologies,
+var PodRenderer = Memoise(ConditionalRenderer(renderKubernetesTopologies,
 	MakeFilter(
 		func(n report.Node) bool {
 			state, ok := n.Latest.Lookup(kubernetes.State)
@@ -65,10 +65,12 @@ var PodRenderer = ConditionalRenderer(renderKubernetesTopologies,
 			ConnectionJoin(MapPod2IP, selectPodsWithDeployments{}),
 		),
 	),
-)
+))
 
 // PodServiceRenderer is a Renderer which produces a renderable kubernetes services
 // graph by merging the pods graph and the services topology.
+//
+// not memoised
 var PodServiceRenderer = ConditionalRenderer(renderKubernetesTopologies,
 	renderParents(
 		report.Pod, []string{report.Service}, "",
@@ -80,6 +82,8 @@ var PodServiceRenderer = ConditionalRenderer(renderKubernetesTopologies,
 // Pods with no controller are mapped to 'Unmanaged'
 // We can't simply combine the rendered graphs of the high level objects as they would never
 // have connections to each other.
+//
+// not memoised
 var KubeControllerRenderer = ConditionalRenderer(renderKubernetesTopologies,
 	renderParents(
 		report.Pod, []string{report.Deployment, report.DaemonSet, report.StatefulSet, report.CronJob}, UnmanagedID,

--- a/render/pod.go
+++ b/render/pod.go
@@ -62,7 +62,9 @@ var PodRenderer = Memoise(ConditionalRenderer(renderKubernetesTopologies,
 					),
 				),
 			),
-			ConnectionJoin(MapPod2IP, selectPodsWithDeployments{}),
+			// ConnectionJoin invokes the renderer twice, hence it
+			// helps to memoise it.
+			ConnectionJoin(MapPod2IP, Memoise(selectPodsWithDeployments{})),
 		),
 	),
 ))

--- a/render/process.go
+++ b/render/process.go
@@ -26,7 +26,7 @@ var EndpointRenderer = SelectEndpoint
 
 // ProcessRenderer is a Renderer which produces a renderable process
 // graph by merging the endpoint graph and the process topology.
-var ProcessRenderer = ConditionalRenderer(renderProcesses,
+var ProcessRenderer = Memoise(ConditionalRenderer(renderProcesses,
 	MakeReduce(
 		MakeMap(
 			MapEndpoint2Process,
@@ -34,13 +34,13 @@ var ProcessRenderer = ConditionalRenderer(renderProcesses,
 		),
 		SelectProcess,
 	),
-)
+))
 
 // ColorConnectedProcessRenderer colors connected nodes from
 // ProcessRenderer. Since the process topology views only show
 // connected processes, we need this info to determine whether
 // processes appearing in a details panel are linkable.
-var ColorConnectedProcessRenderer = ColorConnected(ProcessRenderer)
+var ColorConnectedProcessRenderer = Memoise(ColorConnected(ProcessRenderer))
 
 // processWithContainerNameRenderer is a Renderer which produces a process
 // graph enriched with container names where appropriate

--- a/render/process.go
+++ b/render/process.go
@@ -74,10 +74,14 @@ func (r processWithContainerNameRenderer) Render(rpt report.Report, dct Decorato
 
 // ProcessWithContainerNameRenderer is a Renderer which produces a process
 // graph enriched with container names where appropriate
+//
+// not memoised
 var ProcessWithContainerNameRenderer = processWithContainerNameRenderer{ProcessRenderer}
 
 // ProcessNameRenderer is a Renderer which produces a renderable process
 // name graph by munging the progess graph.
+//
+// not memoised
 var ProcessNameRenderer = ConditionalRenderer(renderProcesses,
 	MakeMap(
 		MapProcess2Name,

--- a/render/render.go
+++ b/render/render.go
@@ -33,19 +33,18 @@ type Reduce []Renderer
 
 // MakeReduce is the only sane way to produce a Reduce Renderer.
 func MakeReduce(renderers ...Renderer) Renderer {
-	r := Reduce(renderers)
-	return Memoise(&r)
+	return Reduce(renderers)
 }
 
 // Render produces a set of Nodes given a Report.
-func (r *Reduce) Render(rpt report.Report, dct Decorator) report.Nodes {
-	l := len(*r)
+func (r Reduce) Render(rpt report.Report, dct Decorator) report.Nodes {
+	l := len(r)
 	switch l {
 	case 0:
 		return report.Nodes{}
 	}
 	c := make(chan report.Nodes, l)
-	for _, renderer := range *r {
+	for _, renderer := range r {
 		renderer := renderer // Pike!!
 		go func() {
 			c <- renderer.Render(rpt, dct)
@@ -61,9 +60,9 @@ func (r *Reduce) Render(rpt report.Report, dct Decorator) report.Nodes {
 }
 
 // Stats implements Renderer
-func (r *Reduce) Stats(rpt report.Report, dct Decorator) Stats {
+func (r Reduce) Stats(rpt report.Report, dct Decorator) Stats {
 	var result Stats
-	for _, renderer := range *r {
+	for _, renderer := range r {
 		result = result.merge(renderer.Stats(rpt, dct))
 	}
 	return result
@@ -78,7 +77,7 @@ type Map struct {
 
 // MakeMap makes a new Map
 func MakeMap(f MapFunc, r Renderer) Renderer {
-	return Memoise(&Map{f, r})
+	return &Map{f, r}
 }
 
 // Render transforms a set of Nodes produces by another Renderer.
@@ -180,7 +179,7 @@ type conditionalRenderer struct {
 // ConditionalRenderer renders nothing if the condition is false, otherwise it defers
 // to the wrapped Renderer.
 func ConditionalRenderer(c Condition, r Renderer) Renderer {
-	return Memoise(conditionalRenderer{c, r})
+	return conditionalRenderer{c, r}
 }
 
 func (cr conditionalRenderer) Render(rpt report.Report, dct Decorator) report.Nodes {

--- a/render/swarm.go
+++ b/render/swarm.go
@@ -5,6 +5,8 @@ import (
 )
 
 // SwarmServiceRenderer is a Renderer for Docker Swarm services
+//
+// not memoised
 var SwarmServiceRenderer = ConditionalRenderer(renderSwarmTopologies,
 	renderParents(
 		report.Container, []string{report.SwarmService}, UnmanagedID,

--- a/render/weave.go
+++ b/render/weave.go
@@ -6,6 +6,8 @@ import (
 )
 
 // WeaveRenderer is a Renderer which produces a renderable weave topology.
+//
+// not memoised
 var WeaveRenderer = MakeMap(
 	MapWeaveIdentity,
 	SelectOverlay,


### PR DESCRIPTION
Remove all memoisation and then re-introduce it a) for top-level renderes, i.e. those closest to the API, and b) shared renderes.

This cuts the number of memoising renderers from 74 to 21.

I ran a number of tests with a recent prod report
```
prog/scope --mode=app --weave=false --app.collector=file:report.json
```
and then timed the fetching of topologies with
```
time curl -so /dev/null http://localhost:4040/api/topology/<topology>
```

| topology               | befor | rpeat | ahost | hits   | after | rpeat | ahost | hits   |
| ------------------------ | ------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- |
| processes              | 0.315 | 0.108 | 0.125 | 0/1/1 | 0.312 | 0.108 | 0.124 | 0/1/1 |
| processes-by-name      | 0.249 | 0.029 |       | 0/1   | 0.229 | 0.026 |       | 0/1   |
| containers             | 1.282 | 0.399 | 0.421 | 0/1/1 | 1.276 | 0.416 | 0.432 | 0/1/1 |
| containers-by-hostname | 0.926 | 0.053 |       | 1/1   | 0.906 | 0.058 |       | 1/1   |
| containers-by-image    | 0.924 | 0.034 |       | 0/1   | 0.898 | 0.038 |       | 0/1   |
| pods                   | 0.954 | 0.074 | 0.082 | 1/1/1 | 0.960 | 0.080 | 0.089 | 2/1/1 |
| kube-controllers       | 0.947 | 0.042 |       | 1/1   | 0.943 | 0.039 |       | 1/1   |
| services               | 0.960 | 0.031 |       | 1/1   | 0.936 | 0.031 |       | 1/1   |
| hosts                  | 1.278 | 0.025 |       | 4/1   | 1.237 | 0.025 |       | 4 /1    |

rpeat = fetching the same topology again
ahost = fetching the topology after first fetching the host topology
hits = memoisation cache hits during fetch / rpeat fetch / ahost fetch

Timings are best run out of five.

So there really is no difference in timing, but it should consume less memory.

Each of the memoisations does have an effect, often very substantial; i.e. disabling any one increases at least one of the numbers above.

Fixes #2923 