### PR TITLE
Stop page router on App unmount

### DIFF
--- a/client/app/scripts/components/app.js
+++ b/client/app/scripts/components/app.js
@@ -76,7 +76,9 @@ class App extends React.Component {
     window.addEventListener('keypress', this.onKeyPress);
     window.addEventListener('keyup', this.onKeyUp);
 
-    getRouter(this.props.dispatch, this.props.urlState).start({hashbang: true});
+    this.router = getRouter(this.props.dispatch, this.props.urlState);
+    this.router.start({ hashbang: true });
+
     if (!this.props.routeSet || process.env.WEAVE_CLOUD) {
       // dont request topologies when already done via router.
       // If running as a component, always request topologies when the app mounts.
@@ -90,6 +92,7 @@ class App extends React.Component {
     window.removeEventListener('keypress', this.onKeyPress);
     window.removeEventListener('keyup', this.onKeyUp);
     this.props.dispatch(shutdown());
+    this.router.stop();
   }
 
   onKeyUp(ev) {


### PR DESCRIPTION
Fixes #3024.

The router hooks weren't properly cleaned up, so when Scope app would be mounted second time, they would be in conflict with the new hooks.

This fix is a prerequisite for making https://github.com/weaveworks/service-ui/pull/1787 work.

