### PR TITLE
optimisation: make Memoise(Memoise(...)) only memoise once

### DIFF
--- a/render/memoise.go
+++ b/render/memoise.go
@@ -27,6 +27,9 @@ type memoise struct {
 
 // Memoise wraps the renderer in a loving embrace of caching.
 func Memoise(r Renderer) Renderer {
+	if _, ok := r.(*memoise); ok {
+		return r // fixpoint
+	}
 	return &memoise{
 		Renderer: r,
 		id:       fmt.Sprintf("%x", rand.Int63()),

--- a/render/memoise_test.go
+++ b/render/memoise_test.go
@@ -20,6 +20,11 @@ func TestMemoise(t *testing.T) {
 		return render.Nodes{Nodes: report.Nodes{rpt.ID: report.MakeNode(rpt.ID)}}
 	})
 	m := render.Memoise(r)
+
+	if render.Memoise(m) != m {
+		t.Errorf("Memoised renderers should be fixpoints.")
+	}
+
 	rpt1 := report.MakeReport()
 
 	result1 := m.Render(rpt1)


### PR DESCRIPTION
All outputs of `Memoise()` are fixpoints to the function, i.e. feeding them as inputs to the function just returns them.

We don't hit this optimisation in current code but have had instances in the past.