### PR TITLE
make `Report.Topology(name)` fast

### DIFF
--- a/probe/plugins/registry.go
+++ b/probe/plugins/registry.go
@@ -231,30 +231,11 @@ func (r *Registry) updateAndRegisterControlsInReport(rpt *report.Report) {
 	key := rpt.Plugins.Keys()[0]
 	spec, _ := rpt.Plugins.Lookup(key)
 	pluginID := spec.ID
-	topologies := topologyPointers(rpt)
 	var newPluginControls []string
-	for _, topology := range topologies {
+	rpt.WalkTopologies(func(topology *report.Topology) {
 		newPluginControls = append(newPluginControls, r.updateAndGetControlsInTopology(pluginID, topology)...)
-	}
+	})
 	r.updatePluginControls(pluginID, report.MakeStringSet(newPluginControls...))
-}
-
-func topologyPointers(rpt *report.Report) []*report.Topology {
-	// We cannot use rpt.Topologies(), because it makes a slice of
-	// topology copies and we need original locations to modify
-	// them.
-	return []*report.Topology{
-		&rpt.Endpoint,
-		&rpt.Process,
-		&rpt.Container,
-		&rpt.ContainerImage,
-		&rpt.Pod,
-		&rpt.Service,
-		&rpt.Deployment,
-		&rpt.ReplicaSet,
-		&rpt.Host,
-		&rpt.Overlay,
-	}
 }
 
 func (r *Registry) updateAndGetControlsInTopology(pluginID string, topology *report.Topology) []string {

--- a/probe/topology_tagger.go
+++ b/probe/topology_tagger.go
@@ -16,10 +16,10 @@ func (topologyTagger) Name() string { return "Topology" }
 
 // Tag implements Tagger
 func (topologyTagger) Tag(r report.Report) (report.Report, error) {
-	for name, t := range r.TopologyMap() {
+	r.WalkNamedTopologies(func(name string, t *report.Topology) {
 		for _, node := range t.Nodes {
 			t.AddNode(node.WithTopology(name))
 		}
-	}
+	})
 	return r, nil
 }

--- a/report/report.go
+++ b/report/report.go
@@ -314,8 +314,39 @@ func (r *Report) WalkPairedTopologies(o *Report, f func(*Topology, *Topology)) {
 
 // Topology gets a topology by name
 func (r Report) Topology(name string) (Topology, bool) {
-	if t, ok := r.TopologyMap()[name]; ok {
-		return *t, true
+	switch name {
+	case Endpoint:
+		return r.Endpoint, true
+	case Process:
+		return r.Process, true
+	case Container:
+		return r.Container, true
+	case ContainerImage:
+		return r.ContainerImage, true
+	case Pod:
+		return r.Pod, true
+	case Service:
+		return r.Service, true
+	case Deployment:
+		return r.Deployment, true
+	case ReplicaSet:
+		return r.ReplicaSet, true
+	case DaemonSet:
+		return r.DaemonSet, true
+	case StatefulSet:
+		return r.StatefulSet, true
+	case CronJob:
+		return r.CronJob, true
+	case Host:
+		return r.Host, true
+	case Overlay:
+		return r.Overlay, true
+	case ECSTask:
+		return r.ECSTask, true
+	case ECSService:
+		return r.ECSService, true
+	case SwarmService:
+		return r.SwarmService, true
 	}
 	return Topology{}, false
 }

--- a/report/report.go
+++ b/report/report.go
@@ -273,16 +273,6 @@ func (r Report) Merge(other Report) Report {
 	return newReport
 }
 
-// Topologies returns a slice of Topologies in this report
-func (r Report) Topologies() []Topology {
-	result := make([]Topology, len(topologyNames))
-	for i, name := range topologyNames {
-		t, _ := r.Topology(name)
-		result[i] = t
-	}
-	return result
-}
-
 // WalkTopologies iterates through the Topologies of the report,
 // potentially modifying them
 func (r *Report) WalkTopologies(f func(*Topology)) {
@@ -358,8 +348,8 @@ func (r Report) Topology(name string) (Topology, bool) {
 // Validate checks the report for various inconsistencies.
 func (r Report) Validate() error {
 	var errs []string
-	for _, topology := range r.Topologies() {
-		if err := topology.Validate(); err != nil {
+	for _, name := range topologyNames {
+		if err := r.topology(name).Validate(); err != nil {
 			errs = append(errs, err.Error())
 		}
 	}

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -20,14 +20,18 @@ func TestReportTopologies(t *testing.T) {
 		topologyType = reflect.TypeOf(report.MakeTopology())
 	)
 
-	var want int
+	var want, have int
 	for i := 0; i < reportType.NumField(); i++ {
 		if reportType.Field(i).Type == topologyType {
 			want++
 		}
 	}
 
-	if have := len(report.MakeReport().Topologies()); want != have {
+	r := report.MakeReport()
+	r.WalkTopologies(func(_ *report.Topology) {
+		have++
+	})
+	if want != have {
 		t.Errorf("want %d, have %d", want, have)
 	}
 }


### PR DESCRIPTION
Previously this was buidling a fresh map of all topologies, just so it could look up the one given as an argument.

Node summarisation (via `detailed.Summaries()`) in particular was badly affected by that.