### PR TITLE
Bump moment.js & ui-components deps

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,7 @@
     "lcp": "1.1.0",
     "lodash": "4.17.4",
     "materialize-css": "0.98.1",
-    "moment": "2.19.1",
+    "moment": "2.21.0",
     "page": "1.7.1",
     "prop-types": "15.6.0",
     "rc-slider": "8.3.2",

--- a/client/package.json
+++ b/client/package.json
@@ -43,7 +43,7 @@
     "reselect": "3.0.1",
     "reselect-map": "1.0.3",
     "styled-components": "2.2.4",
-    "weaveworks-ui-components": "0.4.18",
+    "weaveworks-ui-components": "0.4.36",
     "whatwg-fetch": "2.0.3",
     "xterm": "2.9.2"
   },

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4266,9 +4266,9 @@ mockdate@2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.2.tgz#5ae0c0eaf8fe23e009cd01f9889b42c4f634af12"
 
-moment@2.19.1:
-  version "2.19.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.1.tgz#56da1a2d1cbf01d38b7e1afc31c10bcfa1929167"
+moment@2.21.0:
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
 
 ms@0.7.2:
   version "0.7.2"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1859,6 +1859,10 @@ d3-format@1, d3-format@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.2.0.tgz#6b480baa886885d4651dc248a8f4ac9da16db07a"
 
+d3-format@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.2.2.tgz#1a39c479c8a57fe5051b2e67a3bee27061a74e7a"
+
 d3-interpolate@1:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.1.5.tgz#69e099ff39214716e563c9aec3ea9d1ea4b8a79f"
@@ -6429,14 +6433,16 @@ wd@^0.4.0:
     underscore.string "~3.0.3"
     vargs "~0.1.0"
 
-weaveworks-ui-components@0.4.18:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/weaveworks-ui-components/-/weaveworks-ui-components-0.4.18.tgz#7fc36416eb52844560aa5ada24457c302aea5f45"
+weaveworks-ui-components@0.4.36:
+  version "0.4.36"
+  resolved "https://registry.yarnpkg.com/weaveworks-ui-components/-/weaveworks-ui-components-0.4.36.tgz#d02cf8b591d36bf83bcc0650663fa4ed2d8d3294"
   dependencies:
     classnames "2.2.5"
     d3-drag "1.2.1"
+    d3-format "1.2.2"
     d3-scale "1.0.7"
     d3-selection "1.2.0"
+    d3-shape "1.2.0"
     polished "1.9.0"
     prop-types "15.6.0"
     react-motion "0.5.2"


### PR DESCRIPTION
Fixes #3101.

Also upgrades `ui-components` from `v0.4.18` to `v0.4.36`. That's a big bump but only https://github.com/weaveworks/ui-components/pull/123, https://github.com/weaveworks/ui-components/pull/113 and https://github.com/weaveworks/ui-components/pull/129 have changed the components used by Scope. Out of them, only the last one (changing the circular loader appearance) will have a visible effect in Scope.
