### PR TITLE
Blank out value on LatestMap decode insert

### DIFF
--- a/extras/generate_latest_map
+++ b/extras/generate_latest_map
@@ -143,6 +143,7 @@ function generate_latest_map() {
         if i == len(*m) || (*m)[i].key != key {
             *m = append(*m, ${entry_type}{})
             copy((*m)[i+1:], (*m)[i:])
+            (*m)[i] = ${entry_type}{}
         }
         return i
     }

--- a/report/latest_map_generated.go
+++ b/report/latest_map_generated.go
@@ -111,6 +111,7 @@ func (m *StringLatestMap) locate(key string) int {
 	if i == len(*m) || (*m)[i].key != key {
 		*m = append(*m, stringLatestEntry{})
 		copy((*m)[i+1:], (*m)[i:])
+		(*m)[i] = stringLatestEntry{}
 	}
 	return i
 }
@@ -332,6 +333,7 @@ func (m *NodeControlDataLatestMap) locate(key string) int {
 	if i == len(*m) || (*m)[i].key != key {
 		*m = append(*m, nodeControlDataLatestEntry{})
 		copy((*m)[i+1:], (*m)[i:])
+		(*m)[i] = nodeControlDataLatestEntry{}
 	}
 	return i
 }

--- a/report/latest_map_internal_test.go
+++ b/report/latest_map_internal_test.go
@@ -168,6 +168,36 @@ func BenchmarkLatestMapDecode(b *testing.B) {
 	}
 }
 
+func TestLatestMapDecoding(t *testing.T) {
+	ts, _ := time.Parse(time.RFC3339Nano, "2018-02-26T09:50:43Z")
+	want := MakeStringLatestMap().
+		Set("foo", ts, "bar").
+		Set("bar", ts, "baz").
+		Set("emptyval", ts, "")
+	// The following string is carefully constructed to have 'emptyval' not in alphabetical order
+	data := `
+{
+  "bar": {
+    "timestamp": "2018-02-26T09:50:43Z",
+    "value": "baz"
+  },
+  "foo": {
+    "timestamp": "2018-02-26T09:50:43Z",
+    "value": "bar"
+  },
+  "emptyval": {
+    "timestamp": "2018-02-26T09:50:43Z"
+  }
+}`
+	h := &codec.JsonHandle{}
+	decoder := codec.NewDecoder(bytes.NewBufferString(data), h)
+	have := MakeStringLatestMap()
+	have.CodecDecodeSelf(decoder)
+	if !reflect.DeepEqual(want, have) {
+		t.Error(test.Diff(want, have))
+	}
+}
+
 func TestLatestMapEncoding(t *testing.T) {
 	now := time.Now()
 	want := MakeStringLatestMap().
@@ -188,7 +218,6 @@ func TestLatestMapEncoding(t *testing.T) {
 			t.Error(test.Diff(want, have))
 		}
 	}
-
 }
 
 func TestLatestMapEncodingNil(t *testing.T) {


### PR DESCRIPTION
Fixing a rare case that came up in a test. In order for this to cause a problem, the data being decoded has to have entries out of order, and have a value that is nil or omitted.  Current probes always serialise the entries in order, and don't omit empty values, but I think it's better to be safe.
