### PR TITLE
Save codegen output as CI artifact

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -66,6 +66,8 @@ test:
         parallel: true
     - test "$CIRCLE_NODE_INDEX" != "0" || (goveralls -repotoken $COVERALLS_REPO_TOKEN -coverprofile=$SRCDIR/profile.cov -service=circleci || true):
         parallel: true
+    - test "$CIRCLE_NODE_INDEX" != "0" || (cd $SRCDIR; cp */*.codecgen.go $CIRCLE_ARTIFACTS):
+        parallel: true
 
 deployment:
   hub:

--- a/circle.yml
+++ b/circle.yml
@@ -66,8 +66,6 @@ test:
         parallel: true
     - test "$CIRCLE_NODE_INDEX" != "0" || (goveralls -repotoken $COVERALLS_REPO_TOKEN -coverprofile=$SRCDIR/profile.cov -service=circleci || true):
         parallel: true
-    - test "$CIRCLE_NODE_INDEX" != "0" || (cd $SRCDIR; cp scope.tar $CIRCLE_ARTIFACTS):
-        parallel: true
 
 deployment:
   hub:


### PR DESCRIPTION
Looks like the order of types in the generated output is unpredictable, so we need the actual file Scope was built with for debugging or profiling.

Also drive-by optimisation to stop saving the tarfile - we started in 441b71884b1d434221b8866e6719191eb975eff2, which offers no explanation as to why.  
