### PR TITLE
Put critbitgo library back to master branch

### DIFF
--- a/vendor/manifest
+++ b/vendor/manifest
@@ -849,10 +849,10 @@
 		},
 		{
 			"importpath": "github.com/k-sone/critbitgo",
-			"repository": "https://github.com/weaveworks/critbitgo",
+			"repository": "https://github.com/k-sone/critbitgo",
 			"vcs": "git",
-			"revision": "aa814e9447366a571819e37affacbdc60e3af218",
-			"branch": "contained",
+			"revision": "658116ef1e826b72c603cfe2091b12503f9bca43",
+			"branch": "master",
 			"notests": true
 		},
 		{


### PR DESCRIPTION
Undo the local override introduced in 04ceb0cc87443b63548d6d9bbb58341ca1efc2c5
because https://github.com/k-sone/critbitgo/pull/7 has been merged.