### PR TITLE
optimisation: pre-allocate, and fewer slices during summarisation

### DIFF
--- a/render/detailed/parents.go
+++ b/render/detailed/parents.go
@@ -38,7 +38,11 @@ var (
 
 // Parents renders the parents of this report.Node, which have been aggregated
 // from the probe reports.
-func Parents(r report.Report, n report.Node) (result []Parent) {
+func Parents(r report.Report, n report.Node) []Parent {
+	if n.Parents.Size() == 0 {
+		return nil
+	}
+	result := make([]Parent, 0, n.Parents.Size())
 	topologyIDs := []string{}
 	for topologyID := range getLabelForTopology {
 		topologyIDs = append(topologyIDs, topologyID)
@@ -79,6 +83,9 @@ func Parents(r report.Report, n report.Node) (result []Parent) {
 				TopologyID: apiTopologyID,
 			})
 		}
+	}
+	if len(result) == 0 {
+		return nil
 	}
 	return result
 }

--- a/report/metadata_template.go
+++ b/report/metadata_template.go
@@ -28,8 +28,8 @@ type MetadataTemplate struct {
 	From     string  `json:"from,omitempty"` // Defines how to get the value from a report node
 }
 
-// MetadataRows returns the rows for a node
-func (t MetadataTemplate) MetadataRows(n Node) []MetadataRow {
+// MetadataRow returns the row for a node
+func (t MetadataTemplate) MetadataRow(n Node) (MetadataRow, bool) {
 	from := fromDefault
 	switch t.From {
 	case FromLatest:
@@ -40,16 +40,16 @@ func (t MetadataTemplate) MetadataRows(n Node) []MetadataRow {
 		from = fromCounters
 	}
 	if val, ok := from(n, t.ID); ok {
-		return []MetadataRow{{
+		return MetadataRow{
 			ID:       t.ID,
 			Label:    t.Label,
 			Value:    val,
 			Truncate: t.Truncate,
 			Datatype: t.Datatype,
 			Priority: t.Priority,
-		}}
+		}, true
 	}
-	return nil
+	return MetadataRow{}, false
 }
 
 func fromDefault(n Node, key string) (string, bool) {
@@ -90,9 +90,17 @@ type MetadataTemplates map[string]MetadataTemplate
 
 // MetadataRows returns the rows for a node
 func (e MetadataTemplates) MetadataRows(n Node) []MetadataRow {
-	var rows []MetadataRow
+	if len(e) == 0 {
+		return nil
+	}
+	rows := make([]MetadataRow, 0, len(e))
 	for _, template := range e {
-		rows = append(rows, template.MetadataRows(n)...)
+		if row, ok := template.MetadataRow(n); ok {
+			rows = append(rows, row)
+		}
+	}
+	if len(rows) == 0 {
+		return nil
 	}
 	sort.Sort(MetadataRowsByPriority(rows))
 	return rows

--- a/report/table.go
+++ b/report/table.go
@@ -252,7 +252,10 @@ type TableTemplates map[string]TableTemplate
 
 // Tables renders the TableTemplates for a given node.
 func (t TableTemplates) Tables(node Node) []Table {
-	var result []Table
+	if len(t) == 0 {
+		return nil
+	}
+	result := make([]Table, 0, len(t))
 	for _, template := range t {
 		rows, truncationCount := node.ExtractTable(template)
 		// Extract the type from the template; default to


### PR DESCRIPTION
Pre-allocating slices really pays dividends when we create loads of them and they don't grow very large.

Also, a bunch of code in templates/tables used slices as Maybes, i.e. returning nil or a single-element slice, which is horrendously inefficient.