### PR TITLE
Linux pretty name Issue #2901

### DIFF
--- a/probe/host/reporter.go
+++ b/probe/host/reporter.go
@@ -2,11 +2,9 @@ package host
 
 import (
 	"fmt"
-	"runtime"
 	"strconv"
 	"sync"
 	"time"
-
 	"github.com/weaveworks/common/mtime"
 	"github.com/weaveworks/scope/probe/controls"
 	"github.com/weaveworks/scope/report"

--- a/probe/host/reporter.go
+++ b/probe/host/reporter.go
@@ -124,10 +124,6 @@ func (r *Reporter) Report() (report.Report, error) {
 		return rep, err
 	}
 
-	if os == "unknown" {
-		os = runtime.GOOS
-	}
-
 	now := mtime.Now()
 	metrics := GetLoad(now)
 	cpuUsage, max := GetCPUUsagePercent()

--- a/probe/host/reporter.go
+++ b/probe/host/reporter.go
@@ -117,6 +117,17 @@ func (r *Reporter) Report() (report.Report, error) {
 	rep.Host = rep.Host.WithMetadataTemplates(MetadataTemplates)
 	rep.Host = rep.Host.WithMetricTemplates(MetricTemplates)
 
+
+	os, err := GetPrettyName()
+
+	if err != nil {
+		return rep, err
+	}
+
+	if os == "unknown" {
+		os = runtime.GOOS
+	}
+
 	now := mtime.Now()
 	metrics := GetLoad(now)
 	cpuUsage, max := GetCPUUsagePercent()
@@ -129,7 +140,7 @@ func (r *Reporter) Report() (report.Report, error) {
 			report.ControlProbeID: r.probeID,
 			Timestamp:             mtime.Now().UTC().Format(time.RFC3339Nano),
 			HostName:              r.hostName,
-			OS:                    runtime.GOOS,
+			OS:                    os,
 			KernelVersion:         kernel,
 			Uptime:                strconv.Itoa(int(uptime / time.Second)), // uptime in seconds
 			ScopeVersion:          r.version,

--- a/probe/host/system_darwin.go
+++ b/probe/host/system_darwin.go
@@ -30,6 +30,12 @@ var GetKernelReleaseAndVersion = func() (string, string, error) {
 	return string(release), string(version), nil
 }
 
+// GetPrettyName extracts the PRETTY_NAME from /etc/os-release
+var GetPrettyName = func () (string, error) {
+
+	return "unknown", nil
+}
+
 // GetLoad returns the current load averages as metrics.
 var GetLoad = func(now time.Time) report.Metrics {
 	out, err := exec.Command("w").CombinedOutput()

--- a/probe/host/system_darwin.go
+++ b/probe/host/system_darwin.go
@@ -3,6 +3,7 @@ package host
 import (
 	"bytes"
 	"os/exec"
+	"runtime"
 	"regexp"
 	"strconv"
 	"time"
@@ -32,8 +33,7 @@ var GetKernelReleaseAndVersion = func() (string, string, error) {
 
 // GetPrettyName extracts the PRETTY_NAME from /etc/os-release
 var GetPrettyName = func () (string, error) {
-
-	return "unknown", nil
+	return runtime.GOOS, nil
 }
 
 // GetLoad returns the current load averages as metrics.

--- a/probe/host/system_linux.go
+++ b/probe/host/system_linux.go
@@ -3,6 +3,7 @@ package host
 import (
 	"bytes"
 	"fmt"
+
 	"io/ioutil"
 	"strconv"
 	"strings"
@@ -32,23 +33,65 @@ var GetKernelReleaseAndVersion = func() (string, string, error) {
 	return string(release), string(version), nil
 }
 
-// GetPrettyName extracts the PRETTY_NAME from /etc/os-release
+// GetPrettyName extracts the PRETTY_NAME from host's /etc/os-release
+// SPEC: https://www.freedesktop.org/software/systemd/man/os-release.html
 var GetPrettyName = func () (string, error) {
-	buf, err := ioutil.ReadFile("/etc/os-release")
-	if err != nil {
-		return "unknown", nil
-	}
-	prettyParse, err := regexp.Compile("PRETTY_NAME=\"(.+?)\"\n")
+
+	var buffer bytes.Buffer
+
+	buf, err := ioutil.ReadFile("/var/run/scope/host-os-release")
 	if err != nil {
 		return "unknown", nil
 	}
 
-	prettyName := prettyParse.FindStringSubmatch(string(buf))
+	// If can't find host-os-release, get container's os-release
+	if buf == nil {
+		bufContainer, err := ioutil.ReadFile("/etc/os-release")
+		if err != nil {
+			return "unknown", nil
+		}
+		buf = bufContainer
+	}
+
+	// Pretty Name Fallback Flow:
+	// 1. $PRETTY_NAME
+	// 2. $NAME $VERSION
+	// 3. $ID $VERSION_ID
+	// 4. runtime.GOOS
+
+	prettyNameParse := regexp.MustCompile("PRETTY_NAME=(.+?)\n")
+	nameParse := regexp.MustCompile("NAME=(.+?)\n")
+	versionParse := regexp.MustCompile("VERSION=(.+?)\n")
+	IDParse := regexp.MustCompile("ID=(.+?)\n")
+	versionIDParse := regexp.MustCompile("VERSION_ID=(.+?)\n")
+
+	prettyName := prettyNameParse.FindStringSubmatch(string(buf))
+	name := nameParse.FindStringSubmatch(string(buf))
+	version := versionParse.FindStringSubmatch(string(buf))
+	prettyID := IDParse.FindStringSubmatch(string(buf))
+	versionID := versionIDParse.FindStringSubmatch(string(buf))
+
 	if prettyName == nil {
-		return "unknown", nil
+		if name == nil || version == nil {
+			if prettyID == nil || versionID == nil {
+				return string(buf), nil
+			} else {
+				buffer.WriteString(string(prettyID[1]))
+				buffer.WriteString(" ")
+				buffer.WriteString(string(versionID[1]))
+			}
+		} else {
+			buffer.WriteString(string(name[1]))
+			buffer.WriteString(" ")
+			buffer.WriteString(string(version[1]))
+		}
+	} else {
+		buffer.WriteString(string(prettyName[1]))
 	}
 
-	return string(prettyName[1]), nil
+	// Remove quotation marks from return value
+	quoteParse := regexp.MustCompile("\"")
+	return quoteParse.ReplaceAllString(buffer.String(), ""), nil
 }
 
 // GetLoad returns the current load averages as metrics.

--- a/probe/host/system_linux.go
+++ b/probe/host/system_linux.go
@@ -3,8 +3,8 @@ package host
 import (
 	"bytes"
 	"fmt"
-
 	"io/ioutil"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -41,14 +41,14 @@ var GetPrettyName = func () (string, error) {
 
 	buf, err := ioutil.ReadFile("/var/run/scope/host-os-release")
 	if err != nil {
-		return "unknown", nil
+		return runtime.GOOS, nil
 	}
 
 	// If can't find host-os-release, get container's os-release
 	if buf == nil {
 		bufContainer, err := ioutil.ReadFile("/etc/os-release")
 		if err != nil {
-			return "unknown", nil
+			return runtime.GOOS, nil
 		}
 		buf = bufContainer
 	}
@@ -74,7 +74,7 @@ var GetPrettyName = func () (string, error) {
 	if prettyName == nil {
 		if name == nil || version == nil {
 			if prettyID == nil || versionID == nil {
-				return string(buf), nil
+				return runtime.GOOS, nil
 			} else {
 				buffer.WriteString(string(prettyID[1]))
 				buffer.WriteString(" ")

--- a/probe/host/system_linux.go
+++ b/probe/host/system_linux.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"regexp"
 
 	linuxproc "github.com/c9s/goprocinfo/linux"
 
@@ -29,6 +30,25 @@ var GetKernelReleaseAndVersion = func() (string, string, error) {
 	release := utsname.Release[:bytes.IndexByte(utsname.Release[:], 0)]
 	version := utsname.Version[:bytes.IndexByte(utsname.Version[:], 0)]
 	return string(release), string(version), nil
+}
+
+// GetPrettyName extracts the PRETTY_NAME from /etc/os-release
+var GetPrettyName = func () (string, error) {
+	buf, err := ioutil.ReadFile("/etc/os-release")
+	if err != nil {
+		return "unknown", nil
+	}
+	prettyParse, err := regexp.Compile("PRETTY_NAME=\"(.+?)\"\n")
+	if err != nil {
+		return "unknown", nil
+	}
+
+	prettyName := prettyParse.FindStringSubmatch(string(buf))
+	if prettyName == nil {
+		return "unknown", nil
+	}
+
+	return string(prettyName[1]), nil
 }
 
 // GetLoad returns the current load averages as metrics.

--- a/scope
+++ b/scope
@@ -174,6 +174,7 @@ docker_args() {
         -v /var/run/docker.sock:/var/run/docker.sock \
         -v /var/run/scope/plugins:/var/run/scope/plugins \
         -v /sys/kernel/debug:/sys/kernel/debug \
+        -v /etc/os-release:/var/run/scope/host-os-release \
         -e CHECKPOINT_DISABLE
 }
 


### PR DESCRIPTION
Display Linux OS's PRETTY_NAME rather than Go's runtime.GOOS in the Host details panel.