### PR TITLE
More efficient docker Tagger

### DIFF
--- a/probe/docker/tagger.go
+++ b/probe/docker/tagger.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/weaveworks/common/mtime"
 	"github.com/weaveworks/scope/probe/process"
 	"github.com/weaveworks/scope/report"
 )
@@ -80,7 +81,7 @@ func (t *Tagger) Tag(r report.Report) (report.Report, error) {
 }
 
 func (t *Tagger) tag(tree process.Tree, topology *report.Topology) {
-	for nodeID, node := range topology.Nodes {
+	for _, node := range topology.Nodes {
 		pidStr, ok := node.Latest.Lookup(process.PID)
 		if !ok {
 			continue
@@ -114,9 +115,8 @@ func (t *Tagger) tag(tree process.Tree, topology *report.Topology) {
 			continue
 		}
 
-		node := report.MakeNodeWith(nodeID, map[string]string{
-			ContainerID: c.ID(),
-		}).WithParents(report.MakeSets().
+		node = node.WithLatest(ContainerID, mtime.Now(), c.ID())
+		node = node.WithParents(report.MakeSets().
 			Add(report.Container, report.MakeStringSet(report.MakeContainerNodeID(c.ID()))),
 		)
 
@@ -129,6 +129,6 @@ func (t *Tagger) tag(tree process.Tree, topology *report.Topology) {
 			)
 		}
 
-		topology.AddNode(node)
+		topology.ReplaceNode(node)
 	}
 }


### PR DESCRIPTION
Augment existing node rather than creating a new one then merging it, and avoid creating a set with one entry.

This restores the "item 4" from #3073 that was incorrectly done and removed.