### PR TITLE
WIP Re-implement Sets as sorted slice, for performance

### DIFF
--- a/report/map_helpers.go
+++ b/report/map_helpers.go
@@ -87,6 +87,9 @@ const (
 	containerMapKey   = 2
 	containerMapValue = 3
 	containerMapEnd   = 4
+
+	containerArrayElem = 6
+	containerArrayEnd  = 7
 	// from https://github.com/ugorji/go/blob/master/codec/helper.go#L152
 	cUTF8 = 2
 )

--- a/report/sets.go
+++ b/report/sets.go
@@ -105,7 +105,29 @@ func (m Sets) Merge(n Sets) Sets {
 	}
 
 	i, j := 0, 0
+loop:
+	for i < len(m) {
+		switch {
+		case j >= len(n):
+			return m
+		case m[i].key == n[j].key:
+			if !m[i].Value.ContainsSet(n[j].Value) {
+				break loop
+			}
+			i++
+			j++
+		case m[i].key < n[j].key:
+			i++
+		default:
+			break loop
+		}
+	}
+	if i >= len(m) && j >= len(n) {
+		return m
+	}
+
 	out := make([]stringSetEntry, i, len(m))
+	copy(out, m[:i])
 
 	for i < len(m) {
 		switch {

--- a/report/sets.go
+++ b/report/sets.go
@@ -1,156 +1,211 @@
 package report
 
 import (
+	"bytes"
+	"fmt"
 	"reflect"
+	"sort"
 
 	"github.com/ugorji/go/codec"
-	"github.com/weaveworks/ps"
 )
 
-// Sets is a string->set-of-strings map.
-// It is immutable.
-type Sets struct {
-	psMap ps.Map
+// Sets holds StringSet instances, as a slice sorted by key.
+type Sets []stringSetEntry
+
+type stringSetEntry struct {
+	key   string
+	Value StringSet `json:"value"`
 }
 
-// EmptySets is an empty Sets.  Starts with this.
-var emptySets = Sets{ps.NewMap()}
-
-// MakeSets returns EmptySets
+// MakeSets creates an empty Sets
 func MakeSets() Sets {
-	return emptySets
+	return nil
 }
 
-// Keys returns the keys for this set
-func (s Sets) Keys() []string {
-	if s.psMap == nil {
-		return nil
-	}
-	return s.psMap.Keys()
+// locate the position where key should go, either at the end or in the middle
+func (m Sets) locate(key string) int {
+	return sort.Search(len(m), func(i int) bool {
+		return m[i].key >= key
+	})
 }
 
-// Add the given value to the Sets.
-func (s Sets) Add(key string, value StringSet) Sets {
-	if s.psMap == nil {
-		s = emptySets
-	}
-	if existingValue, ok := s.psMap.Lookup(key); ok {
+// Add the given value to the Sets, merging the contents if the key is already there.
+func (m Sets) Add(key string, value StringSet) Sets {
+	i := m.locate(key)
+	oldM := m
+	if i == len(m) { // insert at end
+		m = make([]stringSetEntry, len(oldM)+1)
+		copy(m, oldM)
+	} else if m[i].key == key { // merge with existing key
 		var unchanged bool
-		value, unchanged = existingValue.(StringSet).Merge(value)
+		value, unchanged = m[i].Value.Merge(value)
 		if unchanged {
-			return s
+			return m
 		}
+		m = make([]stringSetEntry, len(oldM))
+		copy(m, oldM)
+	} else { // insert in the middle
+		m = make([]stringSetEntry, len(oldM)+1)
+		copy(m, oldM[:i])
+		copy(m[i+1:], oldM[i:])
 	}
-	return Sets{
-		psMap: s.psMap.Set(key, value),
-	}
+	m[i] = stringSetEntry{key: key, Value: value}
+	return m
 }
 
 // AddString adds a single string under a key, creating a new StringSet if necessary.
-func (s Sets) AddString(key string, str string) Sets {
-	if s.psMap == nil {
-		s = emptySets
-	}
-	value, found := s.Lookup(key)
+func (m Sets) AddString(key string, str string) Sets {
+	value, found := m.Lookup(key)
 	if found && value.Contains(str) {
-		return s
+		return m
 	}
-	value = value.Add(str)
-	return Sets{
-		psMap: s.psMap.Set(key, value),
-	}
+	return m.Add(key, StringSet{str})
 }
 
 // Delete the given set from the Sets.
-func (s Sets) Delete(key string) Sets {
-	if s.psMap == nil {
-		return emptySets
+func (m Sets) Delete(key string) Sets {
+	i := m.locate(key)
+	if i == len(m) || m[i].key != key {
+		return m // not found
 	}
-	psMap := s.psMap.Delete(key)
-	if psMap.IsNil() {
-		return emptySets
+	result := make([]stringSetEntry, len(m)-1)
+	if i > 0 {
+		copy(result, m[:i-1])
 	}
-	return Sets{psMap: psMap}
+	copy(result[i:], m[i+1:])
+	return result
 }
 
-// Lookup returns the sets stored under key.
-func (s Sets) Lookup(key string) (StringSet, bool) {
-	if s.psMap == nil {
-		return MakeStringSet(), false
+// Lookup the value for the given key.
+func (m Sets) Lookup(key string) (StringSet, bool) {
+	i := m.locate(key)
+	if i < len(m) && m[i].key == key {
+		return m[i].Value, true
 	}
-	if value, ok := s.psMap.Lookup(key); ok {
-		return value.(StringSet), true
-	}
-	return MakeStringSet(), false
+	var zero StringSet
+	return zero, false
 }
 
 // Size returns the number of elements
-func (s Sets) Size() int {
-	if s.psMap == nil {
-		return 0
-	}
-	return s.psMap.Size()
+func (m Sets) Size() int {
+	return len(m)
 }
 
 // Merge merges two sets maps into a fresh set, performing set-union merges as
 // appropriate.
-func (s Sets) Merge(other Sets) Sets {
-	var (
-		sSize     = s.Size()
-		otherSize = other.Size()
-		result    = s.psMap
-		iter      = other.psMap
-	)
+func (m Sets) Merge(n Sets) Sets {
 	switch {
-	case sSize == 0:
-		return other
-	case otherSize == 0:
-		return s
-	case sSize < otherSize:
-		result, iter = iter, result
+	case len(m) == 0:
+		return n
+	case len(n) == 0:
+		return m
+	}
+	if len(n) > len(m) {
+		m, n = n, m //swap so m is always at least as long as n
 	}
 
-	iter.ForEach(func(key string, value interface{}) {
-		set := value.(StringSet)
-		if existingSet, ok := result.Lookup(key); ok {
-			var unchanged bool
-			set, unchanged = existingSet.(StringSet).Merge(set)
-			if unchanged {
-				return
-			}
-		}
-		result = result.Set(key, set)
-	})
+	i, j := 0, 0
+	out := make([]stringSetEntry, i, len(m))
 
-	return Sets{result}
+	for i < len(m) {
+		switch {
+		case j >= len(n):
+			out = append(out, m[i:]...)
+			return out
+		case m[i].key == n[j].key:
+			newValue, _ := m[i].Value.Merge(n[j].Value)
+			out = append(out, stringSetEntry{key: m[i].key, Value: newValue})
+			i++
+			j++
+		case m[i].key < n[j].key:
+			out = append(out, m[i])
+			i++
+		default:
+			out = append(out, n[j])
+			j++
+		}
+	}
+	out = append(out, n[j:]...)
+	return out
 }
 
-func (s Sets) String() string {
-	return mapToString(s.psMap)
+func (m Sets) String() string {
+	buf := bytes.NewBufferString("{")
+	for _, val := range m {
+		fmt.Fprintf(buf, "%s: %v,\n", val.key, val.Value)
+	}
+	fmt.Fprintf(buf, "}")
+	return buf.String()
 }
 
 // DeepEqual tests equality with other Sets
-func (s Sets) DeepEqual(t Sets) bool {
-	return mapEqual(s.psMap, t.psMap, reflect.DeepEqual)
+func (m Sets) DeepEqual(n Sets) bool {
+	if len(m) != len(n) {
+		return false
+	}
+	for i := range m {
+		if !reflect.DeepEqual(m[i], n[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // CodecEncodeSelf implements codec.Selfer
-func (s *Sets) CodecEncodeSelf(encoder *codec.Encoder) {
-	mapWrite(s.psMap, encoder, func(encoder *codec.Encoder, val interface{}) {
-		encoder.Encode(val.(StringSet))
-	})
+// Note this uses undocumented, internal APIs, which could break
+// in the future.  See https://github.com/weaveworks/scope/pull/1709
+// for more information.
+func (m Sets) CodecEncodeSelf(encoder *codec.Encoder) {
+	z, r := codec.GenHelperEncoder(encoder)
+	if m == nil {
+		r.EncodeNil()
+		return
+	}
+	r.EncodeMapStart(len(m))
+	for _, val := range m {
+		z.EncSendContainerState(containerMapKey)
+		r.EncodeString(cUTF8, val.key)
+		z.EncSendContainerState(containerMapValue)
+		val.Value.CodecEncodeSelf(encoder)
+	}
+	z.EncSendContainerState(containerMapEnd)
 }
 
 // CodecDecodeSelf implements codec.Selfer
-func (s *Sets) CodecDecodeSelf(decoder *codec.Decoder) {
-	out := mapRead(decoder, func(isNil bool) interface{} {
-		var value StringSet
-		if !isNil {
-			decoder.Decode(&value)
+// Uses undocumented, internal APIs as for CodecEncodeSelf.
+func (m *Sets) CodecDecodeSelf(decoder *codec.Decoder) {
+	*m = nil
+	z, r := codec.GenHelperDecoder(decoder)
+	if r.TryDecodeAsNil() {
+		return
+	}
+
+	length := r.ReadMapStart()
+	if length > 0 {
+		*m = make([]stringSetEntry, 0, length)
+	}
+	for i := 0; length < 0 || i < length; i++ {
+		if length < 0 && r.CheckBreak() {
+			break
 		}
-		return value
-	})
-	*s = Sets{out}
+		z.DecSendContainerState(containerMapKey)
+		var key string
+		if !r.TryDecodeAsNil() {
+			key = r.DecodeString()
+		}
+		j := m.locate(key)
+		if j == len(*m) || (*m)[j].key != key {
+			*m = append(*m, stringSetEntry{})
+			copy((*m)[j+1:], (*m)[j:])
+			(*m)[j] = stringSetEntry{}
+		}
+		(*m)[j].key = key
+		z.DecSendContainerState(containerMapValue)
+		if !r.TryDecodeAsNil() {
+			(*m)[j].Value.CodecDecodeSelf(decoder)
+		}
+	}
+	z.DecSendContainerState(containerMapEnd)
 }
 
 // MarshalJSON shouldn't be used, use CodecEncodeSelf instead

--- a/report/sets_test.go
+++ b/report/sets_test.go
@@ -67,13 +67,13 @@ func TestSetsMerge(t *testing.T) {
 }
 
 func check(t *testing.T, desc string, haveSets report.Sets, want map[string][]string) {
-	have := map[string][]string{}
-	keys := haveSets.Keys()
-	for _, k := range keys {
-		have[k], _ = haveSets.Lookup(k)
+	if haveSets.Size() != len(want) {
+		t.Errorf("%s: different lengths: want %+v, have %+v", desc, want, haveSets)
 	}
-
-	if !reflect.DeepEqual(want, have) {
-		t.Errorf("%s: want %+v, have %+v", desc, want, have)
+	for k, v := range want {
+		have, _ := haveSets.Lookup(k)
+		if !reflect.DeepEqual([]string(have), v) {
+			t.Errorf("%s: want %+v, have %+v", desc, want, haveSets)
+		}
 	}
 }

--- a/report/string_set.go
+++ b/report/string_set.go
@@ -2,6 +2,8 @@ package report
 
 import (
 	"sort"
+
+	"github.com/ugorji/go/codec"
 )
 
 // StringSet is a sorted set of unique strings. Clients must use the Add
@@ -131,4 +133,42 @@ loop:
 	}
 	result = append(result, other[j:]...)
 	return result, false
+}
+
+func (v StringSet) CodecEncodeSelf(encoder *codec.Encoder) {
+	z, r := codec.GenHelperEncoder(encoder)
+	if v == nil {
+		r.EncodeNil()
+		return
+	}
+	r.EncodeArrayStart(len(v))
+	for _, yyv1 := range v {
+		z.EncSendContainerState(containerArrayElem)
+		r.EncodeString(cUTF8, yyv1)
+	}
+	z.EncSendContainerState(containerArrayEnd)
+}
+
+// CodecDecodeSelf implements codec.Selfer
+func (v *StringSet) CodecDecodeSelf(decoder *codec.Decoder) {
+	z, r := codec.GenHelperDecoder(decoder)
+	yyh1, length := z.DecSliceHelperStart()
+	if length == 0 {
+		*v = []string{}
+		return
+	} else if length < 0 {
+		*v = make([]string, 0, 8)
+	} else {
+		*v = make([]string, 0, length)
+	}
+	for i := 0; length < 0 || i < length; i++ {
+		if length < 0 && r.CheckBreak() {
+			break
+		}
+		yyh1.ElemContainerState(i)
+		b := r.DecodeStringAsBytes()
+		s := string(b)
+		*v = append(*v, s)
+	}
+	yyh1.End()
 }

--- a/report/string_set.go
+++ b/report/string_set.go
@@ -36,6 +36,22 @@ func (s StringSet) Contains(str string) bool {
 	return i < len(s) && s[i] == str
 }
 
+// ContainsSet returns true if the string set includes all strings in the other set
+func (s StringSet) ContainsSet(b StringSet) bool {
+	i, j := 0, 0
+	for i < len(s) && j < len(b) {
+		if s[i] == b[j] {
+			i++
+			j++
+		} else if s[i] < b[j] {
+			i++
+		} else {
+			return false
+		}
+	}
+	return j == len(b)
+}
+
 // Intersection returns the intersections of a and b
 func (s StringSet) Intersection(b StringSet) StringSet {
 	result, i, j := emptyStringSet, 0, 0

--- a/report/string_set.go
+++ b/report/string_set.go
@@ -151,14 +151,15 @@ loop:
 	return result, false
 }
 
-func (v StringSet) CodecEncodeSelf(encoder *codec.Encoder) {
+// CodecEncodeSelf implements codec.Selfer
+func (s StringSet) CodecEncodeSelf(encoder *codec.Encoder) {
 	z, r := codec.GenHelperEncoder(encoder)
-	if v == nil {
+	if s == nil {
 		r.EncodeNil()
 		return
 	}
-	r.EncodeArrayStart(len(v))
-	for _, yyv1 := range v {
+	r.EncodeArrayStart(len(s))
+	for _, yyv1 := range s {
 		z.EncSendContainerState(containerArrayElem)
 		r.EncodeString(cUTF8, yyv1)
 	}
@@ -166,25 +167,24 @@ func (v StringSet) CodecEncodeSelf(encoder *codec.Encoder) {
 }
 
 // CodecDecodeSelf implements codec.Selfer
-func (v *StringSet) CodecDecodeSelf(decoder *codec.Decoder) {
+func (s *StringSet) CodecDecodeSelf(decoder *codec.Decoder) {
 	z, r := codec.GenHelperDecoder(decoder)
 	yyh1, length := z.DecSliceHelperStart()
 	if length == 0 {
-		*v = []string{}
+		*s = []string{}
 		return
 	} else if length < 0 {
-		*v = make([]string, 0, 8)
+		*s = make([]string, 0, 8)
 	} else {
-		*v = make([]string, 0, length)
+		*s = make([]string, 0, length)
 	}
 	for i := 0; length < 0 || i < length; i++ {
 		if length < 0 && r.CheckBreak() {
 			break
 		}
 		yyh1.ElemContainerState(i)
-		b := r.DecodeStringAsBytes()
-		s := string(b)
-		*v = append(*v, s)
+		str := r.DecodeString()
+		*s = append(*s, str)
 	}
 	yyh1.End()
 }


### PR DESCRIPTION
Comparable to #2870 

I should adapt/extend the code-generator from `LatestMap`, really.

Benchmark comparison (the ns timings are extremely variable; I wouldn't read much into them):
```
benchmark                          old ns/op      new ns/op      delta
BenchmarkReportUnmarshal-2         1550377545     1477669912     -4.69%
BenchmarkReportMerge-2             1684092046     1708268415     +1.44%
BenchmarkTopologyList-2            607035752      491860104      -18.97%
BenchmarkTopologyHosts-2           353949174      311919383      -11.87%
BenchmarkTopologyControllers-2     306378851      284710636      -7.07%
BenchmarkTopologyPods-2            240673871      282986959      +17.58%
BenchmarkTopologyContainers-2      188452419      154122803      -18.22%
BenchmarkTopologyProcesses-2       117647086      102960805      -12.48%
BenchmarkSmartMerger-2             78654006       76412340       -2.85%
BenchmarkDumbMerger-2              593382683      429027284      -27.70%

benchmark                          old allocs     new allocs     delta
BenchmarkReportUnmarshal-2         3477338        3137597        -9.77%
BenchmarkReportMerge-2             1951537        1565785        -19.77%
BenchmarkTopologyList-2            821682         810457         -1.37%
BenchmarkTopologyHosts-2           618573         603911         -2.37%
BenchmarkTopologyControllers-2     433439         421355         -2.79%
BenchmarkTopologyPods-2            388042         376551         -2.96%
BenchmarkTopologyContainers-2      261241         251536         -3.71%
BenchmarkTopologyProcesses-2       112362         112382         +0.02%
BenchmarkSmartMerger-2             129514         117970         -8.91%
BenchmarkDumbMerger-2              578302         578325         +0.00%

benchmark                          old bytes     new bytes     delta
BenchmarkReportUnmarshal-2         458400096     440474768     -3.91%
BenchmarkReportMerge-2             350652952     351798312     +0.33%
BenchmarkTopologyList-2            92883797      94307848      +1.53%
BenchmarkTopologyHosts-2           65693070      66135388      +0.67%
BenchmarkTopologyControllers-2     46918684      47246880      +0.70%
BenchmarkTopologyPods-2            41667033      42022456      +0.85%
BenchmarkTopologyContainers-2      28547060      28785196      +0.83%
BenchmarkTopologyProcesses-2       14145046      14549248      +2.86%
BenchmarkSmartMerger-2             36853877      35338592      -4.11%
BenchmarkDumbMerger-2              164080260     173093141     +5.49%
```