### PR TITLE
Parsing optimisations

### DIFF
--- a/render/id.go
+++ b/render/id.go
@@ -1,7 +1,6 @@
 package render
 
 import (
-	"net"
 	"strings"
 
 	"github.com/weaveworks/scope/probe/endpoint"
@@ -66,7 +65,9 @@ func externalNodeID(n report.Node, addr string, local report.Networks) (string, 
 
 	// If the dstNodeAddr is not in a network local to this report, we emit an
 	// internet pseudoNode
-	if ip := net.ParseIP(addr); ip != nil && !local.Contains(ip) {
+	// Create a buffer on the stack of this function, so we don't need to allocate in ParseIP
+	var into [5]byte // one extra byte to save a memory allocation in critbitgo
+	if ip := report.ParseIP([]byte(addr), into[:4]); ip != nil && !local.Contains(ip) {
 		// emit one internet node for incoming, one for outgoing
 		if len(n.Adjacency) > 0 {
 			return IncomingInternetID, true


### PR DESCRIPTION
Make low-level parsing more closely aligned to what we need, to save memory allocations.
See individual commit messages for more details.

These routines are called a lot, so this change reduces garbage collection

Benchmarks before (c5bdebdffebfa7cc0839770a3bf70429260f1bc9):
```
BenchmarkTopologyList-2         	       2	 603197223 ns/op	112161732 B/op	 1253503 allocs/op
BenchmarkTopologyHosts-2        	       3	 385415232 ns/op	82957173 B/op	 1015204 allocs/op
BenchmarkTopologyContainers-2   	      10	 192766565 ns/op	33145659 B/op	  407698 allocs/op
```

after this PR:
```
BenchmarkTopologyList-2         	       3	 484253544 ns/op	104023597 B/op	  977911 allocs/op
BenchmarkTopologyHosts-2        	       3	 366672131 ns/op	75139373 B/op	  742471 allocs/op
BenchmarkTopologyContainers-2   	      10	 178938068 ns/op	29289833 B/op	  272342 allocs/op
```
