### PR TITLE
Add topology.ReplaceNode() for efficiency

### DIFF
--- a/probe/host/tagger.go
+++ b/probe/host/tagger.go
@@ -33,7 +33,7 @@ func (t Tagger) Tag(r report.Report) (report.Report, error) {
 	// and as such do their own host tagging.
 	for _, topology := range []report.Topology{r.Process, r.Container, r.ContainerImage, r.Host, r.Pod} {
 		for _, node := range topology.Nodes {
-			topology.AddNode(node.WithLatests(metadata).WithParents(parents))
+			topology.ReplaceNode(node.WithLatests(metadata).WithParents(parents))
 		}
 	}
 	return r, nil

--- a/probe/topology_tagger.go
+++ b/probe/topology_tagger.go
@@ -18,7 +18,7 @@ func (topologyTagger) Name() string { return "Topology" }
 func (topologyTagger) Tag(r report.Report) (report.Report, error) {
 	r.WalkNamedTopologies(func(name string, t *report.Topology) {
 		for _, node := range t.Nodes {
-			t.AddNode(node.WithTopology(name))
+			t.ReplaceNode(node.WithTopology(name))
 		}
 	})
 	return r, nil

--- a/report/topology.go
+++ b/report/topology.go
@@ -115,12 +115,9 @@ func (t Topology) AddNode(node Node) Topology {
 
 // ReplaceNode adds node to the topology under key nodeID; if a
 // node already exists for this key, node replaces that node.
-// The same topology is returned to enable chaining.
-// This method is similar to AddNode
-// in that it mutates the Topology, to solve issues of GC pressure.
-func (t Topology) ReplaceNode(node Node) Topology {
+// Like AddNode, it mutates the Topology
+func (t Topology) ReplaceNode(node Node) {
 	t.Nodes[node.ID] = node
-	return t
 }
 
 // GetShape returns the current topology shape, or the default if there isn't one.

--- a/report/topology.go
+++ b/report/topology.go
@@ -113,6 +113,16 @@ func (t Topology) AddNode(node Node) Topology {
 	return t
 }
 
+// ReplaceNode adds node to the topology under key nodeID; if a
+// node already exists for this key, node replaces that node.
+// The same topology is returned to enable chaining.
+// This method is similar to AddNode
+// in that it mutates the Topology, to solve issues of GC pressure.
+func (t Topology) ReplaceNode(node Node) Topology {
+	t.Nodes[node.ID] = node
+	return t
+}
+
 // GetShape returns the current topology shape, or the default if there isn't one.
 func (t Topology) GetShape() string {
 	if t.Shape == "" {


### PR DESCRIPTION
In some places `AddNode()` was called after adding to an existing node, in which case the `Merge()` is just a waste of time.  

Spotted in a memory profile of the probe: about 14% of all memory allocated is in `Merge()`:

```
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context 	 	 
----------------------------------------------------------+-------------
                                        16356.22MB 41.27% |   github.com/weaveworks/scope/probe.topologyTagger.Tag.func1 /go/src/github.com/weaveworks/scope/probe/topology_tagger.go
                                        12215.04MB 30.82% |   github.com/weaveworks/scope/probe/host.Tagger.Tag /go/src/github.com/weaveworks/scope/probe/host/tagger.go
                                         4821.62MB 12.17% |   github.com/weaveworks/scope/probe/endpoint.(*connectionTracker).addConnection /go/src/github.com/weaveworks/scope/probe/endpoint/connection_tracker.go
                                         2768.72MB  6.99% |   github.com/weaveworks/scope/probe/docker.(*Tagger).tag /go/src/github.com/weaveworks/scope/probe/docker/tagger.go
                                         1511.73MB  3.81% |   github.com/weaveworks/scope/probe/process.(*Reporter).processTopology.func1 /go/src/github.com/weaveworks/scope/probe/process/reporter.go
                                          557.68MB  1.41% |   github.com/weaveworks/scope/probe/endpoint.natMapper.applyNAT.func1 /go/src/github.com/weaveworks/scope/probe/endpoint/nat.go
                                          400.83MB  1.01% |   github.com/weaveworks/scope/probe/docker.(*Reporter).containerTopology /go/src/github.com/weaveworks/scope/probe/docker/reporter.go
                                          375.10MB  0.95% |   github.com/weaveworks/scope/probe/docker.(*Reporter).containerImageTopology.func1 /go/src/github.com/weaveworks/scope/probe/docker/reporter.go
...
         0     0%     0% 39630.96MB 17.84%                | github.com/weaveworks/scope/report.Topology.AddNode /go/src/github.com/weaveworks/scope/report/topology.go
                                        34675.80MB 87.50% |   github.com/weaveworks/scope/report.Node.Merge /go/src/github.com/weaveworks/scope/report/node.go
                                         4955.16MB 12.50% |   runtime.mapassign /usr/local/go/src/runtime/hashmap.go
----------------------------------------------------------+-------------
```

The three call sites in this PR are number 1, 2 ~and 4~ in the above profile; number 3 is not directly replacing an existing node so left as-is.