### PR TITLE
cheap probe connectedness api endpoint

### DIFF
--- a/app/api_report.go
+++ b/app/api_report.go
@@ -32,6 +32,16 @@ type probeDesc struct {
 // Probe handler
 func makeProbeHandler(rep Reporter) CtxHandlerFunc {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		if _, sparse := r.Form["sparse"]; sparse {
+			// if we have reports, we must have connected probes
+			hasProbes, err := rep.HasReports(ctx, time.Now())
+			if err != nil {
+				respondWith(w, http.StatusInternalServerError, err)
+			}
+			respondWith(w, http.StatusOK, hasProbes)
+			return
+		}
 		rpt, err := rep.Report(ctx, time.Now())
 		if err != nil {
 			respondWith(w, http.StatusInternalServerError, err)

--- a/app/multitenant/aws_collector.go
+++ b/app/multitenant/aws_collector.go
@@ -349,6 +349,11 @@ func (c *awsCollector) Report(ctx context.Context, timestamp time.Time) (report.
 	return c.merger.Merge(reports), nil
 }
 
+func (c *awsCollector) HasReports(ctx context.Context, timestamp time.Time) (bool, error) {
+	reportKeys, err := c.getReportKeys(ctx, timestamp)
+	return len(reportKeys) > 0, err
+}
+
 func (c *awsCollector) HasHistoricReports() bool {
 	return true
 }

--- a/app/multitenant/aws_collector.go
+++ b/app/multitenant/aws_collector.go
@@ -267,12 +267,13 @@ func (c *awsCollector) reportKeysInRange(ctx context.Context, userid string, row
 // getReportKeys returns the S3 for reports in the reporting window ending at timestamp.
 func (c *awsCollector) getReportKeys(ctx context.Context, timestamp time.Time) ([]string, error) {
 	var (
-		end         = timestamp
-		start       = end.Add(-c.window)
-		rowStart    = start.UnixNano() / time.Hour.Nanoseconds()
-		rowEnd      = end.UnixNano() / time.Hour.Nanoseconds()
-		userid, err = c.userIDer(ctx)
+		end      = timestamp
+		start    = end.Add(-c.window)
+		rowStart = start.UnixNano() / time.Hour.Nanoseconds()
+		rowEnd   = end.UnixNano() / time.Hour.Nanoseconds()
 	)
+
+	userid, err := c.userIDer(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -284,12 +285,10 @@ func (c *awsCollector) getReportKeys(ctx context.Context, timestamp time.Time) (
 		if err != nil {
 			return nil, err
 		}
-
 		reportKeys2, err := c.reportKeysInRange(ctx, userid, rowEnd, start, end)
 		if err != nil {
 			return nil, err
 		}
-
 		reportKeys = append(reportKeys, reportKeys1...)
 		reportKeys = append(reportKeys, reportKeys2...)
 	} else {


### PR DESCRIPTION
This introduce a cheap `/api/probes?sparse` variant.

In many cases we only need to know whether there are _any_ connected probes, and not the probe details. Obtaining that info is cheaper since it requires no reading or merging or reports.

Fixes #2982.