### PR TITLE
 Move DNS name mapping from endpoint to report

### DIFF
--- a/probe/endpoint/connection_tracker.go
+++ b/probe/endpoint/connection_tracker.go
@@ -219,21 +219,31 @@ func (t *connectionTracker) addConnection(rpt *report.Report, incoming bool, ft 
 	)
 	rpt.Endpoint.AddNode(fromNode.WithAdjacent(toNode.ID))
 	rpt.Endpoint.AddNode(toNode)
+	t.addDNS(rpt, ft.fromAddr)
+	t.addDNS(rpt, ft.toAddr)
 }
 
 func (t *connectionTracker) makeEndpointNode(namespaceID string, addr string, port uint16, extra map[string]string) report.Node {
 	portStr := strconv.Itoa(int(port))
 	node := report.MakeNodeWith(report.MakeEndpointNodeID(t.conf.HostID, namespaceID, addr, portStr), nil)
-	if names := t.conf.DNSSnooper.CachedNamesForIP(addr); len(names) > 0 {
-		node = node.WithSet(SnoopedDNSNames, report.MakeStringSet(names...))
-	}
-	if names, err := t.reverseResolver.get(addr); err == nil && len(names) > 0 {
-		node = node.WithSet(ReverseDNSNames, report.MakeStringSet(names...))
-	}
 	if extra != nil {
 		node = node.WithLatests(extra)
 	}
 	return node
+}
+
+// Add DNS record for address to report, if not already there
+func (t *connectionTracker) addDNS(rpt *report.Report, addr string) {
+	if _, found := rpt.DNS[addr]; !found {
+		forward := t.conf.DNSSnooper.CachedNamesForIP(addr)
+		record := report.DNSRecord{
+			Forward: report.MakeStringSet(forward...),
+		}
+		if names, err := t.reverseResolver.get(addr); err == nil && len(names) > 0 {
+			record.Reverse = report.MakeStringSet(names...)
+		}
+		rpt.DNS[addr] = record
+	}
 }
 
 func (t *connectionTracker) Stop() error {

--- a/probe/endpoint/resolver.go
+++ b/probe/endpoint/resolver.go
@@ -41,8 +41,7 @@ func newReverseResolver() *reverseResolver {
 }
 
 // get the reverse resolution for an IP address if already in the cache, a
-// gcache.NotFoundKeyError error otherwise. Note: it returns one of the
-// possible names that can be obtained for that IP.
+// gcache.NotFoundKeyError error otherwise.
 func (r *reverseResolver) get(address string) ([]string, error) {
 	val, err := r.cache.Get(address)
 	if hostnames, ok := val.([]string); err == nil && ok {

--- a/render/endpoint.go
+++ b/render/endpoint.go
@@ -36,7 +36,7 @@ func (e mapEndpoints) Render(rpt report.Report) Nodes {
 		// Nodes without a hostid are mapped to pseudo nodes, if
 		// possible.
 		if _, ok := n.Latest.Lookup(report.HostNodeID); !ok {
-			if id, ok := pseudoNodeID(n, local); ok {
+			if id, ok := pseudoNodeID(rpt, n, local); ok {
 				ret.addChild(n, id, Pseudo)
 				continue
 			}

--- a/report/dns.go
+++ b/report/dns.go
@@ -1,0 +1,60 @@
+package report
+
+// DNSRecord contains names that an IP address maps to
+type DNSRecord struct {
+	Forward StringSet `json:"forward,omitempty"`
+	Reverse StringSet `json:"reverse,omitempty"`
+}
+
+// DNSRecords contains all address->name mappings for a report
+type DNSRecords map[string]DNSRecord
+
+// Copy makes a copy of the DNSRecords
+func (r DNSRecords) Copy() DNSRecords {
+	cp := make(DNSRecords, len(r))
+	for k, v := range r {
+		cp[k] = v
+	}
+	return cp
+}
+
+// Merge merges the other object into this one, and returns the result object.
+// The original is not modified.
+func (r DNSRecords) Merge(other DNSRecords) DNSRecords {
+	if len(other) > len(r) {
+		r, other = other, r
+	}
+	cp := r.Copy()
+	for k, v := range other {
+		if v2, ok := cp[k]; ok {
+			cp[k] = DNSRecord{
+				Forward: v.Forward.Merge(v2.Forward),
+				Reverse: v.Reverse.Merge(v2.Reverse),
+			}
+		} else {
+			cp[k] = v
+		}
+	}
+	return cp
+}
+
+// FirstMatch returns the first DNS name where match() returns true
+func (r DNSRecords) FirstMatch(id string, match func(name string) bool) (string, bool) {
+	_, addr, _, ok := ParseEndpointNodeID(id)
+	if !ok {
+		return "", false
+	}
+	// we rely on StringSets being sorted, to make selection deterministic
+	// prioritize forward names
+	for _, hostname := range r[addr].Forward {
+		if match(hostname) {
+			return hostname, true
+		}
+	}
+	for _, hostname := range r[addr].Reverse {
+		if match(hostname) {
+			return hostname, true
+		}
+	}
+	return "", false
+}

--- a/report/string_set.go
+++ b/report/string_set.go
@@ -50,6 +50,19 @@ func (s StringSet) Intersection(b StringSet) StringSet {
 	return result
 }
 
+// Equal returns true if a and b have the same contents
+func (s StringSet) Equal(b StringSet) bool {
+	if len(s) != len(b) {
+		return false
+	}
+	for i := range s {
+		if s[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // Add adds the strings to the StringSet. Add is the only valid way to grow a
 // StringSet. Add returns the StringSet to enable chaining.
 func (s StringSet) Add(strs ...string) StringSet {


### PR DESCRIPTION
Fixes #3058 

If the probe sees many TCP sockets on a host, it will repeat the same address information on each endpoint.  Moving it to report level saves all this repetition.  Also `Sets` is an expensive data structure; for the DNS mapping I used a straightforward `map`, similar to `Topology.Nodes`.

I see about a 6% reduction in JSON file size, on Weave Cloud production reports.

The mapping is used as a mapping from IP address to name, and the current implementation encodes it the same way, but to me it seems more logical to send it as a mapping from name to address.  Probably that doesn't matter.

~I considered moving `DNSFirstMatch` from `render` to `report`, to collect all the behaviour together.  However the decisions made are somewhat related to rendering, so I left it.~