### PR TITLE
make shortcut reports work (again)

### DIFF
--- a/probe/docker/registry.go
+++ b/probe/docker/registry.go
@@ -373,11 +373,9 @@ func (r *registry) updateContainerState(containerID string, intendedState *strin
 	}
 
 	// Trigger anyone watching for updates
-	if err != nil {
-		node := c.GetNode()
-		for _, f := range r.watchers {
-			f(node)
-		}
+	node := c.GetNode()
+	for _, f := range r.watchers {
+		f(node)
 	}
 
 	// And finally, ensure we gather stats for it

--- a/report/report.go
+++ b/report/report.go
@@ -259,6 +259,7 @@ func (r Report) Copy() Report {
 		DNS:      r.DNS.Copy(),
 		Sampling: r.Sampling,
 		Window:   r.Window,
+		Shortcut: r.Shortcut,
 		Plugins:  r.Plugins.Copy(),
 		ID:       fmt.Sprintf("%d", rand.Int63()),
 	}


### PR DESCRIPTION
To test this, run
```
docker run --name=foo --rm -ti alpine sleep 10
```
On master it can take several seconds for the container to appear on the topology view, and then several seconds for it to disappear when it stops.

After the first commit, it disappears immediately when stopped, but still takes time to appear. The latter is cured by the 2nd commit.

Fixes #3113.

In the process I discovered #3120.