### PR TITLE
WIP: Make Node.WithLatests() take a slice instead of a map

### DIFF
--- a/app/api_topologies_test.go
+++ b/app/api_topologies_test.go
@@ -115,9 +115,9 @@ func TestRendererForTopologyWithFiltering(t *testing.T) {
 	}
 
 	input := fixture.Report.Copy()
-	input.Container.Nodes[fixture.ClientContainerNodeID] = input.Container.Nodes[fixture.ClientContainerNodeID].WithLatests(map[string]string{
-		docker.LabelPrefix + "works.weave.role": "system",
-	})
+	input.Container.Nodes[fixture.ClientContainerNodeID] = input.Container.Nodes[fixture.ClientContainerNodeID].WithLatests(
+		docker.LabelPrefix+"works.weave.role", "system",
+	)
 	have := utils.Prune(render.Render(input, renderer, filter).Nodes)
 	want := utils.Prune(expected.RenderedContainers.Copy())
 	delete(want, fixture.ClientContainerNodeID)
@@ -146,9 +146,9 @@ func TestRendererForTopologyNoFiltering(t *testing.T) {
 	}
 
 	input := fixture.Report.Copy()
-	input.Container.Nodes[fixture.ClientContainerNodeID] = input.Container.Nodes[fixture.ClientContainerNodeID].WithLatests(map[string]string{
-		docker.LabelPrefix + "works.weave.role": "system",
-	})
+	input.Container.Nodes[fixture.ClientContainerNodeID] = input.Container.Nodes[fixture.ClientContainerNodeID].WithLatests(
+		docker.LabelPrefix+"works.weave.role", "system",
+	)
 	have := utils.Prune(render.Render(input, renderer, filter).Nodes)
 	want := utils.Prune(expected.RenderedContainers.Copy())
 	delete(want, render.MakePseudoNodeID(render.UncontainedID, fixture.ServerHostID))

