### PR TITLE
Set a timeout to Terminal animation

### DIFF
--- a/client/app/scripts/components/embedded-terminal.js
+++ b/client/app/scripts/components/embedded-terminal.js
@@ -17,9 +17,17 @@ class EmeddedTerminal extends React.Component {
   }
 
   componentDidMount() {
-    setTimeout(() => {
+    this.mountedTimeout = setTimeout(() => {
       this.setState({mounted: true});
     });
+    this.animationTimeout = setTimeout(() => {
+      this.setState({ animated: true });
+    }, 2000);
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.mountedTimeout);
+    clearTimeout(this.animationTimeout);
   }
 
   getTransform() {


### PR DESCRIPTION
If the animation has no effect, `onTransitionEnd`'s handler is not called.
Since `onTransitionEnd`'s handler controls whether the terminal is shown or not (by passing `connect=true` as a Terminal prop), set the `animated` variable to true after a timeout.

Please see:
* https://stackoverflow.com/questions/2087510/callback-on-css-transition/11354026#11354026
* https://github.com/scttnlsn/backbone.viewkit/issues/4
* https://forums.xamarin.com/discussion/58456/why-isnt-my-transitionlistener-getting-called

Fixes: #3020 