### PR TITLE
make report upgrading fast when it's a no-op

### DIFF
--- a/app/benchmark_internal_test.go
+++ b/app/benchmark_internal_test.go
@@ -67,6 +67,20 @@ func BenchmarkReportMerge(b *testing.B) {
 	}
 }
 
+func BenchmarkReportUpgrade(b *testing.B) {
+	reports, err := readReportFiles(*benchReportPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	r := NewSmartMerger().Merge(reports)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		r.Upgrade()
+	}
+}
+
 func BenchmarkTopologyList(b *testing.B) {
 	benchmarkRender(b, func(report report.Report) {
 		request := &http.Request{

--- a/report/report.go
+++ b/report/report.go
@@ -341,6 +341,18 @@ func (r Report) Validate() error {
 //
 // This for now creates node's LatestControls from Controls.
 func (r Report) Upgrade() Report {
+	needUpgrade := false
+	r.WalkTopologies(func(topology *Topology) {
+		for _, node := range topology.Nodes {
+			if node.LatestControls.Size() == 0 && len(node.Controls.Controls) > 0 {
+				needUpgrade = true
+			}
+		}
+	})
+	if !needUpgrade {
+		return r
+	}
+
 	cp := r.Copy()
 	ncd := NodeControlData{
 		Dead: false,


### PR DESCRIPTION
The vast majority of the cost is memory allocation, so doing a first pass to see whether any upgrading is necessary at all, and thus avoiding allocation when it isn't, is a massive saving.

Part of resolving #2959.
