### PR TITLE
Minimal fix to make scope start with Docker for Mac again.

### DIFF
--- a/scope
+++ b/scope
@@ -124,7 +124,7 @@ check_docker_for_mac() {
         && [ -S /var/run/docker.sock ] \
         && [ ! "${DOCKER_HOST+x}" = x ] \
         && [ "${HOME+x}" = x ] \
-        && [ -d "${HOME}/Library/Containers/com.docker.docker/Data/database" ]
+        && [ -d "${HOME}/Library/Containers/com.docker.docker/Data" ]
 }
 
 # Check that a container named $1 with image $2 is not running


### PR DESCRIPTION
@dglaubman found that recent versions of Docker for Mac (Docker version 18.03.0-ce, build 0520e24) don't write out `${HOME}/Library/Containers/com.docker.docker/Data/database` any more.

@foot confirmed this. A fresh installation of Docker for Mac (Version 18.03.0-ce-mac60 (23751), Channel: stable) did not create the file.

The result was that installations which had this leftover file could start scope, whereas newer couldn't. The fix simply changes this check to a path which actually exists.

Thanks @dglaubman and @foot for the analysis and confirmation.

Fixes #3064