### PR TITLE
Upgrade reports before caching

### DIFF
--- a/app/collector.go
+++ b/app/collector.go
@@ -152,7 +152,11 @@ func (c *collector) Report(_ context.Context, timestamp time.Time) (report.Repor
 	c.clean()
 	c.quantise()
 
-	rpt := c.merger.Merge(c.reports).Upgrade()
+	for i := range c.reports {
+		c.reports[i] = c.reports[i].Upgrade()
+	}
+
+	rpt := c.merger.Merge(c.reports)
 	c.cached = &rpt
 	return rpt, nil
 }

--- a/app/multitenant/aws_collector.go
+++ b/app/multitenant/aws_collector.go
@@ -284,6 +284,7 @@ func (c *awsCollector) getReports(ctx context.Context, reportKeys []string) ([]r
 			log.Warningf("Error fetching from cache: %v", err)
 		}
 		for key, report := range found {
+			report = report.Upgrade()
 			c.inProcess.StoreReport(key, report)
 			reports = append(reports, report)
 		}
@@ -337,7 +338,7 @@ func (c *awsCollector) Report(ctx context.Context, timestamp time.Time) (report.
 		return report.MakeReport(), err
 	}
 
-	return c.merger.Merge(reports).Upgrade(), nil
+	return c.merger.Merge(reports), nil
 }
 
 func (c *awsCollector) HasHistoricReports() bool {


### PR DESCRIPTION
This change will reduces upgrades, since `report.Upgrade` only performs an upgrade if necessary.

Fixes https://github.com/weaveworks/scope/issues/2970