### PR TITLE
Simplify Map.Render()

### DIFF
--- a/render/container.go
+++ b/render/container.go
@@ -255,10 +255,10 @@ func MapContainer2IP(m report.Node) []string {
 // format for a container, but without any Major or Minor labels.
 // It does not have enough info to do that, and the resulting graph
 // must be merged with a container graph to get that info.
-func MapProcess2Container(n report.Node) report.Nodes {
+func MapProcess2Container(n report.Node) report.Node {
 	// Propagate pseudo nodes
 	if n.Topology == Pseudo {
-		return report.Nodes{n.ID: n}
+		return n
 	}
 
 	// Otherwise, if the process is not in a container, group it into
@@ -275,7 +275,7 @@ func MapProcess2Container(n report.Node) report.Nodes {
 		id = MakePseudoNodeID(UncontainedID, hostID)
 		node = NewDerivedPseudoNode(id, n)
 	}
-	return report.Nodes{id: node}
+	return node
 }
 
 // MapContainer2ContainerImage maps container Nodes to container
@@ -290,17 +290,17 @@ func MapProcess2Container(n report.Node) report.Nodes {
 // format for a container image, but without any Major or Minor
 // labels.  It does not have enough info to do that, and the resulting
 // graph must be merged with a container image graph to get that info.
-func MapContainer2ContainerImage(n report.Node) report.Nodes {
+func MapContainer2ContainerImage(n report.Node) report.Node {
 	// Propagate all pseudo nodes
 	if n.Topology == Pseudo {
-		return report.Nodes{n.ID: n}
+		return n
 	}
 
 	// Otherwise, if some some reason the container doesn't have a image_id
 	// (maybe slightly out of sync reports), just drop it
 	imageID, ok := n.Latest.Lookup(docker.ImageID)
 	if !ok {
-		return report.Nodes{}
+		return report.Node{}
 	}
 
 	// Add container id key to the counters, which will later be
@@ -308,50 +308,50 @@ func MapContainer2ContainerImage(n report.Node) report.Nodes {
 	id := report.MakeContainerImageNodeID(imageID)
 	result := NewDerivedNode(id, n).WithTopology(report.ContainerImage)
 	result.Counters = result.Counters.Add(n.Topology, 1)
-	return report.Nodes{id: result}
+	return result
 }
 
 // MapContainerImage2Name ignores image versions
-func MapContainerImage2Name(n report.Node) report.Nodes {
+func MapContainerImage2Name(n report.Node) report.Node {
 	// Propagate all pseudo nodes
 	if n.Topology == Pseudo {
-		return report.Nodes{n.ID: n}
+		return n
 	}
 
 	imageName, ok := n.Latest.Lookup(docker.ImageName)
 	if !ok {
-		return report.Nodes{}
+		return report.Node{}
 	}
 
 	imageNameWithoutVersion := docker.ImageNameWithoutVersion(imageName)
 	n.ID = report.MakeContainerImageNodeID(imageNameWithoutVersion)
 
-	return report.Nodes{n.ID: n}
+	return n
 }
 
 var containerHostnameTopology = MakeGroupNodeTopology(report.Container, docker.ContainerHostname)
 
 // MapContainer2Hostname maps container Nodes to 'hostname' renderabled nodes..
-func MapContainer2Hostname(n report.Node) report.Nodes {
+func MapContainer2Hostname(n report.Node) report.Node {
 	// Propagate all pseudo nodes
 	if n.Topology == Pseudo {
-		return report.Nodes{n.ID: n}
+		return n
 	}
 
 	// Otherwise, if some some reason the container doesn't have a hostname
 	// (maybe slightly out of sync reports), just drop it
 	id, ok := n.Latest.Lookup(docker.ContainerHostname)
 	if !ok {
-		return report.Nodes{}
+		return report.Node{}
 	}
 
 	node := NewDerivedNode(id, n).WithTopology(containerHostnameTopology)
 	node.Counters = node.Counters.Add(n.Topology, 1)
-	return report.Nodes{id: node}
+	return node
 }
 
 // MapToEmpty removes all the attributes, children, etc, of a node. Useful when
 // we just want to count the presence of nodes.
-func MapToEmpty(n report.Node) report.Nodes {
-	return report.Nodes{n.ID: report.MakeNode(n.ID).WithTopology(n.Topology)}
+func MapToEmpty(n report.Node) report.Node {
+	return report.MakeNode(n.ID).WithTopology(n.Topology)
 }

--- a/render/container_test.go
+++ b/render/container_test.go
@@ -43,7 +43,7 @@ type testcase struct {
 }
 
 func testMap(t *testing.T, f render.MapFunc, input testcase) {
-	if have := f(input.n); input.ok != (len(have) > 0) {
+	if have := f(input.n); input.ok != (have.ID != "") {
 		name := input.name
 		if name == "" {
 			name = fmt.Sprintf("%v", input.n)

--- a/render/pod.go
+++ b/render/pod.go
@@ -50,16 +50,14 @@ var PodRenderer = Memoise(ConditionalRenderer(renderKubernetesTopologies,
 		},
 		MakeReduce(
 			PropagateSingleMetrics(report.Container,
-				MakeMap(
-					Map2Parent([]string{report.Pod}, UnmanagedID),
-					MakeFilter(
+				Map2Parent{topologies: []string{report.Pod}, noParentsPseudoID: UnmanagedID,
+					chainRenderer: MakeFilter(
 						ComposeFilterFuncs(
 							IsRunning,
 							Complement(isPauseContainer),
 						),
 						ContainerWithImageNameRenderer,
-					),
-				),
+					)},
 			),
 			ConnectionJoin(MapPod2IP, report.Pod),
 		),
@@ -101,10 +99,8 @@ func renderParents(childTopology string, parentTopologies []string, noParentsPse
 	return MakeReduce(append(
 		selectors,
 		PropagateSingleMetrics(childTopology,
-			MakeMap(
-				Map2Parent(parentTopologies, noParentsPseudoID),
-				childRenderer,
-			),
+			Map2Parent{topologies: parentTopologies, noParentsPseudoID: noParentsPseudoID,
+				chainRenderer: childRenderer},
 		),
 	)...)
 }
@@ -126,46 +122,52 @@ func MapPod2IP(m report.Node) []string {
 	return []string{report.MakeScopedEndpointNodeID("", ip, "")}
 }
 
-// Map2Parent returns a MapFunc which maps Nodes to some parent grouping.
-func Map2Parent(
+// Map2Parent is a Renderer which maps Nodes to some parent grouping.
+type Map2Parent struct {
+	// Renderer to chain from
+	chainRenderer Renderer
 	// The topology IDs to look for parents in
-	topologies []string,
+	topologies []string
 	// Either the ID prefix of the pseudo node to use for nodes without
 	// any parents in the group, eg. UnmanagedID, or "" to drop nodes without any parents.
-	noParentsPseudoID string,
-) MapFunc {
-	return func(n report.Node) report.Nodes {
+	noParentsPseudoID string
+}
+
+// Render implements Renderer
+func (m Map2Parent) Render(rpt report.Report) Nodes {
+	input := m.chainRenderer.Render(rpt)
+	ret := newJoinResults(nil)
+
+	for _, n := range input.Nodes {
 		// Uncontained becomes Unmanaged/whatever if noParentsPseudoID is set
-		if noParentsPseudoID != "" && strings.HasPrefix(n.ID, UncontainedIDPrefix) {
-			id := MakePseudoNodeID(noParentsPseudoID, n.ID[len(UncontainedIDPrefix):])
-			node := NewDerivedPseudoNode(id, n)
-			return report.Nodes{id: node}
+		if m.noParentsPseudoID != "" && strings.HasPrefix(n.ID, UncontainedIDPrefix) {
+			id := MakePseudoNodeID(m.noParentsPseudoID, n.ID[len(UncontainedIDPrefix):])
+			ret.addChildAndChildren(n, id, Pseudo)
+			continue
 		}
 
 		// Propagate all pseudo nodes
 		if n.Topology == Pseudo {
-			return report.Nodes{n.ID: n}
+			ret.passThrough(n)
+			continue
 		}
 
+		added := false
 		// For each topology, map to any parents we can find
-		result := report.Nodes{}
-		for _, topology := range topologies {
+		for _, topology := range m.topologies {
 			if groupIDs, ok := n.Parents.Lookup(topology); ok {
 				for _, id := range groupIDs {
-					node := NewDerivedNode(id, n).WithTopology(topology)
-					node.Counters = node.Counters.Add(n.Topology, 1)
-					result[id] = node
+					ret.addChildAndChildren(n, id, topology)
+					added = true
 				}
 			}
 		}
 
-		if len(result) == 0 && noParentsPseudoID != "" {
+		if !added && m.noParentsPseudoID != "" {
 			// Map to pseudo node
-			id := MakePseudoNodeID(noParentsPseudoID, report.ExtractHostID(n))
-			node := NewDerivedPseudoNode(id, n)
-			result[id] = node
+			id := MakePseudoNodeID(m.noParentsPseudoID, report.ExtractHostID(n))
+			ret.addChildAndChildren(n, id, Pseudo)
 		}
-
-		return result
 	}
+	return ret.result(input)
 }

--- a/render/render.go
+++ b/render/render.go
@@ -5,10 +5,10 @@ import (
 )
 
 // MapFunc is anything which can take an arbitrary Node and
-// return a set of other Nodes.
+// return another Node.
 //
-// If the output is empty, the node shall be omitted from the rendered topology.
-type MapFunc func(report.Node) report.Nodes
+// If the output ID is blank, the node shall be omitted from the rendered topology.
+type MapFunc func(report.Node) report.Node
 
 // Renderer is something that can render a report to a set of Nodes.
 type Renderer interface {
@@ -107,7 +107,8 @@ func (m Map) Render(rpt report.Report) Nodes {
 
 	// Rewrite all the nodes according to the map function
 	for _, inRenderable := range input.Nodes {
-		for _, outRenderable := range m.MapFunc(inRenderable) {
+		outRenderable := m.MapFunc(inRenderable)
+		if outRenderable.ID != "" {
 			if existing, ok := output[outRenderable.ID]; ok {
 				outRenderable = outRenderable.Merge(existing)
 			}

--- a/render/render.go
+++ b/render/render.go
@@ -8,6 +8,7 @@ import (
 // return another Node.
 //
 // If the output ID is blank, the node shall be omitted from the rendered topology.
+// (we chose not to return an extra bool because it adds clutter)
 type MapFunc func(report.Node) report.Node
 
 // Renderer is something that can render a report to a set of Nodes.

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -36,8 +36,8 @@ func TestReduceRender(t *testing.T) {
 func TestMapRender1(t *testing.T) {
 	// 1. Check when we return false, the node gets filtered out
 	mapper := render.Map{
-		MapFunc: func(nodes report.Node) report.Nodes {
-			return report.Nodes{}
+		MapFunc: func(nodes report.Node) report.Node {
+			return report.Node{}
 		},
 		Renderer: mockRenderer{Nodes: report.Nodes{
 			"foo": report.MakeNode("foo"),
@@ -53,10 +53,8 @@ func TestMapRender1(t *testing.T) {
 func TestMapRender2(t *testing.T) {
 	// 2. Check we can remap two nodes into one
 	mapper := render.Map{
-		MapFunc: func(nodes report.Node) report.Nodes {
-			return report.Nodes{
-				"bar": report.MakeNode("bar"),
-			}
+		MapFunc: func(nodes report.Node) report.Node {
+			return report.MakeNode("bar")
 		},
 		Renderer: mockRenderer{Nodes: report.Nodes{
 			"foo": report.MakeNode("foo"),
@@ -75,9 +73,9 @@ func TestMapRender2(t *testing.T) {
 func TestMapRender3(t *testing.T) {
 	// 3. Check we can remap adjacencies
 	mapper := render.Map{
-		MapFunc: func(nodes report.Node) report.Nodes {
+		MapFunc: func(nodes report.Node) report.Node {
 			id := "_" + nodes.ID
-			return report.Nodes{id: report.MakeNode(id)}
+			return report.MakeNode(id)
 		},
 		Renderer: mockRenderer{Nodes: report.Nodes{
 			"foo": report.MakeNode("foo").WithAdjacent("baz"),

--- a/render/weave.go
+++ b/render/weave.go
@@ -14,10 +14,10 @@ var WeaveRenderer = MakeMap(
 )
 
 // MapWeaveIdentity maps an overlay topology node to a weave topology node.
-func MapWeaveIdentity(m report.Node) report.Nodes {
+func MapWeaveIdentity(m report.Node) report.Node {
 	peerPrefix, _ := report.ParseOverlayNodeID(m.ID)
 	if peerPrefix != report.WeaveOverlayPeerPrefix {
-		return nil
+		return report.Node{}
 	}
 
 	var (
@@ -33,5 +33,5 @@ func MapWeaveIdentity(m report.Node) report.Nodes {
 		node = NewDerivedPseudoNode(id, m)
 	}
 
-	return report.Nodes{node.ID: node}
+	return node
 }


### PR DESCRIPTION
Make all `MapFunc`s return a single `Node` instead of a set.

This lets us save a bit of time by not creating all those `map`s, and re-integrate the adjacency mapping code that was split out into `joinResults`.

Benchmarks, using a set of reports from Weave Cloud - the timings are a bit mixed but bytes and allocations are generally in the right direction:
```
benchmark                            old ns/op      new ns/op      delta
BenchmarkReportUnmarshal-2           1355945521     1327087556     -2.13%
BenchmarkReportUpgrade-2             70184976       69354449       -1.18%
BenchmarkReportMerge-2               878730403      921976801      +4.92%
BenchmarkRenderList-2                561471520      563783165      +0.41%
BenchmarkRenderHosts-2               403998863      413859127      +2.44%
BenchmarkRenderControllers-2         337145280      350440707      +3.94%
BenchmarkRenderPods-2                324643559      311958921      -3.91%
BenchmarkRenderContainers-2          205667797      191406825      -6.93%
BenchmarkRenderProcesses-2           122603018      125965319      +2.74%
BenchmarkRenderProcessNames-2        147378216      140242434      -4.84%
BenchmarkSummarizeHosts-2            150408         149442         -0.64%
BenchmarkSummarizeControllers-2      818615         815577         -0.37%
BenchmarkSummarizePods-2             2529781        2434542        -3.76%
BenchmarkSummarizeContainers-2       52026615       43669700       -16.06%
BenchmarkSummarizeProcesses-2        57518841       56164831       -2.35%
BenchmarkSummarizeProcessNames-2     585876         647129         +10.45%
BenchmarkSmartMerger-2               36967279       36809862       -0.43%
BenchmarkDumbMerger-2                369488313      388092696      +5.04%

benchmark                            old allocs     new allocs     delta
BenchmarkReportUnmarshal-2           2631054        2631052        -0.00%
BenchmarkReportUpgrade-2             24845          24804          -0.17%
BenchmarkReportMerge-2               1709529        1734064        +1.44%
BenchmarkRenderList-2                797837         765970         -3.99%
BenchmarkRenderHosts-2               603998         581912         -3.66%
BenchmarkRenderControllers-2         429361         405592         -5.54%
BenchmarkRenderPods-2                383985         364901         -4.97%
BenchmarkRenderContainers-2          253973         236530         -6.87%
BenchmarkRenderProcesses-2           119581         119582         +0.00%
BenchmarkRenderProcessNames-2        164271         163203         -0.65%
BenchmarkSummarizeHosts-2            246            246            +0.00%
BenchmarkSummarizeControllers-2      1821           1821           +0.00%
BenchmarkSummarizePods-2             7081           7081           +0.00%
BenchmarkSummarizeContainers-2       80308          80309          +0.00%
BenchmarkSummarizeProcesses-2        69815          69815          +0.00%
BenchmarkSummarizeProcessNames-2     1674           1674           +0.00%
BenchmarkSmartMerger-2               107931         109682         +1.62%
BenchmarkDumbMerger-2                571237         571248         +0.00%

benchmark                            old bytes     new bytes     delta
BenchmarkReportUnmarshal-2           427341952     427345056     +0.00%
BenchmarkReportUpgrade-2             5255060       5255462       +0.01%
BenchmarkReportMerge-2               339534452     344383964     +1.43%
BenchmarkRenderList-2                91196588      85036244      -6.76%
BenchmarkRenderHosts-2               65665560      61840421      -5.83%
BenchmarkRenderControllers-2         47093261      43204658      -8.26%
BenchmarkRenderPods-2                41887292      38614284      -7.81%
BenchmarkRenderContainers-2          28809066      26086785      -9.45%
BenchmarkRenderProcesses-2           13984302      13983102      -0.01%
BenchmarkRenderProcessNames-2        18026190      17906446      -0.66%
BenchmarkSummarizeHosts-2            35020         35016         -0.01%
BenchmarkSummarizeControllers-2      183358        183362        +0.00%
BenchmarkSummarizePods-2             650411        650386        -0.00%
BenchmarkSummarizeContainers-2       10504803      10505320      +0.00%
BenchmarkSummarizeProcesses-2        7626475       7626508       +0.00%
BenchmarkSummarizeProcessNames-2     131706        131705        -0.00%
BenchmarkSmartMerger-2               29837290      30311163      +1.59%
BenchmarkDumbMerger-2                155934731     155937024     +0.00%
```