### PR TITLE
Upgrade Go to 1.9.2

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,12 +1,8 @@
-FROM ubuntu:yakkety
-ENV GOPATH /go
-ENV GOVERSION 1.8.3
-ENV PATH /go/bin:/usr/local/go/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+FROM golang:1.9.2-stretch
 ENV SCOPE_SKIP_UI_ASSETS true
 RUN apt-get update && \
 	apt-get install -y libpcap-dev python-requests time file shellcheck git gcc-arm-linux-gnueabihf curl build-essential python-pip && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN curl -Ls https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz | tar xz -C /usr/local
 RUN go clean -i net && \
 	go install -tags netgo std && \
 	go install -race -tags netgo std


### PR DESCRIPTION
I came up with some benchmarks that say it goes a bit faster, but the timings are highly variable from one minute to the next so without spending an hour trying to tie them down let's just upgrade because Go 1.9 is better than Go 1.8.

Right after a release (1.6.7) is a good time to upgrade.