### PR TITLE
make render.ResetCache() reset all caches

### DIFF
--- a/render/memoise.go
+++ b/render/memoise.go
@@ -75,8 +75,3 @@ func (p *promise) Get() Nodes {
 	<-p.done
 	return p.val
 }
-
-// ResetCache blows away the rendered node cache.
-func ResetCache() {
-	renderCache.Purge()
-}

--- a/render/render.go
+++ b/render/render.go
@@ -225,3 +225,10 @@ func (ret *joinResults) copyUnmatched(input Nodes) {
 func (ret *joinResults) result() Nodes {
 	return Nodes{Nodes: ret.nodes}
 }
+
+// ResetCache blows away the rendered node cache, and known service
+// cache.
+func ResetCache() {
+	renderCache.Purge()
+	knownServiceCache.Purge()
+}


### PR DESCRIPTION
so that benchmarks yield more consistent results.