### PR TITLE
'updateKubeFilters` returns early if there are no namespaces

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -103,6 +103,9 @@ func updateKubeFilters(rpt report.Report, topologies []APITopologyDesc) []APITop
 		}
 		ns = append(ns, name)
 	}
+	if len(ns) == 0 {
+		return topologies
+	}
 	sort.Strings(ns)
 	topologies = append([]APITopologyDesc{}, topologies...) // Make a copy so we can make changes safely
 	for i, t := range topologies {


### PR DESCRIPTION
This change makes sure an empty `APITopologyOptionGroup` struct is not created for namespaces, if there are no namespaces to report.

This was introduced in https://github.com/weaveworks/scope/commit/1fb23dd8f9a8e5402f1e16e0a29e9f1229c5f313 .



  