### PR TITLE
refactor: drop networks from render.MapFunc

### DIFF
--- a/render/container.go
+++ b/render/container.go
@@ -264,7 +264,7 @@ func MapContainer2IP(m report.Node) []string {
 // format for a container, but without any Major or Minor labels.
 // It does not have enough info to do that, and the resulting graph
 // must be merged with a container graph to get that info.
-func MapProcess2Container(n report.Node, _ report.Networks) report.Nodes {
+func MapProcess2Container(n report.Node) report.Nodes {
 	// Propagate pseudo nodes
 	if n.Topology == Pseudo {
 		return report.Nodes{n.ID: n}
@@ -301,7 +301,7 @@ func MapProcess2Container(n report.Node, _ report.Networks) report.Nodes {
 // format for a container, but without any Major or Minor labels.
 // It does not have enough info to do that, and the resulting graph
 // must be merged with a container graph to get that info.
-func MapContainer2ContainerImage(n report.Node, _ report.Networks) report.Nodes {
+func MapContainer2ContainerImage(n report.Node) report.Nodes {
 	// Propagate all pseudo nodes
 	if n.Topology == Pseudo {
 		return report.Nodes{n.ID: n}
@@ -323,7 +323,7 @@ func MapContainer2ContainerImage(n report.Node, _ report.Networks) report.Nodes 
 }
 
 // MapContainerImage2Name ignores image versions
-func MapContainerImage2Name(n report.Node, _ report.Networks) report.Nodes {
+func MapContainerImage2Name(n report.Node) report.Nodes {
 	// Propagate all pseudo nodes
 	if n.Topology == Pseudo {
 		return report.Nodes{n.ID: n}
@@ -345,7 +345,7 @@ func MapContainerImage2Name(n report.Node, _ report.Networks) report.Nodes {
 }
 
 // MapContainer2Hostname maps container Nodes to 'hostname' renderabled nodes..
-func MapContainer2Hostname(n report.Node, _ report.Networks) report.Nodes {
+func MapContainer2Hostname(n report.Node) report.Nodes {
 	// Propagate all pseudo nodes
 	if n.Topology == Pseudo {
 		return report.Nodes{n.ID: n}
@@ -366,6 +366,6 @@ func MapContainer2Hostname(n report.Node, _ report.Networks) report.Nodes {
 
 // MapToEmpty removes all the attributes, children, etc, of a node. Useful when
 // we just want to count the presence of nodes.
-func MapToEmpty(n report.Node, _ report.Networks) report.Nodes {
+func MapToEmpty(n report.Node) report.Nodes {
 	return report.Nodes{n.ID: report.MakeNode(n.ID).WithTopology(n.Topology)}
 }

--- a/render/container_test.go
+++ b/render/container_test.go
@@ -43,11 +43,7 @@ type testcase struct {
 }
 
 func testMap(t *testing.T, f render.MapFunc, input testcase) {
-	localNetworks := report.MakeNetworks()
-	if err := localNetworks.AddCIDR("1.2.3.0/16"); err != nil {
-		t.Fatalf(err.Error())
-	}
-	if have := f(input.n, localNetworks); input.ok != (len(have) > 0) {
+	if have := f(input.n); input.ok != (len(have) > 0) {
 		name := input.name
 		if name == "" {
 			name = fmt.Sprintf("%v", input.n)

--- a/render/metrics.go
+++ b/render/metrics.go
@@ -7,7 +7,7 @@ import (
 // PropagateSingleMetrics puts metrics from one of the children onto the parent
 // iff there is only one child of that type.
 func PropagateSingleMetrics(topology string) MapFunc {
-	return func(n report.Node, _ report.Networks) report.Nodes {
+	return func(n report.Node) report.Nodes {
 		var found []report.Node
 		n.Children.ForEach(func(child report.Node) {
 			if child.Topology == topology {

--- a/render/metrics_test.go
+++ b/render/metrics_test.go
@@ -159,7 +159,7 @@ func TestPropagateSingleMetrics(t *testing.T) {
 			},
 		},
 	} {
-		got := render.PropagateSingleMetrics(c.topology)(c.input, report.Networks{})
+		got := render.PropagateSingleMetrics(c.topology)(c.input)
 		if !reflect.DeepEqual(got, c.output) {
 			t.Errorf("[%s] Diff: %s", c.name, test.Diff(c.output, got))
 		}

--- a/render/pod.go
+++ b/render/pod.go
@@ -136,7 +136,7 @@ func Map2Parent(
 	// any parents in the group, eg. UnmanagedID, or "" to drop nodes without any parents.
 	noParentsPseudoID string,
 ) MapFunc {
-	return func(n report.Node, _ report.Networks) report.Nodes {
+	return func(n report.Node) report.Nodes {
 		// Uncontained becomes Unmanaged/whatever if noParentsPseudoID is set
 		if noParentsPseudoID != "" && strings.HasPrefix(n.ID, UncontainedIDPrefix) {
 			id := MakePseudoNodeID(noParentsPseudoID, report.ExtractHostID(n))

--- a/render/render.go
+++ b/render/render.go
@@ -8,7 +8,7 @@ import (
 // return a set of other Nodes.
 //
 // If the output is empty, the node shall be omitted from the rendered topology.
-type MapFunc func(report.Node, report.Networks) report.Nodes
+type MapFunc func(report.Node) report.Nodes
 
 // Renderer is something that can render a report to a set of Nodes.
 type Renderer interface {
@@ -99,16 +99,15 @@ func MakeMap(f MapFunc, r Renderer) Renderer {
 // using a map function
 func (m Map) Render(rpt report.Report) Nodes {
 	var (
-		input         = m.Renderer.Render(rpt)
-		output        = report.Nodes{}
-		mapped        = map[string]report.IDList{} // input node ID -> output node IDs
-		adjacencies   = map[string]report.IDList{} // output node ID -> input node Adjacencies
-		localNetworks = LocalNetworks(rpt)
+		input       = m.Renderer.Render(rpt)
+		output      = report.Nodes{}
+		mapped      = map[string]report.IDList{} // input node ID -> output node IDs
+		adjacencies = map[string]report.IDList{} // output node ID -> input node Adjacencies
 	)
 
 	// Rewrite all the nodes according to the map function
 	for _, inRenderable := range input.Nodes {
-		for _, outRenderable := range m.MapFunc(inRenderable, localNetworks) {
+		for _, outRenderable := range m.MapFunc(inRenderable) {
 			if existing, ok := output[outRenderable.ID]; ok {
 				outRenderable = outRenderable.Merge(existing)
 			}

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -36,7 +36,7 @@ func TestReduceRender(t *testing.T) {
 func TestMapRender1(t *testing.T) {
 	// 1. Check when we return false, the node gets filtered out
 	mapper := render.Map{
-		MapFunc: func(nodes report.Node, _ report.Networks) report.Nodes {
+		MapFunc: func(nodes report.Node) report.Nodes {
 			return report.Nodes{}
 		},
 		Renderer: mockRenderer{Nodes: report.Nodes{
@@ -53,7 +53,7 @@ func TestMapRender1(t *testing.T) {
 func TestMapRender2(t *testing.T) {
 	// 2. Check we can remap two nodes into one
 	mapper := render.Map{
-		MapFunc: func(nodes report.Node, _ report.Networks) report.Nodes {
+		MapFunc: func(nodes report.Node) report.Nodes {
 			return report.Nodes{
 				"bar": report.MakeNode("bar"),
 			}
@@ -75,7 +75,7 @@ func TestMapRender2(t *testing.T) {
 func TestMapRender3(t *testing.T) {
 	// 3. Check we can remap adjacencies
 	mapper := render.Map{
-		MapFunc: func(nodes report.Node, _ report.Networks) report.Nodes {
+		MapFunc: func(nodes report.Node) report.Nodes {
 			id := "_" + nodes.ID
 			return report.Nodes{id: report.MakeNode(id)}
 		},

--- a/render/weave.go
+++ b/render/weave.go
@@ -14,7 +14,7 @@ var WeaveRenderer = MakeMap(
 )
 
 // MapWeaveIdentity maps an overlay topology node to a weave topology node.
-func MapWeaveIdentity(m report.Node, _ report.Networks) report.Nodes {
+func MapWeaveIdentity(m report.Node) report.Nodes {
 	peerPrefix, _ := report.ParseOverlayNodeID(m.ID)
 	if peerPrefix != report.WeaveOverlayPeerPrefix {
 		return nil


### PR DESCRIPTION
All the MapFuncs that needed networks have been elevated to Renderers.