### PR TITLE
don't show Failed pods

### DIFF
--- a/probe/kubernetes/pod.go
+++ b/probe/kubernetes/pod.go
@@ -16,7 +16,10 @@ const (
 )
 
 // Pod states we handle specially
-const StateDeleted = "deleted"
+const (
+	StateDeleted = "deleted"
+	StateFailed  = "Failed"
+)
 
 // Pod represents a Kubernetes pod
 type Pod interface {

--- a/probe/kubernetes/pod.go
+++ b/probe/kubernetes/pod.go
@@ -13,9 +13,10 @@ const (
 	State           = report.KubernetesState
 	IsInHostNetwork = report.KubernetesIsInHostNetwork
 	RestartCount    = report.KubernetesRestartCount
-
-	StateDeleted = "deleted"
 )
+
+// Pod states we handle specially
+const StateDeleted = "deleted"
 
 // Pod represents a Kubernetes pod
 type Pod interface {

--- a/render/pod.go
+++ b/render/pod.go
@@ -46,7 +46,7 @@ var PodRenderer = Memoise(ConditionalRenderer(renderKubernetesTopologies,
 	MakeFilter(
 		func(n report.Node) bool {
 			state, ok := n.Latest.Lookup(kubernetes.State)
-			return (!ok || state != kubernetes.StateDeleted)
+			return !ok || !(state == kubernetes.StateDeleted || state == kubernetes.StateFailed)
 		},
 		MakeReduce(
 			PropagateSingleMetrics(report.Container,

--- a/report/map_keys.go
+++ b/report/map_keys.go
@@ -69,7 +69,6 @@ const (
 	KubernetesSuspended            = "kubernetes_suspended"
 	KubernetesLastScheduled        = "kubernetes_last_scheduled"
 	KubernetesActiveJobs           = "kubernetes_active_jobs"
-	KubernetesStateDeleted         = "deleted"
 	KubernetesType                 = "kubernetes_type"
 	KubernetesPorts                = "kubernetes_ports"
 	// probe/awsecs

--- a/report/report.go
+++ b/report/report.go
@@ -454,7 +454,7 @@ func (r Report) upgradeNamespaces() Report {
 	namespaces := map[string]struct{}{}
 	for _, t := range []Topology{r.Pod, r.Service, r.Deployment, r.DaemonSet, r.StatefulSet, r.CronJob} {
 		for _, n := range t.Nodes {
-			if state, ok := n.Latest.Lookup(KubernetesState); ok && state == KubernetesStateDeleted {
+			if state, ok := n.Latest.Lookup(KubernetesState); ok && state == "deleted" {
 				continue
 			}
 			if namespace, ok := n.Latest.Lookup(KubernetesNamespace); ok {


### PR DESCRIPTION
Fixes #3083.

An alternative here would be to not even _report_ Failed pods, but that is more work.

