### PR TITLE
Remove unused process tree function GetChildren()

### DIFF
--- a/probe/docker/tagger_test.go
+++ b/probe/docker/tagger_test.go
@@ -23,10 +23,6 @@ func (m *mockProcessTree) GetParent(pid int) (int, error) {
 	return parent, nil
 }
 
-func (m *mockProcessTree) GetChildren(int) ([]int, error) {
-	panic("Not implemented")
-}
-
 func TestTagger(t *testing.T) {
 	mtime.NowForce(time.Now())
 	defer mtime.NowReset()

--- a/probe/process/tree.go
+++ b/probe/process/tree.go
@@ -7,7 +7,6 @@ import (
 // Tree represents all processes on the machine.
 type Tree interface {
 	GetParent(pid int) (int, error)
-	GetChildren(pid int) ([]int, error)
 }
 
 type tree struct {
@@ -32,31 +31,4 @@ func (pt *tree) GetParent(pid int) (int, error) {
 	}
 
 	return proc.PPID, nil
-}
-
-// GetChildren
-func (pt *tree) GetChildren(pid int) ([]int, error) {
-	_, ok := pt.processes[pid]
-	if !ok {
-		return []int{}, fmt.Errorf("PID %d not found", pid)
-	}
-
-	var isChild func(id int) bool
-	isChild = func(id int) bool {
-		p, ok := pt.processes[id]
-		if !ok || p.PPID == 0 {
-			return false
-		} else if p.PPID == pid {
-			return true
-		}
-		return isChild(p.PPID)
-	}
-
-	children := []int{pid}
-	for id := range pt.processes {
-		if isChild(id) {
-			children = append(children, id)
-		}
-	}
-	return children, nil
 }


### PR DESCRIPTION
I was trying to understand how pids were looked up, and wasted some time looking at this function which is never used.