### PR TITLE
Use single-owner code path to accumulate children when rendering

### DIFF
--- a/app/merger_test.go
+++ b/app/merger_test.go
@@ -67,13 +67,17 @@ func benchmarkMerger(b *testing.B, merger app.Merger) {
 	for i := 0; i < numHosts*5; i++ {
 		reports = append(reports, makeReport())
 	}
+	replacements := []report.Report{}
+	for i := 0; i < numHosts/3; i++ {
+		replacements = append(replacements, makeReport())
+	}
 
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
 		// replace 1/3 of hosts work of reports & merge them all
-		for i := 0; i < numHosts/3; i++ {
-			reports[rand.Intn(len(reports))] = makeReport()
+		for i := 0; i < len(replacements); i++ {
+			reports[rand.Intn(len(reports))] = replacements[i]
 		}
 
 		merger.Merge(reports)

--- a/render/render.go
+++ b/render/render.go
@@ -170,7 +170,8 @@ type joinResults struct {
 func newJoinResults(inputNodes report.Nodes) joinResults {
 	nodes := make(report.Nodes, len(inputNodes))
 	for id, n := range inputNodes {
-		n.Adjacency = nil // result() assumes all nodes start with no adjacencies
+		n.Adjacency = nil              // result() assumes all nodes start with no adjacencies
+		n.Children = n.Children.Copy() // so we can do unsafe adds
 		nodes[id] = n
 	}
 	return joinResults{nodes: nodes, mapped: map[string]string{}, multi: map[string][]string{}}
@@ -191,7 +192,7 @@ func (ret *joinResults) addUnmappedChild(m report.Node, id string, topology stri
 	if !exists {
 		result = report.MakeNode(id).WithTopology(topology)
 	}
-	result.Children = result.Children.Add(m)
+	result.Children.UnsafeAdd(m)
 	if m.Topology != report.Endpoint { // optimisation: we never look at endpoint counts
 		result.Counters = result.Counters.Add(m.Topology, 1)
 	}
@@ -219,6 +220,7 @@ func (ret *joinResults) addChildAndChildren(m report.Node, id string, topology s
 func (ret *joinResults) passThrough(n report.Node) {
 	n.Adjacency = nil // result() assumes all nodes start with no adjacencies
 	ret.nodes[n.ID] = n
+	n.Children = n.Children.Copy() // so we can do unsafe adds
 	ret.mapChild(n.ID, n.ID)
 }
 

--- a/report/node_set.go
+++ b/report/node_set.go
@@ -24,8 +24,24 @@ func MakeNodeSet(nodes ...Node) NodeSet {
 	return emptyNodeSet.Add(nodes...)
 }
 
-// Add adds the nodes to the NodeSet. Add is the only valid way to grow a
-// NodeSet. Add returns the NodeSet to enable chaining.
+// Copy returns a value copy of the Nodes.
+func (n NodeSet) Copy() NodeSet {
+	result := ps.NewMap()
+	n.ForEach(func(node Node) {
+		result = result.UnsafeMutableSet(node.ID, node)
+	})
+	return NodeSet{result}
+}
+
+// UnsafeAdd adds a node to the NodeSet. Only call this if n has one owner.
+func (n *NodeSet) UnsafeAdd(node Node) {
+	if n.psMap == nil {
+		n.psMap = ps.NewMap()
+	}
+	n.psMap = n.psMap.UnsafeMutableSet(node.ID, node)
+}
+
+// Add adds the nodes to the NodeSet, and returns the NodeSet to enable chaining.
 func (n NodeSet) Add(nodes ...Node) NodeSet {
 	if len(nodes) == 0 {
 		return n


### PR DESCRIPTION
We added `ps.Map.UnsafeMutableSet()` to optimise the case where you know a NodeSet is not shared with any other nodes.  We can arrange this quite easily for the `Children` of each node in `joinResults`, hence speed up rendering.

I had to adjust the smart/dumb merger benchmarks when they showed an improvement, which is spurious because this code isn't involved in merging.

Benchmarks comparison between first commit and last commit:
```
benchmark                            old ns/op      new ns/op      delta
BenchmarkRenderList-2                575964931      553021897      -3.98%
BenchmarkRenderHosts-2               408721601      362484026      -11.31%
BenchmarkRenderControllers-2         334499307      334047789      -0.13%
BenchmarkRenderPods-2                298092408      289996139      -2.72%
BenchmarkRenderContainers-2          195267791      194515228      -0.39%
BenchmarkRenderProcesses-2           120603030      118073991      -2.10%
BenchmarkRenderProcessNames-2        140712909      137637707      -2.19%

benchmark                            old allocs     new allocs     delta
BenchmarkRenderList-2                803614         699045         -13.01%
BenchmarkRenderHosts-2               603945         508666         -15.78%
BenchmarkRenderControllers-2         427973         388357         -9.26%
BenchmarkRenderPods-2                383876         343816         -10.44%
BenchmarkRenderContainers-2          253831         238770         -5.93%
BenchmarkRenderProcesses-2           119587         104522         -12.60%
BenchmarkRenderProcessNames-2        163859         142304         -13.15%

benchmark                            old bytes     new bytes     delta
BenchmarkRenderList-2                91847940      79224980      -13.74%
BenchmarkRenderHosts-2               65673920      54034450      -17.72%
BenchmarkRenderControllers-2         46943949      41555952      -11.48%
BenchmarkRenderPods-2                41884841      36448283      -12.98%
BenchmarkRenderContainers-2          28795293      26194801      -9.03%
BenchmarkRenderProcesses-2           13985262      11506184      -17.73%
BenchmarkRenderProcessNames-2        17980727      14821811      -17.57%
```