### PR TITLE
Probe reports namespaces

### DIFF
--- a/probe/kubernetes/client.go
+++ b/probe/kubernetes/client.go
@@ -35,7 +35,6 @@ type Client interface {
 	WalkStatefulSets(f func(StatefulSet) error) error
 	WalkCronJobs(f func(CronJob) error) error
 	WalkReplicationControllers(f func(ReplicationController) error) error
-	WalkNodes(f func(*apiv1.Node) error) error
 	WalkNamespaces(f func(NamespaceResource) error) error
 
 	WatchPods(f func(Event, Pod))
@@ -313,16 +312,6 @@ func (c *client) WalkCronJobs(f func(CronJob) error) error {
 	for _, m := range c.cronJobStore.List() {
 		cj := m.(*apibatchv2alpha1.CronJob)
 		if err := f(NewCronJob(cj, jobs)); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (c *client) WalkNodes(f func(*apiv1.Node) error) error {
-	for _, m := range c.nodeStore.List() {
-		node := m.(*apiv1.Node)
-		if err := f(node); err != nil {
 			return err
 		}
 	}

--- a/probe/kubernetes/meta.go
+++ b/probe/kubernetes/meta.go
@@ -58,3 +58,36 @@ func (m meta) MetaNode(id string) report.Node {
 		Created:   m.Created(),
 	}).AddPrefixPropertyList(LabelPrefix, m.Labels())
 }
+
+type namespaceMeta struct {
+	ObjectMeta metav1.ObjectMeta
+}
+
+func (m namespaceMeta) UID() string {
+	return string(m.ObjectMeta.UID)
+}
+
+func (m namespaceMeta) Name() string {
+	return m.ObjectMeta.Name
+}
+
+func (m namespaceMeta) Namespace() string {
+	return m.ObjectMeta.Namespace
+}
+
+func (m namespaceMeta) Created() string {
+	return m.ObjectMeta.CreationTimestamp.Format(time.RFC3339Nano)
+}
+
+func (m namespaceMeta) Labels() map[string]string {
+	return m.ObjectMeta.Labels
+}
+
+// MetaNode gets the node metadata
+// For namespaces, ObjectMeta.Namespace is not set
+func (m namespaceMeta) MetaNode(id string) report.Node {
+	return report.MakeNodeWith(id, map[string]string{
+		Name:    m.Name(),
+		Created: m.Created(),
+	}).AddPrefixPropertyList(LabelPrefix, m.Labels())
+}

--- a/probe/kubernetes/namespace.go
+++ b/probe/kubernetes/namespace.go
@@ -1,0 +1,28 @@
+package kubernetes
+
+import (
+	"github.com/weaveworks/scope/report"
+
+	apiv1 "k8s.io/client-go/pkg/api/v1"
+)
+
+// NamespaceResource represents a Kubernetes namespace
+// `Namespace` is already taken in meta.go
+type NamespaceResource interface {
+	Meta
+	GetNode() report.Node
+}
+
+type namespace struct {
+	ns *apiv1.Namespace
+	Meta
+}
+
+// NewNamespace creates a new Namespace
+func NewNamespace(ns *apiv1.Namespace) NamespaceResource {
+	return &namespace{ns: ns, Meta: namespaceMeta{ns.ObjectMeta}}
+}
+
+func (ns *namespace) GetNode() report.Node {
+	return ns.MetaNode(report.MakeNamespaceNodeID(ns.UID()))
+}

--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -264,6 +264,10 @@ func (r *Reporter) Report() (report.Report, error) {
 	if err != nil {
 		return result, err
 	}
+	namespaceTopology, err := r.namespaceTopology()
+	if err != nil {
+		return result, err
+	}
 	result.Pod = result.Pod.Merge(podTopology)
 	result.Service = result.Service.Merge(serviceTopology)
 	result.Host = result.Host.Merge(hostTopology)
@@ -271,6 +275,7 @@ func (r *Reporter) Report() (report.Report, error) {
 	result.StatefulSet = result.StatefulSet.Merge(statefulSetTopology)
 	result.CronJob = result.CronJob.Merge(cronJobTopology)
 	result.Deployment = result.Deployment.Merge(deploymentTopology)
+	result.Namespace = result.Namespace.Merge(namespaceTopology)
 	return result, nil
 }
 
@@ -499,4 +504,13 @@ func (r *Reporter) podTopology(services []Service, deployments []Deployment, dae
 		return nil
 	})
 	return pods, err
+}
+
+func (r *Reporter) namespaceTopology() (report.Topology, error) {
+	result := report.MakeTopology()
+	err := r.client.WalkNamespaces(func(ns NamespaceResource) error {
+		result = result.AddNode(ns.GetNode())
+		return nil
+	})
+	return result, err
 }

--- a/probe/kubernetes/reporter_test.go
+++ b/probe/kubernetes/reporter_test.go
@@ -151,9 +151,6 @@ func (c *mockClient) WalkReplicaSets(f func(kubernetes.ReplicaSet) error) error 
 func (c *mockClient) WalkReplicationControllers(f func(kubernetes.ReplicationController) error) error {
 	return nil
 }
-func (*mockClient) WalkNodes(f func(*apiv1.Node) error) error {
-	return nil
-}
 func (c *mockClient) WalkNamespaces(f func(kubernetes.NamespaceResource) error) error {
 	return nil
 }

--- a/probe/kubernetes/reporter_test.go
+++ b/probe/kubernetes/reporter_test.go
@@ -154,6 +154,9 @@ func (c *mockClient) WalkReplicationControllers(f func(kubernetes.ReplicationCon
 func (*mockClient) WalkNodes(f func(*apiv1.Node) error) error {
 	return nil
 }
+func (c *mockClient) WalkNamespaces(f func(kubernetes.NamespaceResource) error) error {
+	return nil
+}
 func (*mockClient) WatchPods(func(kubernetes.Event, kubernetes.Pod)) {}
 func (c *mockClient) GetLogs(namespaceID, podName string) (io.ReadCloser, error) {
 	r, ok := c.logs[namespaceID+";"+podName]

--- a/report/id.go
+++ b/report/id.go
@@ -140,6 +140,12 @@ var (
 	// ParseCronJobNodeID parses a cronjob node ID
 	ParseCronJobNodeID = parseSingleComponentID("cronjob")
 
+	// MakeNamespaceNodeID produces a namespace node ID from its composite parts.
+	MakeNamespaceNodeID = makeSingleComponentID("namespace")
+
+	// ParseNamespaceNodeID parses a namespace set node ID
+	ParseNamespaceNodeID = parseSingleComponentID("namespace")
+
 	// MakeECSTaskNodeID produces a ECSTask node ID from its composite parts.
 	MakeECSTaskNodeID = makeSingleComponentID("ecs_task")
 

--- a/report/map_keys.go
+++ b/report/map_keys.go
@@ -69,6 +69,7 @@ const (
 	KubernetesSuspended            = "kubernetes_suspended"
 	KubernetesLastScheduled        = "kubernetes_last_scheduled"
 	KubernetesActiveJobs           = "kubernetes_active_jobs"
+	KubernetesStateDeleted         = "deleted"
 	// probe/awsecs
 	ECSCluster             = "ecs_cluster"
 	ECSCreatedAt           = "ecs_created_at"

--- a/report/report.go
+++ b/report/report.go
@@ -22,6 +22,7 @@ const (
 	DaemonSet      = "daemon_set"
 	StatefulSet    = "stateful_set"
 	CronJob        = "cron_job"
+	Namespace      = "namespace"
 	ContainerImage = "container_image"
 	Host           = "host"
 	Overlay        = "overlay"
@@ -56,6 +57,7 @@ var topologyNames = []string{
 	DaemonSet,
 	StatefulSet,
 	CronJob,
+	Namespace,
 	Host,
 	Overlay,
 	ECSTask,
@@ -114,6 +116,11 @@ type Report struct {
 	// Metadata includes things like Cron Job id, name, etc. Edges are not
 	// present.
 	CronJob Topology
+
+	// Namespace nodes represent all Kubernetes Namespaces running on hosts running probes.
+	// Metadata includes things like Namespace id, name, etc. Edges are not
+	// present.
+	Namespace Topology
 
 	// ContainerImages nodes represent all Docker containers images on
 	// hosts running probes. Metadata includes things like image id, name etc.
@@ -217,6 +224,8 @@ func MakeReport() Report {
 			WithShape(Triangle).
 			WithLabel("cron job", "cron jobs"),
 
+		Namespace: MakeTopology(),
+
 		Overlay: MakeTopology().
 			WithShape(Circle).
 			WithLabel("peer", "peers"),
@@ -317,6 +326,8 @@ func (r *Report) topology(name string) *Topology {
 		return &r.StatefulSet
 	case CronJob:
 		return &r.CronJob
+	case Namespace:
+		return &r.Namespace
 	case Host:
 		return &r.Host
 	case Overlay:


### PR DESCRIPTION
If the probe reports namespace topologies, the app, in particular `updateKubeFilters()`, is able to avoid unnecessary loops.

Fixes #2945.

This PR also fixes incorrect comments and removes `WalkNodes()` which was unused.