### PR TITLE
pass render filters and maps by value rather than reference

### DIFF
--- a/render/filters.go
+++ b/render/filters.go
@@ -108,7 +108,7 @@ type Filter struct {
 
 // MakeFilter makes a new Filter (that ignores pseudo nodes).
 func MakeFilter(f FilterFunc, r Renderer) Renderer {
-	return &Filter{
+	return Filter{
 		Renderer: r,
 		FilterFunc: func(n report.Node) bool {
 			return n.Topology == Pseudo || f(n)
@@ -118,7 +118,7 @@ func MakeFilter(f FilterFunc, r Renderer) Renderer {
 
 // MakeFilterPseudo makes a new Filter that will not ignore pseudo nodes.
 func MakeFilterPseudo(f FilterFunc, r Renderer) Renderer {
-	return &Filter{
+	return Filter{
 		Renderer:   r,
 		FilterFunc: f,
 	}
@@ -141,11 +141,11 @@ func MakeFilterPseudoDecorator(f FilterFunc) Decorator {
 }
 
 // Render implements Renderer
-func (f *Filter) Render(rpt report.Report, dct Decorator) Nodes {
+func (f Filter) Render(rpt report.Report, dct Decorator) Nodes {
 	return f.render(rpt, dct)
 }
 
-func (f *Filter) render(rpt report.Report, dct Decorator) Nodes {
+func (f Filter) render(rpt report.Report, dct Decorator) Nodes {
 	output := report.Nodes{}
 	inDegrees := map[string]int{}
 	filtered := 0

--- a/render/render.go
+++ b/render/render.go
@@ -70,12 +70,12 @@ type Map struct {
 
 // MakeMap makes a new Map
 func MakeMap(f MapFunc, r Renderer) Renderer {
-	return &Map{f, r}
+	return Map{f, r}
 }
 
 // Render transforms a set of Nodes produces by another Renderer.
 // using a map function
-func (m *Map) Render(rpt report.Report, dct Decorator) Nodes {
+func (m Map) Render(rpt report.Report, dct Decorator) Nodes {
 	var (
 		input         = m.Renderer.Render(rpt, dct)
 		output        = report.Nodes{}


### PR DESCRIPTION
They are small and don't carry mutable state, so there is no point passing them by reference.