### PR TITLE
fix incorrect reporting of replicaset DesiredReplicas

### DIFF
--- a/probe/kubernetes/replica_set.go
+++ b/probe/kubernetes/replica_set.go
@@ -53,10 +53,15 @@ func (r *replicaSet) AddParent(topology, id string) {
 }
 
 func (r *replicaSet) GetNode(probeID string) report.Node {
+	// Spec.Replicas can be omitted, and the pointer will be nil. It defaults to 1.
+	desiredReplicas := 1
+	if r.Spec.Replicas != nil {
+		desiredReplicas = int(*r.Spec.Replicas)
+	}
 	return r.MetaNode(report.MakeReplicaSetNodeID(r.UID())).WithLatests(map[string]string{
 		ObservedGeneration:    fmt.Sprint(r.Status.ObservedGeneration),
 		Replicas:              fmt.Sprint(r.Status.Replicas),
-		DesiredReplicas:       fmt.Sprint(r.Spec.Replicas),
+		DesiredReplicas:       fmt.Sprint(desiredReplicas),
 		FullyLabeledReplicas:  fmt.Sprint(r.Status.FullyLabeledReplicas),
 		report.ControlProbeID: probeID,
 	}).WithParents(r.parents).WithLatestActiveControls(ScaleUp, ScaleDown)


### PR DESCRIPTION
`ReplicaSetSpec.Replicas` is an `*int32`. Just like in `DeploymentSpec`, where we deal with that in the same way.

I stumbled across this when looking at a report...
```json
          "kubernetes_desired_replicas": {
            "timestamp": "2017-11-30T15:40:13.064620595Z",
            "value": "0xc42fd73888"
          },
```
Oops.