### PR TITLE
Show Time Travel at all times in Weave Cloud

### DIFF
--- a/client/app/scripts/actions/app-actions.js
+++ b/client/app/scripts/actions/app-actions.js
@@ -339,14 +339,15 @@ export function clickNode(nodeId, label, origin, topologyId = null) {
 
 export function pauseTimeAtNow() {
   return (dispatch, getState) => {
+    const getScopeState = () => getState().scope || getState();
     dispatch({
       type: ActionTypes.PAUSE_TIME_AT_NOW
     });
-    updateRoute(getState);
-    if (!getState().get('nodesLoaded')) {
-      getNodes(getState, dispatch);
-      if (isResourceViewModeSelector(getState())) {
-        getResourceViewNodesSnapshot(getState(), dispatch);
+    updateRoute(getScopeState);
+    if (!getScopeState().get('nodesLoaded')) {
+      getNodes(getScopeState, dispatch);
+      if (isResourceViewModeSelector(getScopeState())) {
+        getResourceViewNodesSnapshot(getScopeState(), dispatch);
       }
     }
   };
@@ -549,7 +550,8 @@ export function receiveNodeDetails(details, requestTimestamp) {
 
 export function receiveNodesDelta(delta) {
   return (dispatch, getState) => {
-    if (!isPausedSelector(getState())) {
+    const getScopeState = () => getState().scope || getState();
+    if (!isPausedSelector(getScopeState())) {
       // Allow css-animation to run smoothly by scheduling it to run on the
       // next tick after any potentially expensive canvas re-draws have been
       // completed.
@@ -559,7 +561,7 @@ export function receiveNodesDelta(delta) {
       // only when the first batch of nodes delta has been received. We
       // do that because we want to keep the previous state blurred instead
       // of transitioning over an empty state like when switching topologies.
-      if (getState().get('timeTravelTransitioning')) {
+      if (getScopeState().get('timeTravelTransitioning')) {
         dispatch({ type: ActionTypes.FINISH_TIME_TRAVEL_TRANSITION });
       }
 
@@ -576,16 +578,17 @@ export function receiveNodesDelta(delta) {
 
 export function resumeTime() {
   return (dispatch, getState) => {
-    if (isPausedSelector(getState())) {
+    const getScopeState = () => getState().scope || getState();
+    if (isPausedSelector(getScopeState())) {
       dispatch({
         type: ActionTypes.RESUME_TIME
       });
-      updateRoute(getState);
+      updateRoute(getScopeState);
       // After unpausing, all of the following calls will re-activate polling.
-      getTopologies(getState, dispatch);
-      getNodes(getState, dispatch, true);
-      if (isResourceViewModeSelector(getState())) {
-        getResourceViewNodesSnapshot(getState(), dispatch);
+      getTopologies(getScopeState, dispatch);
+      getNodes(getScopeState, dispatch, true);
+      if (isResourceViewModeSelector(getScopeState())) {
+        getResourceViewNodesSnapshot(getScopeState(), dispatch);
       }
     }
   };

--- a/client/app/scripts/components/app.js
+++ b/client/app/scripts/components/app.js
@@ -44,6 +44,7 @@ import DebugToolbar, { showingDebugToolbar, toggleDebugToolbar } from './debug-t
 import { getRouter, getUrlState } from '../utils/router-utils';
 import { trackAnalyticsEvent } from '../utils/tracking-utils';
 import { availableNetworksSelector } from '../selectors/node-networks';
+import { timeTravelSupportedSelector } from '../selectors/time-travel';
 import {
   isResourceViewModeSelector,
   isTableViewModeSelector,
@@ -177,10 +178,10 @@ class App extends React.Component {
     const {
       isTableViewMode, isGraphViewMode, isResourceViewMode, showingDetails,
       showingHelp, showingNetworkSelector, showingTroubleshootingMenu,
-      timeTravelTransitioning, showingTimeTravel
+      timeTravelTransitioning, timeTravelSupported
     } = this.props;
 
-    const className = classNames('scope-app', { 'time-travel-open': showingTimeTravel });
+    const className = classNames('scope-app', { 'time-travel-open': timeTravelSupported });
     const isIframe = window !== window.top;
 
     return (
@@ -195,9 +196,11 @@ class App extends React.Component {
           {showingDetails && <Details />}
 
           <div className="header">
-            <CloudFeature alwaysShow>
-              <TimeTravelWrapper />
-            </CloudFeature>
+            {timeTravelSupported && (
+              <CloudFeature alwaysShow>
+                <TimeTravelWrapper />
+              </CloudFeature>
+            )}
 
             <div className="selectors">
               <div className="logo">
@@ -244,11 +247,11 @@ function mapStateToProps(state) {
     searchQuery: state.get('searchQuery'),
     showingDetails: state.get('nodeDetails').size > 0,
     showingHelp: state.get('showingHelp'),
-    showingTimeTravel: state.get('showingTimeTravel'),
     showingTroubleshootingMenu: state.get('showingTroubleshootingMenu'),
     showingNetworkSelector: availableNetworksSelector(state).count() > 0,
     showingTerminal: state.get('controlPipes').size > 0,
     topologyViewMode: state.get('topologyViewMode'),
+    timeTravelSupported: timeTravelSupportedSelector(state),
     timeTravelTransitioning: state.get('timeTravelTransitioning'),
     urlState: getUrlState(state)
   };

--- a/client/app/scripts/components/nodes.js
+++ b/client/app/scripts/components/nodes.js
@@ -86,7 +86,6 @@ function mapStateToProps(state) {
     topologyNodeCountZero: isTopologyNodeCountZero(state),
     nodesDisplayEmpty: isNodesDisplayEmpty(state),
     nodesLoaded: nodesLoadedSelector(state),
-    timeTravelTransitioning: state.get('timeTravelTransitioning'),
     currentTopology: state.get('currentTopology'),
     topologies: state.get('topologies'),
     topologiesLoaded: state.get('topologiesLoaded'),

--- a/client/app/scripts/components/time-travel-wrapper.js
+++ b/client/app/scripts/components/time-travel-wrapper.js
@@ -1,27 +1,17 @@
 import React from 'react';
 import moment from 'moment';
-import styled from 'styled-components';
 import { connect } from 'react-redux';
 import { TimeTravel } from 'weaveworks-ui-components';
 
 import { trackAnalyticsEvent } from '../utils/tracking-utils';
-import { jumpToTime } from '../actions/app-actions';
+import { jumpToTime, resumeTime, pauseTimeAtNow } from '../actions/app-actions';
 
-
-const TimeTravelContainer = styled.div`
-  transition: all .15s ease-in-out;
-  position: relative;
-  overflow: hidden;
-  height: 0;
-
-  ${props => props.visible && `
-    height: 105px;
-  `}
-`;
 
 class TimeTravelWrapper extends React.Component {
   constructor(props, context) {
     super(props, context);
+
+    this.handleLiveModeChange = this.handleLiveModeChange.bind(this);
 
     this.trackTimestampEdit = this.trackTimestampEdit.bind(this);
     this.trackTimelinePanButtonClick = this.trackTimelinePanButtonClick.bind(this);
@@ -71,20 +61,29 @@ class TimeTravelWrapper extends React.Component {
     });
   }
 
+  handleLiveModeChange(showingLive) {
+    if (showingLive) {
+      this.props.resumeTime();
+    } else {
+      this.props.pauseTimeAtNow();
+    }
+  }
+
   render() {
     return (
-      <TimeTravelContainer visible={this.props.visible}>
-        <TimeTravel
-          timestamp={this.props.timestamp}
-          earliestTimestamp={this.props.earliestTimestamp}
-          onChangeTimestamp={this.props.jumpToTime}
-          onTimestampInputEdit={this.trackTimestampEdit}
-          onTimelinePanButtonClick={this.trackTimelinePanButtonClick}
-          onTimelineLabelClick={this.trackTimelineLabelClick}
-          onTimelineZoom={this.trackTimelineZoom}
-          onTimelinePan={this.trackTimelinePan}
-        />
-      </TimeTravelContainer>
+      <TimeTravel
+        hasLiveMode
+        showingLive={this.props.showingLive}
+        onChangeLiveMode={this.handleLiveModeChange}
+        timestamp={this.props.timestamp}
+        earliestTimestamp={this.props.earliestTimestamp}
+        onChangeTimestamp={this.props.jumpToTime}
+        onTimestampInputEdit={this.trackTimestampEdit}
+        onTimelinePanButtonClick={this.trackTimelinePanButtonClick}
+        onTimelineLabelClick={this.trackTimelineLabelClick}
+        onTimelineZoom={this.trackTimelineZoom}
+        onTimelinePan={this.trackTimelinePan}
+      />
     );
   }
 }
@@ -102,7 +101,7 @@ function mapStateToProps(state, { params }) {
   }
 
   return {
-    visible: scopeState.get('showingTimeTravel'),
+    showingLive: !scopeState.get('pausedAt'),
     topologyViewMode: scopeState.get('topologyViewMode'),
     currentTopology: scopeState.get('currentTopology'),
     earliestTimestamp: firstSeenConnectedAt,
@@ -112,5 +111,5 @@ function mapStateToProps(state, { params }) {
 
 export default connect(
   mapStateToProps,
-  { jumpToTime },
+  { jumpToTime, resumeTime, pauseTimeAtNow },
 )(TimeTravelWrapper);

--- a/client/app/scripts/constants/styles.js
+++ b/client/app/scripts/constants/styles.js
@@ -39,13 +39,13 @@ export const EDGE_WAYPOINTS_CAP = 10;
 
 export const CANVAS_MARGINS = {
   [GRAPH_VIEW_MODE]: {
-    top: 160, left: 80, right: 80, bottom: 150
+    top: 220, left: 80, right: 80, bottom: 150
   },
   [TABLE_VIEW_MODE]: {
     top: 220, left: 40, right: 40, bottom: 30
   },
   [RESOURCE_VIEW_MODE]: {
-    top: 140, left: 210, right: 40, bottom: 150
+    top: 200, left: 210, right: 40, bottom: 150
   },
 };
 

--- a/client/app/scripts/reducers/root.js
+++ b/client/app/scripts/reducers/root.js
@@ -75,7 +75,6 @@ export const initialState = makeMap({
   selectedNetwork: null,
   selectedNodeId: null,
   showingHelp: false,
-  showingTimeTravel: false,
   showingTroubleshootingMenu: false,
   showingNetworks: false,
   timeTravelTransitioning: false,
@@ -369,18 +368,15 @@ export function rootReducer(state = initialState, action) {
 
     case ActionTypes.RESUME_TIME: {
       state = state.set('timeTravelTransitioning', true);
-      state = state.set('showingTimeTravel', false);
       return state.set('pausedAt', null);
     }
 
     case ActionTypes.PAUSE_TIME_AT_NOW: {
-      state = state.set('showingTimeTravel', false);
       state = state.set('timeTravelTransitioning', false);
       return state.set('pausedAt', moment().utc().format());
     }
 
     case ActionTypes.START_TIME_TRAVEL: {
-      state = state.set('showingTimeTravel', true);
       state = state.set('timeTravelTransitioning', false);
       return state.set('pausedAt', action.timestamp || moment().utc().format());
     }

--- a/client/app/scripts/selectors/time-travel.js
+++ b/client/app/scripts/selectors/time-travel.js
@@ -7,3 +7,5 @@ export const isPausedSelector = createSelector(
   ],
   pausedAt => !!pausedAt
 );
+
+export const timeTravelSupportedSelector = state => state.getIn(['capabilities', 'historic_reports']);

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -198,7 +198,7 @@ a {
 
   &.time-travel-open {
     .details-wrapper {
-      margin-top: $timeline-height + 15px;
+      margin-top: $timeline-height + 50px;
     }
   }
 }
@@ -391,6 +391,10 @@ a {
     color: $text-secondary-color;
     width: 33%;
     height: 550px;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
 
     .heading {
       font-size: 125%;

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -211,6 +211,7 @@ a {
   .selectors {
     display: flex;
     position: relative;
+
     > * {
       z-index: 20;
       flex: 1 1;


### PR DESCRIPTION
##### Changes

* Show Time Travel at all times if historic reports are supported (in particular in Weave Cloud) together with pause/live buttons, removing the Time Control _live/pause/time travel_ buttons in the top right corner.
* If historic reports are not supported, show only Time Control with _live/paused_ buttons as before.

**Scope in Weave Cloud**
![image](https://user-images.githubusercontent.com/1216874/36046887-c05ffca2-0dda-11e8-84cc-97a12e02a1f0.png)

**Scope standalone**
![image](https://user-images.githubusercontent.com/1216874/36046860-a718a276-0dda-11e8-8b71-f2311f034a71.png)
