### PR TITLE
Bump ui-components to v0.4.18

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -43,7 +43,7 @@
     "reselect": "3.0.1",
     "reselect-map": "1.0.3",
     "styled-components": "2.2.4",
-    "weaveworks-ui-components": "0.4.1",
+    "weaveworks-ui-components": "0.4.18",
     "whatwg-fetch": "2.0.3",
     "xterm": "2.9.2"
   },

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6416,9 +6416,9 @@ wd@^0.4.0:
     underscore.string "~3.0.3"
     vargs "~0.1.0"
 
-weaveworks-ui-components@0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/weaveworks-ui-components/-/weaveworks-ui-components-0.4.1.tgz#cd6fd85882689f19043f2d71081728559689a136"
+weaveworks-ui-components@0.4.18:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/weaveworks-ui-components/-/weaveworks-ui-components-0.4.18.tgz#7fc36416eb52844560aa5ada24457c302aea5f45"
   dependencies:
     classnames "2.2.5"
     d3-drag "1.2.1"


### PR DESCRIPTION
Resolves https://github.com/weaveworks/service-ui/issues/1304.

The issue was actually solved in https://github.com/weaveworks/ui-components/pull/90, but that only got released in `v0.4.2`, so wasn't included in Scope.
