### PR TITLE
Support topology filtering by k8s label

### DIFF
--- a/render/filters.go
+++ b/render/filters.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/weaveworks/common/mtime"
@@ -289,6 +290,20 @@ func IsNamespace(namespace string) FilterFunc {
 			return true
 		}
 		return namespace == gotNamespace
+	}
+}
+
+// IsLabel checks if the node has specific k8s label
+func IsLabel(label string) FilterFunc {
+	return func(n report.Node) bool {
+		s := strings.Split(label, "=")
+		labelKey, labelValue := s[0], s[1]
+		gotApp := ""
+		lookupKey := fmt.Sprintf("%s%s", kubernetes.LabelPrefix, labelKey)
+		if value, ok := n.Latest.Lookup(lookupKey); ok {
+			gotApp = value
+		}
+		return labelValue == gotApp
 	}
 }
 


### PR DESCRIPTION
Resolves https://github.com/weaveworks/scope/issues/3112

- Added label filters to `PODS` `CONTROLLERS` `SERVICES`

<img width="1668" alt="image" src="https://user-images.githubusercontent.com/16092291/37783215-4ee6aeac-2dcb-11e8-8776-8c4526f60fb1.png">


Note: k8s labels are usual a lot and UI doesn't handle it well. So I created another PR to address it https://github.com/weaveworks/scope/pull/3117