### PR TITLE
Fix format string to work for all types

### DIFF
--- a/extras/generate_latest_map
+++ b/extras/generate_latest_map
@@ -181,7 +181,7 @@ function generate_latest_map() {
     func (m ${latest_map_type}) String() string {
         buf := bytes.NewBufferString("{")
         for _, val := range m {
-            fmt.Fprintf(buf, "%s: %s,\n", val.key, val)
+            fmt.Fprintf(buf, "%s: %v,\n", val.key, val)
         }
         fmt.Fprintf(buf, "}")
         return buf.String()

--- a/report/latest_map_generated.go
+++ b/report/latest_map_generated.go
@@ -149,7 +149,7 @@ func (m StringLatestMap) ForEach(fn func(k string, timestamp time.Time, v string
 func (m StringLatestMap) String() string {
 	buf := bytes.NewBufferString("{")
 	for _, val := range m {
-		fmt.Fprintf(buf, "%s: %s,\n", val.key, val)
+		fmt.Fprintf(buf, "%s: %v,\n", val.key, val)
 	}
 	fmt.Fprintf(buf, "}")
 	return buf.String()
@@ -371,7 +371,7 @@ func (m NodeControlDataLatestMap) ForEach(fn func(k string, timestamp time.Time,
 func (m NodeControlDataLatestMap) String() string {
 	buf := bytes.NewBufferString("{")
 	for _, val := range m {
-		fmt.Fprintf(buf, "%s: %s,\n", val.key, val)
+		fmt.Fprintf(buf, "%s: %v,\n", val.key, val)
 	}
 	fmt.Fprintf(buf, "}")
 	return buf.String()


### PR DESCRIPTION
Small issue, but `go vet` complains.

(haven't investigated why our lint step is not catching it)