### PR TITLE
Fixes bug showing "container image status" on all resource types

### DIFF
--- a/client/app/scripts/components/node-details.js
+++ b/client/app/scripts/components/node-details.js
@@ -260,6 +260,7 @@ class NodeDetails extends React.Component {
               name={details.label}
               metadata={details.metadata}
               pseudo={details.pseudo}
+              topologyId={topologyId}
             />
           </CloudFeature>
         </div>

--- a/client/app/scripts/components/node-details/node-details-image-status.js
+++ b/client/app/scripts/components/node-details/node-details-image-status.js
@@ -39,8 +39,8 @@ class NodeDetailsImageStatus extends React.PureComponent {
   }
 
   shouldRender() {
-    const { pseudo, currentTopologyId } = this.props;
-    return !pseudo && currentTopologyId && topologyWhitelist.includes(currentTopologyId);
+    const { pseudo, topologyId } = this.props;
+    return !pseudo && topologyId && topologyWhitelist.includes(topologyId);
   }
 
   renderImages() {
@@ -118,7 +118,6 @@ function mapStateToProps({ scope }, { metadata, name }) {
   return {
     isFetching,
     errors,
-    currentTopologyId: scope.get('currentTopologyId'),
     containers,
     serviceId
   };


### PR DESCRIPTION
- It should only be visible on the kubernetes contoller node-details
  panels.
- This fixes a bug where we were showing it on all node-details if you
  were on the controller topology.

Fixes https://github.com/weaveworks/service-ui/issues/1887