### PR TITLE
produce stats as part of rendering

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -504,19 +504,19 @@ func decorateWithStats(rpt report.Report, renderer render.Renderer, decorator re
 		realNodes int
 		edges     int
 	)
-	for _, n := range renderer.Render(rpt, decorator) {
+	r := renderer.Render(rpt, decorator)
+	for _, n := range r.Nodes {
 		nodes++
 		if n.Topology != render.Pseudo {
 			realNodes++
 		}
 		edges += len(n.Adjacency)
 	}
-	renderStats := renderer.Stats(rpt, decorator)
 	return topologyStats{
 		NodeCount:          nodes,
 		NonpseudoNodeCount: realNodes,
 		EdgeCount:          edges,
-		FilteredNodes:      renderStats.FilteredNodes,
+		FilteredNodes:      r.Filtered,
 	}
 }
 

--- a/app/api_topologies_test.go
+++ b/app/api_topologies_test.go
@@ -118,7 +118,7 @@ func TestRendererForTopologyWithFiltering(t *testing.T) {
 	input.Container.Nodes[fixture.ClientContainerNodeID] = input.Container.Nodes[fixture.ClientContainerNodeID].WithLatests(map[string]string{
 		docker.LabelPrefix + "works.weave.role": "system",
 	})
-	have := utils.Prune(renderer.Render(input, decorator))
+	have := utils.Prune(renderer.Render(input, decorator).Nodes)
 	want := utils.Prune(expected.RenderedContainers.Copy())
 	delete(want, fixture.ClientContainerNodeID)
 	delete(want, render.MakePseudoNodeID(render.UncontainedID, fixture.ServerHostID))
@@ -149,7 +149,7 @@ func TestRendererForTopologyNoFiltering(t *testing.T) {
 	input.Container.Nodes[fixture.ClientContainerNodeID] = input.Container.Nodes[fixture.ClientContainerNodeID].WithLatests(map[string]string{
 		docker.LabelPrefix + "works.weave.role": "system",
 	})
-	have := utils.Prune(renderer.Render(input, decorator))
+	have := utils.Prune(renderer.Render(input, decorator).Nodes)
 	want := utils.Prune(expected.RenderedContainers.Copy())
 	delete(want, render.MakePseudoNodeID(render.UncontainedID, fixture.ServerHostID))
 	delete(want, render.OutgoingInternetID)
@@ -183,7 +183,7 @@ func getTestContainerLabelFilterTopologySummary(t *testing.T, exclude bool) (det
 		return nil, err
 	}
 
-	return detailed.Summaries(report.RenderContext{Report: fixture.Report}, renderer.Render(fixture.Report, decorator)), nil
+	return detailed.Summaries(report.RenderContext{Report: fixture.Report}, renderer.Render(fixture.Report, decorator).Nodes), nil
 }
 
 func TestAPITopologyAddsKubernetes(t *testing.T) {

--- a/app/api_topology.go
+++ b/app/api_topology.go
@@ -31,7 +31,7 @@ type APINode struct {
 // Full topology.
 func handleTopology(ctx context.Context, renderer render.Renderer, decorator render.Decorator, rc report.RenderContext, w http.ResponseWriter, r *http.Request) {
 	respondWith(w, http.StatusOK, APITopology{
-		Nodes: detailed.Summaries(rc, renderer.Render(rc.Report, decorator)),
+		Nodes: detailed.Summaries(rc, renderer.Render(rc.Report, decorator).Nodes),
 	})
 }
 
@@ -42,7 +42,7 @@ func handleNode(ctx context.Context, renderer render.Renderer, decorator render.
 		topologyID       = vars["topology"]
 		nodeID           = vars["id"]
 		preciousRenderer = render.PreciousNodeRenderer{PreciousNodeID: nodeID, Renderer: renderer}
-		rendered         = preciousRenderer.Render(rc.Report, decorator)
+		rendered         = preciousRenderer.Render(rc.Report, decorator).Nodes
 		node, ok         = rendered[nodeID]
 	)
 	if !ok {
@@ -123,7 +123,7 @@ func handleWebsocket(
 			log.Errorf("Error generating report: %v", err)
 			return
 		}
-		newTopo := detailed.Summaries(RenderContextForReporter(rep, re), renderer.Render(re, decorator))
+		newTopo := detailed.Summaries(RenderContextForReporter(rep, re), renderer.Render(re, decorator).Nodes)
 		diff := detailed.TopoDiff(previousTopo, newTopo)
 		previousTopo = newTopo
 

--- a/render/benchmark_test.go
+++ b/render/benchmark_test.go
@@ -74,7 +74,7 @@ func benchmarkRender(b *testing.B, r render.Renderer) {
 		b.StopTimer()
 		render.ResetCache()
 		b.StartTimer()
-		benchmarkRenderResult = r.Render(report, FilterNoop)
+		benchmarkRenderResult = r.Render(report, FilterNoop).Nodes
 		if len(benchmarkRenderResult) == 0 {
 			b.Errorf("Rendered topology contained no nodes")
 		}

--- a/render/benchmark_test.go
+++ b/render/benchmark_test.go
@@ -14,51 +14,29 @@ import (
 
 var (
 	benchReportFile       = flag.String("bench-report-file", "", "json report file to use for benchmarking (relative to this package)")
-	benchmarkRenderResult map[string]report.Node
-	benchmarkStatsResult  render.Stats
+	benchmarkRenderResult render.Nodes
 )
 
 func BenchmarkEndpointRender(b *testing.B) { benchmarkRender(b, render.EndpointRenderer) }
-func BenchmarkEndpointStats(b *testing.B)  { benchmarkStats(b, render.EndpointRenderer) }
 func BenchmarkProcessRender(b *testing.B)  { benchmarkRender(b, render.ProcessRenderer) }
-func BenchmarkProcessStats(b *testing.B)   { benchmarkStats(b, render.ProcessRenderer) }
 func BenchmarkProcessWithContainerNameRender(b *testing.B) {
 	benchmarkRender(b, render.ProcessWithContainerNameRenderer)
 }
-func BenchmarkProcessWithContainerNameStats(b *testing.B) {
-	benchmarkStats(b, render.ProcessWithContainerNameRenderer)
-}
 func BenchmarkProcessNameRender(b *testing.B) { benchmarkRender(b, render.ProcessNameRenderer) }
-func BenchmarkProcessNameStats(b *testing.B)  { benchmarkStats(b, render.ProcessNameRenderer) }
 func BenchmarkContainerRender(b *testing.B)   { benchmarkRender(b, render.ContainerRenderer) }
-func BenchmarkContainerStats(b *testing.B)    { benchmarkStats(b, render.ContainerRenderer) }
 func BenchmarkContainerWithImageNameRender(b *testing.B) {
 	benchmarkRender(b, render.ContainerWithImageNameRenderer)
-}
-func BenchmarkContainerWithImageNameStats(b *testing.B) {
-	benchmarkStats(b, render.ContainerWithImageNameRenderer)
 }
 func BenchmarkContainerImageRender(b *testing.B) {
 	benchmarkRender(b, render.ContainerImageRenderer)
 }
-func BenchmarkContainerImageStats(b *testing.B) {
-	benchmarkStats(b, render.ContainerImageRenderer)
-}
 func BenchmarkContainerHostnameRender(b *testing.B) {
 	benchmarkRender(b, render.ContainerHostnameRenderer)
 }
-func BenchmarkContainerHostnameStats(b *testing.B) {
-	benchmarkStats(b, render.ContainerHostnameRenderer)
-}
 func BenchmarkHostRender(b *testing.B) { benchmarkRender(b, render.HostRenderer) }
-func BenchmarkHostStats(b *testing.B)  { benchmarkStats(b, render.HostRenderer) }
 func BenchmarkPodRender(b *testing.B)  { benchmarkRender(b, render.PodRenderer) }
-func BenchmarkPodStats(b *testing.B)   { benchmarkStats(b, render.PodRenderer) }
 func BenchmarkPodServiceRender(b *testing.B) {
 	benchmarkRender(b, render.PodServiceRenderer)
-}
-func BenchmarkPodServiceStats(b *testing.B) {
-	benchmarkStats(b, render.PodServiceRenderer)
 }
 
 func benchmarkRender(b *testing.B, r render.Renderer) {
@@ -74,27 +52,10 @@ func benchmarkRender(b *testing.B, r render.Renderer) {
 		b.StopTimer()
 		render.ResetCache()
 		b.StartTimer()
-		benchmarkRenderResult = r.Render(report, FilterNoop).Nodes
-		if len(benchmarkRenderResult) == 0 {
+		benchmarkRenderResult = r.Render(report, FilterNoop)
+		if len(benchmarkRenderResult.Nodes) == 0 {
 			b.Errorf("Rendered topology contained no nodes")
 		}
-	}
-}
-
-func benchmarkStats(b *testing.B, r render.Renderer) {
-	report, err := loadReport()
-	if err != nil {
-		b.Fatal(err)
-	}
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		// No way to tell if this was successful :(
-		b.StopTimer()
-		render.ResetCache()
-		b.StartTimer()
-		benchmarkStatsResult = r.Stats(report, FilterNoop)
 	}
 }
 

--- a/render/container.go
+++ b/render/container.go
@@ -105,10 +105,6 @@ func (c connectionJoin) Render(rpt report.Report, dct Decorator) Nodes {
 	return ret.result()
 }
 
-func (c connectionJoin) Stats(rpt report.Report, _ Decorator) Stats {
-	return Stats{} // nothing to report
-}
-
 // FilterEmpty is a Renderer which filters out nodes which have no children
 // from the specified topology.
 func FilterEmpty(topology string, r Renderer) Renderer {

--- a/render/container.go
+++ b/render/container.go
@@ -53,14 +53,14 @@ type connectionJoin struct {
 	r     Renderer
 }
 
-func (c connectionJoin) Render(rpt report.Report, dct Decorator) report.Nodes {
+func (c connectionJoin) Render(rpt report.Report, dct Decorator) Nodes {
 	local := LocalNetworks(rpt)
 	inputNodes := c.r.Render(rpt, dct)
 	endpoints := SelectEndpoint.Render(rpt, dct)
 
 	// Collect all the IPs we are trying to map to, and which ID they map from
 	var ipNodes = map[string]string{}
-	for _, n := range inputNodes {
+	for _, n := range inputNodes.Nodes {
 		for _, ip := range c.toIPs(n) {
 			if _, exists := ipNodes[ip]; exists {
 				// If an IP is shared between multiple nodes, we can't reliably
@@ -74,7 +74,7 @@ func (c connectionJoin) Render(rpt report.Report, dct Decorator) report.Nodes {
 	ret := newJoinResults()
 
 	// Now look at all the endpoints and see which map to IP nodes
-	for _, m := range endpoints {
+	for _, m := range endpoints.Nodes {
 		scope, addr, port, ok := report.ParseEndpointNodeID(m.ID)
 		if !ok {
 			continue
@@ -95,14 +95,14 @@ func (c connectionJoin) Render(rpt report.Report, dct Decorator) report.Nodes {
 		}
 		if found && id != "" { // not one we blanked out earlier
 			ret.addToResults(m, id, func(id string) report.Node {
-				return inputNodes[id]
+				return inputNodes.Nodes[id]
 			})
 		}
 	}
 	ret.copyUnmatched(inputNodes)
 	ret.fixupAdjacencies(inputNodes)
 	ret.fixupAdjacencies(endpoints)
-	return ret.nodes
+	return ret.result()
 }
 
 func (c connectionJoin) Stats(rpt report.Report, _ Decorator) Stats {
@@ -135,18 +135,18 @@ type containerWithImageNameRenderer struct {
 
 // Render produces a container graph where the the latest metadata contains the
 // container image name, if found.
-func (r containerWithImageNameRenderer) Render(rpt report.Report, dct Decorator) report.Nodes {
+func (r containerWithImageNameRenderer) Render(rpt report.Report, dct Decorator) Nodes {
 	containers := r.Renderer.Render(rpt, dct)
 	images := SelectContainerImage.Render(rpt, dct)
 
 	outputs := report.Nodes{}
-	for id, c := range containers {
+	for id, c := range containers.Nodes {
 		outputs[id] = c
 		imageID, ok := c.Latest.Lookup(docker.ImageID)
 		if !ok {
 			continue
 		}
-		image, ok := images[report.MakeContainerImageNodeID(imageID)]
+		image, ok := images.Nodes[report.MakeContainerImageNodeID(imageID)]
 		if !ok {
 			continue
 		}
@@ -166,7 +166,7 @@ func (r containerWithImageNameRenderer) Render(rpt report.Report, dct Decorator)
 			Add(report.ContainerImage, report.MakeStringSet(imageNodeID))
 		outputs[id] = c
 	}
-	return outputs
+	return Nodes{Nodes: outputs, Filtered: containers.Filtered}
 }
 
 // ContainerWithImageNameRenderer is a Renderer which produces a container

--- a/render/container_test.go
+++ b/render/container_test.go
@@ -59,7 +59,7 @@ func testMap(t *testing.T, f render.MapFunc, input testcase) {
 }
 
 func TestContainerRenderer(t *testing.T) {
-	have := utils.Prune(render.ContainerWithImageNameRenderer.Render(fixture.Report, FilterNoop))
+	have := utils.Prune(render.ContainerWithImageNameRenderer.Render(fixture.Report, FilterNoop).Nodes)
 	want := utils.Prune(expected.RenderedContainers)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -76,7 +76,7 @@ func TestContainerFilterRenderer(t *testing.T) {
 		docker.LabelPrefix + "works.weave.role": "system",
 	})
 
-	have := utils.Prune(renderer.Render(input, FilterApplication))
+	have := utils.Prune(renderer.Render(input, FilterApplication).Nodes)
 	want := utils.Prune(expected.RenderedContainers.Copy())
 	delete(want, fixture.ClientContainerNodeID)
 	if !reflect.DeepEqual(want, have) {
@@ -86,7 +86,7 @@ func TestContainerFilterRenderer(t *testing.T) {
 
 func TestContainerHostnameRenderer(t *testing.T) {
 	renderer := render.ApplyDecorator(render.ContainerHostnameRenderer)
-	have := utils.Prune(renderer.Render(fixture.Report, FilterNoop))
+	have := utils.Prune(renderer.Render(fixture.Report, FilterNoop).Nodes)
 	want := utils.Prune(expected.RenderedContainerHostnames)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -95,7 +95,7 @@ func TestContainerHostnameRenderer(t *testing.T) {
 
 func TestContainerHostnameFilterRenderer(t *testing.T) {
 	renderer := render.ApplyDecorator(render.ContainerHostnameRenderer)
-	have := utils.Prune(renderer.Render(fixture.Report, FilterSystem))
+	have := utils.Prune(renderer.Render(fixture.Report, FilterSystem).Nodes)
 	want := utils.Prune(expected.RenderedContainerHostnames.Copy())
 	delete(want, fixture.ClientContainerHostname)
 	delete(want, fixture.ServerContainerHostname)
@@ -107,7 +107,7 @@ func TestContainerHostnameFilterRenderer(t *testing.T) {
 
 func TestContainerImageRenderer(t *testing.T) {
 	renderer := render.ApplyDecorator(render.ContainerImageRenderer)
-	have := utils.Prune(renderer.Render(fixture.Report, FilterNoop))
+	have := utils.Prune(renderer.Render(fixture.Report, FilterNoop).Nodes)
 	want := utils.Prune(expected.RenderedContainerImages)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -116,7 +116,7 @@ func TestContainerImageRenderer(t *testing.T) {
 
 func TestContainerImageFilterRenderer(t *testing.T) {
 	renderer := render.ApplyDecorator(render.ContainerImageRenderer)
-	have := utils.Prune(renderer.Render(fixture.Report, FilterSystem))
+	have := utils.Prune(renderer.Render(fixture.Report, FilterSystem).Nodes)
 	want := utils.Prune(expected.RenderedContainerHostnames.Copy())
 	delete(want, fixture.ClientContainerHostname)
 	delete(want, fixture.ServerContainerHostname)

--- a/render/detailed/node_test.go
+++ b/render/detailed/node_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func child(t *testing.T, r render.Renderer, id string) detailed.NodeSummary {
-	s, ok := detailed.MakeNodeSummary(report.RenderContext{Report: fixture.Report}, r.Render(fixture.Report, nil)[id])
+	s, ok := detailed.MakeNodeSummary(report.RenderContext{Report: fixture.Report}, r.Render(fixture.Report, nil).Nodes[id])
 	if !ok {
 		t.Fatalf("Expected node %s to be summarizable, but wasn't", id)
 	}
@@ -30,7 +30,7 @@ func connectionID(nodeID string, addr string) string {
 }
 
 func TestMakeDetailedHostNode(t *testing.T) {
-	renderableNodes := render.HostRenderer.Render(fixture.Report, nil)
+	renderableNodes := render.HostRenderer.Render(fixture.Report, nil).Nodes
 	renderableNode := renderableNodes[fixture.ClientHostNodeID]
 	have := detailed.MakeNode("hosts", report.RenderContext{Report: fixture.Report}, renderableNodes, renderableNode)
 
@@ -178,7 +178,7 @@ func TestMakeDetailedHostNode(t *testing.T) {
 
 func TestMakeDetailedContainerNode(t *testing.T) {
 	id := fixture.ServerContainerNodeID
-	renderableNodes := render.ContainerWithImageNameRenderer.Render(fixture.Report, nil)
+	renderableNodes := render.ContainerWithImageNameRenderer.Render(fixture.Report, nil).Nodes
 	renderableNode, ok := renderableNodes[id]
 	if !ok {
 		t.Fatalf("Node not found: %s", id)
@@ -308,7 +308,7 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 
 func TestMakeDetailedPodNode(t *testing.T) {
 	id := fixture.ServerPodNodeID
-	renderableNodes := render.PodRenderer.Render(fixture.Report, nil)
+	renderableNodes := render.PodRenderer.Render(fixture.Report, nil).Nodes
 	renderableNode, ok := renderableNodes[id]
 	if !ok {
 		t.Fatalf("Node not found: %s", id)

--- a/render/detailed/parents_test.go
+++ b/render/detailed/parents_test.go
@@ -21,25 +21,25 @@ func TestParents(t *testing.T) {
 	}{
 		{
 			name: "Node accidentally tagged with itself",
-			node: render.HostRenderer.Render(fixture.Report, nil)[fixture.ClientHostNodeID].WithParents(
+			node: render.HostRenderer.Render(fixture.Report, nil).Nodes[fixture.ClientHostNodeID].WithParents(
 				report.MakeSets().Add(report.Host, report.MakeStringSet(fixture.ClientHostNodeID)),
 			),
 			want: nil,
 		},
 		{
-			node: render.HostRenderer.Render(fixture.Report, nil)[fixture.ClientHostNodeID],
+			node: render.HostRenderer.Render(fixture.Report, nil).Nodes[fixture.ClientHostNodeID],
 			want: nil,
 		},
 		{
 			name: "Container image",
-			node: render.ContainerImageRenderer.Render(fixture.Report, nil)[expected.ClientContainerImageNodeID],
+			node: render.ContainerImageRenderer.Render(fixture.Report, nil).Nodes[expected.ClientContainerImageNodeID],
 			want: []detailed.Parent{
 				{ID: fixture.ClientHostNodeID, Label: fixture.ClientHostName, TopologyID: "hosts"},
 			},
 		},
 		{
 			name: "Container",
-			node: render.ContainerWithImageNameRenderer.Render(fixture.Report, nil)[fixture.ClientContainerNodeID],
+			node: render.ContainerWithImageNameRenderer.Render(fixture.Report, nil).Nodes[fixture.ClientContainerNodeID],
 			want: []detailed.Parent{
 				{ID: expected.ClientContainerImageNodeID, Label: fixture.ClientContainerImageName, TopologyID: "containers-by-image"},
 				{ID: fixture.ClientHostNodeID, Label: fixture.ClientHostName, TopologyID: "hosts"},
@@ -47,7 +47,7 @@ func TestParents(t *testing.T) {
 			},
 		},
 		{
-			node: render.ProcessRenderer.Render(fixture.Report, nil)[fixture.ClientProcess1NodeID],
+			node: render.ProcessRenderer.Render(fixture.Report, nil).Nodes[fixture.ClientProcess1NodeID],
 			want: []detailed.Parent{
 				{ID: fixture.ClientContainerNodeID, Label: fixture.ClientContainerName, TopologyID: "containers"},
 				{ID: fixture.ClientHostNodeID, Label: fixture.ClientHostName, TopologyID: "hosts"},

--- a/render/detailed/summary_test.go
+++ b/render/detailed/summary_test.go
@@ -21,7 +21,7 @@ import (
 func TestSummaries(t *testing.T) {
 	{
 		// Just a convenient source of some rendered nodes
-		have := detailed.Summaries(report.RenderContext{Report: fixture.Report}, render.ProcessRenderer.Render(fixture.Report, nil))
+		have := detailed.Summaries(report.RenderContext{Report: fixture.Report}, render.ProcessRenderer.Render(fixture.Report, nil).Nodes)
 		// The ids of the processes rendered above
 		expectedIDs := []string{
 			fixture.ClientProcess1NodeID,
@@ -51,7 +51,7 @@ func TestSummaries(t *testing.T) {
 		input := fixture.Report.Copy()
 
 		input.Process.Nodes[fixture.ClientProcess1NodeID].Metrics[process.CPUUsage] = metric
-		have := detailed.Summaries(report.RenderContext{Report: input}, render.ProcessRenderer.Render(input, nil))
+		have := detailed.Summaries(report.RenderContext{Report: input}, render.ProcessRenderer.Render(input, nil).Nodes)
 
 		node, ok := have[fixture.ClientProcess1NodeID]
 		if !ok {

--- a/render/filters.go
+++ b/render/filters.go
@@ -32,13 +32,6 @@ func (p PreciousNodeRenderer) Render(rpt report.Report, dct Decorator) Nodes {
 	return finalNodes
 }
 
-// Stats implements Renderer
-func (p PreciousNodeRenderer) Stats(rpt report.Report, dct Decorator) Stats {
-	// default to the underlying renderer
-	// TODO: we don't take into account the precious node, so we may be off by one
-	return p.Renderer.Stats(rpt, dct)
-}
-
 // CustomRenderer allow for mapping functions that received the entire topology
 // in one call - useful for functions that need to consider the entire graph.
 // We should minimise the use of this renderer type, as it is very inflexible.
@@ -191,15 +184,6 @@ func (f *Filter) render(rpt report.Report, dct Decorator) Nodes {
 		filtered++
 	}
 	return Nodes{Nodes: output, Filtered: filtered}
-}
-
-// Stats implements Renderer. General logic is to take the first (i.e.
-// highest-level) stats we find, so upstream stats are ignored. This means that
-// if we want to count the stats from multiple filters we need to compose their
-// FilterFuncs, into a single Filter.
-func (f Filter) Stats(rpt report.Report, dct Decorator) Stats {
-	nodes := f.render(rpt, dct)
-	return Stats{FilteredNodes: nodes.Filtered}
 }
 
 // IsConnected is the key added to Node.Metadata by ColorConnected

--- a/render/filters_test.go
+++ b/render/filters_test.go
@@ -16,7 +16,7 @@ func TestFilterRender(t *testing.T) {
 		"baz": report.MakeNode("baz"),
 	}}
 	have := report.MakeIDList()
-	for id := range renderer.Render(report.MakeReport(), render.FilterUnconnected) {
+	for id := range renderer.Render(report.MakeReport(), render.FilterUnconnected).Nodes {
 		have = have.Add(id)
 	}
 	want := report.MakeIDList("foo", "bar")
@@ -41,7 +41,7 @@ func TestFilterRender2(t *testing.T) {
 		"baz": report.MakeNode("baz"),
 	}}
 
-	have := renderer.Render(report.MakeReport(), filter)
+	have := renderer.Render(report.MakeReport(), filter).Nodes
 	if have["foo"].Adjacency.Contains("bar") {
 		t.Error("adjacencies for removed nodes should have been removed")
 	}
@@ -66,7 +66,7 @@ func TestFilterUnconnectedPseudoNodes(t *testing.T) {
 			}
 		}
 		want := nodes
-		have := renderer.Render(report.MakeReport(), filter)
+		have := renderer.Render(report.MakeReport(), filter).Nodes
 		if !reflect.DeepEqual(want, have) {
 			t.Error(test.Diff(want, have))
 		}
@@ -85,7 +85,7 @@ func TestFilterUnconnectedPseudoNodes(t *testing.T) {
 			"bar": report.MakeNode("bar").WithAdjacent("baz"),
 			"baz": report.MakeNode("baz").WithTopology(render.Pseudo),
 		}}
-		have := renderer.Render(report.MakeReport(), filter)
+		have := renderer.Render(report.MakeReport(), filter).Nodes
 		if _, ok := have["baz"]; ok {
 			t.Error("expected the unconnected pseudonode baz to have been removed")
 		}
@@ -104,7 +104,7 @@ func TestFilterUnconnectedPseudoNodes(t *testing.T) {
 			"bar": report.MakeNode("bar").WithAdjacent("foo"),
 			"baz": report.MakeNode("baz").WithTopology(render.Pseudo).WithAdjacent("bar"),
 		}}
-		have := renderer.Render(report.MakeReport(), filter)
+		have := renderer.Render(report.MakeReport(), filter).Nodes
 		if _, ok := have["baz"]; ok {
 			t.Error("expected the unconnected pseudonode baz to have been removed")
 		}
@@ -118,7 +118,7 @@ func TestFilterUnconnectedSelf(t *testing.T) {
 			"foo": report.MakeNode("foo").WithAdjacent("foo"),
 		}
 		renderer := mockRenderer{Nodes: nodes}
-		have := renderer.Render(report.MakeReport(), render.FilterUnconnected)
+		have := renderer.Render(report.MakeReport(), render.FilterUnconnected).Nodes
 		if len(have) > 0 {
 			t.Error("expected node only connected to self to be removed")
 		}

--- a/render/host.go
+++ b/render/host.go
@@ -65,12 +65,12 @@ func MapX2Host(n report.Node, _ report.Networks) report.Nodes {
 type endpoints2Hosts struct {
 }
 
-func (e endpoints2Hosts) Render(rpt report.Report, dct Decorator) report.Nodes {
+func (e endpoints2Hosts) Render(rpt report.Report, dct Decorator) Nodes {
 	local := LocalNetworks(rpt)
 	endpoints := SelectEndpoint.Render(rpt, dct)
 	ret := newJoinResults()
 
-	for _, n := range endpoints {
+	for _, n := range endpoints.Nodes {
 		// Nodes without a hostid are treated as pseudo nodes
 		hostNodeID, timestamp, ok := n.Latest.LookupEntry(report.HostNodeID)
 		if !ok {
@@ -88,7 +88,7 @@ func (e endpoints2Hosts) Render(rpt report.Report, dct Decorator) report.Nodes {
 		}
 	}
 	ret.fixupAdjacencies(endpoints)
-	return ret.nodes
+	return ret.result()
 }
 
 func (e endpoints2Hosts) Stats(rpt report.Report, _ Decorator) Stats {

--- a/render/host.go
+++ b/render/host.go
@@ -7,7 +7,8 @@ import (
 // HostRenderer is a Renderer which produces a renderable host
 // graph from the host topology.
 //
-var HostRenderer = Memoise(MakeReduce(
+// not memoised
+var HostRenderer = MakeReduce(
 	endpoints2Hosts{},
 	MakeMap(
 		MapX2Host,
@@ -26,7 +27,7 @@ var HostRenderer = Memoise(MakeReduce(
 		PodRenderer,
 	),
 	SelectHost,
-))
+)
 
 // MapX2Host maps any Nodes to host Nodes.
 //

--- a/render/host.go
+++ b/render/host.go
@@ -90,7 +90,3 @@ func (e endpoints2Hosts) Render(rpt report.Report, dct Decorator) Nodes {
 	ret.fixupAdjacencies(endpoints)
 	return ret.result()
 }
-
-func (e endpoints2Hosts) Stats(rpt report.Report, _ Decorator) Stats {
-	return Stats{} // nothing to report
-}

--- a/render/host_test.go
+++ b/render/host_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestHostRenderer(t *testing.T) {
-	have := utils.Prune(render.HostRenderer.Render(fixture.Report, FilterNoop))
+	have := utils.Prune(render.HostRenderer.Render(fixture.Report, FilterNoop).Nodes)
 	want := utils.Prune(expected.RenderedHosts)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))

--- a/render/memoise.go
+++ b/render/memoise.go
@@ -39,7 +39,7 @@ func Memoise(r Renderer) Renderer {
 // m.Renderer.
 //
 // The cache is bypassed when rendering a report with a decorator.
-func (m *memoise) Render(rpt report.Report, dct Decorator) report.Nodes {
+func (m *memoise) Render(rpt report.Report, dct Decorator) Nodes {
 	if dct != nil {
 		return m.Renderer.Render(rpt, dct)
 	}
@@ -64,7 +64,7 @@ func (m *memoise) Render(rpt report.Report, dct Decorator) report.Nodes {
 }
 
 type promise struct {
-	val  report.Nodes
+	val  Nodes
 	done chan struct{}
 }
 
@@ -72,12 +72,12 @@ func newPromise() *promise {
 	return &promise{done: make(chan struct{})}
 }
 
-func (p *promise) Set(val report.Nodes) {
+func (p *promise) Set(val Nodes) {
 	p.val = val
 	close(p.done)
 }
 
-func (p *promise) Get() report.Nodes {
+func (p *promise) Get() Nodes {
 	<-p.done
 	return p.val
 }

--- a/render/memoise_test.go
+++ b/render/memoise_test.go
@@ -12,7 +12,6 @@ import (
 type renderFunc func(r report.Report) render.Nodes
 
 func (f renderFunc) Render(r report.Report, _ render.Decorator) render.Nodes { return f(r) }
-func (f renderFunc) Stats(r report.Report, _ render.Decorator) render.Stats  { return render.Stats{} }
 
 func TestMemoise(t *testing.T) {
 	calls := 0

--- a/render/memoise_test.go
+++ b/render/memoise_test.go
@@ -9,23 +9,23 @@ import (
 	"github.com/weaveworks/scope/test/reflect"
 )
 
-type renderFunc func(r report.Report) report.Nodes
+type renderFunc func(r report.Report) render.Nodes
 
-func (f renderFunc) Render(r report.Report, _ render.Decorator) report.Nodes { return f(r) }
+func (f renderFunc) Render(r report.Report, _ render.Decorator) render.Nodes { return f(r) }
 func (f renderFunc) Stats(r report.Report, _ render.Decorator) render.Stats  { return render.Stats{} }
 
 func TestMemoise(t *testing.T) {
 	calls := 0
-	r := renderFunc(func(rpt report.Report) report.Nodes {
+	r := renderFunc(func(rpt report.Report) render.Nodes {
 		calls++
-		return report.Nodes{rpt.ID: report.MakeNode(rpt.ID)}
+		return render.Nodes{Nodes: report.Nodes{rpt.ID: report.MakeNode(rpt.ID)}}
 	})
 	m := render.Memoise(r)
 	rpt1 := report.MakeReport()
 
 	result1 := m.Render(rpt1, nil)
 	// it should have rendered it.
-	if _, ok := result1[rpt1.ID]; !ok {
+	if _, ok := result1.Nodes[rpt1.ID]; !ok {
 		t.Errorf("Expected rendered report to contain a node, but got: %v", result1)
 	}
 	if calls != 1 {

--- a/render/pod.go
+++ b/render/pod.go
@@ -117,7 +117,7 @@ func renderParents(childTopology string, parentTopologies []string, noParentsPse
 // to deployments where applicable.
 type selectPodsWithDeployments struct{}
 
-func (s selectPodsWithDeployments) Render(rpt report.Report, dct Decorator) report.Nodes {
+func (s selectPodsWithDeployments) Render(rpt report.Report, dct Decorator) Nodes {
 	result := report.Nodes{}
 	// For each pod, we check for any replica sets, and merge any deployments they point to
 	// into a replacement Parents value.
@@ -135,7 +135,7 @@ func (s selectPodsWithDeployments) Render(rpt report.Report, dct Decorator) repo
 		}
 		result[podID] = pod
 	}
-	return result
+	return Nodes{Nodes: result}
 }
 
 func (s selectPodsWithDeployments) Stats(rpt report.Report, _ Decorator) Stats {

--- a/render/pod.go
+++ b/render/pod.go
@@ -138,10 +138,6 @@ func (s selectPodsWithDeployments) Render(rpt report.Report, dct Decorator) Node
 	return Nodes{Nodes: result}
 }
 
-func (s selectPodsWithDeployments) Stats(rpt report.Report, _ Decorator) Stats {
-	return Stats{}
-}
-
 // MapPod2IP maps pod nodes to their IP address.  This allows pods to
 // be joined directly with the endpoint topology.
 func MapPod2IP(m report.Node) []string {

--- a/render/pod_test.go
+++ b/render/pod_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestPodRenderer(t *testing.T) {
-	have := utils.Prune(render.PodRenderer.Render(fixture.Report, nil))
+	have := utils.Prune(render.PodRenderer.Render(fixture.Report, nil).Nodes)
 	want := utils.Prune(expected.RenderedPods)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -34,7 +34,7 @@ func TestPodFilterRenderer(t *testing.T) {
 		kubernetes.Namespace: "kube-system",
 	})
 
-	have := utils.Prune(renderer.Render(input, filterNonKubeSystem))
+	have := utils.Prune(renderer.Render(input, filterNonKubeSystem).Nodes)
 	want := utils.Prune(expected.RenderedPods.Copy())
 	delete(want, fixture.ClientPodNodeID)
 	if !reflect.DeepEqual(want, have) {
@@ -43,7 +43,7 @@ func TestPodFilterRenderer(t *testing.T) {
 }
 
 func TestPodServiceRenderer(t *testing.T) {
-	have := utils.Prune(render.PodServiceRenderer.Render(fixture.Report, nil))
+	have := utils.Prune(render.PodServiceRenderer.Render(fixture.Report, nil).Nodes)
 	want := utils.Prune(expected.RenderedPodServices)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -60,7 +60,7 @@ func TestPodServiceFilterRenderer(t *testing.T) {
 		kubernetes.Namespace: "kube-system",
 	})
 
-	have := utils.Prune(renderer.Render(input, filterNonKubeSystem))
+	have := utils.Prune(renderer.Render(input, filterNonKubeSystem).Nodes)
 	want := utils.Prune(expected.RenderedPodServices.Copy())
 	delete(want, fixture.ServiceNodeID)
 	delete(want, render.IncomingInternetID)

--- a/render/process.go
+++ b/render/process.go
@@ -132,10 +132,6 @@ func (e endpoints2Processes) Render(rpt report.Report, dct Decorator) Nodes {
 	return ret.result()
 }
 
-func (e endpoints2Processes) Stats(rpt report.Report, _ Decorator) Stats {
-	return Stats{} // nothing to report
-}
-
 // MapProcess2Name maps process Nodes to Nodes
 // for each process name.
 //

--- a/render/process_test.go
+++ b/render/process_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestEndpointRenderer(t *testing.T) {
-	have := utils.Prune(render.EndpointRenderer.Render(fixture.Report, FilterNoop))
+	have := utils.Prune(render.EndpointRenderer.Render(fixture.Report, FilterNoop).Nodes)
 	want := utils.Prune(expected.RenderedEndpoints)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -20,7 +20,7 @@ func TestEndpointRenderer(t *testing.T) {
 }
 
 func TestProcessRenderer(t *testing.T) {
-	have := utils.Prune(render.ProcessRenderer.Render(fixture.Report, FilterNoop))
+	have := utils.Prune(render.ProcessRenderer.Render(fixture.Report, FilterNoop).Nodes)
 	want := utils.Prune(expected.RenderedProcesses)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -28,7 +28,7 @@ func TestProcessRenderer(t *testing.T) {
 }
 
 func TestProcessNameRenderer(t *testing.T) {
-	have := utils.Prune(render.ProcessNameRenderer.Render(fixture.Report, FilterNoop))
+	have := utils.Prune(render.ProcessNameRenderer.Render(fixture.Report, FilterNoop).Nodes)
 	want := utils.Prune(expected.RenderedProcessNames)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -13,11 +13,11 @@ type mockRenderer struct {
 	report.Nodes
 }
 
-func (m mockRenderer) Render(rpt report.Report, d render.Decorator) report.Nodes {
+func (m mockRenderer) Render(rpt report.Report, d render.Decorator) render.Nodes {
 	if d != nil {
 		return d(mockRenderer{m.Nodes}).Render(rpt, nil)
 	}
-	return m.Nodes
+	return render.Nodes{Nodes: m.Nodes}
 }
 func (m mockRenderer) Stats(rpt report.Report, _ render.Decorator) render.Stats { return render.Stats{} }
 
@@ -31,7 +31,7 @@ func TestReduceRender(t *testing.T) {
 		"foo": report.MakeNode("foo"),
 		"bar": report.MakeNode("bar"),
 	}
-	have := renderer.Render(report.MakeReport(), FilterNoop)
+	have := renderer.Render(report.MakeReport(), FilterNoop).Nodes
 	if !reflect.DeepEqual(want, have) {
 		t.Errorf("want %+v, have %+v", want, have)
 	}
@@ -48,7 +48,7 @@ func TestMapRender1(t *testing.T) {
 		}},
 	}
 	want := report.Nodes{}
-	have := mapper.Render(report.MakeReport(), FilterNoop)
+	have := mapper.Render(report.MakeReport(), FilterNoop).Nodes
 	if !reflect.DeepEqual(want, have) {
 		t.Errorf("want %+v, have %+v", want, have)
 	}
@@ -70,7 +70,7 @@ func TestMapRender2(t *testing.T) {
 	want := report.Nodes{
 		"bar": report.MakeNode("bar"),
 	}
-	have := mapper.Render(report.MakeReport(), FilterNoop)
+	have := mapper.Render(report.MakeReport(), FilterNoop).Nodes
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}
@@ -92,7 +92,7 @@ func TestMapRender3(t *testing.T) {
 		"_foo": report.MakeNode("_foo").WithAdjacent("_baz"),
 		"_baz": report.MakeNode("_baz").WithAdjacent("_foo"),
 	}
-	have := mapper.Render(report.MakeReport(), FilterNoop)
+	have := mapper.Render(report.MakeReport(), FilterNoop).Nodes
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -19,7 +19,6 @@ func (m mockRenderer) Render(rpt report.Report, d render.Decorator) render.Nodes
 	}
 	return render.Nodes{Nodes: m.Nodes}
 }
-func (m mockRenderer) Stats(rpt report.Report, _ render.Decorator) render.Stats { return render.Stats{} }
 
 func TestReduceRender(t *testing.T) {
 	renderer := render.Reduce([]render.Renderer{

--- a/render/selectors.go
+++ b/render/selectors.go
@@ -14,11 +14,6 @@ func (t TopologySelector) Render(r report.Report, _ Decorator) Nodes {
 	return Nodes{Nodes: topology.Nodes}
 }
 
-// Stats implements Renderer
-func (t TopologySelector) Stats(r report.Report, _ Decorator) Stats {
-	return Stats{}
-}
-
 // The topology selectors implement a Renderer which fetch the nodes from the
 // various report topologies.
 var (

--- a/render/selectors.go
+++ b/render/selectors.go
@@ -9,9 +9,9 @@ import (
 type TopologySelector string
 
 // Render implements Renderer
-func (t TopologySelector) Render(r report.Report, _ Decorator) report.Nodes {
+func (t TopologySelector) Render(r report.Report, _ Decorator) Nodes {
 	topology, _ := r.Topology(string(t))
-	return topology.Nodes
+	return Nodes{Nodes: topology.Nodes}
 }
 
 // Stats implements Renderer

--- a/render/short_lived_connections_test.go
+++ b/render/short_lived_connections_test.go
@@ -109,7 +109,7 @@ var (
 )
 
 func TestShortLivedInternetNodeConnections(t *testing.T) {
-	have := utils.Prune(render.ContainerWithImageNameRenderer.Render(rpt, FilterNoop))
+	have := utils.Prune(render.ContainerWithImageNameRenderer.Render(rpt, FilterNoop).Nodes)
 
 	// Conntracked-only connections from the internet should be assigned to the internet pseudonode
 	internet, ok := have[render.IncomingInternetID]
@@ -123,7 +123,7 @@ func TestShortLivedInternetNodeConnections(t *testing.T) {
 }
 
 func TestPauseContainerDiscarded(t *testing.T) {
-	have := utils.Prune(render.ContainerWithImageNameRenderer.Render(rpt, FilterNoop))
+	have := utils.Prune(render.ContainerWithImageNameRenderer.Render(rpt, FilterNoop).Nodes)
 	// There should only be a connection from container1 and the destination should be container2
 	container1, ok := have[container1NodeID]
 	if !ok {


### PR DESCRIPTION
Stats are easily (and efficiently) produced as part of `Render`ing so there is no need for a separate `Stats` method.