### PR TITLE
Optimise processTopology()

### DIFF
--- a/probe/process/reporter.go
+++ b/probe/process/reporter.go
@@ -85,35 +85,34 @@ func (r *Reporter) processTopology() (report.Topology, error) {
 		pidstr := strconv.Itoa(p.PID)
 		nodeID := report.MakeProcessNodeID(r.scope, pidstr)
 		node := report.MakeNode(nodeID)
-		for _, tuple := range []struct{ key, value string }{
-			{PID, pidstr},
-			{Name, p.Name},
-			{Threads, strconv.Itoa(p.Threads)},
-		} {
-			if tuple.value != "" {
-				node = node.WithLatests(map[string]string{tuple.key: tuple.value})
-			}
+		node = node.WithLatest(PID, now, pidstr)
+		node = node.WithLatest(Threads, now, strconv.Itoa(p.Threads))
+		if p.Name != "" {
+			node = node.WithLatest(Name, now, p.Name)
 		}
 
 		if p.Cmdline != "" {
 			if r.noCommandLineArguments {
-				node = node.WithLatests(map[string]string{Cmdline: strings.Split(p.Cmdline, " ")[0]})
+				node = node.WithLatest(Cmdline, now, strings.Split(p.Cmdline, " ")[0])
 			} else {
-				node = node.WithLatests(map[string]string{Cmdline: p.Cmdline})
+				node = node.WithLatest(Cmdline, now, p.Cmdline)
 			}
 		}
 
 		if p.PPID > 0 {
-			node = node.WithLatests(map[string]string{PPID: strconv.Itoa(p.PPID)})
+			node = node.WithLatest(PPID, now, strconv.Itoa(p.PPID))
 		}
 
+		var metrics = report.Metrics{
+			MemoryUsage:    report.MakeSingletonMetric(now, float64(p.RSSBytes)).WithMax(float64(p.RSSBytesLimit)),
+			OpenFilesCount: report.MakeSingletonMetric(now, float64(p.OpenFilesCount)).WithMax(float64(p.OpenFilesLimit)),
+		}
 		if deltaTotal > 0 {
 			cpuUsage := float64(p.Jiffies-prev.Jiffies) / float64(deltaTotal) * 100.
-			node = node.WithMetric(CPUUsage, report.MakeSingletonMetric(now, cpuUsage).WithMax(maxCPU))
+			metrics[CPUUsage] = report.MakeSingletonMetric(now, cpuUsage).WithMax(maxCPU)
 		}
 
-		node = node.WithMetric(MemoryUsage, report.MakeSingletonMetric(now, float64(p.RSSBytes)).WithMax(float64(p.RSSBytesLimit)))
-		node = node.WithMetric(OpenFilesCount, report.MakeSingletonMetric(now, float64(p.OpenFilesCount)).WithMax(float64(p.OpenFilesLimit)))
+		node = node.WithMetrics(metrics)
 
 		t.AddNode(node)
 	})

--- a/probe/process/reporter_test.go
+++ b/probe/process/reporter_test.go
@@ -134,3 +134,17 @@ func TestCmdlineRemoval(t *testing.T) {
 	}
 	testReporter(t, true, test)
 }
+
+func BenchmarkReporter(t *testing.B) {
+	walker := &mockWalker{processes: processes}
+	getDeltaTotalJiffies := func() (uint64, float64, error) { return 0, 0., nil }
+	reporter := process.NewReporter(walker, "", getDeltaTotalJiffies, false)
+	t.ResetTimer()
+
+	for i := 0; i < t.N; i++ {
+		_, err := reporter.Report()
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/report/controls.go
+++ b/report/controls.go
@@ -20,6 +20,12 @@ type Control struct {
 
 // Merge merges other with cs, returning a fresh Controls.
 func (cs Controls) Merge(other Controls) Controls {
+	if len(other) > len(cs) {
+		cs, other = other, cs
+	}
+	if len(other) == 0 {
+		return cs
+	}
 	result := cs.Copy()
 	for k, v := range other {
 		result[k] = v

--- a/report/metadata_template.go
+++ b/report/metadata_template.go
@@ -121,11 +121,11 @@ func (e MetadataTemplates) Copy() MetadataTemplates {
 // Merge merges two sets of MetadataTemplates so far just ignores based
 // on duplicate id key
 func (e MetadataTemplates) Merge(other MetadataTemplates) MetadataTemplates {
-	if e == nil && other == nil {
-		return nil
-	}
 	if len(other) > len(e) {
 		e, other = other, e
+	}
+	if len(other) == 0 {
+		return e
 	}
 	result := e.Copy()
 	for k, v := range other {

--- a/report/metric_template.go
+++ b/report/metric_template.go
@@ -76,6 +76,9 @@ func (e MetricTemplates) Merge(other MetricTemplates) MetricTemplates {
 	if len(other) > len(e) {
 		e, other = other, e
 	}
+	if len(other) == 0 {
+		return e
+	}
 	result := e.Copy()
 	for k, v := range other {
 		if existing, ok := result[k]; !ok || existing.Priority < v.Priority {

--- a/report/metrics.go
+++ b/report/metrics.go
@@ -22,6 +22,9 @@ func (m Metrics) Merge(other Metrics) Metrics {
 	if len(other) > len(m) {
 		m, other = other, m
 	}
+	if len(other) == 0 {
+		return m
+	}
 	result := m.Copy()
 	for k, v := range other {
 		if rv, ok := result[k]; ok {

--- a/report/topology.go
+++ b/report/topology.go
@@ -177,6 +177,9 @@ func (n Nodes) Merge(other Nodes) Nodes {
 	if len(other) > len(n) {
 		n, other = other, n
 	}
+	if len(other) == 0 {
+		return n
+	}
 	cp := n.Copy()
 	for k, v := range other {
 		if n, ok := cp[k]; ok { // don't overwrite


### PR DESCRIPTION
From a memory profile, 11% of all space is allocated in `process.reporter.processTopology()`; this PR creates a benchmark and reduces allocations by half through calling different APIs.

Also optimised the merge-to-empty case in a few sub-structures that should help a little elsewhere.

before:
```
BenchmarkReporter-2   	   10000	    105043 ns/op	   32205 B/op	     227 allocs/op
```

after:
```
BenchmarkReporter-2   	   50000	     34800 ns/op	   15818 B/op	     161 allocs/op
```
