### PR TITLE
 Use unsafe merge in joinResults.addChildAndChildren()

### DIFF
--- a/render/render.go
+++ b/render/render.go
@@ -169,6 +169,7 @@ func (ret *joinResults) mapChild(from, to string) {
 }
 
 // Add m into the results as a top-level node, mapped from original ID
+// Note it is not safe to mix calls to add() with addChild(), addChildAndChildren() or addUnmappedChild()
 func (ret *joinResults) add(from string, m report.Node) {
 	if existing, ok := ret.nodes[m.ID]; ok {
 		m = m.Merge(existing)

--- a/render/render.go
+++ b/render/render.go
@@ -203,7 +203,7 @@ func (ret *joinResults) addChild(m report.Node, id string, topology string) {
 func (ret *joinResults) addChildAndChildren(m report.Node, id string, topology string) {
 	ret.addUnmappedChild(m, id, topology)
 	result := ret.nodes[id]
-	result.Children = result.Children.Merge(m.Children)
+	result.Children.UnsafeMerge(m.Children)
 	ret.nodes[id] = result
 	ret.mapChild(m.ID, id)
 }

--- a/report/node_set.go
+++ b/report/node_set.go
@@ -72,6 +72,13 @@ func (n NodeSet) Delete(ids ...string) NodeSet {
 	return NodeSet{result}
 }
 
+// UnsafeMerge combines the two NodeSets, altering n
+func (n *NodeSet) UnsafeMerge(other NodeSet) {
+	other.psMap.ForEach(func(key string, otherVal interface{}) {
+		n.psMap = n.psMap.UnsafeMutableSet(key, otherVal)
+	})
+}
+
 // Merge combines the two NodeSets and returns a new result.
 func (n NodeSet) Merge(other NodeSet) NodeSet {
 	nSize, otherSize := n.Size(), other.Size()


### PR DESCRIPTION
This was missed from #3138.  It's a bug as-is - `Merge()` can return the rhs which is not safe to do further 'unsafe' operations on.

Benchmarks show the impact is mixed:
```
benchmark                         old ns/op     new ns/op     delta
BenchmarkRenderList-2             553973514     505759984     -8.70%
BenchmarkRenderHosts-2            345194045     366304720     +6.12%
BenchmarkRenderControllers-2      314828412     309772476     -1.61%
BenchmarkRenderPods-2             283650521     313774503     +10.62%
BenchmarkRenderContainers-2       187017594     194096252     +3.79%
BenchmarkRenderProcesses-2        121727679     111295296     -8.57%
BenchmarkRenderProcessNames-2     127764403     121302933     -5.06%

benchmark                         old allocs     new allocs     delta
BenchmarkRenderList-2             684645         621168         -9.27%
BenchmarkRenderHosts-2            486703         497536         +2.23%
BenchmarkRenderControllers-2      376311         358656         -4.69%
BenchmarkRenderPods-2             325505         334824         +2.86%
BenchmarkRenderContainers-2       221536         221534         -0.00%
BenchmarkRenderProcesses-2        104514         104513         -0.00%
BenchmarkRenderProcessNames-2     142520         130292         -8.58%

benchmark                         old bytes     new bytes     delta
BenchmarkRenderList-2             76111276      69272488      -8.99%
BenchmarkRenderHosts-2            50265090      51547970      +2.55%
BenchmarkRenderControllers-2      39539499      37658241      -4.76%
BenchmarkRenderPods-2             33302721      34403579      +3.31%
BenchmarkRenderContainers-2       23492377      23494531      +0.01%
BenchmarkRenderProcesses-2        11504046      11503747      -0.00%
BenchmarkRenderProcessNames-2     14845492      13599020      -8.40%
```

Also comment the `add()` call introduced in #3135 is inconsistent with #3138 - no impact as the two sets of calls are never used together, but it's not ideal.  Changing `add()` to copy children makes performance worse.