### PR TITLE
filter out unconnected pseudo nodes just once, at the end

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -200,7 +200,8 @@ func MakeRegistry() *Registry {
 	registry.Add(
 		APITopologyDesc{
 			id:          processesID,
-			renderer:    render.FilterUnconnected(render.ProcessWithContainerNameRenderer),
+			renderer:    render.ProcessWithContainerNameRenderer,
+			filter:      render.FilterUnconnected,
 			Name:        "Processes",
 			Rank:        1,
 			Options:     unconnectedFilter,
@@ -209,14 +210,16 @@ func MakeRegistry() *Registry {
 		APITopologyDesc{
 			id:          processesByNameID,
 			parent:      processesID,
-			renderer:    render.FilterUnconnected(render.ProcessNameRenderer),
+			renderer:    render.ProcessNameRenderer,
+			filter:      render.FilterUnconnected,
 			Name:        "by name",
 			Options:     unconnectedFilter,
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{
 			id:       containersID,
-			renderer: render.FilterUnconnectedPseudo(render.ContainerWithImageNameRenderer),
+			renderer: render.ContainerWithImageNameRenderer,
+			filter:   render.FilterUnconnectedPseudo,
 			Name:     "Containers",
 			Rank:     2,
 			Options:  containerFilters,
@@ -224,20 +227,23 @@ func MakeRegistry() *Registry {
 		APITopologyDesc{
 			id:       containersByHostnameID,
 			parent:   containersID,
-			renderer: render.FilterUnconnectedPseudo(render.ContainerHostnameRenderer),
+			renderer: render.ContainerHostnameRenderer,
+			filter:   render.FilterUnconnectedPseudo,
 			Name:     "by DNS name",
 			Options:  containerFilters,
 		},
 		APITopologyDesc{
 			id:       containersByImageID,
 			parent:   containersID,
-			renderer: render.FilterUnconnectedPseudo(render.ContainerImageRenderer),
+			renderer: render.ContainerImageRenderer,
+			filter:   render.FilterUnconnectedPseudo,
 			Name:     "by image",
 			Options:  containerFilters,
 		},
 		APITopologyDesc{
 			id:          podsID,
-			renderer:    render.FilterUnconnectedPseudo(render.PodRenderer),
+			renderer:    render.PodRenderer,
+			filter:      render.FilterUnconnectedPseudo,
 			Name:        "Pods",
 			Rank:        3,
 			Options:     []APITopologyOptionGroup{unmanagedFilter},
@@ -246,7 +252,8 @@ func MakeRegistry() *Registry {
 		APITopologyDesc{
 			id:          kubeControllersID,
 			parent:      podsID,
-			renderer:    render.FilterUnconnectedPseudo(render.KubeControllerRenderer),
+			renderer:    render.KubeControllerRenderer,
+			filter:      render.FilterUnconnectedPseudo,
 			Name:        "controllers",
 			Options:     []APITopologyOptionGroup{unmanagedFilter},
 			HideIfEmpty: true,
@@ -254,14 +261,16 @@ func MakeRegistry() *Registry {
 		APITopologyDesc{
 			id:          servicesID,
 			parent:      podsID,
-			renderer:    render.FilterUnconnectedPseudo(render.PodServiceRenderer),
+			renderer:    render.PodServiceRenderer,
+			filter:      render.FilterUnconnectedPseudo,
 			Name:        "services",
 			Options:     []APITopologyOptionGroup{unmanagedFilter},
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{
 			id:          ecsTasksID,
-			renderer:    render.FilterUnconnectedPseudo(render.ECSTaskRenderer),
+			renderer:    render.ECSTaskRenderer,
+			filter:      render.FilterUnconnectedPseudo,
 			Name:        "Tasks",
 			Rank:        3,
 			Options:     []APITopologyOptionGroup{unmanagedFilter},
@@ -270,14 +279,16 @@ func MakeRegistry() *Registry {
 		APITopologyDesc{
 			id:          ecsServicesID,
 			parent:      ecsTasksID,
-			renderer:    render.FilterUnconnectedPseudo(render.ECSServiceRenderer),
+			renderer:    render.ECSServiceRenderer,
+			filter:      render.FilterUnconnectedPseudo,
 			Name:        "services",
 			Options:     []APITopologyOptionGroup{unmanagedFilter},
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{
 			id:          swarmServicesID,
-			renderer:    render.FilterUnconnectedPseudo(render.SwarmServiceRenderer),
+			renderer:    render.SwarmServiceRenderer,
+			filter:      render.FilterUnconnectedPseudo,
 			Name:        "services",
 			Rank:        3,
 			Options:     []APITopologyOptionGroup{unmanagedFilter},
@@ -285,14 +296,16 @@ func MakeRegistry() *Registry {
 		},
 		APITopologyDesc{
 			id:       hostsID,
-			renderer: render.FilterUnconnectedPseudo(render.HostRenderer),
+			renderer: render.HostRenderer,
+			filter:   render.FilterUnconnectedPseudo,
 			Name:     "Hosts",
 			Rank:     4,
 		},
 		APITopologyDesc{
 			id:       weaveID,
 			parent:   hostsID,
-			renderer: render.FilterUnconnectedPseudo(render.WeaveRenderer),
+			renderer: render.WeaveRenderer,
+			filter:   render.FilterUnconnectedPseudo,
 			Name:     "Weave Net",
 		},
 	)
@@ -305,6 +318,7 @@ type APITopologyDesc struct {
 	id       string
 	parent   string
 	renderer render.Renderer
+	filter   func(render.Renderer) render.Renderer
 
 	Name        string                   `json:"name"`
 	Rank        int                      `json:"rank"`
@@ -433,7 +447,7 @@ func (r *Registry) Add(ts ...APITopologyDesc) {
 	defer r.Unlock()
 	for _, t := range ts {
 		t.URL = apiTopologyURL + t.id
-		t.renderer = render.Memoise(t.renderer)
+		t.renderer = render.Memoise(t.filter(t.renderer))
 
 		if t.parent != "" {
 			parent := r.items[t.parent]

--- a/app/api_topologies_test.go
+++ b/app/api_topologies_test.go
@@ -164,14 +164,14 @@ func getTestContainerLabelFilterTopologySummary(t *testing.T, exclude bool) (det
 
 	var (
 		topologyRegistry = app.MakeRegistry()
-		filter           render.FilterFunc
+		filterFunc       render.FilterFunc
 	)
 	if exclude == true {
-		filter = render.DoesNotHaveLabel(fixture.TestLabelKey2, fixture.ApplicationLabelValue2)
+		filterFunc = render.DoesNotHaveLabel(fixture.TestLabelKey2, fixture.ApplicationLabelValue2)
 	} else {
-		filter = render.HasLabel(fixture.TestLabelKey1, fixture.ApplicationLabelValue1)
+		filterFunc = render.HasLabel(fixture.TestLabelKey1, fixture.ApplicationLabelValue1)
 	}
-	option := app.MakeAPITopologyOption(customAPITopologyOptionFilterID, "title", filter, false)
+	option := app.MakeAPITopologyOption(customAPITopologyOptionFilterID, "title", filterFunc, false)
 	topologyRegistry.AddContainerFilters(option)
 
 	urlvalues := url.Values{}

--- a/render/container.go
+++ b/render/container.go
@@ -33,7 +33,7 @@ var ContainerRenderer = Memoise(MakeFilter(
 	MakeReduce(
 		MakeMap(
 			MapProcess2Container,
-			ColorConnectedProcessRenderer,
+			ProcessRenderer,
 		),
 		ConnectionJoin(MapContainer2IP, SelectContainer),
 	),

--- a/render/container_test.go
+++ b/render/container_test.go
@@ -74,7 +74,7 @@ func TestContainerFilterRenderer(t *testing.T) {
 }
 
 func TestContainerHostnameRenderer(t *testing.T) {
-	have := utils.Prune(render.Render(fixture.Report, render.ContainerHostnameRenderer, nil).Nodes)
+	have := utils.Prune(render.Render(fixture.Report, render.ContainerHostnameRenderer, render.Transformers(nil)).Nodes)
 	want := utils.Prune(expected.RenderedContainerHostnames)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))
@@ -93,7 +93,7 @@ func TestContainerHostnameFilterRenderer(t *testing.T) {
 }
 
 func TestContainerImageRenderer(t *testing.T) {
-	have := utils.Prune(render.Render(fixture.Report, render.ContainerImageRenderer, nil).Nodes)
+	have := utils.Prune(render.Render(fixture.Report, render.ContainerImageRenderer, render.Transformers(nil)).Nodes)
 	want := utils.Prune(expected.RenderedContainerImages)
 	if !reflect.DeepEqual(want, have) {
 		t.Error(test.Diff(want, have))

--- a/render/container_test.go
+++ b/render/container_test.go
@@ -16,8 +16,14 @@ import (
 )
 
 var (
-	filterApplication = render.AnyFilterFunc(render.IsPseudoTopology, render.IsApplication)
-	filterSystem      = render.AnyFilterFunc(render.IsPseudoTopology, render.IsSystem)
+	filterApplication = render.Transformers([]render.Transformer{
+		render.AnyFilterFunc(render.IsPseudoTopology, render.IsApplication),
+		render.FilterUnconnectedPseudo,
+	})
+	filterSystem = render.Transformers([]render.Transformer{
+		render.AnyFilterFunc(render.IsPseudoTopology, render.IsSystem),
+		render.FilterUnconnectedPseudo,
+	})
 )
 
 func TestMapProcess2Container(t *testing.T) {

--- a/render/filters.go
+++ b/render/filters.go
@@ -167,27 +167,12 @@ type filterUnconnected struct {
 // Transform implements Transformer
 func (f filterUnconnected) Transform(input Nodes) Nodes {
 	connected := connected(input.Nodes)
-	output := report.Nodes{}
-	filtered := input.Filtered
-	for id, node := range input.Nodes {
-		if _, ok := connected[id]; ok || (f.onlyPseudo && !IsPseudoTopology(node)) {
-			output[id] = node
-		} else {
-			filtered++
+	return FilterFunc(func(node report.Node) bool {
+		if _, ok := connected[node.ID]; ok || (f.onlyPseudo && !IsPseudoTopology(node)) {
+			return true
 		}
-	}
-	// Deleted nodes also need to be cut as destinations in adjacency lists.
-	for id, node := range output {
-		newAdjacency := report.MakeIDList()
-		for _, dstID := range node.Adjacency {
-			if _, ok := output[dstID]; ok {
-				newAdjacency = newAdjacency.Add(dstID)
-			}
-		}
-		node.Adjacency = newAdjacency
-		output[id] = node
-	}
-	return Nodes{Nodes: output, Filtered: filtered}
+		return false
+	}).Transform(input)
 }
 
 // FilterUnconnected is a transformer that filters unconnected nodes

--- a/render/filters.go
+++ b/render/filters.go
@@ -60,8 +60,8 @@ func Complement(f FilterFunc) FilterFunc {
 	return func(node report.Node) bool { return !f(node) }
 }
 
-// Apply applies the filter to all nodes
-func (f FilterFunc) Apply(nodes Nodes) Nodes {
+// Transform applies the filter to all nodes
+func (f FilterFunc) Transform(nodes Nodes) Nodes {
 	output := report.Nodes{}
 	inDegrees := map[string]int{}
 	filtered := nodes.Filtered
@@ -128,7 +128,7 @@ func MakeFilterPseudo(f FilterFunc, r Renderer) Renderer {
 
 // Render implements Renderer
 func (f Filter) Render(rpt report.Report) Nodes {
-	return f.FilterFunc.Apply(f.Renderer.Render(rpt))
+	return f.FilterFunc.Transform(f.Renderer.Render(rpt))
 }
 
 // IsConnectedMark is the key added to Node.Metadata by

--- a/render/filters.go
+++ b/render/filters.go
@@ -63,12 +63,10 @@ func Complement(f FilterFunc) FilterFunc {
 // Transform applies the filter to all nodes
 func (f FilterFunc) Transform(nodes Nodes) Nodes {
 	output := report.Nodes{}
-	inDegrees := map[string]int{}
 	filtered := nodes.Filtered
 	for id, node := range nodes.Nodes {
 		if f(node) {
 			output[id] = node
-			inDegrees[id] = 0
 		} else {
 			filtered++
 		}
@@ -80,25 +78,12 @@ func (f FilterFunc) Transform(nodes Nodes) Nodes {
 		for _, dstID := range node.Adjacency {
 			if _, ok := output[dstID]; ok {
 				newAdjacency = newAdjacency.Add(dstID)
-				inDegrees[dstID]++
 			}
 		}
 		node.Adjacency = newAdjacency
 		output[id] = node
 	}
 
-	// Remove unconnected pseudo nodes, see #483.
-	for id, inDegree := range inDegrees {
-		if inDegree > 0 {
-			continue
-		}
-		node := output[id]
-		if node.Topology != Pseudo || len(node.Adjacency) > 0 {
-			continue
-		}
-		delete(output, id)
-		filtered++
-	}
 	return Nodes{Nodes: output, Filtered: filtered}
 }
 

--- a/render/filters.go
+++ b/render/filters.go
@@ -175,12 +175,17 @@ func ColorConnected(r Renderer) Renderer {
 	}
 }
 
-func filterUnconnected(input Nodes, onlyPseudo bool) Nodes {
+type filterUnconnected struct {
+	onlyPseudo bool
+}
+
+// Transform implements Transformer
+func (f filterUnconnected) Transform(input Nodes) Nodes {
 	connected := connected(input.Nodes)
 	output := report.Nodes{}
 	filtered := input.Filtered
 	for id, node := range input.Nodes {
-		if _, ok := connected[id]; ok || (onlyPseudo && !IsPseudoTopology(node)) {
+		if _, ok := connected[id]; ok || (f.onlyPseudo && !IsPseudoTopology(node)) {
 			output[id] = node
 		} else {
 			filtered++
@@ -200,23 +205,12 @@ func filterUnconnected(input Nodes, onlyPseudo bool) Nodes {
 	return Nodes{Nodes: output, Filtered: filtered}
 }
 
-// FilterUnconnected produces a renderer that filters unconnected nodes
-// from the given renderer
-func FilterUnconnected(r Renderer) Renderer {
-	return CustomRenderer{
-		Renderer:   r,
-		RenderFunc: func(input Nodes) Nodes { return filterUnconnected(input, false) },
-	}
-}
+// FilterUnconnected is a transformer that filters unconnected nodes
+var FilterUnconnected = filterUnconnected{onlyPseudo: false}
 
-// FilterUnconnectedPseudo produces a renderer that filters
-// unconnected pseudo nodes from the given renderer
-func FilterUnconnectedPseudo(r Renderer) Renderer {
-	return CustomRenderer{
-		Renderer:   r,
-		RenderFunc: func(input Nodes) Nodes { return filterUnconnected(input, true) },
-	}
-}
+// FilterUnconnectedPseudo is a transformer that filters unconnected
+// pseudo nodes
+var FilterUnconnectedPseudo = filterUnconnected{onlyPseudo: true}
 
 // Noop allows all nodes through
 func Noop(_ report.Node) bool { return true }

--- a/render/filters_test.go
+++ b/render/filters_test.go
@@ -20,7 +20,7 @@ func TestFilterRender(t *testing.T) {
 		"baz": report.MakeNode("baz"),
 	}}
 	have := report.MakeIDList()
-	for id := range render.Render(report.MakeReport(), render.ColorConnected(renderer), render.IsConnected).Nodes {
+	for id := range render.Render(report.MakeReport(), render.ColorConnected(renderer), render.FilterFunc(render.IsConnected)).Nodes {
 		have = have.Add(id)
 	}
 	want := report.MakeIDList("foo", "bar")
@@ -36,7 +36,7 @@ func TestFilterRender2(t *testing.T) {
 		"bar": report.MakeNode("bar").WithAdjacent("foo"),
 		"baz": report.MakeNode("baz"),
 	}}
-	have := render.Render(report.MakeReport(), renderer, isNotBar).Nodes
+	have := render.Render(report.MakeReport(), renderer, render.FilterFunc(isNotBar)).Nodes
 	if have["foo"].Adjacency.Contains("bar") {
 		t.Error("adjacencies for removed nodes should have been removed")
 	}
@@ -53,7 +53,7 @@ func TestFilterUnconnectedPseudoNodes(t *testing.T) {
 		}
 		renderer := mockRenderer{Nodes: nodes}
 		want := nodes
-		have := render.Render(report.MakeReport(), renderer, nil).Nodes
+		have := render.Render(report.MakeReport(), renderer, render.Transformers(nil)).Nodes
 		if !reflect.DeepEqual(want, have) {
 			t.Error(test.Diff(want, have))
 		}
@@ -64,7 +64,7 @@ func TestFilterUnconnectedPseudoNodes(t *testing.T) {
 			"bar": report.MakeNode("bar").WithAdjacent("baz"),
 			"baz": report.MakeNode("baz").WithTopology(render.Pseudo),
 		}}
-		have := render.Render(report.MakeReport(), renderer, isNotBar).Nodes
+		have := render.Render(report.MakeReport(), renderer, render.FilterFunc(isNotBar)).Nodes
 		if _, ok := have["baz"]; ok {
 			t.Error("expected the unconnected pseudonode baz to have been removed")
 		}
@@ -75,7 +75,7 @@ func TestFilterUnconnectedPseudoNodes(t *testing.T) {
 			"bar": report.MakeNode("bar").WithAdjacent("foo"),
 			"baz": report.MakeNode("baz").WithTopology(render.Pseudo).WithAdjacent("bar"),
 		}}
-		have := render.Render(report.MakeReport(), renderer, isNotBar).Nodes
+		have := render.Render(report.MakeReport(), renderer, render.FilterFunc(isNotBar)).Nodes
 		if _, ok := have["baz"]; ok {
 			t.Error("expected the unconnected pseudonode baz to have been removed")
 		}
@@ -89,7 +89,7 @@ func TestFilterUnconnectedSelf(t *testing.T) {
 			"foo": report.MakeNode("foo").WithAdjacent("foo"),
 		}
 		renderer := mockRenderer{Nodes: nodes}
-		have := render.Render(report.MakeReport(), render.ColorConnected(renderer), render.IsConnected).Nodes
+		have := render.Render(report.MakeReport(), render.ColorConnected(renderer), render.FilterFunc(render.IsConnected)).Nodes
 		if len(have) > 0 {
 			t.Error("expected node only connected to self to be removed")
 		}

--- a/render/filters_test.go
+++ b/render/filters_test.go
@@ -9,9 +9,12 @@ import (
 	"github.com/weaveworks/scope/test/reflect"
 )
 
-func isNotBar(node report.Node) bool {
-	return node.ID != "bar"
-}
+var filterBar = render.Transformers([]render.Transformer{
+	render.FilterFunc(func(node report.Node) bool {
+		return node.ID != "bar"
+	}),
+	render.FilterUnconnectedPseudo,
+})
 
 func TestFilterRender(t *testing.T) {
 	renderer := mockRenderer{Nodes: report.Nodes{
@@ -36,7 +39,7 @@ func TestFilterRender2(t *testing.T) {
 		"bar": report.MakeNode("bar").WithAdjacent("foo"),
 		"baz": report.MakeNode("baz"),
 	}}
-	have := render.Render(report.MakeReport(), renderer, render.FilterFunc(isNotBar)).Nodes
+	have := render.Render(report.MakeReport(), renderer, filterBar).Nodes
 	if have["foo"].Adjacency.Contains("bar") {
 		t.Error("adjacencies for removed nodes should have been removed")
 	}
@@ -64,7 +67,7 @@ func TestFilterUnconnectedPseudoNodes(t *testing.T) {
 			"bar": report.MakeNode("bar").WithAdjacent("baz"),
 			"baz": report.MakeNode("baz").WithTopology(render.Pseudo),
 		}}
-		have := render.Render(report.MakeReport(), renderer, render.FilterFunc(isNotBar)).Nodes
+		have := render.Render(report.MakeReport(), renderer, filterBar).Nodes
 		if _, ok := have["baz"]; ok {
 			t.Error("expected the unconnected pseudonode baz to have been removed")
 		}
@@ -75,7 +78,7 @@ func TestFilterUnconnectedPseudoNodes(t *testing.T) {
 			"bar": report.MakeNode("bar").WithAdjacent("foo"),
 			"baz": report.MakeNode("baz").WithTopology(render.Pseudo).WithAdjacent("bar"),
 		}}
-		have := render.Render(report.MakeReport(), renderer, render.FilterFunc(isNotBar)).Nodes
+		have := render.Render(report.MakeReport(), renderer, filterBar).Nodes
 		if _, ok := have["baz"]; ok {
 			t.Error("expected the unconnected pseudonode baz to have been removed")
 		}

--- a/render/host.go
+++ b/render/host.go
@@ -10,7 +10,7 @@ import (
 // not memoised
 var HostRenderer = MakeReduce(
 	endpoints2Hosts{},
-	CustomRenderer{RenderFunc: nodes2Hosts, Renderer: ColorConnectedProcessRenderer},
+	CustomRenderer{RenderFunc: nodes2Hosts, Renderer: ProcessRenderer},
 	CustomRenderer{RenderFunc: nodes2Hosts, Renderer: ContainerRenderer},
 	CustomRenderer{RenderFunc: nodes2Hosts, Renderer: ContainerImageRenderer},
 	CustomRenderer{RenderFunc: nodes2Hosts, Renderer: PodRenderer},

--- a/render/pod_test.go
+++ b/render/pod_test.go
@@ -20,7 +20,10 @@ func TestPodRenderer(t *testing.T) {
 	}
 }
 
-var filterNonKubeSystem = render.Complement(render.IsNamespace("kube-system"))
+var filterNonKubeSystem = render.Transformers([]render.Transformer{
+	render.Complement(render.IsNamespace("kube-system")),
+	render.FilterUnconnectedPseudo,
+})
 
 func TestPodFilterRenderer(t *testing.T) {
 	// tag on containers or pod namespace in the topology and ensure

--- a/render/process.go
+++ b/render/process.go
@@ -25,14 +25,11 @@ func renderProcesses(rpt report.Report) bool {
 var EndpointRenderer = SelectEndpoint
 
 // ProcessRenderer is a Renderer which produces a renderable process
-// graph by merging the endpoint graph and the process topology.
-var ProcessRenderer = Memoise(endpoints2Processes{})
-
-// ColorConnectedProcessRenderer colors connected nodes from
-// ProcessRenderer. Since the process topology views only show
-// connected processes, we need this info to determine whether
+// graph by merging the endpoint graph and the process topology. It
+// also colors connected nodes. Since the process topology views only
+// show connected processes, we need this info to determine whether
 // processes appearing in a details panel are linkable.
-var ColorConnectedProcessRenderer = Memoise(ColorConnected(ProcessRenderer))
+var ProcessRenderer = Memoise(ColorConnected(endpoints2Processes{}))
 
 // processWithContainerNameRenderer is a Renderer which produces a process
 // graph enriched with container names where appropriate

--- a/render/render.go
+++ b/render/render.go
@@ -29,13 +29,26 @@ func (r Nodes) Merge(o Nodes) Nodes {
 	}
 }
 
-// Render renders the report and then applies the filter
-func Render(rpt report.Report, renderer Renderer, filter FilterFunc) Nodes {
-	nodes := renderer.Render(rpt)
-	if filter != nil {
-		nodes = filter.Apply(nodes)
+// Transformer is something that transforms one set of Nodes to
+// another set of Nodes.
+type Transformer interface {
+	Transform(nodes Nodes) Nodes
+}
+
+// Transformers is a composition of Transformers
+type Transformers []Transformer
+
+// Transform implements Transformer
+func (ts Transformers) Transform(nodes Nodes) Nodes {
+	for _, t := range ts {
+		nodes = t.Transform(nodes)
 	}
 	return nodes
+}
+
+// Render renders the report and then transforms it
+func Render(rpt report.Report, renderer Renderer, transformer Transformer) Nodes {
+	return transformer.Transform(renderer.Render(rpt))
 }
 
 // Reduce renderer is a Renderer which merges together the output of several


### PR DESCRIPTION
The current rendering pipeline looks like this:
```
render . filterUnconnectedPseudo . memoise . filter(options)
```
We render a report, filter unconnected pseudo nodes, memoise the result, and apply user-specified filters.

Some of the steps are composites. `filterUnConnectedPseudo` nodes colours connected nodes in one step and then applies an ordinary filter that drops uncoloured nodes:
```
filterUnconnectedPseudo = colorConnected . filter(unconnectedPseudo)
```
And filtering always filters unconnected pseudo nodes:
```
filter(x) = filter'(x) . filterU
```
where `filter'(x)` is the "raw" filter operation and `filterU` is the "filter unconnected pseudo nodes" step.

So the current pipeline actually looks like this:
```
render . colorConnected . filter'(unconnectedPseudo) . filterU . memoise . filter'(options) . filterU
```
There are couple of problems with this. Firstly, we filter unconnected pseudo nodes three times, which is inefficient. Secondly, `colorConnected` marking is expensive since it updates nodes' LatestMap.

Thirdly, while the filtering done by `colorConnected . filter'(unconnectedPseudo)` drops nodes which are only connected to themselves, `filterU` fails to do that. Hence end result may contain such nodes because the `colorConnected` step and subsequent filtering occurs prior to applying the user-specified filters.

The changes in this PR yield a pipeline like this:
```
render . memoise . filter'(options) . filter'(unconnectedPseudo')
```
where `unconnectedPseudo'` is a filter predictate that is dynamically constructed from a calculation of a connected nodes, that correctly excludes self-connections.

One slight complication is that for the process topology we want to filter all unconnected nodes, not just unconnected pseudo nodes. We do this by calculating connected nodes differently in that case.

There is one wart: we cannot get rid of `ColorConnected` completely. We still need it in `ColorConnectedProcessRenderer`, which uses it to mark nodes; the marks are required by `detailed.processNodeSummary` to determine whether a process in the details panel can be rendered as a link.