### PR TITLE
 Use the default value for a TopologyOption if omitted

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -314,7 +314,7 @@ func (a byName) Less(i, j int) bool { return a[i].Name < a[j].Name }
 // APITopologyOptionGroup describes a group of APITopologyOptions
 type APITopologyOptionGroup struct {
 	ID string `json:"id"`
-	// Default value for the UI to adopt. NOT used as the default if the value is omitted, allowing "" as a distinct value.
+	// Default value for the option. Used if the value is omitted; not used if the value is ""
 	Default string              `json:"defaultValue"`
 	Options []APITopologyOption `json:"options,omitempty"`
 	// SelectType describes how options can be picked. Currently defined values:
@@ -518,7 +518,10 @@ func (r *Registry) RendererForTopology(topologyID string, values url.Values, rpt
 
 	var filters []render.FilterFunc
 	for _, group := range topology.Options {
-		value := values.Get(group.ID)
+		value := group.Default
+		if vs := values[group.ID]; len(vs) > 0 {
+			value = vs[0]
+		}
 		if filter := group.filter(value); filter != nil {
 			filters = append(filters, filter)
 		}

--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -328,18 +328,14 @@ type APITopologyOptionGroup struct {
 
 // Get the render filters to use for this option group, if any, or nil otherwise.
 func (g APITopologyOptionGroup) filter(value string) render.FilterFunc {
-	selectType := g.SelectType
-	if selectType == "" {
-		selectType = "one"
-	}
 	var values []string
-	switch selectType {
-	case "one":
+	switch g.SelectType {
+	case "", "one":
 		values = []string{value}
 	case "union":
 		values = strings.Split(value, ",")
 	default:
-		log.Errorf("Invalid select type %s for option group %s, ignoring option", selectType, g.ID)
+		log.Errorf("Invalid select type %s for option group %s, ignoring option", g.SelectType, g.ID)
 		return nil
 	}
 	filters := []render.FilterFunc{}


### PR DESCRIPTION
Without this, we see unmanaged, uncontained or not-running containers in the graph until the front-end requests them to go away.

There was a shouty comment saying not to use the default, but I can't see any reason to take that stance. There is only one place where `""` is a valid value, which is namespaces, and it is also the default there.

To be safe, I changed the code to distinguish a lack of value from `""` so you can have both.