### PR TITLE
Don't update route if it hasn't changed

### DIFF
--- a/client/app/scripts/utils/router-utils.js
+++ b/client/app/scripts/utils/router-utils.js
@@ -1,4 +1,5 @@
 import page from 'page';
+import stableStringify from 'json-stable-stringify';
 import { fromJS, is as isDeepEqual } from 'immutable';
 import { each, omit, omitBy, isEmpty } from 'lodash';
 
@@ -107,9 +108,12 @@ export function getUrlState(state) {
 
 export function updateRoute(getState) {
   const state = getUrlState(getState());
-  const stateUrl = encodeURL(JSON.stringify(state));
-  const dispatch = false;
   const prevState = parseHashState();
+  const dispatch = false;
+
+  const stateUrl = encodeURL(stableStringify(state));
+  const prevStateUrl = encodeURL(stableStringify(prevState));
+  if (stateUrl === prevStateUrl) return;
 
   // back up state in storage as well
   storageSet(STORAGE_STATE_KEY, stateUrl);
@@ -152,7 +156,7 @@ export function getRouter(dispatch, initialState) {
       } else {
         const mergedState = Object.assign(initialState, parsedState);
         // push storage state to URL
-        window.location.hash = `!/state/${JSON.stringify(mergedState)}`;
+        window.location.hash = `!/state/${stableStringify(mergedState)}`;
         dispatch(route(mergedState));
       }
     } else {

--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "filter-invalid-dom-props": "2.0.0",
     "font-awesome": "4.7.0",
     "immutable": "3.8.2",
+    "json-stable-stringify": "1.0.1",
     "lcp": "1.1.0",
     "lodash": "4.17.4",
     "materialize-css": "0.98.1",


### PR DESCRIPTION
Fixes browser history when deep linking into node details with time context in https://github.com/weaveworks/service-ui/pull/2254.

The problem was that the URLs with the same hash, but permutted keys would be treated as different ones, so we'd end up in routing loops under some circumstances.he 

My solution was to use `json-stable-sort` helper in some parts where `JSON.stringify` was previously used. We might want to generalize this policy whenever encoding Scope JSON state - https://github.com/weaveworks/scope/issues/3133.

Let's see if https://github.com/weaveworks/service-ui/issues/2021 also gets fixed by this change.
