### PR TITLE
Don't count page cache as part of the process memory

### DIFF
--- a/render/detailed/links.go
+++ b/render/detailed/links.go
@@ -68,7 +68,7 @@ var (
 		report.CronJob:     podIDHashQueries,
 		report.Service: {
 			docker.CPUTotalUsage: `sum(rate(container_cpu_usage_seconds_total{image!="",namespace="{{namespace}}",_weave_pod_name="{{label}}",job="cadvisor",container_name!="POD"}[5m]))`,
-			docker.MemoryUsage:   `sum(rate(container_memory_usage_bytes{image!="",namespace="{{namespace}}",_weave_pod_name="{{label}}",job="cadvisor",container_name!="POD"}[5m]))`,
+			docker.MemoryUsage:   `sum(rate(container_memory_rss{image!="",namespace="{{namespace}}",_weave_pod_name="{{label}}",job="cadvisor",container_name!="POD"}[5m]))`,
 		},
 	}
 )
@@ -79,7 +79,7 @@ func formatMetricQueries(filter string, ids []string) map[string]string {
 		// All  `container_*`metrics  are provided by cAdvisor in Kubelets
 		switch id {
 		case docker.MemoryUsage:
-			queries[id] = fmt.Sprintf("sum(container_memory_usage_bytes{%s})", filter)
+			queries[id] = fmt.Sprintf("sum(container_memory_rss{%s})", filter)
 		case docker.CPUTotalUsage:
 			queries[id] = fmt.Sprintf(
 				"sum(rate(container_cpu_usage_seconds_total{%s}[1m]))/count(container_cpu_usage_seconds_total{%s})*100",

--- a/render/detailed/links_test.go
+++ b/render/detailed/links_test.go
@@ -61,7 +61,7 @@ func TestRenderMetricURLs_Pod(t *testing.T) {
 	result := detailed.RenderMetricURLs(s, samplePodNode, report.MakeReport(), sampleMetricsGraphURL)
 
 	checkURL(t, result.Metrics[0].URL, sampleMetricsGraphURL,
-		[]string{"container_memory_usage_bytes", `pod_name=\"foo\"`, `namespace=\"noospace\"`})
+		[]string{"container_memory_rss", `pod_name=\"foo\"`, `namespace=\"noospace\"`})
 	checkURL(t, result.Metrics[1].URL, sampleMetricsGraphURL,
 		[]string{"container_cpu_usage_seconds", `pod_name=\"foo\"`, `namespace=\"noospace\"`})
 }
@@ -71,7 +71,7 @@ func TestRenderMetricURLs_Container(t *testing.T) {
 	result := detailed.RenderMetricURLs(s, sampleContainerNode, report.MakeReport(), sampleMetricsGraphURL)
 
 	checkURL(t, result.Metrics[0].URL, sampleMetricsGraphURL,
-		[]string{"container_memory_usage_bytes", `name=\"cooname\"`})
+		[]string{"container_memory_rss", `name=\"cooname\"`})
 	checkURL(t, result.Metrics[1].URL, sampleMetricsGraphURL,
 		[]string{"container_cpu_usage_seconds", `name=\"cooname\"`})
 }
@@ -109,7 +109,7 @@ func TestRenderMetricURLs_QueryReplacement(t *testing.T) {
 	result := detailed.RenderMetricURLs(s, samplePodNode, report.MakeReport(), "http://example.test/?q=:query")
 
 	checkURL(t, result.Metrics[0].URL, "http://example.test/?q=",
-		[]string{"container_memory_usage_bytes", `pod_name="foo"`, `namespace="noospace"`})
+		[]string{"container_memory_rss", `pod_name="foo"`, `namespace="noospace"`})
 	checkURL(t, result.Metrics[1].URL, "http://example.test/?q=",
 		[]string{"container_cpu_usage_seconds", `pod_name="foo"`, `namespace="noospace"`})
 }


### PR DESCRIPTION
The container_memory_usage_bytes metric contains the page cache allocations
done by the kernel when the process does some I/O to speed subsequent accesses
eg. when reading 32 bytes a file, the kernel I/O scheduler will optimistically
load more data into that page cache to speed subsequent read operations.

This page cache is an implementation detail of disk I/O and the process have
roughly no control over it (not exactly true, but a good enough approximation).

RSS is a truer measure of memory consumption ie. the actual number of system
memory pages used by the process eg. when allocating 10MB on the heap with
malloc() but not accessing it, that memory isn't actually pinned in RAM and not
accounted for in RSS.