--- a/probe/awsecs/reporter.go
+++ b/probe/awsecs/reporter.go
@@ -150,12 +150,12 @@ func (r Reporter) Tag(rpt report.Report) (report.Report, error) {
 		// Create all the services first
 		for serviceName, service := range ecsInfo.Services {
 			serviceID := report.MakeECSServiceNodeID(cluster, serviceName)
-			rpt.ECSService.AddNode(report.MakeNodeWith(serviceID, map[string]string{
-				Cluster:               cluster,
-				ServiceDesiredCount:   fmt.Sprintf("%d", service.DesiredCount),
-				ServiceRunningCount:   fmt.Sprintf("%d", service.RunningCount),
-				report.ControlProbeID: r.probeID,
-			}).WithLatestControls(map[string]report.NodeControlData{
+			rpt.ECSService.AddNode(report.MakeNodeWith(serviceID,
+				Cluster, cluster,
+				ServiceDesiredCount, fmt.Sprintf("%d", service.DesiredCount),
+				ServiceRunningCount, fmt.Sprintf("%d", service.RunningCount),
+				report.ControlProbeID, r.probeID,
+			).WithLatestControls(map[string]report.NodeControlData{
 				ScaleUp: {Dead: false},
 				// We've decided for now to disable ScaleDown when only 1 task is desired,
 				// since scaling down to 0 would cause the service to disappear (#2085)
@@ -173,11 +173,11 @@ func (r Reporter) Tag(rpt report.Report) (report.Report, error) {
 
 			// new task node
 			taskID := report.MakeECSTaskNodeID(taskArn)
-			node := report.MakeNodeWith(taskID, map[string]string{
-				TaskFamily: info.Family,
-				Cluster:    cluster,
-				CreatedAt:  task.CreatedAt.Format(time.RFC3339Nano),
-			})
+			node := report.MakeNodeWith(taskID,
+				TaskFamily, info.Family,
+				Cluster, cluster,
+				CreatedAt, task.CreatedAt.Format(time.RFC3339Nano),
+			)
 			rpt.ECSTask.AddNode(node)
 
 			// parents sets to merge into all matching container nodes

--- a/probe/awsecs/reporter_test.go
+++ b/probe/awsecs/reporter_test.go
@@ -22,17 +22,17 @@ var (
 	testServiceName       = "test-service"
 	testServiceCount      = 1
 	testContainer         = "test-container"
-	testContainerData     = map[string]string{
-		docker.LabelPrefix + "com.amazonaws.ecs.task-arn":               testTaskARN,
-		docker.LabelPrefix + "com.amazonaws.ecs.cluster":                testCluster,
-		docker.LabelPrefix + "com.amazonaws.ecs.task-definition-family": testFamily,
+	testContainerData     = []string{
+		docker.LabelPrefix + "com.amazonaws.ecs.task-arn", testTaskARN,
+		docker.LabelPrefix + "com.amazonaws.ecs.cluster", testCluster,
+		docker.LabelPrefix + "com.amazonaws.ecs.task-definition-family", testFamily,
 	}
 )
 
 func getTestContainerNode() report.Node {
 	return report.MakeNodeWith(
 		report.MakeContainerNodeID(testContainer),
-		testContainerData,
+		testContainerData...,
 	)
 }
 

--- a/probe/docker/container_test.go
+++ b/probe/docker/container_test.go
@@ -70,19 +70,19 @@ func TestContainer(t *testing.T) {
 			docker.StartContainer:   {Dead: true},
 			docker.RemoveContainer:  {Dead: true},
 		}
-		want := report.MakeNodeWith("ping;<container>", map[string]string{
-			"docker_container_command":     "ping foo.bar.local",
-			"docker_container_created":     "0001-01-01T00:00:00Z",
-			"docker_container_id":          "ping",
-			"docker_container_name":        "pong",
-			"docker_image_id":              "baz",
-			"docker_label_foo1":            "bar1",
-			"docker_label_foo2":            "bar2",
-			"docker_container_state":       "running",
-			"docker_container_state_human": c.Container().State.String(),
-			"docker_container_uptime":      strconv.Itoa(uptimeSeconds),
-			"docker_env_FOO":               "secret-bar",
-		}).WithLatestControls(
+		want := report.MakeNodeWith("ping;<container>",
+			"docker_container_command", "ping foo.bar.local",
+			"docker_container_created", "0001-01-01T00:00:00Z",
+			"docker_container_id", "ping",
+			"docker_container_name", "pong",
+			"docker_image_id", "baz",
+			"docker_label_foo1", "bar1",
+			"docker_label_foo2", "bar2",
+			"docker_container_state", "running",
+			"docker_container_state_human", c.Container().State.String(),
+			"docker_container_uptime", strconv.Itoa(uptimeSeconds),
+			"docker_env_FOO", "secret-bar",
+		).WithLatestControls(
 			controls,
 		).WithMetrics(report.Metrics{
 			"docker_cpu_total_usage": report.MakeMetric(nil),

--- a/probe/docker/registry.go
+++ b/probe/docker/registry.go
@@ -340,10 +340,10 @@ func (r *registry) updateContainerState(containerID string, intendedState *strin
 		}
 
 		if intendedState != nil {
-			node := report.MakeNodeWith(report.MakeContainerNodeID(containerID), map[string]string{
-				ContainerID:    containerID,
-				ContainerState: *intendedState,
-			})
+			node := report.MakeNodeWith(report.MakeContainerNodeID(containerID),
+				ContainerID, containerID,
+				ContainerState, *intendedState,
+			)
 			// Trigger anyone watching for updates
 			for _, f := range r.watchers {
 				f(node)

--- a/probe/docker/registry_test.go
+++ b/probe/docker/registry_test.go
@@ -67,11 +67,11 @@ func (c *mockContainer) StartGatheringStats(docker.StatsGatherer) error {
 func (c *mockContainer) StopGatheringStats() {}
 
 func (c *mockContainer) GetNode() report.Node {
-	return report.MakeNodeWith(report.MakeContainerNodeID(c.c.ID), map[string]string{
-		docker.ContainerID:   c.c.ID,
-		docker.ContainerName: c.c.Name,
-		docker.ImageID:       c.c.Image,
-	}).WithParents(report.MakeSets().
+	return report.MakeNodeWith(report.MakeContainerNodeID(c.c.ID),
+		docker.ContainerID, c.c.ID,
+		docker.ContainerName, c.c.Name,
+		docker.ImageID, c.c.Image,
+	).WithParents(report.MakeSets().
 		Add(report.ContainerImage, report.MakeStringSet(report.MakeContainerImageNodeID(c.c.Image))),
 	)
 }
@@ -502,10 +502,10 @@ func TestRegistryDelete(t *testing.T) {
 
 			mtx.Lock()
 			want := []report.Node{
-				report.MakeNodeWith(report.MakeContainerNodeID("ping"), map[string]string{
-					docker.ContainerID:    "ping",
-					docker.ContainerState: "deleted",
-				}),
+				report.MakeNodeWith(report.MakeContainerNodeID("ping"),
+					docker.ContainerID, "ping",
+					docker.ContainerState, "deleted",
+				),
 			}
 			if !reflect.DeepEqual(want, nodes) {
 				t.Errorf("Didn't get right container updates: %v", commonTest.Diff(want, nodes))

--- a/probe/docker/tagger.go
+++ b/probe/docker/tagger.go
@@ -68,10 +68,10 @@ func (t *Tagger) Tag(r report.Report) (report.Report, error) {
 		}
 
 		nodeID := report.MakeSwarmServiceNodeID(serviceID)
-		node := report.MakeNodeWith(nodeID, map[string]string{
-			ServiceName:    serviceName,
-			StackNamespace: stackNamespace,
-		})
+		node := report.MakeNodeWith(nodeID,
+			ServiceName, serviceName,
+			StackNamespace, stackNamespace,
+		)
 		r.SwarmService.AddNode(node)
 
 		r.Container.Nodes[containerID] = container.WithParents(container.Parents.Add(report.SwarmService, report.MakeStringSet(nodeID)))

--- a/probe/docker/tagger_test.go
+++ b/probe/docker/tagger_test.go
@@ -40,8 +40,8 @@ func TestTagger(t *testing.T) {
 	)
 
 	input := report.MakeReport()
-	input.Process.AddNode(report.MakeNodeWith(pid1NodeID, map[string]string{process.PID: "2"}))
-	input.Process.AddNode(report.MakeNodeWith(pid2NodeID, map[string]string{process.PID: "3"}))
+	input.Process.AddNode(report.MakeNodeWith(pid1NodeID, process.PID, "2"))
+	input.Process.AddNode(report.MakeNodeWith(pid2NodeID, process.PID, "3"))
 
 	have, err := docker.NewTagger(mockRegistryInstance, nil).Tag(input)
 	if err != nil {

--- a/probe/endpoint/nat.go
+++ b/probe/endpoint/nat.go
@@ -62,8 +62,6 @@ func (n natMapper) applyNAT(rpt report.Report, scope string) {
 			return
 		}
 
-		rpt.Endpoint.AddNode(node.WithID(copyEndpointID).WithLatests(map[string]string{
-			CopyOf: realEndpointID,
-		}))
+		rpt.Endpoint.AddNode(node.WithID(copyEndpointID).WithLatests(CopyOf, realEndpointID))
 	})
 }

--- a/probe/endpoint/nat_internal_test.go
+++ b/probe/endpoint/nat_internal_test.go
@@ -69,16 +69,16 @@ func TestNat(t *testing.T) {
 
 		have := report.MakeReport()
 		originalID := report.MakeEndpointNodeID("host1", "", "10.0.47.1", "80")
-		have.Endpoint.AddNode(report.MakeNodeWith(originalID, map[string]string{
-			"foo": "bar",
-		}))
+		have.Endpoint.AddNode(report.MakeNodeWith(originalID,
+			"foo", "bar",
+		))
 
 		want := have.Copy()
 		wantID := report.MakeEndpointNodeID("host1", "", "1.2.3.4", "80")
-		want.Endpoint.AddNode(report.MakeNodeWith(wantID, map[string]string{
-			CopyOf: originalID,
-			"foo":  "bar",
-		}))
+		want.Endpoint.AddNode(report.MakeNodeWith(wantID,
+			CopyOf, originalID,
+			"foo", "bar",
+		))
 
 		makeNATMapper(ct).applyNAT(have, "host1")
 		if !reflect.DeepEqual(want, have) {
@@ -122,15 +122,15 @@ func TestNat(t *testing.T) {
 
 		have := report.MakeReport()
 		originalID := report.MakeEndpointNodeID("host2", "", "10.0.47.2", "22222")
-		have.Endpoint.AddNode(report.MakeNodeWith(originalID, map[string]string{
-			"foo": "baz",
-		}))
+		have.Endpoint.AddNode(report.MakeNodeWith(originalID,
+			"foo", "baz",
+		))
 
 		want := have.Copy()
-		want.Endpoint.AddNode(report.MakeNodeWith(report.MakeEndpointNodeID("host2", "", "2.3.4.5", "22223"), map[string]string{
-			CopyOf: originalID,
-			"foo":  "baz",
-		}))
+		want.Endpoint.AddNode(report.MakeNodeWith(report.MakeEndpointNodeID("host2", "", "2.3.4.5", "22223"),
+			CopyOf, originalID,
+			"foo", "baz",
+		))
 
 		makeNATMapper(ct).applyNAT(have, "host1")
 		if !reflect.DeepEqual(want, have) {

--- a/probe/host/reporter.go
+++ b/probe/host/reporter.go
@@ -125,15 +125,15 @@ func (r *Reporter) Report() (report.Report, error) {
 	metrics[MemoryUsage] = report.MakeSingletonMetric(now, memoryUsage).WithMax(max)
 
 	rep.Host.AddNode(
-		report.MakeNodeWith(report.MakeHostNodeID(r.hostID), map[string]string{
-			report.ControlProbeID: r.probeID,
-			Timestamp:             mtime.Now().UTC().Format(time.RFC3339Nano),
-			HostName:              r.hostName,
-			OS:                    runtime.GOOS,
-			KernelVersion:         kernel,
-			Uptime:                strconv.Itoa(int(uptime / time.Second)), // uptime in seconds
-			ScopeVersion:          r.version,
-		}).
+		report.MakeNodeWith(report.MakeHostNodeID(r.hostID),
+			report.ControlProbeID, r.probeID,
+			Timestamp, mtime.Now().UTC().Format(time.RFC3339Nano),
+			HostName, r.hostName,
+			OS, runtime.GOOS,
+			KernelVersion, kernel,
+			Uptime, strconv.Itoa(int(uptime/time.Second)), // uptime in seconds
+			ScopeVersion, r.version,
+		).
 			WithSets(report.MakeSets().
 				Add(LocalNetworks, report.MakeStringSet(localCIDRs...)),
 			).

--- a/probe/host/tagger.go
+++ b/probe/host/tagger.go
@@ -25,7 +25,7 @@ func (Tagger) Name() string { return "Host" }
 // Tag implements Tagger.
 func (t Tagger) Tag(r report.Report) (report.Report, error) {
 	var (
-		metadata = map[string]string{report.HostNodeID: t.hostNodeID}
+		metadata = []string{report.HostNodeID, t.hostNodeID}
 		parents  = report.MakeSets().Add(report.Host, report.MakeStringSet(t.hostNodeID))
 	)
 
@@ -33,7 +33,7 @@ func (t Tagger) Tag(r report.Report) (report.Report, error) {
 	// and as such do their own host tagging.
 	for _, topology := range []report.Topology{r.Process, r.Container, r.ContainerImage, r.Host, r.Pod} {
 		for _, node := range topology.Nodes {
-			topology.ReplaceNode(node.WithLatests(metadata).WithParents(parents))
+			topology.ReplaceNode(node.WithLatests(metadata...).WithParents(parents))
 		}
 	}
 	return r, nil

--- a/probe/host/tagger_test.go
+++ b/probe/host/tagger_test.go
@@ -11,7 +11,7 @@ func TestTagger(t *testing.T) {
 	var (
 		hostID         = "foo"
 		endpointNodeID = report.MakeEndpointNodeID(hostID, "", "1.2.3.4", "56789") // hostID ignored
-		node           = report.MakeNodeWith(endpointNodeID, map[string]string{"foo": "bar"})
+		node           = report.MakeNodeWith(endpointNodeID, "foo", "bar")
 	)
 
 	r := report.MakeReport()

--- a/probe/kubernetes/cronjob.go
+++ b/probe/kubernetes/cronjob.go
@@ -75,17 +75,17 @@ func (cj *cronJob) Selectors() ([]labels.Selector, error) {
 }
 
 func (cj *cronJob) GetNode(probeID string) report.Node {
-	latest := map[string]string{
-		NodeType:              "CronJob",
-		Schedule:              cj.Spec.Schedule,
-		Suspended:             fmt.Sprint(cj.Spec.Suspend != nil && *cj.Spec.Suspend), // nil -> false
-		ActiveJobs:            fmt.Sprint(len(cj.jobs)),
-		report.ControlProbeID: probeID,
+	latest := []string{
+		NodeType, "CronJob",
+		Schedule, cj.Spec.Schedule,
+		Suspended, fmt.Sprint(cj.Spec.Suspend != nil && *cj.Spec.Suspend), // nil -> false
+		ActiveJobs, fmt.Sprint(len(cj.jobs)),
+		report.ControlProbeID, probeID,
 	}
 	if cj.Status.LastScheduleTime != nil {
-		latest[LastScheduled] = cj.Status.LastScheduleTime.Format(time.RFC3339Nano)
+		latest = append(latest, LastScheduled, cj.Status.LastScheduleTime.Format(time.RFC3339Nano))
 	}
-	return cj.MetaNode(report.MakeCronJobNodeID(cj.UID())).WithLatests(latest)
+	return cj.MetaNode(report.MakeCronJobNodeID(cj.UID())).WithLatests(latest...)
 }
 
 func upgradeCronJob(legacy *batchv2alpha1.CronJob) *batchv1beta1.CronJob {

--- a/probe/kubernetes/daemonset.go
+++ b/probe/kubernetes/daemonset.go
@@ -44,11 +44,11 @@ func (d *daemonSet) Selector() (labels.Selector, error) {
 }
 
 func (d *daemonSet) GetNode(probeID string) report.Node {
-	return d.MetaNode(report.MakeDaemonSetNodeID(d.UID())).WithLatests(map[string]string{
-		DesiredReplicas:       fmt.Sprint(d.Status.DesiredNumberScheduled),
-		Replicas:              fmt.Sprint(d.Status.CurrentNumberScheduled),
-		MisscheduledReplicas:  fmt.Sprint(d.Status.NumberMisscheduled),
-		NodeType:              "DaemonSet",
-		report.ControlProbeID: probeID,
-	})
+	return d.MetaNode(report.MakeDaemonSetNodeID(d.UID())).WithLatests(
+		DesiredReplicas, fmt.Sprint(d.Status.DesiredNumberScheduled),
+		Replicas, fmt.Sprint(d.Status.CurrentNumberScheduled),
+		MisscheduledReplicas, fmt.Sprint(d.Status.NumberMisscheduled),
+		NodeType, "DaemonSet",
+		report.ControlProbeID, probeID,
+	)
 }

--- a/probe/kubernetes/deployment.go
+++ b/probe/kubernetes/deployment.go
@@ -51,15 +51,15 @@ func (d *deployment) GetNode(probeID string) report.Node {
 	if d.Spec.Replicas != nil {
 		desiredReplicas = int(*d.Spec.Replicas)
 	}
-	return d.MetaNode(report.MakeDeploymentNodeID(d.UID())).WithLatests(map[string]string{
-		ObservedGeneration:    fmt.Sprint(d.Status.ObservedGeneration),
-		DesiredReplicas:       fmt.Sprint(desiredReplicas),
-		Replicas:              fmt.Sprint(d.Status.Replicas),
-		UpdatedReplicas:       fmt.Sprint(d.Status.UpdatedReplicas),
-		AvailableReplicas:     fmt.Sprint(d.Status.AvailableReplicas),
-		UnavailableReplicas:   fmt.Sprint(d.Status.UnavailableReplicas),
-		Strategy:              string(d.Spec.Strategy.Type),
-		report.ControlProbeID: probeID,
-		NodeType:              "Deployment",
-	}).WithLatestActiveControls(ScaleUp, ScaleDown)
+	return d.MetaNode(report.MakeDeploymentNodeID(d.UID())).WithLatests(
+		ObservedGeneration, fmt.Sprint(d.Status.ObservedGeneration),
+		DesiredReplicas, fmt.Sprint(desiredReplicas),
+		Replicas, fmt.Sprint(d.Status.Replicas),
+		UpdatedReplicas, fmt.Sprint(d.Status.UpdatedReplicas),
+		AvailableReplicas, fmt.Sprint(d.Status.AvailableReplicas),
+		UnavailableReplicas, fmt.Sprint(d.Status.UnavailableReplicas),
+		Strategy, string(d.Spec.Strategy.Type),
+		report.ControlProbeID, probeID,
+		NodeType, "Deployment",
+	).WithLatestActiveControls(ScaleUp, ScaleDown)
 }

--- a/probe/kubernetes/meta.go
+++ b/probe/kubernetes/meta.go
@@ -53,11 +53,11 @@ func (m meta) Labels() map[string]string {
 
 // MetaNode gets the node metadata
 func (m meta) MetaNode(id string) report.Node {
-	return report.MakeNodeWith(id, map[string]string{
-		Name:      m.Name(),
-		Namespace: m.Namespace(),
-		Created:   m.Created(),
-	}).AddPrefixPropertyList(LabelPrefix, m.Labels())
+	return report.MakeNodeWith(id,
+		Name, m.Name(),
+		Namespace, m.Namespace(),
+		Created, m.Created(),
+	).AddPrefixPropertyList(LabelPrefix, m.Labels())
 }
 
 type namespaceMeta struct {
@@ -87,8 +87,8 @@ func (m namespaceMeta) Labels() map[string]string {
 // MetaNode gets the node metadata
 // For namespaces, ObjectMeta.Namespace is not set
 func (m namespaceMeta) MetaNode(id string) report.Node {
-	return report.MakeNodeWith(id, map[string]string{
-		Name:    m.Name(),
-		Created: m.Created(),
-	}).AddPrefixPropertyList(LabelPrefix, m.Labels())
+	return report.MakeNodeWith(id,
+		Name, m.Name(),
+		Created, m.Created(),
+	).AddPrefixPropertyList(LabelPrefix, m.Labels())
 }

--- a/probe/kubernetes/persistentvolume.go
+++ b/probe/kubernetes/persistentvolume.go
@@ -47,11 +47,11 @@ func (p *persistentVolume) GetVolume() string {
 
 // GetNode returns Persistent Volume as Node
 func (p *persistentVolume) GetNode() report.Node {
-	return p.MetaNode(report.MakePersistentVolumeNodeID(p.UID())).WithLatests(map[string]string{
-		NodeType:         "Persistent Volume",
-		VolumeClaim:      p.GetVolume(),
-		StorageClassName: p.Spec.StorageClassName,
-		Status:           string(p.Status.Phase),
-		AccessModes:      p.GetAccessMode(),
-	})
+	return p.MetaNode(report.MakePersistentVolumeNodeID(p.UID())).WithLatests(
+		NodeType, "Persistent Volume",
+		VolumeClaim, p.GetVolume(),
+		StorageClassName, p.Spec.StorageClassName,
+		Status, string(p.Status.Phase),
+		AccessModes, p.GetAccessMode(),
+	)
 }

--- a/probe/kubernetes/persistentvolumeclaim.go
+++ b/probe/kubernetes/persistentvolumeclaim.go
@@ -49,12 +49,12 @@ func (p *persistentVolumeClaim) GetStorageClass() string {
 
 // GetNode returns Persistent Volume Claim as Node
 func (p *persistentVolumeClaim) GetNode() report.Node {
-	return p.MetaNode(report.MakePersistentVolumeClaimNodeID(p.UID())).WithLatests(map[string]string{
-		NodeType:         "Persistent Volume Claim",
-		Status:           string(p.Status.Phase),
-		VolumeName:       p.Spec.VolumeName,
-		StorageClassName: p.GetStorageClass(),
-	})
+	return p.MetaNode(report.MakePersistentVolumeClaimNodeID(p.UID())).WithLatests(
+		NodeType, "Persistent Volume Claim",
+		Status, string(p.Status.Phase),
+		VolumeName, p.Spec.VolumeName,
+		StorageClassName, p.GetStorageClass(),
+	)
 }
 
 // Selector returns all Persistent Volume Claim selector

--- a/probe/kubernetes/pod.go
+++ b/probe/kubernetes/pod.go
@@ -95,7 +95,7 @@ func (p *pod) GetNode(probeID string) report.Node {
 	}
 
 	if p.VolumeClaimName() != "" {
-		latests[VolumeClaim] = p.VolumeClaimName()
+		latests = append(latests, VolumeClaim, p.VolumeClaimName())
 	}
 
 	if p.Pod.Spec.HostNetwork {

--- a/probe/kubernetes/pod.go
+++ b/probe/kubernetes/pod.go
@@ -87,11 +87,11 @@ func (p *pod) VolumeClaimName() string {
 }
 
 func (p *pod) GetNode(probeID string) report.Node {
-	latests := map[string]string{
-		State: p.State(),
-		IP:    p.Status.PodIP,
-		report.ControlProbeID: probeID,
-		RestartCount:          strconv.FormatUint(uint64(p.RestartCount()), 10),
+	latests := []string{
+		State, p.State(),
+		IP, p.Status.PodIP,
+		report.ControlProbeID, probeID,
+		RestartCount, strconv.FormatUint(uint64(p.RestartCount()), 10),
 	}
 
 	if p.VolumeClaimName() != "" {
@@ -99,10 +99,10 @@ func (p *pod) GetNode(probeID string) report.Node {
 	}
 
 	if p.Pod.Spec.HostNetwork {
-		latests[IsInHostNetwork] = "true"
+		latests = append(latests, IsInHostNetwork, "true")
 	}
 
-	return p.MetaNode(report.MakePodNodeID(p.UID())).WithLatests(latests).
+	return p.MetaNode(report.MakePodNodeID(p.UID())).WithLatests(latests...).
 		WithParents(p.parents).
 		WithLatestActiveControls(GetLogs, DeletePod)
 }

--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -203,7 +203,7 @@ func (r *Reporter) podEvent(e Event, pod Pod) {
 		rpt.Pod.AddNode(
 			report.MakeNodeWith(
 				report.MakePodNodeID(pod.UID()),
-				map[string]string{State: StateDeleted},
+				State, StateDeleted,
 			),
 		)
 		r.probe.Publish(rpt)

--- a/probe/kubernetes/reporter_test.go
+++ b/probe/kubernetes/reporter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	apiv1 "k8s.io/api/core/v1"
+	apiv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -111,9 +112,10 @@ func newMockClient() *mockClient {
 }
 
 type mockClient struct {
-	pods     []kubernetes.Pod
-	services []kubernetes.Service
-	logs     map[string]io.ReadCloser
+	pods        []kubernetes.Pod
+	services    []kubernetes.Service
+	deployments []kubernetes.Deployment
+	logs        map[string]io.ReadCloser
 }
 
 func (c *mockClient) Stop() {}
@@ -143,6 +145,11 @@ func (c *mockClient) WalkCronJobs(f func(kubernetes.CronJob) error) error {
 	return nil
 }
 func (c *mockClient) WalkDeployments(f func(kubernetes.Deployment) error) error {
+	for _, deployment := range c.deployments {
+		if err := f(deployment); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 func (c *mockClient) WalkNamespaces(f func(kubernetes.NamespaceResource) error) error {
@@ -280,6 +287,39 @@ func TestReporter(t *testing.T) {
 		}
 	}
 
+}
+
+func BenchmarkReporter(b *testing.B) {
+	hr := controls.NewDefaultHandlerRegistry()
+	mockK8s := newMockClient()
+	// Add more dummy data
+	for i := 0; i < 50; i++ {
+		service := apiService1
+		service.ObjectMeta.UID = types.UID(fmt.Sprintf("service%d", i))
+		mockK8s.services = append(mockK8s.services, kubernetes.NewService(&service))
+		pod := apiPod1
+		pod.ObjectMeta.UID = types.UID(fmt.Sprintf("pod%d", i))
+		mockK8s.pods = append(mockK8s.pods, kubernetes.NewPod(&pod))
+		deployment := apiv1beta1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "v1beta1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              fmt.Sprintf("deployment%d", i),
+				UID:               types.UID(fmt.Sprintf("deployment%d", i)),
+				Namespace:         "ping",
+				CreationTimestamp: metav1.Now(),
+			},
+		}
+		mockK8s.deployments = append(mockK8s.deployments, kubernetes.NewDeployment(&deployment))
+	}
+	reporter := kubernetes.NewReporter(mockK8s, nil, "probe-id", "foo", nil, hr, nodeName, 0)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		reporter.Report()
+	}
 }
 
 func TestTagger(t *testing.T) {

--- a/probe/kubernetes/reporter_test.go
+++ b/probe/kubernetes/reporter_test.go
@@ -284,9 +284,9 @@ func TestReporter(t *testing.T) {
 
 func TestTagger(t *testing.T) {
 	rpt := report.MakeReport()
-	rpt.Container.AddNode(report.MakeNodeWith("container1", map[string]string{
-		docker.LabelPrefix + "io.kubernetes.pod.uid": "123456",
-	}))
+	rpt.Container.AddNode(report.MakeNodeWith("container1",
+		docker.LabelPrefix+"io.kubernetes.pod.uid", "123456",
+	))
 
 	hr := controls.NewDefaultHandlerRegistry()
 	rpt, err := kubernetes.NewReporter(newMockClient(), nil, "", "", nil, hr, "", 0).Tag(rpt)

--- a/probe/kubernetes/service.go
+++ b/probe/kubernetes/service.go
@@ -48,22 +48,22 @@ func servicePortString(p apiv1.ServicePort) string {
 }
 
 func (s *service) GetNode(probeID string) report.Node {
-	latest := map[string]string{
-		IP:   s.Spec.ClusterIP,
-		Type: string(s.Spec.Type),
-		report.ControlProbeID: probeID,
+	latest := []string{
+		IP, s.Spec.ClusterIP,
+		Type, string(s.Spec.Type),
+		report.ControlProbeID, probeID,
 	}
 	if s.Spec.LoadBalancerIP != "" {
-		latest[PublicIP] = s.Spec.LoadBalancerIP
+		latest = append(latest, PublicIP, s.Spec.LoadBalancerIP)
 	}
 	if len(s.Spec.Ports) != 0 {
 		portStr := ""
 		for _, p := range s.Spec.Ports {
 			portStr = portStr + servicePortString(p) + ","
 		}
-		latest[Ports] = portStr[:len(portStr)-1]
+		latest = append(latest, Ports, portStr[:len(portStr)-1])
 	}
-	return s.MetaNode(report.MakeServiceNodeID(s.UID())).WithLatests(latest)
+	return s.MetaNode(report.MakeServiceNodeID(s.UID())).WithLatests(latest...)
 }
 
 func (s *service) ClusterIP() string {

--- a/probe/kubernetes/statefulset.go
+++ b/probe/kubernetes/statefulset.go
@@ -43,14 +43,14 @@ func (s *statefulSet) GetNode(probeID string) report.Node {
 	if s.Spec.Replicas != nil {
 		desiredReplicas = int(*s.Spec.Replicas)
 	}
-	latests := map[string]string{
-		NodeType:              "StatefulSet",
-		DesiredReplicas:       fmt.Sprint(desiredReplicas),
-		Replicas:              fmt.Sprint(s.Status.Replicas),
-		report.ControlProbeID: probeID,
+	latests := []string{
+		NodeType, "StatefulSet",
+		DesiredReplicas, fmt.Sprint(desiredReplicas),
+		Replicas, fmt.Sprint(s.Status.Replicas),
+		report.ControlProbeID, probeID,
 	}
 	if s.Status.ObservedGeneration != nil {
-		latests[ObservedGeneration] = fmt.Sprint(*s.Status.ObservedGeneration)
+		latests = append(latests, ObservedGeneration, fmt.Sprint(*s.Status.ObservedGeneration))
 	}
-	return s.MetaNode(report.MakeStatefulSetNodeID(s.UID())).WithLatests(latests)
+	return s.MetaNode(report.MakeStatefulSetNodeID(s.UID())).WithLatests(latests...)
 }

--- a/probe/kubernetes/storageclass.go
+++ b/probe/kubernetes/storageclass.go
@@ -24,9 +24,9 @@ func NewStorageClass(p *storagev1.StorageClass) StorageClass {
 
 // GetNode returns StorageClass as Node
 func (p *storageClass) GetNode() report.Node {
-	return p.MetaNode(report.MakeStorageClassNodeID(p.UID())).WithLatests(map[string]string{
-		NodeType:    "Storage Class",
-		Name:        p.GetName(),
-		Provisioner: p.Provisioner,
-	})
+	return p.MetaNode(report.MakeStorageClassNodeID(p.UID())).WithLatests(
+		NodeType, "Storage Class",
+		Name, p.GetName(),
+		Provisioner, p.Provisioner,
+	)
 }

--- a/probe/overlay/weave_test.go
+++ b/probe/overlay/weave_test.go
@@ -41,9 +41,9 @@ func TestContainerTopologyTagging(t *testing.T) {
 		// Container nodes should be tagged with their overlay info
 		nodeID := report.MakeContainerNodeID(weave.MockContainerID)
 		topology := report.MakeTopology()
-		topology.AddNode(report.MakeNodeWith(nodeID, map[string]string{
-			docker.ContainerID: weave.MockContainerID,
-		}))
+		topology.AddNode(report.MakeNodeWith(nodeID,
+			docker.ContainerID, weave.MockContainerID,
+		))
 		have, err := w.Tag(report.Report{Container: topology})
 		if err != nil {
 			t.Fatal(err)

--- a/probe/probe_internal_test.go
+++ b/probe/probe_internal_test.go
@@ -13,7 +13,7 @@ import (
 func TestApply(t *testing.T) {
 	var (
 		endpointNodeID = "c"
-		endpointNode   = report.MakeNodeWith(endpointNodeID, map[string]string{"5": "6"})
+		endpointNode   = report.MakeNodeWith(endpointNodeID, "5", "6")
 	)
 
 	p := New(0, 0, nil, false)
@@ -66,7 +66,7 @@ func TestProbe(t *testing.T) {
 	defer mtime.NowReset()
 
 	want := report.MakeReport()
-	node := report.MakeNodeWith("a", map[string]string{"b": "c"})
+	node := report.MakeNodeWith("a", "b", "c")
 
 	// marshalling->unmarshaling is not idempotent due to `json:"omitempty"`
 	// tags, transforming empty slices into nils. So, we make DeepEqual

--- a/render/container.go
+++ b/render/container.go
@@ -143,11 +143,8 @@ func (r containerWithImageNameRenderer) Render(rpt report.Report) Nodes {
 		imageNameWithoutTag := docker.ImageNameWithoutTag(imageName)
 		imageNodeID := report.MakeContainerImageNodeID(imageNameWithoutTag)
 
-		c = propagateLatest(docker.ImageName, image, c)
-		c = propagateLatest(docker.ImageTag, image, c)
-		c = propagateLatest(docker.ImageSize, image, c)
-		c = propagateLatest(docker.ImageVirtualSize, image, c)
-		c = propagateLatest(docker.ImageLabelPrefix+"works.weave.role", image, c)
+		c = propagateLatests(image, c, docker.ImageName, docker.ImageTag, docker.ImageSize, docker.ImageVirtualSize,
+			docker.ImageLabelPrefix+"works.weave.role")
 		c.Parents = c.Parents.
 			Delete(report.ContainerImage).
 			Add(report.ContainerImage, report.MakeStringSet(imageNodeID))

--- a/render/container_test.go
+++ b/render/container_test.go
@@ -29,8 +29,8 @@ var (
 func TestMapProcess2Container(t *testing.T) {
 	for _, input := range []testcase{
 		{"empty", report.MakeNode("empty"), true},
-		{"basic process", report.MakeNodeWith("basic", map[string]string{process.PID: "201", docker.ContainerID: "a1b2c3"}), true},
-		{"uncontained", report.MakeNodeWith("uncontained", map[string]string{process.PID: "201", report.HostNodeID: report.MakeHostNodeID("foo")}), true},
+		{"basic process", report.MakeNodeWith("basic", process.PID, "201", docker.ContainerID, "a1b2c3"), true},
+		{"uncontained", report.MakeNodeWith("uncontained", process.PID, "201", report.HostNodeID, report.MakeHostNodeID("foo")), true},
 	} {
 		testMap(t, render.MapProcess2Container, input)
 	}
@@ -64,9 +64,9 @@ func TestContainerFilterRenderer(t *testing.T) {
 	// tag on of the containers in the topology and ensure
 	// it is filtered out correctly.
 	input := fixture.Report.Copy()
-	input.Container.Nodes[fixture.ClientContainerNodeID] = input.Container.Nodes[fixture.ClientContainerNodeID].WithLatests(map[string]string{
-		docker.LabelPrefix + "works.weave.role": "system",
-	})
+	input.Container.Nodes[fixture.ClientContainerNodeID] = input.Container.Nodes[fixture.ClientContainerNodeID].WithLatests(
+		docker.LabelPrefix+"works.weave.role", "system",
+	)
 	have := utils.Prune(render.Render(input, render.ContainerWithImageNameRenderer, filterApplication).Nodes)
 	want := utils.Prune(expected.RenderedContainers.Copy())
 	delete(want, fixture.ClientContainerNodeID)

--- a/render/detailed/links_test.go
+++ b/render/detailed/links_test.go
@@ -21,10 +21,10 @@ var (
 	sampleUnknownNode = report.MakeNode("???").WithTopology("foo")
 	samplePodNode     = report.MakeNode("noo").
 				WithTopology(report.Pod).
-				WithLatests(map[string]string{kubernetes.Namespace: "noospace"})
+				WithLatests(kubernetes.Namespace, "noospace")
 	sampleContainerNode = report.MakeNode("coo").
 				WithTopology(report.Container).
-				WithLatests(map[string]string{docker.ContainerName: "cooname"})
+				WithLatests(docker.ContainerName, "cooname")
 	sampleMetrics = []report.MetricRow{
 		{ID: docker.MemoryUsage},
 		{ID: docker.CPUTotalUsage},

--- a/render/detailed/summary_test.go
+++ b/render/detailed/summary_test.go
@@ -244,11 +244,11 @@ func TestNodeMetadata(t *testing.T) {
 	}{
 		{
 			name: "container",
-			node: report.MakeNodeWith(fixture.ClientContainerNodeID, map[string]string{
-				docker.ContainerID:            fixture.ClientContainerID,
-				docker.LabelPrefix + "label1": "label1value",
-				docker.ContainerStateHuman:    docker.StateRunning,
-			}).WithTopology(report.Container).WithSets(report.MakeSets().
+			node: report.MakeNodeWith(fixture.ClientContainerNodeID,
+				docker.ContainerID, fixture.ClientContainerID,
+				docker.LabelPrefix+"label1", "label1value",
+				docker.ContainerStateHuman, docker.StateRunning,
+			).WithTopology(report.Container).WithSets(report.MakeSets().
 				Add(docker.ContainerIPs, report.MakeStringSet("10.10.10.0/24", "10.10.10.1/24")),
 			),
 			want: []report.MetadataRow{
@@ -259,9 +259,9 @@ func TestNodeMetadata(t *testing.T) {
 		},
 		{
 			name: "unknown topology",
-			node: report.MakeNodeWith(fixture.ClientContainerNodeID, map[string]string{
-				docker.ContainerID: fixture.ClientContainerID,
-			}).WithTopology("foobar"),
+			node: report.MakeNodeWith(fixture.ClientContainerNodeID,
+				docker.ContainerID, fixture.ClientContainerID,
+			).WithTopology("foobar"),
 			want: nil,
 		},
 	}
@@ -418,11 +418,11 @@ func TestNodeTables(t *testing.T) {
 				Container: report.MakeTopology().
 					WithTableTemplates(docker.ContainerTableTemplates),
 			},
-			node: report.MakeNodeWith(fixture.ClientContainerNodeID, map[string]string{
-				docker.ContainerID:            fixture.ClientContainerID,
-				docker.LabelPrefix + "label1": "label1value",
-				docker.ContainerState:         docker.StateRunning,
-			}).WithTopology(report.Container).WithSets(report.MakeSets().
+			node: report.MakeNodeWith(fixture.ClientContainerNodeID,
+				docker.ContainerID, fixture.ClientContainerID,
+				docker.LabelPrefix+"label1", "label1value",
+				docker.ContainerState, docker.StateRunning,
+			).WithTopology(report.Container).WithSets(report.MakeSets().
 				Add(docker.ContainerIPs, report.MakeStringSet("10.10.10.0/24", "10.10.10.1/24")),
 			),
 			want: []report.Table{
@@ -457,9 +457,9 @@ func TestNodeTables(t *testing.T) {
 		{
 			name: "unknown topology",
 			rpt:  report.MakeReport(),
-			node: report.MakeNodeWith(fixture.ClientContainerNodeID, map[string]string{
-				docker.ContainerID: fixture.ClientContainerID,
-			}).WithTopology("foobar"),
+			node: report.MakeNodeWith(fixture.ClientContainerNodeID,
+				docker.ContainerID, fixture.ClientContainerID,
+			).WithTopology("foobar"),
 			want: nil,
 		},
 	}

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -273,30 +273,30 @@ var (
 			)),
 
 		fixture.PersistentVolumeClaimNodeID: persistentVolumeClaim(fixture.PersistentVolumeClaimNodeID, fixture.PersistentVolumeNodeID).
-			WithLatests(map[string]string{
-				kubernetes.Name:             "pvc-6124",
-				kubernetes.Namespace:        "ping",
-				kubernetes.Status:           "bound",
-				kubernetes.VolumeName:       "pongvolume",
-				kubernetes.AccessModes:      "ReadWriteOnce",
-				kubernetes.StorageClassName: "standard",
-			}).WithChild(report.MakeNode(fixture.PersistentVolumeNodeID).WithTopology(report.PersistentVolume)),
+			WithLatests(
+				kubernetes.Name, "pvc-6124",
+				kubernetes.Namespace, "ping",
+				kubernetes.Status, "bound",
+				kubernetes.VolumeName, "pongvolume",
+				kubernetes.AccessModes, "ReadWriteOnce",
+				kubernetes.StorageClassName, "standard",
+			).WithChild(report.MakeNode(fixture.PersistentVolumeNodeID).WithTopology(report.PersistentVolume)),
 
 		fixture.PersistentVolumeNodeID: persistentVolume(fixture.PersistentVolumeNodeID).
-			WithLatests(map[string]string{
-				kubernetes.Name:             "pongvolume",
-				kubernetes.Namespace:        "ping",
-				kubernetes.Status:           "bound",
-				kubernetes.VolumeClaim:      "pvc-6124",
-				kubernetes.AccessModes:      "ReadWriteOnce",
-				kubernetes.StorageClassName: "standard",
-			}),
+			WithLatests(
+				kubernetes.Name, "pongvolume",
+				kubernetes.Namespace, "ping",
+				kubernetes.Status, "bound",
+				kubernetes.VolumeClaim, "pvc-6124",
+				kubernetes.AccessModes, "ReadWriteOnce",
+				kubernetes.StorageClassName, "standard",
+			),
 
 		fixture.StorageClassNodeID: StorageClass(fixture.StorageClassNodeID, fixture.PersistentVolumeClaimNodeID).
-			WithLatests(map[string]string{
-				kubernetes.Name:        "standard",
-				kubernetes.Provisioner: "pong",
-			}).WithChild(report.MakeNode(fixture.PersistentVolumeClaimNodeID).WithTopology(report.PersistentVolumeClaim)),
+			WithLatests(
+				kubernetes.Name, "standard",
+				kubernetes.Provisioner, "pong",
+			).WithChild(report.MakeNode(fixture.PersistentVolumeClaimNodeID).WithTopology(report.PersistentVolumeClaim)),
 
 		UnmanagedServerID:         unmanagedServerNode,
 		render.IncomingInternetID: theIncomingInternetNode(fixture.ServerPodNodeID),

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -87,11 +87,11 @@ var (
 
 	RenderedProcesses = report.Nodes{
 		fixture.ClientProcess1NodeID: processNode(fixture.ClientProcess1NodeID, fixture.ServerProcessNodeID).
-			WithLatests(map[string]string{
-				report.HostNodeID: fixture.ClientHostNodeID,
-				process.PID:       fixture.Client1PID,
-				process.Name:      fixture.Client1Name,
-			}).
+			WithLatests(
+				report.HostNodeID, fixture.ClientHostNodeID,
+				process.PID, fixture.Client1PID,
+				process.Name, fixture.Client1Name,
+			).
 			WithChildren(report.MakeNodeSet(
 				RenderedEndpoints[fixture.Client54001NodeID],
 			)),
@@ -121,7 +121,7 @@ var (
 
 	RenderedProcessNames = report.Nodes{
 		fixture.Client1Name: processNameNode(fixture.Client1Name, fixture.ServerName).
-			WithLatests(map[string]string{process.Name: fixture.Client1Name}).
+			WithLatests(process.Name, fixture.Client1Name).
 			WithCounters(map[string]int{report.Process: 2}).
 			WithChildren(report.MakeNodeSet(
 				RenderedEndpoints[fixture.Client54001NodeID],
@@ -131,7 +131,7 @@ var (
 			)),
 
 		fixture.ServerName: processNameNode(fixture.ServerName).
-			WithLatests(map[string]string{process.Name: fixture.ServerName}).
+			WithLatests(process.Name, fixture.ServerName).
 			WithCounters(map[string]int{report.Process: 1}).
 			WithChildren(report.MakeNodeSet(
 				RenderedEndpoints[fixture.Server80NodeID],
@@ -160,12 +160,12 @@ var (
 
 	RenderedContainers = report.Nodes{
 		fixture.ClientContainerNodeID: container(fixture.ClientContainerNodeID, fixture.ServerContainerNodeID).
-			WithLatests(map[string]string{
-				report.HostNodeID:    fixture.ClientHostNodeID,
-				docker.ContainerID:   fixture.ClientContainerID,
-				docker.ContainerName: fixture.ClientContainerName,
-				docker.ImageName:     fixture.ClientContainerImageName,
-			}).
+			WithLatests(
+				report.HostNodeID, fixture.ClientHostNodeID,
+				docker.ContainerID, fixture.ClientContainerID,
+				docker.ContainerName, fixture.ClientContainerName,
+				docker.ImageName, fixture.ClientContainerImageName,
+			).
 			WithChildren(report.MakeNodeSet(
 				RenderedEndpoints[fixture.Client54001NodeID],
 				RenderedEndpoints[fixture.Client54002NodeID],
@@ -186,9 +186,9 @@ var (
 
 	RenderedContainerHostnames = report.Nodes{
 		fixture.ClientContainerHostname: containerHostnameNode(fixture.ClientContainerHostname, fixture.ServerContainerHostname).
-			WithLatests(map[string]string{
-				docker.ContainerHostname: fixture.ClientContainerHostname,
-			}).
+			WithLatests(
+				docker.ContainerHostname, fixture.ClientContainerHostname,
+			).
 			WithCounters(map[string]int{
 				report.Container: 1,
 			}).
@@ -201,9 +201,9 @@ var (
 			)),
 
 		fixture.ServerContainerHostname: containerHostnameNode(fixture.ServerContainerHostname).
-			WithLatests(map[string]string{
-				docker.ContainerHostname: fixture.ServerContainerHostname,
-			}).
+			WithLatests(
+				docker.ContainerHostname, fixture.ServerContainerHostname,
+			).
 			WithChildren(report.MakeNodeSet(
 				RenderedEndpoints[fixture.Server80NodeID],
 				RenderedProcesses[fixture.ServerProcessNodeID],
@@ -220,11 +220,11 @@ var (
 
 	RenderedContainerImages = report.Nodes{
 		ClientContainerImageNodeID: containerImage(ClientContainerImageNodeID, ServerContainerImageNodeID).
-			WithLatests(map[string]string{
-				report.HostNodeID: fixture.ClientHostNodeID,
-				docker.ImageID:    fixture.ClientContainerImageID,
-				docker.ImageName:  fixture.ClientContainerImageName,
-			}).
+			WithLatests(
+				report.HostNodeID, fixture.ClientHostNodeID,
+				docker.ImageID, fixture.ClientContainerImageID,
+				docker.ImageName, fixture.ClientContainerImageName,
+			).
 			WithCounters(map[string]int{
 				report.Container: 1,
 			}).
@@ -325,9 +325,9 @@ var (
 
 	RenderedHosts = report.Nodes{
 		fixture.ClientHostNodeID: hostNode(fixture.ClientHostNodeID, fixture.ServerHostNodeID).
-			WithLatests(map[string]string{
-				host.HostName: fixture.ClientHostName,
-			}).
+			WithLatests(
+				host.HostName, fixture.ClientHostName,
+			).
 			WithChildren(report.MakeNodeSet(
 				RenderedEndpoints[fixture.Client54001NodeID],
 				RenderedEndpoints[fixture.Client54002NodeID],

--- a/render/pod_test.go
+++ b/render/pod_test.go
@@ -29,9 +29,8 @@ func TestPodFilterRenderer(t *testing.T) {
 	// tag on containers or pod namespace in the topology and ensure
 	// it is filtered out correctly.
 	input := fixture.Report.Copy()
-	input.Pod.Nodes[fixture.ClientPodNodeID] = input.Pod.Nodes[fixture.ClientPodNodeID].WithLatests(map[string]string{
-		kubernetes.Namespace: "kube-system",
-	})
+	input.Pod.Nodes[fixture.ClientPodNodeID] = input.Pod.Nodes[fixture.ClientPodNodeID].
+		WithLatests(kubernetes.Namespace, "kube-system")
 
 	have := utils.Prune(render.Render(input, render.PodRenderer, filterNonKubeSystem).Nodes)
 	want := utils.Prune(expected.RenderedPods.Copy())
@@ -53,9 +52,8 @@ func TestPodServiceFilterRenderer(t *testing.T) {
 	// tag on containers or pod namespace in the topology and ensure
 	// it is filtered out correctly.
 	input := fixture.Report.Copy()
-	input.Service.Nodes[fixture.ServiceNodeID] = input.Service.Nodes[fixture.ServiceNodeID].WithLatests(map[string]string{
-		kubernetes.Namespace: "kube-system",
-	})
+	input.Service.Nodes[fixture.ServiceNodeID] = input.Service.Nodes[fixture.ServiceNodeID].
+		WithLatests(kubernetes.Namespace, "kube-system")
 
 	have := utils.Prune(render.Render(input, render.PodServiceRenderer, filterNonKubeSystem).Nodes)
 	want := utils.Prune(expected.RenderedPodServices.Copy())

--- a/render/render.go
+++ b/render/render.go
@@ -1,6 +1,8 @@
 package render
 
 import (
+	"time"
+
 	"github.com/weaveworks/scope/report"
 )
 
@@ -115,10 +117,18 @@ func (m Map) Render(rpt report.Report) Nodes {
 	return output.result(input)
 }
 
-func propagateLatest(key string, from, to report.Node) report.Node {
-	if value, timestamp, ok := from.Latest.LookupEntry(key); ok {
-		to.Latest = to.Latest.Set(key, timestamp, value)
+func propagateLatests(from, to report.Node, keys ...string) report.Node {
+	var pairs []string
+	var ts time.Time
+	for _, key := range keys {
+		if value, timestamp, ok := from.Latest.LookupEntry(key); ok {
+			pairs = append(pairs, key, value)
+			if ts.Before(timestamp) {
+				ts = timestamp
+			}
+		}
 	}
+	to.Latest = to.Latest.SetMulti(ts, pairs...)
 	return to
 }
 

--- a/render/short_lived_connections_test.go
+++ b/render/short_lived_connections_test.go
@@ -65,30 +65,30 @@ var (
 		},
 		Container: report.Topology{
 			Nodes: report.Nodes{
-				container1NodeID: report.MakeNodeWith(container1NodeID, map[string]string{
-					docker.ContainerID:   container1ID,
-					docker.ContainerName: container1Name,
-					report.HostNodeID:    serverHostNodeID,
-				}).
+				container1NodeID: report.MakeNodeWith(container1NodeID,
+					docker.ContainerID, container1ID,
+					docker.ContainerName, container1Name,
+					report.HostNodeID, serverHostNodeID,
+				).
 					WithSets(report.MakeSets().
 						Add(docker.ContainerIPs, report.MakeStringSet(container1IP)).
 						Add(docker.ContainerIPsWithScopes, report.MakeStringSet(report.MakeAddressNodeID("", container1IP))).
 						Add(docker.ContainerPorts, report.MakeStringSet(fmt.Sprintf("%s:%s->%s/tcp", serverIP, serverPort, serverPort))),
 					).WithTopology(report.Container),
-				container2NodeID: report.MakeNodeWith(container2NodeID, map[string]string{
-					docker.ContainerID:   container2ID,
-					docker.ContainerName: container2Name,
-					report.HostNodeID:    serverHostNodeID,
-				}).
+				container2NodeID: report.MakeNodeWith(container2NodeID,
+					docker.ContainerID, container2ID,
+					docker.ContainerName, container2Name,
+					report.HostNodeID, serverHostNodeID,
+				).
 					WithSets(report.MakeSets().
 						Add(docker.ContainerIPs, report.MakeStringSet(container2IP)).
 						Add(docker.ContainerIPsWithScopes, report.MakeStringSet(report.MakeAddressNodeID("", container2IP))),
 					).WithTopology(report.Container),
-				pauseContainerNodeID: report.MakeNodeWith(pauseContainerNodeID, map[string]string{
-					docker.ContainerID:   pauseContainerID,
-					docker.ContainerName: pauseContainerName,
-					report.HostNodeID:    serverHostNodeID,
-				}).
+				pauseContainerNodeID: report.MakeNodeWith(pauseContainerNodeID,
+					docker.ContainerID, pauseContainerID,
+					docker.ContainerName, pauseContainerName,
+					report.HostNodeID, serverHostNodeID,
+				).
 					WithSets(report.MakeSets().
 						Add(docker.ContainerIPs, report.MakeStringSet(pauseContainerIP)).
 						Add(docker.ContainerIPsWithScopes, report.MakeStringSet(report.MakeAddressNodeID("", pauseContainerIP))),
@@ -97,9 +97,9 @@ var (
 		},
 		Host: report.Topology{
 			Nodes: report.Nodes{
-				serverHostNodeID: report.MakeNodeWith(serverHostNodeID, map[string]string{
-					report.HostNodeID: serverHostNodeID,
-				}).
+				serverHostNodeID: report.MakeNodeWith(serverHostNodeID,
+					report.HostNodeID, serverHostNodeID,
+				).
 					WithSets(report.MakeSets().
 						Add(host.LocalNetworks, report.MakeStringSet("192.168.0.0/16")),
 					).WithTopology(report.Host),

--- a/report/node.go
+++ b/report/node.go
@@ -39,8 +39,8 @@ func MakeNode(id string) Node {
 }
 
 // MakeNodeWith creates a new Node with the supplied map.
-func MakeNodeWith(id string, m map[string]string) Node {
-	return MakeNode(id).WithLatests(m)
+func MakeNodeWith(id string, m ...string) Node {
+	return MakeNode(id).WithLatests(m...)
 }
 
 // WithID returns a fresh copy of n, with ID changed.
@@ -70,12 +70,9 @@ func (n Node) After(other Node) bool {
 	return other.Topology < n.Topology || (other.Topology == n.Topology && other.ID < n.ID)
 }
 
-// WithLatests returns a fresh copy of n, with Metadata m merged in.
-func (n Node) WithLatests(m map[string]string) Node {
-	ts := mtime.Now()
-	for k, v := range m {
-		n.Latest = n.Latest.Set(k, ts, v)
-	}
+// WithLatests returns a fresh copy of n, with Metadata m (pairs of key,value) merged in.
+func (n Node) WithLatests(m ...string) Node {
+	n.Latest = n.Latest.SetMulti(mtime.Now(), m...)
 	return n
 }
 

--- a/report/node_set_test.go
+++ b/report/node_set_test.go
@@ -51,10 +51,10 @@ func TestMakeNodeSet(t *testing.T) {
 func BenchmarkMakeNodeSet(b *testing.B) {
 	nodes := []report.Node{}
 	for i := 1000; i >= 0; i-- {
-		nodes = append(nodes, report.MakeNodeWith(fmt.Sprint(i), map[string]string{
-			"a": "1",
-			"b": "2",
-		}))
+		nodes = append(nodes, report.MakeNodeWith(fmt.Sprint(i),
+			"a", "1",
+			"b", "2",
+		))
 	}
 
 	b.ResetTimer()
@@ -149,17 +149,17 @@ func BenchmarkNodeSetAdd(b *testing.B) {
 	n := report.MakeNodeSet()
 	for i := 0; i < 600; i++ {
 		n = n.Add(
-			report.MakeNodeWith(fmt.Sprint(i), map[string]string{
-				"a": "1",
-				"b": "2",
-			}),
+			report.MakeNodeWith(fmt.Sprint(i),
+				"a", "1",
+				"b", "2",
+			),
 		)
 	}
 
-	node := report.MakeNodeWith("401.5", map[string]string{
-		"a": "1",
-		"b": "2",
-	})
+	node := report.MakeNodeWith("401.5",
+		"a", "1",
+		"b", "2",
+	)
 
 	b.ResetTimer()
 
@@ -283,19 +283,19 @@ func BenchmarkNodeSetMerge(b *testing.B) {
 	n, other := report.NodeSet{}, report.NodeSet{}
 	for i := 0; i < 600; i++ {
 		n = n.Add(
-			report.MakeNodeWith(fmt.Sprint(i), map[string]string{
-				"a": "1",
-				"b": "2",
-			}),
+			report.MakeNodeWith(fmt.Sprint(i),
+				"a", "1",
+				"b", "2",
+			),
 		)
 	}
 
 	for i := 400; i < 1000; i++ {
 		other = other.Add(
-			report.MakeNodeWith(fmt.Sprint(i), map[string]string{
-				"c": "1",
-				"d": "2",
-			}),
+			report.MakeNodeWith(fmt.Sprint(i),
+				"c", "1",
+				"d", "2",
+			),
 		)
 	}
 

--- a/report/node_test.go
+++ b/report/node_test.go
@@ -26,107 +26,107 @@ func TestMergeNodes(t *testing.T) {
 		"Empty a": {
 			a: report.Nodes{},
 			b: report.Nodes{
-				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345", map[string]string{
-					PID:    "23128",
-					Name:   "curl",
-					Domain: "node-a.local",
-				}),
+				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345",
+					PID, "23128",
+					Name, "curl",
+					Domain, "node-a.local",
+				),
 			},
 			want: report.Nodes{
-				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345", map[string]string{
-					PID:    "23128",
-					Name:   "curl",
-					Domain: "node-a.local",
-				}),
+				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345",
+					PID, "23128",
+					Name, "curl",
+					Domain, "node-a.local",
+				),
 			},
 		},
 		"Empty b": {
 			a: report.Nodes{
-				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345", map[string]string{
-					PID:    "23128",
-					Name:   "curl",
-					Domain: "node-a.local",
-				}),
+				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345",
+					PID, "23128",
+					Name, "curl",
+					Domain, "node-a.local",
+				),
 			},
 			b: report.Nodes{},
 			want: report.Nodes{
-				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345", map[string]string{
-					PID:    "23128",
-					Name:   "curl",
-					Domain: "node-a.local",
-				}),
+				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345",
+					PID, "23128",
+					Name, "curl",
+					Domain, "node-a.local",
+				),
 			},
 		},
 		"Simple merge": {
 			a: report.Nodes{
-				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345", map[string]string{
-					PID:    "23128",
-					Name:   "curl",
-					Domain: "node-a.local",
-				}),
+				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345",
+					PID, "23128",
+					Name, "curl",
+					Domain, "node-a.local",
+				),
 			},
 			b: report.Nodes{
-				":192.168.1.2:12345": report.MakeNodeWith(":192.168.1.2:12345", map[string]string{
-					PID:    "42",
-					Name:   "curl",
-					Domain: "node-a.local",
-				}),
+				":192.168.1.2:12345": report.MakeNodeWith(":192.168.1.2:12345",
+					PID, "42",
+					Name, "curl",
+					Domain, "node-a.local",
+				),
 			},
 			want: report.Nodes{
-				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345", map[string]string{
-					PID:    "23128",
-					Name:   "curl",
-					Domain: "node-a.local",
-				}),
-				":192.168.1.2:12345": report.MakeNodeWith(":192.168.1.2:12345", map[string]string{
-					PID:    "42",
-					Name:   "curl",
-					Domain: "node-a.local",
-				}),
+				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345",
+					PID, "23128",
+					Name, "curl",
+					Domain, "node-a.local",
+				),
+				":192.168.1.2:12345": report.MakeNodeWith(":192.168.1.2:12345",
+					PID, "42",
+					Name, "curl",
+					Domain, "node-a.local",
+				),
 			},
 		},
 		"Merge conflict with rank difference": {
 			a: report.Nodes{
-				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345", map[string]string{
-					PID:    "23128",
-					Name:   "curl",
-					Domain: "node-a.local",
-				}),
+				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345",
+					PID, "23128",
+					Name, "curl",
+					Domain, "node-a.local",
+				),
 			},
 			b: report.Nodes{
-				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345", map[string]string{ // <-- same ID
-					Name:   "curl",
-					Domain: "node-a.local",
-				}).WithLatest(PID, time.Now().Add(-1*time.Minute), "0"),
+				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345", // <-- same ID
+					Name, "curl",
+					Domain, "node-a.local",
+				).WithLatest(PID, time.Now().Add(-1*time.Minute), "0"),
 			},
 			want: report.Nodes{
-				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345", map[string]string{
-					PID:    "23128",
-					Name:   "curl",
-					Domain: "node-a.local",
-				}),
+				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345",
+					PID, "23128",
+					Name, "curl",
+					Domain, "node-a.local",
+				),
 			},
 		},
 		"Merge conflict with no rank difference": {
 			a: report.Nodes{
-				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345", map[string]string{
-					PID:    "23128",
-					Name:   "curl",
-					Domain: "node-a.local",
-				}),
+				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345",
+					PID, "23128",
+					Name, "curl",
+					Domain, "node-a.local",
+				),
 			},
 			b: report.Nodes{
-				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345", map[string]string{ // <-- same ID
-					Name:   "curl",
-					Domain: "node-a.local",
-				}).WithLatest(PID, time.Now().Add(-1*time.Minute), "0"),
+				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345", // <-- same ID
+					Name, "curl",
+					Domain, "node-a.local",
+				).WithLatest(PID, time.Now().Add(-1*time.Minute), "0"),
 			},
 			want: report.Nodes{
-				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345", map[string]string{
-					PID:    "23128",
-					Name:   "curl",
-					Domain: "node-a.local",
-				}),
+				":192.168.1.1:12345": report.MakeNodeWith(":192.168.1.1:12345",
+					PID, "23128",
+					Name, "curl",
+					Domain, "node-a.local",
+				),
 			},
 		},
 		"Counters": {

--- a/report/report.go
+++ b/report/report.go
@@ -512,7 +512,7 @@ func (r Report) upgradeNamespaces() Report {
 		// Probes did not use to report namespace ids, but since creating a report node requires an id,
 		// the namespace name, which is unique, is passed to `MakeNamespaceNodeID`
 		namespaceID := MakeNamespaceNodeID(ns)
-		nodes[namespaceID] = MakeNodeWith(namespaceID, map[string]string{KubernetesName: ns})
+		nodes[namespaceID] = MakeNodeWith(namespaceID, KubernetesName, ns)
 	}
 	r.Namespace.Nodes = nodes
 

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -48,9 +48,9 @@ func TestReportTopology(t *testing.T) {
 
 func TestNode(t *testing.T) {
 	{
-		node := report.MakeNodeWith("foo", map[string]string{
-			"foo": "bar",
-		})
+		node := report.MakeNodeWith("foo",
+			"foo", "bar",
+		)
 
 		if v, _ := node.Latest.Lookup("foo"); v != "bar" {
 			t.Errorf("want foo, have %s", v)
@@ -81,7 +81,7 @@ func TestReportUpgrade(t *testing.T) {
 	namespaceName := "ns"
 	namespaceID := report.MakeNamespaceNodeID(namespaceName)
 	podNode := report.MakeNode("foo").
-		WithLatests(map[string]string{report.KubernetesNamespace: namespaceName}).
+		WithLatests(report.KubernetesNamespace, namespaceName).
 		WithControls("alive").
 		WithParents(report.MakeSets().Add(report.ReplicaSet, report.MakeStringSet("bar")))
 	controls := map[string]report.NodeControlData{
@@ -94,7 +94,7 @@ func TestReportUpgrade(t *testing.T) {
 	rpt.ReplicaSet.AddNode(rsNode)
 	rpt.Pod.AddNode(podNode)
 	namespaceNode := report.MakeNode(namespaceID).
-		WithLatests(map[string]string{report.KubernetesName: namespaceName})
+		WithLatests(report.KubernetesName, namespaceName)
 	expected := report.MakeReport()
 	expected.ReplicaSet.AddNode(rsNode)
 	expected.Pod.AddNode(expectedPodNode)

--- a/report/table_test.go
+++ b/report/table_test.go
@@ -107,10 +107,10 @@ func TestFixedPropertyLists(t *testing.T) {
 		},
 	}
 
-	nmd := report.MakeNodeWith("foo1", map[string]string{
-		"foo2key": "bar2",
-		"foo1key": "bar1",
-	})
+	nmd := report.MakeNodeWith("foo1",
+		"foo2key", "bar2",
+		"foo1key", "bar1",
+	)
 
 	template := report.TableTemplate{
 		Type: report.PropertyListType,
@@ -192,10 +192,10 @@ func TestTables(t *testing.T) {
 		},
 	}
 
-	nmd := report.MakeNodeWith("foo1", map[string]string{
-		"foo3key": "bar3",
-		"foo1key": "bar1",
-	})
+	nmd := report.MakeNodeWith("foo1",
+		"foo3key", "bar3",
+		"foo1key", "bar1",
+	)
 	nmd = nmd.AddPrefixMulticolumnTable("bbb_", []report.Row{
 		{ID: "row1", Entries: map[string]string{"col1": "r1c1"}},
 		{ID: "row2", Entries: map[string]string{"col3": "r2c3"}},

--- a/test/fixture/report_fixture.go
+++ b/test/fixture/report_fixture.go
@@ -132,25 +132,25 @@ var (
 				// Node is arbitrary. We're free to put only precisely what we
 				// care to test into the fixture. Just be sure to include the bits
 				// that the mapping funcs extract :)
-				Client54001NodeID: report.MakeNode(Client54001NodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
-					process.PID:       Client1PID,
-					report.HostNodeID: ClientHostNodeID,
-				}).WithAdjacent(Server80NodeID),
+				Client54001NodeID: report.MakeNode(Client54001NodeID).WithTopology(report.Endpoint).WithLatests(
+					process.PID, Client1PID,
+					report.HostNodeID, ClientHostNodeID,
+				).WithAdjacent(Server80NodeID),
 
-				Client54002NodeID: report.MakeNode(Client54002NodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
-					process.PID:       Client2PID,
-					report.HostNodeID: ClientHostNodeID,
-				}).WithAdjacent(Server80NodeID),
+				Client54002NodeID: report.MakeNode(Client54002NodeID).WithTopology(report.Endpoint).WithLatests(
+					process.PID, Client2PID,
+					report.HostNodeID, ClientHostNodeID,
+				).WithAdjacent(Server80NodeID),
 
-				Server80NodeID: report.MakeNode(Server80NodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
-					process.PID:       ServerPID,
-					report.HostNodeID: ServerHostNodeID,
-				}),
+				Server80NodeID: report.MakeNode(Server80NodeID).WithTopology(report.Endpoint).WithLatests(
+					process.PID, ServerPID,
+					report.HostNodeID, ServerHostNodeID,
+				),
 
-				NonContainerNodeID: report.MakeNode(NonContainerNodeID).WithTopology(report.Endpoint).WithLatests(map[string]string{
-					process.PID:       NonContainerPID,
-					report.HostNodeID: ServerHostNodeID,
-				}).WithAdjacent(GoogleEndpointNodeID),
+				NonContainerNodeID: report.MakeNode(NonContainerNodeID).WithTopology(report.Endpoint).WithLatests(
+					process.PID, NonContainerPID,
+					report.HostNodeID, ServerHostNodeID,
+				).WithAdjacent(GoogleEndpointNodeID),
 
 				// Probe pseudo nodes
 				UnknownClient1NodeID: report.MakeNode(UnknownClient1NodeID).WithTopology(report.Endpoint).WithAdjacent(Server80NodeID),
@@ -162,12 +162,12 @@ var (
 		},
 		Process: report.Topology{
 			Nodes: report.Nodes{
-				ClientProcess1NodeID: report.MakeNodeWith(ClientProcess1NodeID, map[string]string{
-					process.PID:        Client1PID,
-					process.Name:       Client1Name,
-					docker.ContainerID: ClientContainerID,
-					report.HostNodeID:  ClientHostNodeID,
-				}).
+				ClientProcess1NodeID: report.MakeNodeWith(ClientProcess1NodeID,
+					process.PID, Client1PID,
+					process.Name, Client1Name,
+					docker.ContainerID, ClientContainerID,
+					report.HostNodeID, ClientHostNodeID,
+				).
 					WithTopology(report.Process).WithParents(report.MakeSets().
 					Add("host", report.MakeStringSet(ClientHostNodeID)).
 					Add("container", report.MakeStringSet(ClientContainerNodeID)),
@@ -175,31 +175,31 @@ var (
 					process.CPUUsage:    ClientProcess1CPUMetric,
 					process.MemoryUsage: ClientProcess1MemoryMetric,
 				}),
-				ClientProcess2NodeID: report.MakeNodeWith(ClientProcess2NodeID, map[string]string{
-					process.PID:        Client2PID,
-					process.Name:       Client2Name,
-					docker.ContainerID: ClientContainerID,
-					report.HostNodeID:  ClientHostNodeID,
-				}).
+				ClientProcess2NodeID: report.MakeNodeWith(ClientProcess2NodeID,
+					process.PID, Client2PID,
+					process.Name, Client2Name,
+					docker.ContainerID, ClientContainerID,
+					report.HostNodeID, ClientHostNodeID,
+				).
 					WithTopology(report.Process).WithParents(report.MakeSets().
 					Add("host", report.MakeStringSet(ClientHostNodeID)).
 					Add("container", report.MakeStringSet(ClientContainerNodeID)),
 				),
-				ServerProcessNodeID: report.MakeNodeWith(ServerProcessNodeID, map[string]string{
-					process.PID:        ServerPID,
-					process.Name:       ServerName,
-					docker.ContainerID: ServerContainerID,
-					report.HostNodeID:  ServerHostNodeID,
-				}).
+				ServerProcessNodeID: report.MakeNodeWith(ServerProcessNodeID,
+					process.PID, ServerPID,
+					process.Name, ServerName,
+					docker.ContainerID, ServerContainerID,
+					report.HostNodeID, ServerHostNodeID,
+				).
 					WithTopology(report.Process).WithParents(report.MakeSets().
 					Add("host", report.MakeStringSet(ServerHostNodeID)).
 					Add("container", report.MakeStringSet(ServerContainerNodeID)),
 				),
-				NonContainerProcessNodeID: report.MakeNodeWith(NonContainerProcessNodeID, map[string]string{
-					process.PID:       NonContainerPID,
-					process.Name:      NonContainerName,
-					report.HostNodeID: ServerHostNodeID,
-				}).
+				NonContainerProcessNodeID: report.MakeNodeWith(NonContainerProcessNodeID,
+					process.PID, NonContainerPID,
+					process.Name, NonContainerName,
+					report.HostNodeID, ServerHostNodeID,
+				).
 					WithTopology(report.Process).WithParents(report.MakeSets().
 					Add("host", report.MakeStringSet(ServerHostNodeID)),
 				),
@@ -211,18 +211,18 @@ var (
 			Nodes: report.Nodes{
 				ClientContainerNodeID: report.MakeNodeWith(
 
-					ClientContainerNodeID, map[string]string{
-						docker.ContainerID:                           ClientContainerID,
-						docker.ContainerName:                         ClientContainerName,
-						docker.ContainerHostname:                     ClientContainerHostname,
-						docker.ImageID:                               ClientContainerImageID,
-						report.HostNodeID:                            ClientHostNodeID,
-						docker.LabelPrefix + "io.kubernetes.pod.uid": ClientPodUID,
-						docker.LabelPrefix + TestLabelKey1:           ApplicationLabelValue1,
-						kubernetes.Namespace:                         KubernetesNamespace,
-						docker.ContainerState:                        docker.StateRunning,
-						docker.ContainerStateHuman:                   docker.StateRunning,
-					}).
+					ClientContainerNodeID,
+					docker.ContainerID, ClientContainerID,
+					docker.ContainerName, ClientContainerName,
+					docker.ContainerHostname, ClientContainerHostname,
+					docker.ImageID, ClientContainerImageID,
+					report.HostNodeID, ClientHostNodeID,
+					docker.LabelPrefix+"io.kubernetes.pod.uid", ClientPodUID,
+					docker.LabelPrefix+TestLabelKey1, ApplicationLabelValue1,
+					kubernetes.Namespace, KubernetesNamespace,
+					docker.ContainerState, docker.StateRunning,
+					docker.ContainerStateHuman, docker.StateRunning,
+				).
 					WithTopology(report.Container).WithParents(report.MakeSets().
 					Add("host", report.MakeStringSet(ClientHostNodeID)).
 					Add("container_image", report.MakeStringSet(ClientContainerImageNodeID)).
@@ -233,21 +233,21 @@ var (
 				}),
 				ServerContainerNodeID: report.MakeNodeWith(
 
-					ServerContainerNodeID, map[string]string{
-						docker.ContainerID:                                        ServerContainerID,
-						docker.ContainerName:                                      ServerContainerName,
-						docker.ContainerHostname:                                  ServerContainerHostname,
-						docker.ContainerState:                                     docker.StateRunning,
-						docker.ContainerStateHuman:                                docker.StateRunning,
-						docker.ImageID:                                            ServerContainerImageID,
-						report.HostNodeID:                                         ServerHostNodeID,
-						docker.LabelPrefix + detailed.AmazonECSContainerNameLabel: "server",
-						docker.LabelPrefix + "foo1":                               "bar1",
-						docker.LabelPrefix + "foo2":                               "bar2",
-						docker.LabelPrefix + "io.kubernetes.pod.uid":              ServerPodUID,
-						docker.LabelPrefix + TestLabelKey2:                        ApplicationLabelValue2,
-						kubernetes.Namespace:                                      KubernetesNamespace,
-					}).
+					ServerContainerNodeID,
+					docker.ContainerID, ServerContainerID,
+					docker.ContainerName, ServerContainerName,
+					docker.ContainerHostname, ServerContainerHostname,
+					docker.ContainerState, docker.StateRunning,
+					docker.ContainerStateHuman, docker.StateRunning,
+					docker.ImageID, ServerContainerImageID,
+					report.HostNodeID, ServerHostNodeID,
+					docker.LabelPrefix+detailed.AmazonECSContainerNameLabel, "server",
+					docker.LabelPrefix+"foo1", "bar1",
+					docker.LabelPrefix+"foo2", "bar2",
+					docker.LabelPrefix+"io.kubernetes.pod.uid", ServerPodUID,
+					docker.LabelPrefix+TestLabelKey2, ApplicationLabelValue2,
+					kubernetes.Namespace, KubernetesNamespace,
+				).
 					WithTopology(report.Container).WithParents(report.MakeSets().
 					Add("host", report.MakeStringSet(ServerHostNodeID)).
 					Add("container_image", report.MakeStringSet(ServerContainerImageNodeID)).
@@ -262,21 +262,21 @@ var (
 		}.WithShape(report.Hexagon).WithLabel("container", "containers"),
 		ContainerImage: report.Topology{
 			Nodes: report.Nodes{
-				ClientContainerImageNodeID: report.MakeNodeWith(ClientContainerImageNodeID, map[string]string{
-					docker.ImageID:    ClientContainerImageID,
-					docker.ImageName:  ClientContainerImageName,
-					report.HostNodeID: ClientHostNodeID,
-				}).
+				ClientContainerImageNodeID: report.MakeNodeWith(ClientContainerImageNodeID,
+					docker.ImageID, ClientContainerImageID,
+					docker.ImageName, ClientContainerImageName,
+					report.HostNodeID, ClientHostNodeID,
+				).
 					WithParents(report.MakeSets().
 						Add("host", report.MakeStringSet(ClientHostNodeID)),
 					).WithTopology(report.ContainerImage),
-				ServerContainerImageNodeID: report.MakeNodeWith(ServerContainerImageNodeID, map[string]string{
-					docker.ImageID:              ServerContainerImageID,
-					docker.ImageName:            ServerContainerImageName,
-					report.HostNodeID:           ServerHostNodeID,
-					docker.LabelPrefix + "foo1": "bar1",
-					docker.LabelPrefix + "foo2": "bar2",
-				}).
+				ServerContainerImageNodeID: report.MakeNodeWith(ServerContainerImageNodeID,
+					docker.ImageID, ServerContainerImageID,
+					docker.ImageName, ServerContainerImageName,
+					report.HostNodeID, ServerHostNodeID,
+					docker.LabelPrefix+"foo1", "bar1",
+					docker.LabelPrefix+"foo2", "bar2",
+				).
 					WithParents(report.MakeSets().
 						Add("host", report.MakeStringSet(ServerHostNodeID)),
 					).WithTopology(report.ContainerImage),
@@ -287,11 +287,11 @@ var (
 			Nodes: report.Nodes{
 				ClientHostNodeID: report.MakeNodeWith(
 
-					ClientHostNodeID, map[string]string{
-						"host_name":       ClientHostName,
-						"os":              "Linux",
-						report.HostNodeID: ClientHostNodeID,
-					}).
+					ClientHostNodeID,
+					"host_name", ClientHostName,
+					"os", "Linux",
+					report.HostNodeID, ClientHostNodeID,
+				).
 					WithTopology(report.Host).WithSets(report.MakeSets().
 					Add(host.LocalNetworks, report.MakeStringSet("10.10.10.0/24")),
 				).WithMetrics(report.Metrics{
@@ -301,11 +301,11 @@ var (
 				}),
 				ServerHostNodeID: report.MakeNodeWith(
 
-					ServerHostNodeID, map[string]string{
-						"host_name":       ServerHostName,
-						"os":              "Linux",
-						report.HostNodeID: ServerHostNodeID,
-					}).
+					ServerHostNodeID,
+					"host_name", ServerHostName,
+					"os", "Linux",
+					report.HostNodeID, ServerHostNodeID,
+				).
 					WithTopology(report.Host).WithSets(report.MakeSets().
 					Add(host.LocalNetworks, report.MakeStringSet("10.10.10.0/24")),
 				).WithMetrics(report.Metrics{
@@ -320,22 +320,22 @@ var (
 		Pod: report.Topology{
 			Nodes: report.Nodes{
 				ClientPodNodeID: report.MakeNodeWith(
-					ClientPodNodeID, map[string]string{
-						kubernetes.Name:      "pong-a",
-						kubernetes.Namespace: KubernetesNamespace,
-						report.HostNodeID:    ClientHostNodeID,
-					}).
+					ClientPodNodeID,
+					kubernetes.Name, "pong-a",
+					kubernetes.Namespace, KubernetesNamespace,
+					report.HostNodeID, ClientHostNodeID,
+				).
 					WithTopology(report.Pod).WithParents(report.MakeSets().
 					Add("host", report.MakeStringSet(ClientHostNodeID)).
 					Add("service", report.MakeStringSet(ServiceNodeID)),
 				),
 				ServerPodNodeID: report.MakeNodeWith(
-					ServerPodNodeID, map[string]string{
-						kubernetes.Name:      "pong-b",
-						kubernetes.Namespace: KubernetesNamespace,
-						kubernetes.State:     "running",
-						report.HostNodeID:    ServerHostNodeID,
-					}).
+					ServerPodNodeID,
+					kubernetes.Name, "pong-b",
+					kubernetes.Namespace, KubernetesNamespace,
+					kubernetes.State, "running",
+					report.HostNodeID, ServerHostNodeID,
+				).
 					WithTopology(report.Pod).WithParents(report.MakeSets().
 					Add("host", report.MakeStringSet(ServerHostNodeID)).
 					Add("service", report.MakeStringSet(ServiceNodeID)),
@@ -347,10 +347,10 @@ var (
 			Nodes: report.Nodes{
 				ServiceNodeID: report.MakeNodeWith(
 
-					ServiceNodeID, map[string]string{
-						kubernetes.Name:      "pongservice",
-						kubernetes.Namespace: "ping",
-					}).
+					ServiceNodeID,
+					kubernetes.Name, "pongservice",
+					kubernetes.Namespace, "ping",
+				).
 					WithTopology(report.Service),
 			},
 		}.WithShape(report.Heptagon).WithLabel("service", "services"),

--- a/test/fixture/report_fixture.go
+++ b/test/fixture/report_fixture.go
@@ -358,14 +358,14 @@ var (
 			Nodes: report.Nodes{
 				PersistentVolumeClaimNodeID: report.MakeNodeWith(
 
-					PersistentVolumeClaimNodeID, map[string]string{
-						kubernetes.Name:             "pvc-6124",
-						kubernetes.Namespace:        "ping",
-						kubernetes.Status:           "bound",
-						kubernetes.VolumeName:       "pongvolume",
-						kubernetes.AccessModes:      "ReadWriteOnce",
-						kubernetes.StorageClassName: "standard",
-					}).
+					PersistentVolumeClaimNodeID,
+					kubernetes.Name, "pvc-6124",
+					kubernetes.Namespace, "ping",
+					kubernetes.Status, "bound",
+					kubernetes.VolumeName, "pongvolume",
+					kubernetes.AccessModes, "ReadWriteOnce",
+					kubernetes.StorageClassName, "standard",
+				).
 					WithTopology(report.PersistentVolumeClaim),
 			},
 		}.WithShape(report.DottedCylinder).WithLabel("persistent volume claim", "persistent volume claims"),
@@ -373,14 +373,14 @@ var (
 			Nodes: report.Nodes{
 				PersistentVolumeNodeID: report.MakeNodeWith(
 
-					PersistentVolumeNodeID, map[string]string{
-						kubernetes.Name:             "pongvolume",
-						kubernetes.Namespace:        "ping",
-						kubernetes.Status:           "bound",
-						kubernetes.VolumeClaim:      "pvc-6124",
-						kubernetes.AccessModes:      "ReadWriteOnce",
-						kubernetes.StorageClassName: "standard",
-					}).
+					PersistentVolumeNodeID,
+					kubernetes.Name, "pongvolume",
+					kubernetes.Namespace, "ping",
+					kubernetes.Status, "bound",
+					kubernetes.VolumeClaim, "pvc-6124",
+					kubernetes.AccessModes, "ReadWriteOnce",
+					kubernetes.StorageClassName, "standard",
+				).
 					WithTopology(report.PersistentVolume),
 			},
 		}.WithShape(report.Cylinder).WithLabel("persistent volume", "persistent volumes"),
@@ -388,10 +388,10 @@ var (
 			Nodes: report.Nodes{
 				StorageClassNodeID: report.MakeNodeWith(
 
-					StorageClassNodeID, map[string]string{
-						kubernetes.Name:        "standard",
-						kubernetes.Provisioner: "pong",
-					}).
+					StorageClassNodeID,
+					kubernetes.Name, "standard",
+					kubernetes.Provisioner, "pong",
+				).
 					WithTopology(report.StorageClass),
 			},
 		}.WithShape(report.StorageSheet).WithLabel("storage class", "storage classes"),


### PR DESCRIPTION
Then do the additions as a merge rather than repeated adds, to avoid memory allocations.

It appears that `WithLatests` is not something we do a lot in the benchmarks, but probably more in the probes. The follow-up change to `propagateLatest` gives us a healthy boost when rendering.

~Also a drive-by fix to `processWithContainerNameRenderer`.~

Benchmarks:
```
benchmark                            old ns/op      new ns/op      delta
BenchmarkRenderList-2                665307761      527805245      -20.67%
BenchmarkRenderHosts-2               413642784      408523260      -1.24%
BenchmarkRenderControllers-2         364129636      344651406      -5.35%
BenchmarkRenderPods-2                341522570      314960182      -7.78%
BenchmarkRenderContainers-2          204275436      193586083      -5.23%
BenchmarkRenderProcesses-2           129523723      122403160      -5.50%
BenchmarkRenderProcessNames-2        143726808      138044775      -3.95%

benchmark                            old allocs     new allocs     delta
BenchmarkRenderList-2                801654         803633         +0.25%
BenchmarkRenderHosts-2               605887         605869         -0.00%
BenchmarkRenderControllers-2         429942         429789         -0.04%
BenchmarkRenderPods-2                383866         385131         +0.33%
BenchmarkRenderContainers-2          253898         255118         +0.48%
BenchmarkRenderProcesses-2           119585         120188         +0.50%
BenchmarkRenderProcessNames-2        163417         163872         +0.28%

benchmark                            old bytes     new bytes     delta
BenchmarkRenderList-2                91623684      88391116      -3.53%
BenchmarkRenderHosts-2               65873664      62455445      -5.19%
BenchmarkRenderControllers-2         47176061      43729286      -7.31%
BenchmarkRenderPods-2                41874317      38607350      -7.80%
BenchmarkRenderContainers-2          28799258      25524452      -11.37%
BenchmarkRenderProcesses-2           13984811      14002312      +0.13%
BenchmarkRenderProcessNames-2        17930731      17981694      +0.28%
```