### PR TITLE
do not report allocations in benchmarks 

### DIFF
--- a/app/benchmark_internal_test.go
+++ b/app/benchmark_internal_test.go
@@ -40,7 +40,6 @@ func readReportFiles(path string) ([]report.Report, error) {
 }
 
 func BenchmarkReportUnmarshal(b *testing.B) {
-	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
@@ -58,7 +57,6 @@ func BenchmarkReportMerge(b *testing.B) {
 	}
 	merger := NewSmartMerger()
 
-	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
@@ -86,7 +84,6 @@ func benchmarkRender(b *testing.B, f func(report.Report)) {
 		r = NewSmartMerger().Merge(reports)
 	}
 
-	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {

--- a/app/benchmark_internal_test.go
+++ b/app/benchmark_internal_test.go
@@ -42,8 +42,6 @@ func readReportFiles(path string) ([]report.Report, error) {
 func BenchmarkReportUnmarshal(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		b.StopTimer()
-		b.StartTimer()
 		if _, err := readReportFiles(*benchReportPath); err != nil {
 			b.Fatal(err)
 		}
@@ -58,9 +56,8 @@ func BenchmarkReportMerge(b *testing.B) {
 	merger := NewSmartMerger()
 
 	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
-		b.StopTimer()
-		b.StartTimer()
 		merger.Merge(reports)
 	}
 }

--- a/app/merger_test.go
+++ b/app/merger_test.go
@@ -69,7 +69,6 @@ func benchmarkMerger(b *testing.B, merger app.Merger) {
 		reports = append(reports, makeReport())
 	}
 
-	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {

--- a/common/xfer/plugin_spec_internal_test.go
+++ b/common/xfer/plugin_spec_internal_test.go
@@ -48,7 +48,7 @@ func BenchmarkMakePluginSpecs(b *testing.B) {
 	for i := 1000; i >= 0; i-- {
 		plugins = append(plugins, PluginSpec{ID: fmt.Sprint(i)})
 	}
-	b.ReportAllocs()
+
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -145,7 +145,6 @@ func BenchmarkPluginSpecsAdd(b *testing.B) {
 
 	plugin := PluginSpec{ID: "401.5"}
 
-	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -216,7 +215,7 @@ func BenchmarkPluginSpecsMerge(b *testing.B) {
 	for i := 400; i < 1000; i++ {
 		other = other.Add(PluginSpec{ID: fmt.Sprint(i)})
 	}
-	b.ReportAllocs()
+
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {

--- a/render/benchmark_test.go
+++ b/render/benchmark_test.go
@@ -40,12 +40,11 @@ func BenchmarkPodServiceRender(b *testing.B) {
 }
 
 func benchmarkRender(b *testing.B, r render.Renderer) {
-
 	report, err := loadReport()
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.ReportAllocs()
+
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {

--- a/report/latest_map_internal_test.go
+++ b/report/latest_map_internal_test.go
@@ -136,8 +136,9 @@ func BenchmarkLatestMapMerge(b *testing.B) {
 	// two large maps with some overlap
 	left := makeBenchmarkMap(0, 1000, time.Now())
 	right := makeBenchmarkMap(700, 1700, time.Now().Add(1*time.Minute))
-	b.ReportAllocs()
+
 	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
 		left.Merge(right)
 	}
@@ -145,8 +146,9 @@ func BenchmarkLatestMapMerge(b *testing.B) {
 
 func BenchmarkLatestMapEncode(b *testing.B) {
 	map1 := makeBenchmarkMap(0, 1000, time.Now())
-	b.ReportAllocs()
+
 	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
 		buf := &bytes.Buffer{}
 		codec.NewEncoder(buf, &codec.MsgpackHandle{}).Encode(&map1)
@@ -157,8 +159,9 @@ func BenchmarkLatestMapDecode(b *testing.B) {
 	map1 := makeBenchmarkMap(0, 1000, time.Now())
 	buf := &bytes.Buffer{}
 	codec.NewEncoder(buf, &codec.MsgpackHandle{}).Encode(&map1)
-	b.ReportAllocs()
+
 	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
 		var map1 StringLatestMap
 		codec.NewDecoderBytes(buf.Bytes(), &codec.MsgpackHandle{}).Decode(&map1)

--- a/report/node_set_test.go
+++ b/report/node_set_test.go
@@ -56,7 +56,7 @@ func BenchmarkMakeNodeSet(b *testing.B) {
 			"b": "2",
 		}))
 	}
-	b.ReportAllocs()
+
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -161,7 +161,6 @@ func BenchmarkNodeSetAdd(b *testing.B) {
 		"b": "2",
 	})
 
-	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -299,7 +298,7 @@ func BenchmarkNodeSetMerge(b *testing.B) {
 			}),
 		)
 	}
-	b.ReportAllocs()
+
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
That's what `-benchmem` is for.