### PR TITLE
Simplifying backgrounds to match lightgray in service-ui and ui-compo…

### DIFF
--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -96,7 +96,7 @@ a {
 
 .overlay-wrapper {
   align-items: center;
-  background-color: fade-out($background-average-color, 0.1);
+  background-color: fade-out($background-color, 0.1);
   border-radius: 4px;
   color: $text-tertiary-color;
   display: flex;

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -2044,7 +2044,7 @@ a {
     }
 
     tr:nth-child(even) {
-      background: $background-color;
+      background: $background-darker-secondary-color;
     }
 
     tbody tr {

--- a/client/app/styles/_variables.scss
+++ b/client/app/styles/_variables.scss
@@ -12,9 +12,8 @@ $mono-font: "Menlo", "DejaVu Sans Mono", "Liberation Mono", monospace;
 $base-ease: ease-in-out;
 $primary-color: $weave-charcoal-blue;
 
-$background-color: lighten($primary-color, 66%);
+$background-color: #f8f8f8;
 $background-lighter-color: lighten($background-color, 8%);
-$background-average-color: mix($background-color, $background-lighter-color);
 $background-darker-color: darken($background-color, 8%);
 $background-darker-secondary-color: darken($background-color, 4%);
 $background-dark-color: $primary-color;
@@ -58,5 +57,5 @@ $search-border-width: 1px;
 $timeline-height: 55px;
 
 /* specific elements */
-$body-background-color: $background-average-color;
-$label-background-color: fade-out($background-average-color, .3);
+$body-background-color: $background-color;
+$label-background-color: fade-out($background-color, .3);

--- a/client/app/styles/_variables.scss
+++ b/client/app/styles/_variables.scss
@@ -14,8 +14,8 @@ $primary-color: $weave-charcoal-blue;
 
 $background-color: #f8f8f8;
 $background-lighter-color: lighten($background-color, 8%);
-$background-darker-color: darken($background-color, 8%);
-$background-darker-secondary-color: darken($background-color, 4%);
+$background-darker-color: darken($background-color, 16%);
+$background-darker-secondary-color: darken($background-color, 8%);
 $background-dark-color: $primary-color;
 $text-color: lighten($primary-color, 5%);
 $text-secondary-color: lighten($text-color, 15%);


### PR DESCRIPTION
…nents
Breaks unless service-ui is also updated to https://github.com/weaveworks/service-ui/pull/1672

The corresponding gray shift in Explore to addresses the issues in https://github.com/weaveworks/ui-components/pull/93
Trying to consolidate and simplify some colouring and settled on this after quite a few more more drastic attempts..
Is this enough contrast?

<img width="1440" alt="screen shot 2018-01-02 at 20 48 16" src="https://user-images.githubusercontent.com/92439/34497614-9467f46e-effe-11e7-82cd-2d6dfa9a65e9.png">

  