### PR TITLE
`report` upgrade based on probe version

### DIFF
--- a/app/api_report.go
+++ b/app/api_report.go
@@ -41,7 +41,7 @@ func makeProbeHandler(rep Reporter) CtxHandlerFunc {
 		for _, n := range rpt.Host.Nodes {
 			id, _ := n.Latest.Lookup(report.ControlProbeID)
 			hostname, _ := n.Latest.Lookup(host.HostName)
-			version, dt, _ := n.Latest.LookupEntry(host.ScopeVersion)
+			version, dt, _ := n.Latest.LookupEntry(report.ScopeVersion)
 			result = append(result, probeDesc{
 				ID:       id,
 				Hostname: hostname,

--- a/app/collector_test.go
+++ b/app/collector_test.go
@@ -36,7 +36,7 @@ func TestCollector(t *testing.T) {
 		t.Error(test.Diff(want, have))
 	}
 
-	c.Add(ctx, r1, nil)
+	c.Add(ctx, "", r1, nil)
 	have, err = c.Report(ctx, mtime.Now())
 	if err != nil {
 		t.Error(err)
@@ -48,7 +48,7 @@ func TestCollector(t *testing.T) {
 	timeBefore := mtime.Now()
 	mtime.NowForce(now.Add(time.Second))
 
-	c.Add(ctx, r2, nil)
+	c.Add(ctx, "", r2, nil)
 	merged := report.MakeReport()
 	merged = merged.Merge(r1)
 	merged = merged.Merge(r2)
@@ -92,7 +92,7 @@ func TestCollectorExpire(t *testing.T) {
 	// Now check an added report is returned
 	r1 := report.MakeReport()
 	r1.Endpoint.AddNode(report.MakeNode("foo"))
-	c.Add(ctx, r1, nil)
+	c.Add(ctx, "", r1, nil)
 	have, err = c.Report(ctx, mtime.Now())
 	if err != nil {
 		t.Error(err)

--- a/app/multitenant/aws_collector.go
+++ b/app/multitenant/aws_collector.go
@@ -337,7 +337,7 @@ func (c *awsCollector) Report(ctx context.Context, timestamp time.Time) (report.
 		return report.MakeReport(), err
 	}
 
-	return c.merger.Merge(reports).Upgrade(), nil
+	return c.merger.Merge(reports).Upgrade(""), nil
 }
 
 func (c *awsCollector) HasHistoricReports() bool {
@@ -401,7 +401,7 @@ func (c *awsCollector) putItemInDynamo(rowKey, colKey, reportKey string) (*dynam
 	return resp, err
 }
 
-func (c *awsCollector) Add(ctx context.Context, rep report.Report, buf []byte) error {
+func (c *awsCollector) Add(ctx context.Context, version string, rep report.Report, buf []byte) error {
 	userid, err := c.userIDer(ctx)
 	if err != nil {
 		return err

--- a/app/multitenant/billing_emitter.go
+++ b/app/multitenant/billing_emitter.go
@@ -45,7 +45,7 @@ func NewBillingEmitter(upstream app.Collector, billingClient *billing.Client, cf
 }
 
 // Add implements app.Collector
-func (e *BillingEmitter) Add(ctx context.Context, rep report.Report, buf []byte) error {
+func (e *BillingEmitter) Add(ctx context.Context, version string, rep report.Report, buf []byte) error {
 	now := time.Now().UTC()
 	userID, err := e.UserIDer(ctx)
 	if err != nil {
@@ -89,7 +89,7 @@ func (e *BillingEmitter) Add(ctx context.Context, rep report.Report, buf []byte)
 		log.Errorf("Failed emitting billing data: %v", err)
 	}
 
-	return e.Collector.Add(ctx, rep, buf)
+	return e.Collector.Add(ctx, version, rep, buf)
 }
 
 // reportInterval tries to find the custom report interval of this report. If

--- a/app/router.go
+++ b/app/router.go
@@ -154,7 +154,7 @@ func RegisterReportPostHandler(a Adder, router *mux.Router) {
 			rpt.WriteBinary(&buf, gzip.DefaultCompression)
 		}
 
-		if err := a.Add(ctx, rpt, buf.Bytes()); err != nil {
+		if err := a.Add(ctx, Version, rpt, buf.Bytes()); err != nil {
 			log.Errorf("Error Adding report: %v", err)
 			respondWith(w, http.StatusInternalServerError, err)
 			return

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -1,0 +1,75 @@
+package version
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+const (
+	versionRegexp = "^v?(\\d+)\\.(\\d+)\\.(\\d+)$"
+)
+
+// Version represents a release version decomposed in (major,minor,patch)
+type Version struct {
+	major int
+	minor int
+	patch int
+}
+
+// New returns a new Version
+func New(major, minor, patch int) Version {
+	return Version{major, minor, patch}
+}
+
+// ParseVersion parses a version string and, if successful, returns a Version
+func ParseVersion(version string) (*Version, error) {
+	// the regexp catches this, short circuiting does not hurt though
+	if version == "" {
+		return nil, fmt.Errorf("Invalid version: %v", version)
+	}
+
+	re := regexp.MustCompile(versionRegexp)
+	match := re.FindStringSubmatch(version)
+	if len(match) != 4 {
+		return nil, fmt.Errorf("Invalid version: %v", version)
+	}
+
+	major, err := strconv.Atoi(match[1])
+	if err != nil {
+		return nil, fmt.Errorf("Invalid version: %v", version)
+	}
+	minor, err := strconv.Atoi(match[2])
+	if err != nil {
+		return nil, fmt.Errorf("Invalid version: %v", version)
+	}
+	patch, err := strconv.Atoi(match[3])
+	if err != nil {
+		return nil, fmt.Errorf("Invalid version: %v", version)
+	}
+
+	return &Version{major, minor, patch}, nil
+}
+
+// Lower compares v against version and returns true if v is lower than version
+func (v Version) Lower(version Version) bool {
+	if v.major < version.major {
+		return true
+	}
+	if v.major > version.major {
+		return false
+	}
+	// major versions are equal
+	if v.minor < version.minor {
+		return true
+	}
+	if v.minor > version.minor {
+		return false
+	}
+	// minor versions are equal
+	return v.patch < version.patch
+}
+
+func (v Version) String() string {
+	return fmt.Sprintf("%v.%v.%v", v.major, v.minor, v.patch)
+}

--- a/common/version/version_test.go
+++ b/common/version/version_test.go
@@ -1,0 +1,87 @@
+package version
+
+import (
+	"testing"
+)
+
+func TestParseVersion(t *testing.T) {
+	for input, expected := range map[string]*Version{
+		"0.0.0":     {0, 0, 0},
+		"0.0.1":     {0, 0, 1},
+		"0.10.0":    {0, 10, 0},
+		"0.9.0":     {0, 9, 0},
+		"0.10.1":    {0, 10, 1},
+		"1.10.1":    {1, 10, 1},
+		"1.1100.1":  {1, 1100, 1},
+		"23.11.657": {23, 11, 657},
+		"v0.0.0":    {0, 0, 0},
+		"v0.0.1":    {0, 0, 1},
+		"v0.10.0":   {0, 10, 0},
+		"v0.9.0":    {0, 9, 0},
+		"v0.10.1":   {0, 10, 1},
+		"v1.10.1":   {1, 10, 1},
+		"v1.1100.1": {1, 1100, 1},
+		"0.0":       nil,
+		"0.9":       nil,
+		"0.10":      nil,
+		"v0.0":      nil,
+		"v0.10":     nil,
+		"v1.10":     nil,
+		"1.10.1-b":  nil,
+		"v1.10.1-b": nil,
+		"1.10.1-r":  nil,
+		"v1.10.1-r": nil,
+		"":          nil,
+		"a":         nil,
+		"abc":       nil,
+		"1":         nil,
+		"12":        nil,
+		"v1":        nil,
+		"v12":       nil,
+		"1669ff8e":  nil,
+		"1669ff8e285641526c3e56e942e9f50cbe6b03b6": nil,
+	} {
+		v, err := ParseVersion(input)
+		if err == nil && expected == nil {
+			t.Errorf("%v parsed to %v, but did not expect to parse", input, v)
+		} else if err == nil && *expected != *v {
+			t.Errorf("%v parsed to %v, but expected %v", input, v, expected)
+		} else if err != nil && expected != nil {
+			t.Errorf("%v did not parse, but expected to parse to %v", input, expected)
+		}
+	}
+}
+
+func parse(t *testing.T, version string) Version {
+	v, err := ParseVersion(version)
+	if err != nil {
+		t.Errorf("%v did not parse", version)
+	}
+	return *v
+}
+
+func TestVerionLower(t *testing.T) {
+	successes := map[string]string{
+		"1.30.0": "2.0.0",
+		"1.31.1": "1.32.1",
+	}
+	failures := map[string]string{
+		"2.65.130":    "2.65.130",
+		"2.123.15565": "0.23123.2111",
+	}
+
+	for lhs, rhs := range successes {
+		vLHS := parse(t, lhs)
+		vRHS := parse(t, rhs)
+		if !vLHS.Lower(vRHS) {
+			t.Errorf("expected %v < %v", vLHS, vRHS)
+		}
+	}
+	for lhs, rhs := range failures {
+		vLHS := parse(t, lhs)
+		vRHS := parse(t, rhs)
+		if vLHS.Lower(vRHS) {
+			t.Errorf("expected %v >= %v", vLHS, vRHS)
+		}
+	}
+}

--- a/probe/host/reporter.go
+++ b/probe/host/reporter.go
@@ -23,7 +23,6 @@ const (
 	Load1         = "load1"
 	CPUUsage      = "host_cpu_usage_percent"
 	MemoryUsage   = "host_mem_usage_bytes"
-	ScopeVersion  = "host_scope_version"
 )
 
 // Exposed for testing.
@@ -37,12 +36,12 @@ const (
 // Exposed for testing.
 var (
 	MetadataTemplates = report.MetadataTemplates{
-		KernelVersion: {ID: KernelVersion, Label: "Kernel Version", From: report.FromLatest, Priority: 1},
-		Uptime:        {ID: Uptime, Label: "Uptime", From: report.FromLatest, Priority: 2, Datatype: report.Duration},
-		HostName:      {ID: HostName, Label: "Hostname", From: report.FromLatest, Priority: 11},
-		OS:            {ID: OS, Label: "OS", From: report.FromLatest, Priority: 12},
-		LocalNetworks: {ID: LocalNetworks, Label: "Local Networks", From: report.FromSets, Priority: 13},
-		ScopeVersion:  {ID: ScopeVersion, Label: "Scope Version", From: report.FromLatest, Priority: 14},
+		KernelVersion:       {ID: KernelVersion, Label: "Kernel Version", From: report.FromLatest, Priority: 1},
+		Uptime:              {ID: Uptime, Label: "Uptime", From: report.FromLatest, Priority: 2, Datatype: report.Duration},
+		HostName:            {ID: HostName, Label: "Hostname", From: report.FromLatest, Priority: 11},
+		OS:                  {ID: OS, Label: "OS", From: report.FromLatest, Priority: 12},
+		LocalNetworks:       {ID: LocalNetworks, Label: "Local Networks", From: report.FromSets, Priority: 13},
+		report.ScopeVersion: {ID: report.ScopeVersion, Label: "Scope Version", From: report.FromLatest, Priority: 14},
 	}
 
 	MetricTemplates = report.MetricTemplates{
@@ -132,7 +131,7 @@ func (r *Reporter) Report() (report.Report, error) {
 			OS:                    runtime.GOOS,
 			KernelVersion:         kernel,
 			Uptime:                strconv.Itoa(int(uptime / time.Second)), // uptime in seconds
-			ScopeVersion:          r.version,
+			report.ScopeVersion:   r.version,
 		}).
 			WithSets(report.MakeSets().
 				Add(LocalNetworks, report.MakeStringSet(localCIDRs...)),

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -116,8 +116,47 @@ func TestReportUpgrade(t *testing.T) {
 	rpt.Pod.AddNode(node)
 	expected := report.MakeReport()
 	expected.Pod.AddNode(expectedNode)
-	got := rpt.Upgrade()
+	got := rpt.Upgrade("")
 	if !s_reflect.DeepEqual(expected, got) {
 		t.Error(test.Diff(expected, got))
+	}
+}
+
+func TestReportRequiresUpgrade(t *testing.T) {
+	node := report.MakeNodeWith("foo", map[string]string{report.ScopeVersion: "0.1.3"})
+	rpt := report.MakeReport()
+	rpt.Host.AddNode(node)
+	if !rpt.RequiresUpgrade("1.60.0") {
+		t.Errorf("report %v does require upgrading", rpt)
+	}
+
+	node = report.MakeNodeWith("foo", map[string]string{report.ScopeVersion: "1.50.0"})
+	rpt = report.MakeReport()
+	rpt.Host.AddNode(node)
+	if rpt.RequiresUpgrade("1.60.0") {
+		t.Errorf("report %v does not require upgrading", rpt)
+	}
+
+	node = report.MakeNodeWith("foo", map[string]string{report.ScopeVersion: "1.50.0"})
+	rpt = report.MakeReport()
+	rpt.Host.AddNode(node)
+	if !rpt.RequiresUpgrade("abcd1234") {
+		t.Errorf("report %v does require upgrading", rpt)
+	}
+
+	node = report.MakeNodeWith("foo", map[string]string{report.ScopeVersion: "abcd1234"})
+	rpt = report.MakeReport()
+	rpt.Host.AddNode(node)
+	if rpt.RequiresUpgrade("abcd1234") {
+		t.Errorf("report %v does not require upgrading", rpt)
+	}
+
+	node = report.MakeNodeWith("foo", map[string]string{report.ScopeVersion: "1.50.0"})
+	node2 := report.MakeNodeWith("foo", map[string]string{report.ScopeVersion: "0.1.3"})
+	rpt = report.MakeReport()
+	rpt.Host.AddNode(node)
+	rpt.Host.AddNode(node2)
+	if !rpt.RequiresUpgrade("1.60.0") {
+		t.Errorf("report %v does require upgrading", rpt)
 	}
 }


### PR DESCRIPTION
* `report.node.LatestControls` and `NodeControlData` was introduced before version 0.16.2, therefore only upgrade the report if the probe's version is below.
* Do not upgrade the report if both the probe and the app have git revisions as version and they are equal.
* The probe's version is stored in the header and in the report itself. Only the version in the report is used to avoid issues when merging reports.
* `Upgrade()` is now also called on the ingest path

See #2959