### PR TITLE
Set 'omitempty' on Node Adjacency

### DIFF
--- a/report/node.go
+++ b/report/node.go
@@ -14,7 +14,7 @@ type Node struct {
 	Topology       string                   `json:"topology,omitempty"`
 	Counters       Counters                 `json:"counters,omitempty"`
 	Sets           Sets                     `json:"sets,omitempty"`
-	Adjacency      IDList                   `json:"adjacency"`
+	Adjacency      IDList                   `json:"adjacency,omitempty"`
 	Controls       NodeControls             `json:"controls,omitempty"`
 	LatestControls NodeControlDataLatestMap `json:"latestControls,omitempty"`
 	Latest         StringLatestMap          `json:"latest,omitempty"`


### PR DESCRIPTION
Looks like an omission from #462

(mostly we don't get `omitempty` because codecgen can't look through our data structures to spot they are empty, but `IDList` is a simple slice so it does work)

(later versions of codecgen do this better)