### PR TITLE
refactor: don't return receiver in Topology.AddNode()

### DIFF
--- a/app/merger_test.go
+++ b/app/merger_test.go
@@ -23,10 +23,9 @@ func TestMerger(t *testing.T) {
 		report1, report2, report3,
 	}
 	want := report.MakeReport()
-	want.Endpoint.
-		AddNode(report.MakeNode("foo")).
-		AddNode(report.MakeNode("bar")).
-		AddNode(report.MakeNode("baz"))
+	want.Endpoint.AddNode(report.MakeNode("foo"))
+	want.Endpoint.AddNode(report.MakeNode("bar"))
+	want.Endpoint.AddNode(report.MakeNode("baz"))
 
 	for _, merger := range []app.Merger{app.MakeDumbMerger(), app.NewSmartMerger()} {
 		// Test the empty list case

--- a/probe/awsecs/reporter.go
+++ b/probe/awsecs/reporter.go
@@ -150,7 +150,7 @@ func (r Reporter) Tag(rpt report.Report) (report.Report, error) {
 		// Create all the services first
 		for serviceName, service := range ecsInfo.Services {
 			serviceID := report.MakeECSServiceNodeID(cluster, serviceName)
-			rpt.ECSService = rpt.ECSService.AddNode(report.MakeNodeWith(serviceID, map[string]string{
+			rpt.ECSService.AddNode(report.MakeNodeWith(serviceID, map[string]string{
 				Cluster:               cluster,
 				ServiceDesiredCount:   fmt.Sprintf("%d", service.DesiredCount),
 				ServiceRunningCount:   fmt.Sprintf("%d", service.RunningCount),
@@ -178,7 +178,7 @@ func (r Reporter) Tag(rpt report.Report) (report.Report, error) {
 				Cluster:    cluster,
 				CreatedAt:  task.CreatedAt.Format(time.RFC3339Nano),
 			})
-			rpt.ECSTask = rpt.ECSTask.AddNode(node)
+			rpt.ECSTask.AddNode(node)
 
 			// parents sets to merge into all matching container nodes
 			parentsSets := report.MakeSets()

--- a/probe/awsecs/reporter_test.go
+++ b/probe/awsecs/reporter_test.go
@@ -49,7 +49,7 @@ func TestGetLabelInfo(t *testing.T) {
 		t.Errorf("Empty report did not produce empty label info: %v != %v", labelInfo, expected)
 	}
 
-	rpt.Container = rpt.Container.AddNode(getTestContainerNode())
+	rpt.Container.AddNode(getTestContainerNode())
 	labelInfo = awsecs.GetLabelInfo(rpt)
 	expected = map[string]map[string]*awsecs.TaskLabelInfo{
 		testCluster: {
@@ -127,7 +127,7 @@ func TestTagReport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error making report")
 	}
-	rpt.Container = rpt.Container.AddNode(getTestContainerNode())
+	rpt.Container.AddNode(getTestContainerNode())
 	rpt, err = r.Tag(rpt)
 	if err != nil {
 		t.Fatalf("Failed to tag: %v", err)

--- a/probe/docker/reporter.go
+++ b/probe/docker/reporter.go
@@ -301,7 +301,9 @@ func (r *Reporter) overlayTopology() report.Topology {
 	// since we treat container IPs as local
 	node := report.MakeNode(report.MakeOverlayNodeID(report.DockerOverlayPeerPrefix, r.hostID)).WithSets(
 		report.MakeSets().Add(host.LocalNetworks, report.MakeStringSet(subnets...)))
-	return report.MakeTopology().AddNode(node)
+	t := report.MakeTopology()
+	t.AddNode(node)
+	return t
 }
 
 func (r *Reporter) swarmServiceTopology() report.Topology {

--- a/probe/docker/tagger.go
+++ b/probe/docker/tagger.go
@@ -71,7 +71,7 @@ func (t *Tagger) Tag(r report.Report) (report.Report, error) {
 			ServiceName:    serviceName,
 			StackNamespace: stackNamespace,
 		})
-		r.SwarmService = r.SwarmService.AddNode(node)
+		r.SwarmService.AddNode(node)
 
 		r.Container.Nodes[containerID] = container.WithParents(container.Parents.Add(report.SwarmService, report.MakeStringSet(nodeID)))
 	}

--- a/probe/endpoint/connection_tracker.go
+++ b/probe/endpoint/connection_tracker.go
@@ -217,8 +217,8 @@ func (t *connectionTracker) addConnection(rpt *report.Report, incoming bool, ft 
 		fromNode = t.makeEndpointNode(namespaceID, ft.fromAddr, ft.fromPort, extraFromNode)
 		toNode   = t.makeEndpointNode(namespaceID, ft.toAddr, ft.toPort, extraToNode)
 	)
-	rpt.Endpoint = rpt.Endpoint.AddNode(fromNode.WithAdjacent(toNode.ID))
-	rpt.Endpoint = rpt.Endpoint.AddNode(toNode)
+	rpt.Endpoint.AddNode(fromNode.WithAdjacent(toNode.ID))
+	rpt.Endpoint.AddNode(toNode)
 }
 
 func (t *connectionTracker) makeEndpointNode(namespaceID string, addr string, port uint16, extra map[string]string) report.Node {

--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -278,7 +278,7 @@ func (r *Reporter) serviceTopology() (report.Topology, []Service, error) {
 		services = []Service{}
 	)
 	err := r.client.WalkServices(func(s Service) error {
-		result = result.AddNode(s.GetNode())
+		result.AddNode(s.GetNode())
 		services = append(services, s)
 		return nil
 	})
@@ -308,9 +308,11 @@ func (r *Reporter) hostTopology(services []Service) report.Topology {
 	if serviceNetwork == nil {
 		return report.MakeTopology()
 	}
-	return report.MakeTopology().AddNode(
+	t := report.MakeTopology()
+	t.AddNode(
 		report.MakeNode(report.MakeHostNodeID(r.hostID)).
 			WithSets(report.MakeSets().Add(host.LocalNetworks, report.MakeStringSet(serviceNetwork.String()))))
+	return t
 }
 
 func (r *Reporter) deploymentTopology(probeID string) (report.Topology, []Deployment, error) {
@@ -324,7 +326,7 @@ func (r *Reporter) deploymentTopology(probeID string) (report.Topology, []Deploy
 	result.Controls.AddControls(ScalingControls)
 
 	err := r.client.WalkDeployments(func(d Deployment) error {
-		result = result.AddNode(d.GetNode(probeID))
+		result.AddNode(d.GetNode(probeID))
 		deployments = append(deployments, d)
 		return nil
 	})
@@ -338,7 +340,7 @@ func (r *Reporter) daemonSetTopology() (report.Topology, []DaemonSet, error) {
 		WithMetricTemplates(DaemonSetMetricTemplates).
 		WithTableTemplates(TableTemplates)
 	err := r.client.WalkDaemonSets(func(d DaemonSet) error {
-		result = result.AddNode(d.GetNode())
+		result.AddNode(d.GetNode())
 		daemonSets = append(daemonSets, d)
 		return nil
 	})
@@ -352,7 +354,7 @@ func (r *Reporter) statefulSetTopology() (report.Topology, []StatefulSet, error)
 		WithMetricTemplates(StatefulSetMetricTemplates).
 		WithTableTemplates(TableTemplates)
 	err := r.client.WalkStatefulSets(func(s StatefulSet) error {
-		result = result.AddNode(s.GetNode())
+		result.AddNode(s.GetNode())
 		statefulSets = append(statefulSets, s)
 		return nil
 	})
@@ -366,7 +368,7 @@ func (r *Reporter) cronJobTopology() (report.Topology, []CronJob, error) {
 		WithMetricTemplates(CronJobMetricTemplates).
 		WithTableTemplates(TableTemplates)
 	err := r.client.WalkCronJobs(func(c CronJob) error {
-		result = result.AddNode(c.GetNode())
+		result.AddNode(c.GetNode())
 		cronJobs = append(cronJobs, c)
 		return nil
 	})
@@ -490,7 +492,7 @@ func (r *Reporter) podTopology(services []Service, deployments []Deployment, dae
 		for _, selector := range selectors {
 			selector(p)
 		}
-		pods = pods.AddNode(p.GetNode(r.probeID))
+		pods.AddNode(p.GetNode(r.probeID))
 		return nil
 	})
 	return pods, err
@@ -499,7 +501,7 @@ func (r *Reporter) podTopology(services []Service, deployments []Deployment, dae
 func (r *Reporter) namespaceTopology() (report.Topology, error) {
 	result := report.MakeTopology()
 	err := r.client.WalkNamespaces(func(ns NamespaceResource) error {
-		result = result.AddNode(ns.GetNode())
+		result.AddNode(ns.GetNode())
 		return nil
 	})
 	return result, err

--- a/probe/overlay/weave_test.go
+++ b/probe/overlay/weave_test.go
@@ -41,11 +41,11 @@ func TestContainerTopologyTagging(t *testing.T) {
 	test := func(w *overlay.Weave) {
 		// Container nodes should be tagged with their overlay info
 		nodeID := report.MakeContainerNodeID(weave.MockContainerID)
-		have, err := w.Tag(report.Report{
-			Container: report.MakeTopology().AddNode(report.MakeNodeWith(nodeID, map[string]string{
-				docker.ContainerID: weave.MockContainerID,
-			})),
-		})
+		topology := report.MakeTopology()
+		topology.AddNode(report.MakeNodeWith(nodeID, map[string]string{
+			docker.ContainerID: weave.MockContainerID,
+		}))
+		have, err := w.Tag(report.Report{Container: topology})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/probe/plugins/registry_internal_test.go
+++ b/probe/plugins/registry_internal_test.go
@@ -685,7 +685,8 @@ func nodeControls(indices []int) []string {
 func topologyWithControls(label, nodeID string, controlIndices, nodeControlIndices []int) report.Topology {
 	topology := report.MakeTopology().WithLabel(label, "")
 	topology.Controls = topologyControls(controlIndices)
-	return topology.AddNode(report.MakeNode(nodeID).WithLatestActiveControls(nodeControls(nodeControlIndices)...))
+	topology.AddNode(report.MakeNode(nodeID).WithLatestActiveControls(nodeControls(nodeControlIndices)...))
+	return topology
 }
 
 func pluginSpec(ID string, interfaces ...string) xfer.PluginSpec {

--- a/report/topology.go
+++ b/report/topology.go
@@ -102,15 +102,13 @@ func (t Topology) WithLabel(label, labelPlural string) Topology {
 
 // AddNode adds node to the topology under key nodeID; if a
 // node already exists for this key, nmd is merged with that node.
-// The same topology is returned to enable chaining.
 // This method is different from all the other similar methods
 // in that it mutates the Topology, to solve issues of GC pressure.
-func (t Topology) AddNode(node Node) Topology {
+func (t Topology) AddNode(node Node) {
 	if existing, ok := t.Nodes[node.ID]; ok {
 		node = node.Merge(existing)
 	}
 	t.Nodes[node.ID] = node
-	return t
 }
 
 // GetShape returns the current topology shape, or the default if there isn't one.


### PR DESCRIPTION
This had little use and was obscuring the mutating nature of `AddNode()`.