### PR TITLE
Expand the app's k8s namespace calculation

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -96,7 +96,8 @@ func updateSwarmFilters(rpt report.Report, topologies []APITopologyDesc) []APITo
 
 func updateKubeFilters(rpt report.Report, topologies []APITopologyDesc) []APITopologyDesc {
 	namespaces := map[string]struct{}{}
-	for _, t := range []report.Topology{rpt.Pod, rpt.Service, rpt.Deployment} {
+	// We exclude ReplicaSets since we don't show them anywhere.
+	for _, t := range []report.Topology{rpt.Pod, rpt.Service, rpt.Deployment, rpt.DaemonSet, rpt.StatefulSet, rpt.CronJob} {
 		for _, n := range t.Nodes {
 			if state, ok := n.Latest.Lookup(kubernetes.State); ok && state == kubernetes.StateDeleted {
 				continue


### PR DESCRIPTION
to include recently added k8s types.

This is all rather inefficient. See #2945.