### PR TITLE
Decorators, begone!

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -485,17 +485,17 @@ func (r *Registry) renderTopologies(rpt report.Report, req *http.Request) []APIT
 	req.ParseForm()
 	r.walk(func(desc APITopologyDesc) {
 		renderer, filter, _ := r.RendererForTopology(desc.id, req.Form, rpt)
-		desc.Stats = decorateWithStats(rpt, renderer, filter)
+		desc.Stats = computeStats(rpt, renderer, filter)
 		for i, sub := range desc.SubTopologies {
 			renderer, filter, _ := r.RendererForTopology(sub.id, req.Form, rpt)
-			desc.SubTopologies[i].Stats = decorateWithStats(rpt, renderer, filter)
+			desc.SubTopologies[i].Stats = computeStats(rpt, renderer, filter)
 		}
 		topologies = append(topologies, desc)
 	})
 	return updateFilters(rpt, topologies)
 }
 
-func decorateWithStats(rpt report.Report, renderer render.Renderer, filter render.FilterFunc) topologyStats {
+func computeStats(rpt report.Report, renderer render.Renderer, filter render.FilterFunc) topologyStats {
 	var (
 		nodes     int
 		realNodes int

--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -504,7 +504,7 @@ func decorateWithStats(rpt report.Report, renderer render.Renderer, decorator re
 		realNodes int
 		edges     int
 	)
-	r := renderer.Render(rpt, decorator)
+	r := render.Decorate(rpt, renderer, decorator)
 	for _, n := range r.Nodes {
 		nodes++
 		if n.Topology != render.Pseudo {
@@ -541,10 +541,7 @@ func (r *Registry) RendererForTopology(topologyID string, values url.Values, rpt
 		}
 	}
 	if len(decorators) > 0 {
-		// Here we tell the topology renderer to apply the filtering decorator
-		// that we construct as a composition of all the selected filters.
-		composedFilterDecorator := render.ComposeDecorators(decorators...)
-		return render.ApplyDecorator(topology.renderer), composedFilterDecorator, nil
+		return topology.renderer, render.ComposeDecorators(decorators...), nil
 	}
 	return topology.renderer, nil, nil
 }

--- a/app/api_topologies_test.go
+++ b/app/api_topologies_test.go
@@ -109,7 +109,7 @@ func TestRendererForTopologyWithFiltering(t *testing.T) {
 	urlvalues.Set(systemGroupID, customAPITopologyOptionFilterID)
 	urlvalues.Set("stopped", "running")
 	urlvalues.Set("pseudo", "hide")
-	renderer, decorator, err := topologyRegistry.RendererForTopology("containers", urlvalues, fixture.Report)
+	renderer, filter, err := topologyRegistry.RendererForTopology("containers", urlvalues, fixture.Report)
 	if err != nil {
 		t.Fatalf("Topology Registry Report error: %s", err)
 	}
@@ -118,7 +118,7 @@ func TestRendererForTopologyWithFiltering(t *testing.T) {
 	input.Container.Nodes[fixture.ClientContainerNodeID] = input.Container.Nodes[fixture.ClientContainerNodeID].WithLatests(map[string]string{
 		docker.LabelPrefix + "works.weave.role": "system",
 	})
-	have := utils.Prune(render.Decorate(input, renderer, decorator).Nodes)
+	have := utils.Prune(render.Render(input, renderer, filter).Nodes)
 	want := utils.Prune(expected.RenderedContainers.Copy())
 	delete(want, fixture.ClientContainerNodeID)
 	delete(want, render.MakePseudoNodeID(render.UncontainedID, fixture.ServerHostID))
@@ -140,7 +140,7 @@ func TestRendererForTopologyNoFiltering(t *testing.T) {
 	urlvalues.Set(systemGroupID, customAPITopologyOptionFilterID)
 	urlvalues.Set("stopped", "running")
 	urlvalues.Set("pseudo", "hide")
-	renderer, decorator, err := topologyRegistry.RendererForTopology("containers", urlvalues, fixture.Report)
+	renderer, filter, err := topologyRegistry.RendererForTopology("containers", urlvalues, fixture.Report)
 	if err != nil {
 		t.Fatalf("Topology Registry Report error: %s", err)
 	}
@@ -149,7 +149,7 @@ func TestRendererForTopologyNoFiltering(t *testing.T) {
 	input.Container.Nodes[fixture.ClientContainerNodeID] = input.Container.Nodes[fixture.ClientContainerNodeID].WithLatests(map[string]string{
 		docker.LabelPrefix + "works.weave.role": "system",
 	})
-	have := utils.Prune(render.Decorate(input, renderer, decorator).Nodes)
+	have := utils.Prune(render.Render(input, renderer, filter).Nodes)
 	want := utils.Prune(expected.RenderedContainers.Copy())
 	delete(want, render.MakePseudoNodeID(render.UncontainedID, fixture.ServerHostID))
 	delete(want, render.OutgoingInternetID)
@@ -178,12 +178,12 @@ func getTestContainerLabelFilterTopologySummary(t *testing.T, exclude bool) (det
 	urlvalues.Set(systemGroupID, customAPITopologyOptionFilterID)
 	urlvalues.Set("stopped", "running")
 	urlvalues.Set("pseudo", "hide")
-	renderer, decorator, err := topologyRegistry.RendererForTopology("containers", urlvalues, fixture.Report)
+	renderer, filter, err := topologyRegistry.RendererForTopology("containers", urlvalues, fixture.Report)
 	if err != nil {
 		return nil, err
 	}
 
-	return detailed.Summaries(report.RenderContext{Report: fixture.Report}, render.Decorate(fixture.Report, renderer, decorator).Nodes), nil
+	return detailed.Summaries(report.RenderContext{Report: fixture.Report}, render.Render(fixture.Report, renderer, filter).Nodes), nil
 }
 
 func TestAPITopologyAddsKubernetes(t *testing.T) {

--- a/app/api_topologies_test.go
+++ b/app/api_topologies_test.go
@@ -118,7 +118,7 @@ func TestRendererForTopologyWithFiltering(t *testing.T) {
 	input.Container.Nodes[fixture.ClientContainerNodeID] = input.Container.Nodes[fixture.ClientContainerNodeID].WithLatests(map[string]string{
 		docker.LabelPrefix + "works.weave.role": "system",
 	})
-	have := utils.Prune(renderer.Render(input, decorator).Nodes)
+	have := utils.Prune(render.Decorate(input, renderer, decorator).Nodes)
 	want := utils.Prune(expected.RenderedContainers.Copy())
 	delete(want, fixture.ClientContainerNodeID)
 	delete(want, render.MakePseudoNodeID(render.UncontainedID, fixture.ServerHostID))
@@ -149,7 +149,7 @@ func TestRendererForTopologyNoFiltering(t *testing.T) {
 	input.Container.Nodes[fixture.ClientContainerNodeID] = input.Container.Nodes[fixture.ClientContainerNodeID].WithLatests(map[string]string{
 		docker.LabelPrefix + "works.weave.role": "system",
 	})
-	have := utils.Prune(renderer.Render(input, decorator).Nodes)
+	have := utils.Prune(render.Decorate(input, renderer, decorator).Nodes)
 	want := utils.Prune(expected.RenderedContainers.Copy())
 	delete(want, render.MakePseudoNodeID(render.UncontainedID, fixture.ServerHostID))
 	delete(want, render.OutgoingInternetID)
@@ -183,7 +183,7 @@ func getTestContainerLabelFilterTopologySummary(t *testing.T, exclude bool) (det
 		return nil, err
 	}
 
-	return detailed.Summaries(report.RenderContext{Report: fixture.Report}, renderer.Render(fixture.Report, decorator).Nodes), nil
+	return detailed.Summaries(report.RenderContext{Report: fixture.Report}, render.Decorate(fixture.Report, renderer, decorator).Nodes), nil
 }
 
 func TestAPITopologyAddsKubernetes(t *testing.T) {

--- a/app/api_topology.go
+++ b/app/api_topology.go
@@ -51,7 +51,7 @@ func handleNode(ctx context.Context, renderer render.Renderer, decorator render.
 	// To avoid repeating the work from step (1) in step (2), we
 	// replace the renderer in the latter with a constant renderer of
 	// the result obtained in step (1).
-	nodes := renderer.Render(rc.Report, nil)
+	nodes := renderer.Render(rc.Report)
 	node, ok := nodes.Nodes[nodeID]
 	if !ok {
 		http.NotFound(w, r)

--- a/app/api_topology.go
+++ b/app/api_topology.go
@@ -44,13 +44,9 @@ func handleNode(ctx context.Context, renderer render.Renderer, filter render.Fil
 	)
 	// We must not lose the node during filtering. We achieve that by
 	// (1) rendering the report with the base renderer, without
-	// filtering, which gives us the node (if it exists at all), then
-	// (2) performing a normal filtered render of the report. If the
+	// filtering, which gives us the node (if it exists at all), and
+	// then (2) applying the filter separately to that result.  If the
 	// node is lost in the second step, we simply put it back.
-	//
-	// To avoid repeating the work from step (1) in step (2), we
-	// replace the renderer in the latter with a constant renderer of
-	// the result obtained in step (1).
 	nodes := renderer.Render(rc.Report)
 	node, ok := nodes.Nodes[nodeID]
 	if !ok {
@@ -58,7 +54,7 @@ func handleNode(ctx context.Context, renderer render.Renderer, filter render.Fil
 		return
 	}
 	if filter != nil {
-		nodes = render.Render(rc.Report, render.ConstantRenderer{Nodes: nodes}, filter)
+		nodes = filter.Apply(nodes)
 		if filteredNode, ok := nodes.Nodes[nodeID]; ok {
 			node = filteredNode
 		} else { // we've lost the node during filtering; put it back

--- a/app/benchmark_internal_test.go
+++ b/app/benchmark_internal_test.go
@@ -65,10 +65,10 @@ func BenchmarkTopologyContainers(b *testing.B) {
 
 func benchmarkOneTopology(b *testing.B, topologyID string) {
 	benchmarkRender(b, func(report report.Report) {
-		renderer, decorator, err := topologyRegistry.RendererForTopology(topologyID, url.Values{}, report)
+		renderer, filter, err := topologyRegistry.RendererForTopology(topologyID, url.Values{}, report)
 		if err != nil {
 			b.Fatal(err)
 		}
-		render.Decorate(report, renderer, decorator)
+		render.Render(report, renderer, filter)
 	})
 }

--- a/app/benchmark_internal_test.go
+++ b/app/benchmark_internal_test.go
@@ -69,6 +69,6 @@ func benchmarkOneTopology(b *testing.B, topologyID string) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		renderer.Render(report, decorator)
+		render.Decorate(report, renderer, decorator)
 	})
 }

--- a/render/benchmark_test.go
+++ b/render/benchmark_test.go
@@ -52,7 +52,7 @@ func benchmarkRender(b *testing.B, r render.Renderer) {
 		b.StopTimer()
 		render.ResetCache()
 		b.StartTimer()
-		benchmarkRenderResult = r.Render(report, FilterNoop)
+		benchmarkRenderResult = r.Render(report)
 		if len(benchmarkRenderResult.Nodes) == 0 {
 			b.Errorf("Rendered topology contained no nodes")
 		}

--- a/render/container.go
+++ b/render/container.go
@@ -53,10 +53,10 @@ type connectionJoin struct {
 	r     Renderer
 }
 
-func (c connectionJoin) Render(rpt report.Report, dct Decorator) Nodes {
+func (c connectionJoin) Render(rpt report.Report) Nodes {
 	local := LocalNetworks(rpt)
-	inputNodes := c.r.Render(rpt, dct)
-	endpoints := SelectEndpoint.Render(rpt, dct)
+	inputNodes := c.r.Render(rpt)
+	endpoints := SelectEndpoint.Render(rpt)
 
 	// Collect all the IPs we are trying to map to, and which ID they map from
 	var ipNodes = map[string]string{}
@@ -131,9 +131,9 @@ type containerWithImageNameRenderer struct {
 
 // Render produces a container graph where the the latest metadata contains the
 // container image name, if found.
-func (r containerWithImageNameRenderer) Render(rpt report.Report, dct Decorator) Nodes {
-	containers := r.Renderer.Render(rpt, dct)
-	images := SelectContainerImage.Render(rpt, dct)
+func (r containerWithImageNameRenderer) Render(rpt report.Report) Nodes {
+	containers := r.Renderer.Render(rpt)
+	images := SelectContainerImage.Render(rpt)
 
 	outputs := report.Nodes{}
 	for id, c := range containers.Nodes {

--- a/render/container.go
+++ b/render/container.go
@@ -285,7 +285,7 @@ func MapProcess2Container(n report.Node, _ report.Networks) report.Nodes {
 		id = MakePseudoNodeID(UncontainedID, report.ExtractHostID(n))
 		node = NewDerivedPseudoNode(id, n)
 		node = propagateLatest(report.HostNodeID, n, node)
-		node = propagateLatest(IsConnected, n, node)
+		node = propagateLatest(IsConnectedMark, n, node)
 	}
 	return report.Nodes{id: node}
 }

--- a/render/container_test.go
+++ b/render/container_test.go
@@ -59,7 +59,7 @@ func testMap(t *testing.T, f render.MapFunc, input testcase) {
 }
 
 func TestContainerRenderer(t *testing.T) {
-	have := utils.Prune(render.ContainerWithImageNameRenderer.Render(fixture.Report, FilterNoop).Nodes)
+	have := utils.Prune(render.ContainerWithImageNameRenderer.Render(fixture.Report).Nodes)
 	want := utils.Prune(expected.RenderedContainers)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))

--- a/render/container_test.go
+++ b/render/container_test.go
@@ -70,13 +70,12 @@ func TestContainerFilterRenderer(t *testing.T) {
 	// tag on of the containers in the topology and ensure
 	// it is filtered out correctly.
 	input := fixture.Report.Copy()
-	renderer := render.ApplyDecorator(render.ContainerWithImageNameRenderer)
 
 	input.Container.Nodes[fixture.ClientContainerNodeID] = input.Container.Nodes[fixture.ClientContainerNodeID].WithLatests(map[string]string{
 		docker.LabelPrefix + "works.weave.role": "system",
 	})
 
-	have := utils.Prune(renderer.Render(input, FilterApplication).Nodes)
+	have := utils.Prune(render.Decorate(input, render.ContainerWithImageNameRenderer, FilterApplication).Nodes)
 	want := utils.Prune(expected.RenderedContainers.Copy())
 	delete(want, fixture.ClientContainerNodeID)
 	if !reflect.DeepEqual(want, have) {
@@ -85,8 +84,7 @@ func TestContainerFilterRenderer(t *testing.T) {
 }
 
 func TestContainerHostnameRenderer(t *testing.T) {
-	renderer := render.ApplyDecorator(render.ContainerHostnameRenderer)
-	have := utils.Prune(renderer.Render(fixture.Report, FilterNoop).Nodes)
+	have := utils.Prune(render.Decorate(fixture.Report, render.ContainerHostnameRenderer, FilterNoop).Nodes)
 	want := utils.Prune(expected.RenderedContainerHostnames)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -94,8 +92,7 @@ func TestContainerHostnameRenderer(t *testing.T) {
 }
 
 func TestContainerHostnameFilterRenderer(t *testing.T) {
-	renderer := render.ApplyDecorator(render.ContainerHostnameRenderer)
-	have := utils.Prune(renderer.Render(fixture.Report, FilterSystem).Nodes)
+	have := utils.Prune(render.Decorate(fixture.Report, render.ContainerHostnameRenderer, FilterSystem).Nodes)
 	want := utils.Prune(expected.RenderedContainerHostnames.Copy())
 	delete(want, fixture.ClientContainerHostname)
 	delete(want, fixture.ServerContainerHostname)
@@ -106,8 +103,7 @@ func TestContainerHostnameFilterRenderer(t *testing.T) {
 }
 
 func TestContainerImageRenderer(t *testing.T) {
-	renderer := render.ApplyDecorator(render.ContainerImageRenderer)
-	have := utils.Prune(renderer.Render(fixture.Report, FilterNoop).Nodes)
+	have := utils.Prune(render.Decorate(fixture.Report, render.ContainerImageRenderer, FilterNoop).Nodes)
 	want := utils.Prune(expected.RenderedContainerImages)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -115,8 +111,7 @@ func TestContainerImageRenderer(t *testing.T) {
 }
 
 func TestContainerImageFilterRenderer(t *testing.T) {
-	renderer := render.ApplyDecorator(render.ContainerImageRenderer)
-	have := utils.Prune(renderer.Render(fixture.Report, FilterSystem).Nodes)
+	have := utils.Prune(render.Decorate(fixture.Report, render.ContainerImageRenderer, FilterSystem).Nodes)
 	want := utils.Prune(expected.RenderedContainerHostnames.Copy())
 	delete(want, fixture.ClientContainerHostname)
 	delete(want, fixture.ServerContainerHostname)

--- a/render/detailed/node_test.go
+++ b/render/detailed/node_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func child(t *testing.T, r render.Renderer, id string) detailed.NodeSummary {
-	s, ok := detailed.MakeNodeSummary(report.RenderContext{Report: fixture.Report}, r.Render(fixture.Report, nil).Nodes[id])
+	s, ok := detailed.MakeNodeSummary(report.RenderContext{Report: fixture.Report}, r.Render(fixture.Report).Nodes[id])
 	if !ok {
 		t.Fatalf("Expected node %s to be summarizable, but wasn't", id)
 	}
@@ -30,7 +30,7 @@ func connectionID(nodeID string, addr string) string {
 }
 
 func TestMakeDetailedHostNode(t *testing.T) {
-	renderableNodes := render.HostRenderer.Render(fixture.Report, nil).Nodes
+	renderableNodes := render.HostRenderer.Render(fixture.Report).Nodes
 	renderableNode := renderableNodes[fixture.ClientHostNodeID]
 	have := detailed.MakeNode("hosts", report.RenderContext{Report: fixture.Report}, renderableNodes, renderableNode)
 
@@ -178,7 +178,7 @@ func TestMakeDetailedHostNode(t *testing.T) {
 
 func TestMakeDetailedContainerNode(t *testing.T) {
 	id := fixture.ServerContainerNodeID
-	renderableNodes := render.ContainerWithImageNameRenderer.Render(fixture.Report, nil).Nodes
+	renderableNodes := render.ContainerWithImageNameRenderer.Render(fixture.Report).Nodes
 	renderableNode, ok := renderableNodes[id]
 	if !ok {
 		t.Fatalf("Node not found: %s", id)
@@ -308,7 +308,7 @@ func TestMakeDetailedContainerNode(t *testing.T) {
 
 func TestMakeDetailedPodNode(t *testing.T) {
 	id := fixture.ServerPodNodeID
-	renderableNodes := render.PodRenderer.Render(fixture.Report, nil).Nodes
+	renderableNodes := render.PodRenderer.Render(fixture.Report).Nodes
 	renderableNode, ok := renderableNodes[id]
 	if !ok {
 		t.Fatalf("Node not found: %s", id)

--- a/render/detailed/parents_test.go
+++ b/render/detailed/parents_test.go
@@ -21,25 +21,25 @@ func TestParents(t *testing.T) {
 	}{
 		{
 			name: "Node accidentally tagged with itself",
-			node: render.HostRenderer.Render(fixture.Report, nil).Nodes[fixture.ClientHostNodeID].WithParents(
+			node: render.HostRenderer.Render(fixture.Report).Nodes[fixture.ClientHostNodeID].WithParents(
 				report.MakeSets().Add(report.Host, report.MakeStringSet(fixture.ClientHostNodeID)),
 			),
 			want: nil,
 		},
 		{
-			node: render.HostRenderer.Render(fixture.Report, nil).Nodes[fixture.ClientHostNodeID],
+			node: render.HostRenderer.Render(fixture.Report).Nodes[fixture.ClientHostNodeID],
 			want: nil,
 		},
 		{
 			name: "Container image",
-			node: render.ContainerImageRenderer.Render(fixture.Report, nil).Nodes[expected.ClientContainerImageNodeID],
+			node: render.ContainerImageRenderer.Render(fixture.Report).Nodes[expected.ClientContainerImageNodeID],
 			want: []detailed.Parent{
 				{ID: fixture.ClientHostNodeID, Label: fixture.ClientHostName, TopologyID: "hosts"},
 			},
 		},
 		{
 			name: "Container",
-			node: render.ContainerWithImageNameRenderer.Render(fixture.Report, nil).Nodes[fixture.ClientContainerNodeID],
+			node: render.ContainerWithImageNameRenderer.Render(fixture.Report).Nodes[fixture.ClientContainerNodeID],
 			want: []detailed.Parent{
 				{ID: expected.ClientContainerImageNodeID, Label: fixture.ClientContainerImageName, TopologyID: "containers-by-image"},
 				{ID: fixture.ClientHostNodeID, Label: fixture.ClientHostName, TopologyID: "hosts"},
@@ -47,7 +47,7 @@ func TestParents(t *testing.T) {
 			},
 		},
 		{
-			node: render.ProcessRenderer.Render(fixture.Report, nil).Nodes[fixture.ClientProcess1NodeID],
+			node: render.ProcessRenderer.Render(fixture.Report).Nodes[fixture.ClientProcess1NodeID],
 			want: []detailed.Parent{
 				{ID: fixture.ClientContainerNodeID, Label: fixture.ClientContainerName, TopologyID: "containers"},
 				{ID: fixture.ClientHostNodeID, Label: fixture.ClientHostName, TopologyID: "hosts"},

--- a/render/detailed/summary.go
+++ b/render/detailed/summary.go
@@ -209,8 +209,7 @@ func processNodeSummary(base NodeSummary, n report.Node) (NodeSummary, bool) {
 		base.LabelMinor = fmt.Sprintf("%s (%s)", report.ExtractHostID(n), pid)
 	}
 
-	_, isConnected := n.Latest.Lookup(render.IsConnected)
-	base.Linkable = isConnected
+	base.Linkable = render.IsConnected(n)
 	return base, true
 }
 

--- a/render/detailed/summary_test.go
+++ b/render/detailed/summary_test.go
@@ -21,7 +21,7 @@ import (
 func TestSummaries(t *testing.T) {
 	{
 		// Just a convenient source of some rendered nodes
-		have := detailed.Summaries(report.RenderContext{Report: fixture.Report}, render.ProcessRenderer.Render(fixture.Report, nil).Nodes)
+		have := detailed.Summaries(report.RenderContext{Report: fixture.Report}, render.ProcessRenderer.Render(fixture.Report).Nodes)
 		// The ids of the processes rendered above
 		expectedIDs := []string{
 			fixture.ClientProcess1NodeID,
@@ -51,7 +51,7 @@ func TestSummaries(t *testing.T) {
 		input := fixture.Report.Copy()
 
 		input.Process.Nodes[fixture.ClientProcess1NodeID].Metrics[process.CPUUsage] = metric
-		have := detailed.Summaries(report.RenderContext{Report: input}, render.ProcessRenderer.Render(input, nil).Nodes)
+		have := detailed.Summaries(report.RenderContext{Report: input}, render.ProcessRenderer.Render(input).Nodes)
 
 		node, ok := have[fixture.ClientProcess1NodeID]
 		if !ok {

--- a/render/filters.go
+++ b/render/filters.go
@@ -106,22 +106,6 @@ func MakeFilterPseudo(f FilterFunc, r Renderer) Renderer {
 	}
 }
 
-// MakeFilterDecorator makes a decorator that filters out non-pseudo nodes
-// which match the predicate.
-func MakeFilterDecorator(f FilterFunc) Decorator {
-	return func(renderer Renderer) Renderer {
-		return MakeFilter(f, renderer)
-	}
-}
-
-// MakeFilterPseudoDecorator makes a decorator that filters out all nodes
-// (including pseudo nodes) which match the predicate.
-func MakeFilterPseudoDecorator(f FilterFunc) Decorator {
-	return func(renderer Renderer) Renderer {
-		return MakeFilterPseudo(f, renderer)
-	}
-}
-
 // Render implements Renderer
 func (f Filter) Render(rpt report.Report) Nodes {
 	return f.render(rpt)

--- a/render/filters.go
+++ b/render/filters.go
@@ -23,8 +23,8 @@ type CustomRenderer struct {
 }
 
 // Render implements Renderer
-func (c CustomRenderer) Render(rpt report.Report, dct Decorator) Nodes {
-	return c.RenderFunc(c.Renderer.Render(rpt, dct))
+func (c CustomRenderer) Render(rpt report.Report) Nodes {
+	return c.RenderFunc(c.Renderer.Render(rpt))
 }
 
 // ColorConnected colors nodes with the IsConnected key if
@@ -123,15 +123,15 @@ func MakeFilterPseudoDecorator(f FilterFunc) Decorator {
 }
 
 // Render implements Renderer
-func (f Filter) Render(rpt report.Report, dct Decorator) Nodes {
-	return f.render(rpt, dct)
+func (f Filter) Render(rpt report.Report) Nodes {
+	return f.render(rpt)
 }
 
-func (f Filter) render(rpt report.Report, dct Decorator) Nodes {
+func (f Filter) render(rpt report.Report) Nodes {
 	output := report.Nodes{}
 	inDegrees := map[string]int{}
 	filtered := 0
-	for id, node := range f.Renderer.Render(rpt, dct).Nodes {
+	for id, node := range f.Renderer.Render(rpt).Nodes {
 		if f.FilterFunc(node) {
 			output[id] = node
 			inDegrees[id] = 0

--- a/render/filters.go
+++ b/render/filters.go
@@ -14,24 +14,6 @@ const (
 	swarmNamespaceLabel = "com.docker.stack.namespace"
 )
 
-// PreciousNodeRenderer ensures a node is never filtered out by decorators
-type PreciousNodeRenderer struct {
-	PreciousNodeID string
-	Renderer
-}
-
-// Render implements Renderer
-func (p PreciousNodeRenderer) Render(rpt report.Report, dct Decorator) Nodes {
-	undecoratedNodes := p.Renderer.Render(rpt, nil)
-	preciousNode, foundBeforeDecoration := undecoratedNodes.Nodes[p.PreciousNodeID]
-	finalNodes := applyDecorator{ConstantRenderer{undecoratedNodes}}.Render(rpt, dct)
-	if _, ok := finalNodes.Nodes[p.PreciousNodeID]; !ok && foundBeforeDecoration {
-		finalNodes.Nodes[p.PreciousNodeID] = preciousNode
-		finalNodes.Filtered--
-	}
-	return finalNodes
-}
-
 // CustomRenderer allow for mapping functions that received the entire topology
 // in one call - useful for functions that need to consider the entire graph.
 // We should minimise the use of this renderer type, as it is very inflexible.

--- a/render/filters_test.go
+++ b/render/filters_test.go
@@ -16,7 +16,7 @@ func TestFilterRender(t *testing.T) {
 		"baz": report.MakeNode("baz"),
 	}}
 	have := report.MakeIDList()
-	for id := range renderer.Render(report.MakeReport(), render.FilterUnconnected).Nodes {
+	for id := range render.Decorate(report.MakeReport(), renderer, render.FilterUnconnected).Nodes {
 		have = have.Add(id)
 	}
 	want := report.MakeIDList("foo", "bar")
@@ -41,7 +41,7 @@ func TestFilterRender2(t *testing.T) {
 		"baz": report.MakeNode("baz"),
 	}}
 
-	have := renderer.Render(report.MakeReport(), filter).Nodes
+	have := render.Decorate(report.MakeReport(), renderer, filter).Nodes
 	if have["foo"].Adjacency.Contains("bar") {
 		t.Error("adjacencies for removed nodes should have been removed")
 	}
@@ -66,7 +66,7 @@ func TestFilterUnconnectedPseudoNodes(t *testing.T) {
 			}
 		}
 		want := nodes
-		have := renderer.Render(report.MakeReport(), filter).Nodes
+		have := render.Decorate(report.MakeReport(), renderer, filter).Nodes
 		if !reflect.DeepEqual(want, have) {
 			t.Error(test.Diff(want, have))
 		}
@@ -85,7 +85,7 @@ func TestFilterUnconnectedPseudoNodes(t *testing.T) {
 			"bar": report.MakeNode("bar").WithAdjacent("baz"),
 			"baz": report.MakeNode("baz").WithTopology(render.Pseudo),
 		}}
-		have := renderer.Render(report.MakeReport(), filter).Nodes
+		have := render.Decorate(report.MakeReport(), renderer, filter).Nodes
 		if _, ok := have["baz"]; ok {
 			t.Error("expected the unconnected pseudonode baz to have been removed")
 		}
@@ -104,7 +104,7 @@ func TestFilterUnconnectedPseudoNodes(t *testing.T) {
 			"bar": report.MakeNode("bar").WithAdjacent("foo"),
 			"baz": report.MakeNode("baz").WithTopology(render.Pseudo).WithAdjacent("bar"),
 		}}
-		have := renderer.Render(report.MakeReport(), filter).Nodes
+		have := render.Decorate(report.MakeReport(), renderer, filter).Nodes
 		if _, ok := have["baz"]; ok {
 			t.Error("expected the unconnected pseudonode baz to have been removed")
 		}
@@ -118,7 +118,7 @@ func TestFilterUnconnectedSelf(t *testing.T) {
 			"foo": report.MakeNode("foo").WithAdjacent("foo"),
 		}
 		renderer := mockRenderer{Nodes: nodes}
-		have := renderer.Render(report.MakeReport(), render.FilterUnconnected).Nodes
+		have := render.Decorate(report.MakeReport(), renderer, render.FilterUnconnected).Nodes
 		if len(have) > 0 {
 			t.Error("expected node only connected to self to be removed")
 		}

--- a/render/host.go
+++ b/render/host.go
@@ -66,9 +66,9 @@ func MapX2Host(n report.Node, _ report.Networks) report.Nodes {
 type endpoints2Hosts struct {
 }
 
-func (e endpoints2Hosts) Render(rpt report.Report, dct Decorator) Nodes {
+func (e endpoints2Hosts) Render(rpt report.Report) Nodes {
 	local := LocalNetworks(rpt)
-	endpoints := SelectEndpoint.Render(rpt, dct)
+	endpoints := SelectEndpoint.Render(rpt)
 	ret := newJoinResults()
 
 	for _, n := range endpoints.Nodes {

--- a/render/host_test.go
+++ b/render/host_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestHostRenderer(t *testing.T) {
-	have := utils.Prune(render.HostRenderer.Render(fixture.Report, FilterNoop).Nodes)
+	have := utils.Prune(render.HostRenderer.Render(fixture.Report).Nodes)
 	want := utils.Prune(expected.RenderedHosts)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))

--- a/render/memoise.go
+++ b/render/memoise.go
@@ -37,13 +37,7 @@ func Memoise(r Renderer) Renderer {
 // retrieves a promise from the cache and returns its value, otherwise
 // it stores a new promise and fulfils it by calling through to
 // m.Renderer.
-//
-// The cache is bypassed when rendering a report with a decorator.
-func (m *memoise) Render(rpt report.Report, dct Decorator) Nodes {
-	if dct != nil {
-		return m.Renderer.Render(rpt, dct)
-	}
-
+func (m *memoise) Render(rpt report.Report) Nodes {
 	key := fmt.Sprintf("%s-%s", rpt.ID, m.id)
 
 	m.Lock()
@@ -56,7 +50,7 @@ func (m *memoise) Render(rpt report.Report, dct Decorator) Nodes {
 	renderCache.Set(key, promise)
 	m.Unlock()
 
-	output := m.Renderer.Render(rpt, dct)
+	output := m.Renderer.Render(rpt)
 
 	promise.Set(output)
 

--- a/render/memoise_test.go
+++ b/render/memoise_test.go
@@ -11,7 +11,7 @@ import (
 
 type renderFunc func(r report.Report) render.Nodes
 
-func (f renderFunc) Render(r report.Report, _ render.Decorator) render.Nodes { return f(r) }
+func (f renderFunc) Render(r report.Report) render.Nodes { return f(r) }
 
 func TestMemoise(t *testing.T) {
 	calls := 0
@@ -22,7 +22,7 @@ func TestMemoise(t *testing.T) {
 	m := render.Memoise(r)
 	rpt1 := report.MakeReport()
 
-	result1 := m.Render(rpt1, nil)
+	result1 := m.Render(rpt1)
 	// it should have rendered it.
 	if _, ok := result1.Nodes[rpt1.ID]; !ok {
 		t.Errorf("Expected rendered report to contain a node, but got: %v", result1)
@@ -31,7 +31,7 @@ func TestMemoise(t *testing.T) {
 		t.Errorf("Expected renderer to have been called the first time")
 	}
 
-	result2 := m.Render(rpt1, nil)
+	result2 := m.Render(rpt1)
 	if !reflect.DeepEqual(result1, result2) {
 		t.Errorf("Expected memoised result to be returned: %s", test.Diff(result1, result2))
 	}
@@ -40,7 +40,7 @@ func TestMemoise(t *testing.T) {
 	}
 
 	rpt2 := report.MakeReport()
-	result3 := m.Render(rpt2, nil)
+	result3 := m.Render(rpt2)
 	if reflect.DeepEqual(result1, result3) {
 		t.Errorf("Expected different result for different report, but were the same")
 	}
@@ -49,7 +49,7 @@ func TestMemoise(t *testing.T) {
 	}
 
 	render.ResetCache()
-	result4 := m.Render(rpt1, nil)
+	result4 := m.Render(rpt1)
 	if !reflect.DeepEqual(result1, result4) {
 		t.Errorf("Expected original result to be returned: %s", test.Diff(result1, result4))
 	}

--- a/render/pod.go
+++ b/render/pod.go
@@ -117,7 +117,7 @@ func renderParents(childTopology string, parentTopologies []string, noParentsPse
 // to deployments where applicable.
 type selectPodsWithDeployments struct{}
 
-func (s selectPodsWithDeployments) Render(rpt report.Report, dct Decorator) Nodes {
+func (s selectPodsWithDeployments) Render(rpt report.Report) Nodes {
 	result := report.Nodes{}
 	// For each pod, we check for any replica sets, and merge any deployments they point to
 	// into a replacement Parents value.

--- a/render/pod_test.go
+++ b/render/pod_test.go
@@ -28,13 +28,11 @@ func TestPodFilterRenderer(t *testing.T) {
 	// tag on containers or pod namespace in the topology and ensure
 	// it is filtered out correctly.
 	input := fixture.Report.Copy()
-	renderer := render.ApplyDecorator(render.PodRenderer)
-
 	input.Pod.Nodes[fixture.ClientPodNodeID] = input.Pod.Nodes[fixture.ClientPodNodeID].WithLatests(map[string]string{
 		kubernetes.Namespace: "kube-system",
 	})
 
-	have := utils.Prune(renderer.Render(input, filterNonKubeSystem).Nodes)
+	have := utils.Prune(render.Decorate(input, render.PodRenderer, filterNonKubeSystem).Nodes)
 	want := utils.Prune(expected.RenderedPods.Copy())
 	delete(want, fixture.ClientPodNodeID)
 	if !reflect.DeepEqual(want, have) {
@@ -54,13 +52,11 @@ func TestPodServiceFilterRenderer(t *testing.T) {
 	// tag on containers or pod namespace in the topology and ensure
 	// it is filtered out correctly.
 	input := fixture.Report.Copy()
-	renderer := render.ApplyDecorator(render.PodServiceRenderer)
-
 	input.Service.Nodes[fixture.ServiceNodeID] = input.Service.Nodes[fixture.ServiceNodeID].WithLatests(map[string]string{
 		kubernetes.Namespace: "kube-system",
 	})
 
-	have := utils.Prune(renderer.Render(input, filterNonKubeSystem).Nodes)
+	have := utils.Prune(render.Decorate(input, render.PodServiceRenderer, filterNonKubeSystem).Nodes)
 	want := utils.Prune(expected.RenderedPodServices.Copy())
 	delete(want, fixture.ServiceNodeID)
 	delete(want, render.IncomingInternetID)

--- a/render/pod_test.go
+++ b/render/pod_test.go
@@ -20,9 +20,7 @@ func TestPodRenderer(t *testing.T) {
 	}
 }
 
-func filterNonKubeSystem(renderer render.Renderer) render.Renderer {
-	return render.MakeFilter(render.Complement(render.IsNamespace("kube-system")), renderer)
-}
+var filterNonKubeSystem = render.Complement(render.IsNamespace("kube-system"))
 
 func TestPodFilterRenderer(t *testing.T) {
 	// tag on containers or pod namespace in the topology and ensure
@@ -32,7 +30,7 @@ func TestPodFilterRenderer(t *testing.T) {
 		kubernetes.Namespace: "kube-system",
 	})
 
-	have := utils.Prune(render.Decorate(input, render.PodRenderer, filterNonKubeSystem).Nodes)
+	have := utils.Prune(render.Render(input, render.PodRenderer, filterNonKubeSystem).Nodes)
 	want := utils.Prune(expected.RenderedPods.Copy())
 	delete(want, fixture.ClientPodNodeID)
 	if !reflect.DeepEqual(want, have) {
@@ -56,7 +54,7 @@ func TestPodServiceFilterRenderer(t *testing.T) {
 		kubernetes.Namespace: "kube-system",
 	})
 
-	have := utils.Prune(render.Decorate(input, render.PodServiceRenderer, filterNonKubeSystem).Nodes)
+	have := utils.Prune(render.Render(input, render.PodServiceRenderer, filterNonKubeSystem).Nodes)
 	want := utils.Prune(expected.RenderedPodServices.Copy())
 	delete(want, fixture.ServiceNodeID)
 	delete(want, render.IncomingInternetID)

--- a/render/pod_test.go
+++ b/render/pod_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestPodRenderer(t *testing.T) {
-	have := utils.Prune(render.PodRenderer.Render(fixture.Report, nil).Nodes)
+	have := utils.Prune(render.PodRenderer.Render(fixture.Report).Nodes)
 	want := utils.Prune(expected.RenderedPods)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -41,7 +41,7 @@ func TestPodFilterRenderer(t *testing.T) {
 }
 
 func TestPodServiceRenderer(t *testing.T) {
-	have := utils.Prune(render.PodServiceRenderer.Render(fixture.Report, nil).Nodes)
+	have := utils.Prune(render.PodServiceRenderer.Render(fixture.Report).Nodes)
 	want := utils.Prune(expected.RenderedPodServices)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))

--- a/render/process.go
+++ b/render/process.go
@@ -40,9 +40,9 @@ type processWithContainerNameRenderer struct {
 	Renderer
 }
 
-func (r processWithContainerNameRenderer) Render(rpt report.Report, dct Decorator) Nodes {
-	processes := r.Renderer.Render(rpt, dct)
-	containers := SelectContainer.Render(rpt, dct)
+func (r processWithContainerNameRenderer) Render(rpt report.Report) Nodes {
+	processes := r.Renderer.Render(rpt)
+	containers := SelectContainer.Render(rpt)
 
 	outputs := report.Nodes{}
 	for id, p := range processes.Nodes {
@@ -86,13 +86,13 @@ var ProcessNameRenderer = ConditionalRenderer(renderProcesses,
 type endpoints2Processes struct {
 }
 
-func (e endpoints2Processes) Render(rpt report.Report, dct Decorator) Nodes {
+func (e endpoints2Processes) Render(rpt report.Report) Nodes {
 	if len(rpt.Process.Nodes) == 0 {
 		return Nodes{}
 	}
 	local := LocalNetworks(rpt)
-	processes := SelectProcess.Render(rpt, dct)
-	endpoints := SelectEndpoint.Render(rpt, dct)
+	processes := SelectProcess.Render(rpt)
+	endpoints := SelectEndpoint.Render(rpt)
 	ret := newJoinResults()
 
 	for _, n := range endpoints.Nodes {

--- a/render/process_test.go
+++ b/render/process_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestEndpointRenderer(t *testing.T) {
-	have := utils.Prune(render.EndpointRenderer.Render(fixture.Report, FilterNoop).Nodes)
+	have := utils.Prune(render.EndpointRenderer.Render(fixture.Report).Nodes)
 	want := utils.Prune(expected.RenderedEndpoints)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -20,7 +20,7 @@ func TestEndpointRenderer(t *testing.T) {
 }
 
 func TestProcessRenderer(t *testing.T) {
-	have := utils.Prune(render.ProcessRenderer.Render(fixture.Report, FilterNoop).Nodes)
+	have := utils.Prune(render.ProcessRenderer.Render(fixture.Report).Nodes)
 	want := utils.Prune(expected.RenderedProcesses)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -28,7 +28,7 @@ func TestProcessRenderer(t *testing.T) {
 }
 
 func TestProcessNameRenderer(t *testing.T) {
-	have := utils.Prune(render.ProcessNameRenderer.Render(fixture.Report, FilterNoop).Nodes)
+	have := utils.Prune(render.ProcessNameRenderer.Render(fixture.Report).Nodes)
 	want := utils.Prune(expected.RenderedProcessNames)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))

--- a/render/render.go
+++ b/render/render.go
@@ -31,10 +31,11 @@ func (r Nodes) Merge(o Nodes) Nodes {
 
 // Render renders the report and then applies the filter
 func Render(rpt report.Report, renderer Renderer, filter FilterFunc) Nodes {
+	nodes := renderer.Render(rpt)
 	if filter != nil {
-		renderer = MakeFilterPseudo(filter, renderer)
+		nodes = filter.Apply(nodes)
 	}
-	return renderer.Render(rpt)
+	return nodes
 }
 
 // Reduce renderer is a Renderer which merges together the output of several
@@ -145,16 +146,6 @@ func (cr conditionalRenderer) Render(rpt report.Report) Nodes {
 		return cr.Renderer.Render(rpt)
 	}
 	return Nodes{}
-}
-
-// ConstantRenderer renders a fixed set of nodes
-type ConstantRenderer struct {
-	Nodes
-}
-
-// Render implements Renderer
-func (c ConstantRenderer) Render(_ report.Report) Nodes {
-	return c.Nodes
 }
 
 // joinResults is used by Renderers that join sets of nodes

--- a/render/render.go
+++ b/render/render.go
@@ -29,6 +29,14 @@ func (r Nodes) Merge(o Nodes) Nodes {
 	}
 }
 
+// Decorate renders the report with a decorated renderer
+func Decorate(rpt report.Report, renderer Renderer, dct Decorator) Nodes {
+	if dct != nil {
+		renderer = dct(renderer)
+	}
+	return renderer.Render(rpt, nil)
+}
+
 // Reduce renderer is a Renderer which merges together the output of several
 // other renderers.
 type Reduce []Renderer
@@ -122,22 +130,6 @@ func ComposeDecorators(decorators ...Decorator) Decorator {
 		}
 		return r
 	}
-}
-
-type applyDecorator struct {
-	Renderer
-}
-
-func (ad applyDecorator) Render(rpt report.Report, dct Decorator) Nodes {
-	if dct != nil {
-		return dct(ad.Renderer).Render(rpt, nil)
-	}
-	return ad.Renderer.Render(rpt, nil)
-}
-
-// ApplyDecorator returns a renderer which will apply the given decorator to the child render.
-func ApplyDecorator(renderer Renderer) Renderer {
-	return applyDecorator{renderer}
 }
 
 func propagateLatest(key string, from, to report.Node) report.Node {

--- a/render/render.go
+++ b/render/render.go
@@ -29,10 +29,10 @@ func (r Nodes) Merge(o Nodes) Nodes {
 	}
 }
 
-// Decorate renders the report with a decorated renderer
-func Decorate(rpt report.Report, renderer Renderer, dct Decorator) Nodes {
-	if dct != nil {
-		renderer = dct(renderer)
+// Render renders the report and then applies the filter
+func Render(rpt report.Report, renderer Renderer, filter FilterFunc) Nodes {
+	if filter != nil {
+		renderer = MakeFilterPseudo(filter, renderer)
 	}
 	return renderer.Render(rpt)
 }
@@ -117,19 +117,6 @@ func (m Map) Render(rpt report.Report) Nodes {
 	}
 
 	return Nodes{Nodes: output}
-}
-
-// Decorator transforms one renderer to another. e.g. Filters.
-type Decorator func(Renderer) Renderer
-
-// ComposeDecorators composes decorators into one.
-func ComposeDecorators(decorators ...Decorator) Decorator {
-	return func(r Renderer) Renderer {
-		for _, decorator := range decorators {
-			r = decorator(r)
-		}
-		return r
-	}
 }
 
 func propagateLatest(key string, from, to report.Node) report.Node {

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -13,10 +13,7 @@ type mockRenderer struct {
 	report.Nodes
 }
 
-func (m mockRenderer) Render(rpt report.Report, d render.Decorator) render.Nodes {
-	if d != nil {
-		return d(mockRenderer{m.Nodes}).Render(rpt, nil)
-	}
+func (m mockRenderer) Render(rpt report.Report) render.Nodes {
 	return render.Nodes{Nodes: m.Nodes}
 }
 
@@ -30,7 +27,7 @@ func TestReduceRender(t *testing.T) {
 		"foo": report.MakeNode("foo"),
 		"bar": report.MakeNode("bar"),
 	}
-	have := renderer.Render(report.MakeReport(), FilterNoop).Nodes
+	have := renderer.Render(report.MakeReport()).Nodes
 	if !reflect.DeepEqual(want, have) {
 		t.Errorf("want %+v, have %+v", want, have)
 	}
@@ -47,7 +44,7 @@ func TestMapRender1(t *testing.T) {
 		}},
 	}
 	want := report.Nodes{}
-	have := mapper.Render(report.MakeReport(), FilterNoop).Nodes
+	have := mapper.Render(report.MakeReport()).Nodes
 	if !reflect.DeepEqual(want, have) {
 		t.Errorf("want %+v, have %+v", want, have)
 	}
@@ -69,7 +66,7 @@ func TestMapRender2(t *testing.T) {
 	want := report.Nodes{
 		"bar": report.MakeNode("bar"),
 	}
-	have := mapper.Render(report.MakeReport(), FilterNoop).Nodes
+	have := mapper.Render(report.MakeReport()).Nodes
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}
@@ -91,7 +88,7 @@ func TestMapRender3(t *testing.T) {
 		"_foo": report.MakeNode("_foo").WithAdjacent("_baz"),
 		"_baz": report.MakeNode("_baz").WithAdjacent("_foo"),
 	}
-	have := mapper.Render(report.MakeReport(), FilterNoop).Nodes
+	have := mapper.Render(report.MakeReport()).Nodes
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
 	}

--- a/render/selectors.go
+++ b/render/selectors.go
@@ -9,7 +9,7 @@ import (
 type TopologySelector string
 
 // Render implements Renderer
-func (t TopologySelector) Render(r report.Report, _ Decorator) Nodes {
+func (t TopologySelector) Render(r report.Report) Nodes {
 	topology, _ := r.Topology(string(t))
 	return Nodes{Nodes: topology.Nodes}
 }

--- a/render/short_lived_connections_test.go
+++ b/render/short_lived_connections_test.go
@@ -109,7 +109,7 @@ var (
 )
 
 func TestShortLivedInternetNodeConnections(t *testing.T) {
-	have := utils.Prune(render.ContainerWithImageNameRenderer.Render(rpt, FilterNoop).Nodes)
+	have := utils.Prune(render.ContainerWithImageNameRenderer.Render(rpt).Nodes)
 
 	// Conntracked-only connections from the internet should be assigned to the internet pseudonode
 	internet, ok := have[render.IncomingInternetID]
@@ -123,7 +123,7 @@ func TestShortLivedInternetNodeConnections(t *testing.T) {
 }
 
 func TestPauseContainerDiscarded(t *testing.T) {
-	have := utils.Prune(render.ContainerWithImageNameRenderer.Render(rpt, FilterNoop).Nodes)
+	have := utils.Prune(render.ContainerWithImageNameRenderer.Render(rpt).Nodes)
 	// There should only be a connection from container1 and the destination should be container2
 	container1, ok := have[container1NodeID]
 	if !ok {


### PR DESCRIPTION
Decorators turn out to be an unnecessary abstraction that rather obscures what's going on. So let's get rid of them!

Decorators were used to dynamically construct filters from UI selections - e.g. namespaces, system vs app containers, etc; the selectors in the bottom left corner of the current scope UI - and apply them to the output of topology renderers - pods, containers-by-image, etc; the selectors at the top centre of the current scope UI. Decorators were accomplishing that in a rather complicated way, by composing renderers that wrap the base topology renderers.

This PR unravels all that.

The filter selection from the UI is now turned into a `FilterFunc`, which we `Apply()` to the output of topology renderers. The `render.Render()` function does exactly that, and very clearly so. The one place where we need to do something special is when rendering a single node, e.g. for the details panel in the UI. See comments in the `handleNode` code.

The PR looks larger than it actually is. There are a bunch of mechanical changes that touch several files, especially the removal of Decorators from the `Renderer.Render()` signature, and use of the new `render.Render()` function. The individual commits are self-contained, but the first one is very much an intermediate step which is largely superseded by later commits. Also note that GH does a poor job of showing the diff for the change that moves the filter logic to `FilterFunc.Apply()`.