### PR TITLE
Faster path to check an IP address against known networks

### DIFF
--- a/report/networks.go
+++ b/report/networks.go
@@ -34,8 +34,8 @@ func (n Networks) AddCIDR(cidr string) error {
 
 // Contains returns true if IP is in Networks.
 func (n Networks) Contains(ip net.IP) bool {
-	network, _, _ := n.MatchIP(ip)
-	return network != nil
+	contained, _ := n.ContainedIP(ip)
+	return contained
 }
 
 // LocalAddresses returns a list of the local IP addresses.

--- a/vendor/github.com/k-sone/critbitgo/net.go
+++ b/vendor/github.com/k-sone/critbitgo/net.go
@@ -97,9 +97,25 @@ func (n *Net) MatchCIDR(s string) (route *net.IPNet, value interface{}, err erro
 	return
 }
 
+// Return a bool indicating whether a route would be found
+func (n *Net) ContainedIP(ip net.IP) (contained bool, err error) {
+	k, _, err := n.matchIP(ip)
+	contained = k != nil
+	return
+}
+
 // Return a specific route by using the longest prefix matching.
 // If `ip` is invalid IP, or a route is not found, `route` is nil.
 func (n *Net) MatchIP(ip net.IP) (route *net.IPNet, value interface{}, err error) {
+	k, v, err := n.matchIP(ip)
+	if k != nil {
+		route = netKeyToIPNet(k)
+		value = v
+	}
+	return
+}
+
+func (n *Net) matchIP(ip net.IP) (k []byte, v interface{}, err error) {
 	var isV4 bool
 	ip, isV4, err = netValidateIP(ip)
 	if err != nil {
@@ -111,10 +127,7 @@ func (n *Net) MatchIP(ip net.IP) (route *net.IPNet, value interface{}, err error
 	} else {
 		mask = mask128
 	}
-	if k, v := n.match(netIPNetToKey(ip, mask)); k != nil {
-		route = netKeyToIPNet(k)
-		value = v
-	}
+	k, v = n.match(netIPNetToKey(ip, mask))
 	return
 }
 

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -849,10 +849,10 @@
 		},
 		{
 			"importpath": "github.com/k-sone/critbitgo",
-			"repository": "https://github.com/k-sone/critbitgo",
+			"repository": "https://github.com/weaveworks/critbitgo",
 			"vcs": "git",
-			"revision": "327359a051d71948cb756142d112c7df283fac4d",
-			"branch": "master",
+			"revision": "aa814e9447366a571819e37affacbdc60e3af218",
+			"branch": "contained",
 			"notests": true
 		},
 		{


### PR DESCRIPTION
We modify the critbitgo library to skip creating a route object we don't use.

The weaveworks-local modification can be removed if https://github.com/k-sone/critbitgo/pull/7 is merged.

Benchmarks (fastest of 10 runs; timings are highly variable):
```
benchmark                         old ns/op     new ns/op     delta
BenchmarkRenderList-2             593307328     555257029     -6.41%
BenchmarkRenderHosts-2            433287444     394693695     -8.91%
BenchmarkRenderControllers-2      361384179     323186742     -10.57%
BenchmarkRenderPods-2             346144553     329953227     -4.68%
BenchmarkRenderContainers-2       201489916     200237356     -0.62%
BenchmarkRenderProcesses-2        135127597     123572216     -8.55%
BenchmarkRenderProcessNames-2     152146655     149658203     -1.64%

benchmark                         old allocs     new allocs     delta
BenchmarkRenderList-2             798184         610624         -23.50%
BenchmarkRenderHosts-2            603982         413645         -31.51%
BenchmarkRenderControllers-2      428532         284927         -33.51%
BenchmarkRenderPods-2             383885         240848         -37.26%
BenchmarkRenderContainers-2       253945         158539         -37.57%
BenchmarkRenderProcesses-2        119584         71915          -39.86%
BenchmarkRenderProcessNames-2     164045         116223         -29.15%

benchmark                         old bytes     new bytes     delta
BenchmarkRenderList-2             91234788      86609764      -5.07%
BenchmarkRenderHosts-2            65662378      60745008      -7.49%
BenchmarkRenderControllers-2      47002552      43220707      -8.05%
BenchmarkRenderPods-2             41884588      38159420      -8.89%
BenchmarkRenderContainers-2       28806560      26319518      -8.63%
BenchmarkRenderProcesses-2        13985787      12745817      -8.87%
BenchmarkRenderProcessNames-2     18001992      16745256      -6.98%
```
