### PR TITLE
Rewrite more Map-Reduces as Renderers to save garbage

### DIFF
--- a/render/container.go
+++ b/render/container.go
@@ -82,7 +82,7 @@ func (c connectionJoin) Render(rpt report.Report) Nodes {
 		// Nodes without a hostid may be pseudo nodes - if so, pass through to result
 		if _, ok := m.Latest.Lookup(report.HostNodeID); !ok {
 			if id, ok := externalNodeID(m, addr, local); ok {
-				ret.addToResults(m, id, newPseudoNode)
+				ret.addChild(m, id, newPseudoNode)
 				continue
 			}
 		}
@@ -94,7 +94,7 @@ func (c connectionJoin) Render(rpt report.Report) Nodes {
 			id, found = ipNodes[report.MakeScopedEndpointNodeID(scope, addr, port)]
 		}
 		if found && id != "" { // not one we blanked out earlier
-			ret.addToResults(m, id, func(id string) report.Node {
+			ret.addChild(m, id, func(id string) report.Node {
 				return inputNodes.Nodes[id]
 			})
 		}

--- a/render/host.go
+++ b/render/host.go
@@ -10,26 +10,14 @@ import (
 // not memoised
 var HostRenderer = MakeReduce(
 	endpoints2Hosts{},
-	MakeMap(
-		MapX2Host,
-		ColorConnectedProcessRenderer,
-	),
-	MakeMap(
-		MapX2Host,
-		ContainerRenderer,
-	),
-	MakeMap(
-		MapX2Host,
-		ContainerImageRenderer,
-	),
-	MakeMap(
-		MapX2Host,
-		PodRenderer,
-	),
+	CustomRenderer{RenderFunc: nodes2Hosts, Renderer: ColorConnectedProcessRenderer},
+	CustomRenderer{RenderFunc: nodes2Hosts, Renderer: ContainerRenderer},
+	CustomRenderer{RenderFunc: nodes2Hosts, Renderer: ContainerImageRenderer},
+	CustomRenderer{RenderFunc: nodes2Hosts, Renderer: PodRenderer},
 	SelectHost,
 )
 
-// MapX2Host maps any Nodes to host Nodes.
+// nodes2Hosts maps any Nodes to host Nodes.
 //
 // If this function is given a node without a hostname
 // (including other pseudo nodes), it will drop the node.
@@ -38,27 +26,22 @@ var HostRenderer = MakeReduce(
 // format for a host, but without any Major or Minor labels.  It does
 // not have enough info to do that, and the resulting graph must be
 // merged with a host graph to get that info.
-func MapX2Host(n report.Node, _ report.Networks) report.Nodes {
-	// Don't propagate pseudo nodes - we do this in MapEndpoint2Host
-	if n.Topology == Pseudo {
-		return report.Nodes{}
-	}
+func nodes2Hosts(nodes Nodes) Nodes {
+	ret := newJoinResults()
 
-	hostIDs, ok := n.Parents.Lookup(report.Host)
-	if !ok {
-		return report.Nodes{}
+	for _, n := range nodes.Nodes {
+		if n.Topology == Pseudo {
+			continue // Don't propagate pseudo nodes - we do this in MapEndpoint2Host
+		}
+		hostIDs, _ := n.Parents.Lookup(report.Host)
+		for _, id := range hostIDs {
+			ret.addChild(n, id, func(id string) report.Node {
+				return report.MakeNode(id).WithTopology(report.Host)
+			})
+		}
 	}
-
-	result := report.Nodes{}
-	children := report.MakeNodeSet(n)
-	for _, id := range hostIDs {
-		node := NewDerivedNode(id, n).WithTopology(report.Host)
-		node.Counters = node.Counters.Add(n.Topology, 1)
-		node.Children = children
-		result[id] = node
-	}
-
-	return result
+	ret.fixupAdjacencies(nodes)
+	return ret.result()
 }
 
 // endpoints2Hosts takes nodes from the endpoint topology and produces

--- a/render/host.go
+++ b/render/host.go
@@ -79,10 +79,10 @@ func (e endpoints2Hosts) Render(rpt report.Report) Nodes {
 			if !ok {
 				continue
 			}
-			ret.addToResults(n, id, newPseudoNode)
+			ret.addChild(n, id, newPseudoNode)
 		} else {
 			id := report.MakeHostNodeID(report.ExtractHostID(n))
-			ret.addToResults(n, id, func(id string) report.Node {
+			ret.addChild(n, id, func(id string) report.Node {
 				return report.MakeNode(id).WithTopology(report.Host).
 					WithLatest(report.HostNodeID, timestamp, hostNodeID)
 			})

--- a/render/host.go
+++ b/render/host.go
@@ -31,7 +31,7 @@ func nodes2Hosts(nodes Nodes) Nodes {
 
 	for _, n := range nodes.Nodes {
 		if n.Topology == Pseudo {
-			continue // Don't propagate pseudo nodes - we do this in MapEndpoint2Host
+			continue // Don't propagate pseudo nodes - we do this in endpoints2Hosts
 		}
 		hostIDs, _ := n.Parents.Lookup(report.Host)
 		for _, id := range hostIDs {

--- a/render/process.go
+++ b/render/process.go
@@ -99,7 +99,7 @@ func (e endpoints2Processes) Render(rpt report.Report) Nodes {
 		// Nodes without a hostid are treated as pseudo nodes
 		if hostNodeID, ok := n.Latest.Lookup(report.HostNodeID); !ok {
 			if id, ok := pseudoNodeID(n, local); ok {
-				ret.addToResults(n, id, newPseudoNode)
+				ret.addChild(n, id, newPseudoNode)
 			}
 		} else {
 			pid, timestamp, ok := n.Latest.LookupEntry(process.PID)
@@ -116,7 +116,7 @@ func (e endpoints2Processes) Render(rpt report.Report) Nodes {
 
 			hostID, _, _ := report.ParseNodeID(hostNodeID)
 			id := report.MakeProcessNodeID(hostID, pid)
-			ret.addToResults(n, id, func(id string) report.Node {
+			ret.addChild(n, id, func(id string) report.Node {
 				if processNode, found := processes.Nodes[id]; found {
 					return processNode
 				}

--- a/render/process.go
+++ b/render/process.go
@@ -74,12 +74,7 @@ var ProcessWithContainerNameRenderer = processWithContainerNameRenderer{ProcessR
 // name graph by munging the progess graph.
 //
 // not memoised
-var ProcessNameRenderer = ConditionalRenderer(renderProcesses,
-	MakeMap(
-		MapProcess2Name,
-		ProcessRenderer,
-	),
-)
+var ProcessNameRenderer = CustomRenderer{RenderFunc: processes2Names, Renderer: ProcessRenderer}
 
 // endpoints2Processes joins the endpoint topology to the process
 // topology, matching on hostID and pid.
@@ -132,23 +127,23 @@ func (e endpoints2Processes) Render(rpt report.Report) Nodes {
 	return ret.result()
 }
 
-// MapProcess2Name maps process Nodes to Nodes
-// for each process name.
-//
-// This mapper is unlike the other foo2bar mappers as the intention
-// is not to join the information with another topology.
-func MapProcess2Name(n report.Node, _ report.Networks) report.Nodes {
-	if n.Topology == Pseudo {
-		return report.Nodes{n.ID: n}
-	}
+// processes2Names maps process Nodes to Nodes for each process name.
+func processes2Names(processes Nodes) Nodes {
+	ret := newJoinResults()
 
-	name, timestamp, ok := n.Latest.LookupEntry(process.Name)
-	if !ok {
-		return report.Nodes{}
+	for _, n := range processes.Nodes {
+		if n.Topology == Pseudo {
+			ret.passThrough(n)
+		} else {
+			name, timestamp, ok := n.Latest.LookupEntry(process.Name)
+			if ok {
+				ret.addChildAndChildren(n, name, func(id string) report.Node {
+					return report.MakeNode(id).WithTopology(MakeGroupNodeTopology(n.Topology, process.Name)).
+						WithLatest(process.Name, timestamp, name)
+				})
+			}
+		}
 	}
-
-	node := NewDerivedNode(name, n).WithTopology(MakeGroupNodeTopology(n.Topology, process.Name))
-	node.Latest = node.Latest.Set(process.Name, timestamp, name)
-	node.Counters = node.Counters.Add(n.Topology, 1)
-	return report.Nodes{name: node}
+	ret.fixupAdjacencies(processes)
+	return ret.result()
 }

--- a/render/render.go
+++ b/render/render.go
@@ -188,6 +188,13 @@ func (ret *joinResults) addChildAndChildren(m report.Node, id string, create fun
 	ret.mapped[m.ID] = id
 }
 
+// Add a copy of n straight into the results
+func (ret *joinResults) passThrough(n report.Node) {
+	n.Adjacency = nil // fixupAdjacencies assumes all nodes start with blank lists
+	ret.nodes[n.ID] = n
+	ret.mapped[n.ID] = n.ID
+}
+
 // Rewrite Adjacency for new nodes in ret for original nodes in input
 func (ret *joinResults) fixupAdjacencies(input Nodes) {
 	for _, n := range input.Nodes {


### PR DESCRIPTION
`MapX2Host` and to a lesser extent `MapProcess2Name` have the property that they map many nodes onto fewer nodes, so looping and using the machinery in `joinResults` is more effective than creating many copies of the same node and merging.

Benchmarks before (c5bdebdffebfa7cc0839770a3bf70429260f1bc9):
```
BenchmarkTopologyList-2         	       2	 603197223 ns/op	112161732 B/op	 1253503 allocs/op
BenchmarkTopologyHosts-2        	       3	 385415232 ns/op	82957173 B/op	 1015204 allocs/op
BenchmarkTopologyContainers-2   	      10	 192766565 ns/op	33145659 B/op	  407698 allocs/op
```

after this PR:
```
BenchmarkTopologyList-2         	       3	 476705872 ns/op	101366640 B/op	 1109042 allocs/op
BenchmarkTopologyHosts-2        	       3	 373288182 ns/op	76540733 B/op	  933301 allocs/op
BenchmarkTopologyContainers-2   	      10	 183615683 ns/op	33132417 B/op	  407672 allocs/op
```
