### PR TITLE
refactor: extract common code in endpoint mapping

### DIFF
--- a/render/container.go
+++ b/render/container.go
@@ -82,12 +82,16 @@ func (c connectionJoin) Render(rpt report.Report) Nodes {
 			if !found {
 				id, found = ipNodes[report.MakeScopedEndpointNodeID(scope, addr, port)]
 			}
-			if found && id != "" { // not one we blanked out earlier
-				// We are guaranteed to find the id, so really this
-				// should never end up creating a node.
-				return id
+			if !found || id == "" {
+				return ""
 			}
-			return ""
+			// Not an IP we blanked out earlier.
+			//
+			// MapEndpoints is guaranteed to find a node with this id
+			// (and hence not have to create one), since we got the id
+			// from ipNodes, which is populated from c.topology, which
+			// is where MapEndpoints will look.
+			return id
 		}, c.topology).Render(rpt)
 }
 

--- a/render/endpoint.go
+++ b/render/endpoint.go
@@ -1,0 +1,49 @@
+package render
+
+import (
+	"github.com/weaveworks/scope/report"
+)
+
+// Pseudo is the topology for nodes that aren't "real" nodes inside a
+// cluster, such as nodes representing the internet, external
+// services, and artificial grouping such as "uncontained processes"
+// and "unmanaged containers".
+const Pseudo = "pseudo"
+
+// EndpointRenderer is a Renderer which produces a renderable endpoint graph.
+var EndpointRenderer = SelectEndpoint
+
+type endpointMapFunc func(report.Node) string
+
+type mapEndpoints struct {
+	f        endpointMapFunc
+	topology string
+}
+
+// MapEndpoints creates a renderer for the endpoint topology. Each
+// endpoint is either turned into a pseudo node, or mapped to a node
+// in the specified topology by the supplied function.
+func MapEndpoints(f endpointMapFunc, topology string) Renderer {
+	return mapEndpoints{f: f, topology: topology}
+}
+
+func (e mapEndpoints) Render(rpt report.Report) Nodes {
+	local := LocalNetworks(rpt)
+	endpoints := SelectEndpoint.Render(rpt)
+	ret := newJoinResults(TopologySelector(e.topology).Render(rpt).Nodes)
+
+	for _, n := range endpoints.Nodes {
+		// Nodes without a hostid are mapped to pseudo nodes, if
+		// possible.
+		if _, ok := n.Latest.Lookup(report.HostNodeID); !ok {
+			if id, ok := pseudoNodeID(n, local); ok {
+				ret.addChild(n, id, Pseudo)
+				continue
+			}
+		}
+		if id := e.f(n); id != "" {
+			ret.addChild(n, id, e.topology)
+		}
+	}
+	return ret.result(endpoints)
+}

--- a/render/pod.go
+++ b/render/pod.go
@@ -61,7 +61,7 @@ var PodRenderer = Memoise(ConditionalRenderer(renderKubernetesTopologies,
 					),
 				),
 			),
-			ConnectionJoin(MapPod2IP, SelectPod),
+			ConnectionJoin(MapPod2IP, report.Pod),
 		),
 	),
 ))


### PR DESCRIPTION
This isn't quite as neat as we'd want to make it, because two of the three call sites still require a closure, but it's still an improvement.

Note that every instance of MapEndpoints only ever maps to one topology, which, furthermore, is a core report topology. Hence we can just parameterise MapEndpoints with that topology, and then the map functions can return just the node ids.