### PR TITLE
probe: Use an absolute FQDN for cloud.weave.works by default

### DIFF
--- a/prog/probe.go
+++ b/prog/probe.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	versionCheckPeriod = 6 * time.Hour
-	defaultServiceHost = "https://cloud.weave.works:443"
+	defaultServiceHost = "https://cloud.weave.works.:443"
 )
 
 var (


### PR DESCRIPTION
This can save a few DNS queries here and there!