### PR TITLE
Remove default values from URL state hash

### DIFF
--- a/client/app/scripts/reducers/__tests__/root-test.js
+++ b/client/app/scripts/reducers/__tests__/root-test.js
@@ -352,7 +352,7 @@ describe('RootReducer', () => {
     expect(activeTopologyOptionsSelector(nextState).has('option1')).toBeTruthy();
     expect(activeTopologyOptionsSelector(nextState).get('option1')).toBeInstanceOf(Array);
     expect(activeTopologyOptionsSelector(nextState).get('option1')).toEqual(['off']);
-    expect(getUrlState(nextState).topologyOptions.topo1.option1).toEqual(['off']);
+    expect(getUrlState(nextState).topologyOptions).toBeUndefined();
 
     // turn on
     nextState = reducer(nextState, ChangeTopologyOptionAction);
@@ -362,17 +362,17 @@ describe('RootReducer', () => {
     // turn off
     nextState = reducer(nextState, ChangeTopologyOptionAction2);
     expect(activeTopologyOptionsSelector(nextState).get('option1')).toEqual(['off']);
-    expect(getUrlState(nextState).topologyOptions.topo1.option1).toEqual(['off']);
+    expect(getUrlState(nextState).topologyOptions).toBeUndefined();
 
     // sub-topology should retain main topo options
     nextState = reducer(nextState, ClickSubTopologyAction);
     expect(activeTopologyOptionsSelector(nextState).get('option1')).toEqual(['off']);
-    expect(getUrlState(nextState).topologyOptions.topo1.option1).toEqual(['off']);
+    expect(getUrlState(nextState).topologyOptions).toBeUndefined();
 
     // other topology w/o options dont return options, but keep in app state
     nextState = reducer(nextState, ClickTopology2Action);
     expect(activeTopologyOptionsSelector(nextState).size).toEqual(0);
-    expect(getUrlState(nextState).topologyOptions.topo1.option1).toEqual(['off']);
+    expect(getUrlState(nextState).topologyOptions).toBeUndefined();
   });
 
   it('adds/removes a topology option', () => {
@@ -433,7 +433,7 @@ describe('RootReducer', () => {
     nextState = reducer(nextState, ReceiveTopologiesAction);
     nextState = reducer(nextState, ClickTopologyAction);
     expect(activeTopologyOptionsSelector(nextState).get('option1')).toEqual(['off']);
-    expect(getUrlState(nextState).topologyOptions.topo1.option1).toEqual(['off']);
+    expect(getUrlState(nextState).topologyOptions).toBeUndefined();
   });
 
   // nodes delta
@@ -479,7 +479,7 @@ describe('RootReducer', () => {
     nextState = reducer(nextState, ReceiveTopologiesAction);
     nextState = reducer(nextState, ClickTopologyAction);
     nextState = reducer(nextState, ReceiveNodesDeltaAction);
-    expect(getUrlState(nextState).selectedNodeId).toEqual(null);
+    expect(getUrlState(nextState).selectedNodeId).toBeUndefined();
 
     nextState = reducer(nextState, ClickNodeAction);
     expect(getUrlState(nextState).selectedNodeId).toEqual('n1');
@@ -487,7 +487,7 @@ describe('RootReducer', () => {
     // go back in browsing
     RouteAction.state = {topologyId: 'topo1', selectedNodeId: null};
     nextState = reducer(nextState, RouteAction);
-    expect(nextState.get('selectedNodeId')).toBe(null);
+    expect(nextState.get('selectedNodeId')).toBeNull();
     expect(nextState.get('nodes').toJS()).toEqual(NODE_SET);
   });
 
@@ -497,7 +497,7 @@ describe('RootReducer', () => {
     nextState = reducer(nextState, ClickTopologyAction);
     nextState = reducer(nextState, ReceiveNodesDeltaAction);
 
-    expect(getUrlState(nextState).selectedNodeId).toEqual(null);
+    expect(getUrlState(nextState).selectedNodeId).toBeUndefined();
     expect(getUrlState(nextState).topologyId).toEqual('topo1');
 
     nextState = reducer(nextState, ClickNodeAction);
@@ -505,7 +505,7 @@ describe('RootReducer', () => {
     expect(getUrlState(nextState).topologyId).toEqual('topo1');
 
     nextState = reducer(nextState, ClickSubTopologyAction);
-    expect(getUrlState(nextState).selectedNodeId).toEqual(null);
+    expect(getUrlState(nextState).selectedNodeId).toBeUndefined();
     expect(getUrlState(nextState).topologyId).toEqual('topo1-grouped');
   });
 

--- a/client/app/scripts/utils/hash-utils.js
+++ b/client/app/scripts/utils/hash-utils.js
@@ -1,0 +1,19 @@
+import { isPlainObject, mapValues, isEmpty, omitBy } from 'lodash';
+
+
+export function hashDifferenceDeep(A, B) {
+  // If the elements have exactly the same content, the difference is an empty object.
+  // This could fail if the objects are both hashes with different permutation of keys,
+  // but this case we handle below by digging in recursively.
+  if (JSON.stringify(A) === JSON.stringify(B)) return {};
+
+  // Otherwise, if either element is not a hash, always return the first element
+  // unchanged as this function only takes difference of hash objects.
+  if (!isPlainObject(A) || !isPlainObject(B)) return A;
+
+  // If both elements are hashes, recursively take the difference by all keys
+  const rawDiff = mapValues(A, (value, key) => hashDifferenceDeep(value, B[key]));
+
+  // ... and filter out all the empty values.
+  return omitBy(rawDiff, value => isEmpty(value));
+}


### PR DESCRIPTION
Resolves #1727.

##### Changes

_major_
* Use only non-default values for `topologyOptions` in Scope state. These are calculated via new helper `hashDifferenceDeep` which basically omits all the deep non-hash values which correspond literally to default options.
* Filter out all (other) URL state fields which correspond to their initial Redux state.

_minor_
* Removed `label` field from `nodeDetails` Scope state hash array, as it wasn't used anywhere.
* Changed `searchQuery` Redux state default to `''` for better matching with the URL state.

Note: I'm aware that `topologyId` field could also have been omitted in the URL in case it has a default value, but that default topology is somewhat arbitrary and I didn't want to make a special case of it.