### PR TITLE
refactor: banish TheInternet

### DIFF
--- a/render/detailed/connections.go
+++ b/render/detailed/connections.go
@@ -107,7 +107,7 @@ func (c *connectionCounters) add(outgoing bool, localNode, remoteNode, localEndp
 }
 
 func internetAddr(node report.Node, ep report.Node) (string, bool) {
-	if !isInternetNode(node) {
+	if !render.IsInternetNode(node) {
 		return "", true
 	}
 	_, addr, _, ok := report.ParseEndpointNodeID(ep.ID)
@@ -181,7 +181,7 @@ func incomingConnectionsSummary(topologyID string, r report.Report, n report.Nod
 	}
 
 	columnHeaders := NormalColumns
-	if isInternetNode(n) {
+	if render.IsInternetNode(n) {
 		columnHeaders = InternetColumns
 	}
 	return ConnectionsSummary{
@@ -189,7 +189,7 @@ func incomingConnectionsSummary(topologyID string, r report.Report, n report.Nod
 		TopologyID:  topologyID,
 		Label:       "Inbound",
 		Columns:     columnHeaders,
-		Connections: counts.rows(r, ns, isInternetNode(n)),
+		Connections: counts.rows(r, ns, render.IsInternetNode(n)),
 	}
 }
 
@@ -213,7 +213,7 @@ func outgoingConnectionsSummary(topologyID string, r report.Report, n report.Nod
 	}
 
 	columnHeaders := NormalColumns
-	if isInternetNode(n) {
+	if render.IsInternetNode(n) {
 		columnHeaders = InternetColumns
 	}
 	return ConnectionsSummary{
@@ -221,7 +221,7 @@ func outgoingConnectionsSummary(topologyID string, r report.Report, n report.Nod
 		TopologyID:  topologyID,
 		Label:       "Outbound",
 		Columns:     columnHeaders,
-		Connections: counts.rows(r, ns, isInternetNode(n)),
+		Connections: counts.rows(r, ns, render.IsInternetNode(n)),
 	}
 }
 
@@ -263,8 +263,4 @@ func canonicalEndpointID(copies map[string]string, id string) string {
 		return original
 	}
 	return id
-}
-
-func isInternetNode(n report.Node) bool {
-	return n.ID == render.IncomingInternetID || n.ID == render.OutgoingInternetID
 }

--- a/render/detailed/summary.go
+++ b/render/detailed/summary.go
@@ -79,7 +79,6 @@ var renderers = map[string]func(NodeSummary, report.Node) (NodeSummary, bool){
 }
 
 var templates = map[string]struct{ Label, LabelMinor string }{
-	render.TheInternetID:      {render.InboundMajor, ""},
 	render.IncomingInternetID: {render.InboundMajor, render.InboundMinor},
 	render.OutgoingInternetID: {render.OutboundMajor, render.OutboundMinor},
 }

--- a/render/filters.go
+++ b/render/filters.go
@@ -268,7 +268,7 @@ func DoesNotHaveLabel(labelKey string, labelValue string) FilterFunc {
 // IsNotPseudo returns true if the node is not a pseudo node
 // or internet/service nodes.
 func IsNotPseudo(n report.Node) bool {
-	return n.Topology != Pseudo || strings.HasSuffix(n.ID, TheInternetID) || strings.HasPrefix(n.ID, ServiceNodeIDPrefix)
+	return n.Topology != Pseudo || IsInternetNode(n) || strings.HasPrefix(n.ID, ServiceNodeIDPrefix)
 }
 
 // IsNamespace checks if the node is a pod/service in the specified namespace

--- a/render/id.go
+++ b/render/id.go
@@ -9,10 +9,14 @@ import (
 
 // Constants are used in the tests.
 const (
-	TheInternetID      = "theinternet"
-	IncomingInternetID = "in-" + TheInternetID
-	OutgoingInternetID = "out-" + TheInternetID
+	IncomingInternetID = "in-theinternet"
+	OutgoingInternetID = "out-theinternet"
 )
+
+// IsInternetNode determines whether the node represents the Internet.
+func IsInternetNode(n report.Node) bool {
+	return n.ID == IncomingInternetID || n.ID == OutgoingInternetID
+}
 
 // MakePseudoNodeID joins the parts of an id into the id of a pseudonode
 func MakePseudoNodeID(parts ...string) string {

--- a/report/id.go
+++ b/report/id.go
@@ -5,9 +5,6 @@ import (
 	"strings"
 )
 
-// TheInternet is used as a node ID to indicate a remote IP.
-const TheInternet = "theinternet"
-
 // Delimiters are used to separate parts of node IDs, to guarantee uniqueness
 // in particular contexts.
 const (


### PR DESCRIPTION
TheInternet hasn't existed as a single node for a long time.

We also move & export the IsInternetNode predicate so it can be used in more places.