### PR TITLE
Add org.opencontainers.image.* labels to Dockerfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ SCOPE_UI_BUILD_UPTODATE=.scope_ui_build.uptodate
 SCOPE_BACKEND_BUILD_IMAGE=$(DOCKERHUB_USER)/scope-backend-build
 SCOPE_BACKEND_BUILD_UPTODATE=.scope_backend_build.uptodate
 SCOPE_VERSION=$(shell git rev-parse --short HEAD)
+GIT_REVISION=$(shell git rev-parse HEAD)
 WEAVENET_VERSION=2.1.3
 RUNSVINIT=vendor/runsvinit/runsvinit
 CODECGEN_DIR=vendor/github.com/ugorji/go/codec/codecgen
@@ -56,7 +57,7 @@ docker/%: %
 	cp $* docker/
 
 %.tar: docker/Dockerfile.%
-	$(SUDO) docker build -t $(DOCKERHUB_USER)/$* -f $< docker/
+	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) -t $(DOCKERHUB_USER)/$* -f $< docker/
 	$(SUDO) docker tag $(DOCKERHUB_USER)/$* $(DOCKERHUB_USER)/$*:$(IMAGE_TAG)
 	$(SUDO) docker save $(DOCKERHUB_USER)/$*:latest > $@
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,3 +21,10 @@ RUN go get -tags netgo \
 RUN pip install yapf==0.16.2 flake8==3.3.0
 COPY build.sh /
 ENTRYPOINT ["/build.sh"]
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="backend" \
+      org.opencontainers.image.source="https://github.com/weaveworks/scope/tree/master/backend" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -4,3 +4,10 @@ COPY package.json yarn.lock /home/weave/
 ENV NPM_CONFIG_LOGLEVEL=warn NPM_CONFIG_PROGRESS=false
 RUN yarn --pure-lockfile
 COPY webpack.local.config.js webpack.production.config.js server.js .babelrc .eslintrc .eslintignore .stylelintrc .sass-lint.yml /home/weave/
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="client" \
+      org.opencontainers.image.source="https://github.com/weaveworks/scope" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/docker/Dockerfile.cloud-agent
+++ b/docker/Dockerfile.cloud-agent
@@ -1,9 +1,15 @@
 FROM alpine:3.5
-LABEL maintainer="Weaveworks Inc <help@weave.works>"
-LABEL works.weave.role=system
 WORKDIR /home/weave
 RUN apk add --update bash conntrack-tools iproute2 util-linux curl && \
 	rm -rf /var/cache/apk/*
 ADD ./weave ./weaveutil /usr/bin/
 COPY ./scope /home/weave/
 ENTRYPOINT ["/home/weave/scope", "--mode=probe", "--no-app", "--probe.docker=true"]
+
+ARG revision
+LABEL works.weave.role="system" \
+      maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="cloud-agent" \
+      org.opencontainers.image.source="https://github.com/weaveworks/scope" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/docker/Dockerfile.scope
+++ b/docker/Dockerfile.scope
@@ -7,3 +7,10 @@ COPY ./run-app /etc/service/app/run
 COPY ./run-probe /etc/service/probe/run
 EXPOSE 4040
 ENTRYPOINT ["/home/weave/entrypoint.sh"]
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="scope" \
+      org.opencontainers.image.source="https://github.com/weaveworks/scope" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/extras/dialer/Dockerfile
+++ b/extras/dialer/Dockerfile
@@ -1,2 +1,9 @@
 FROM golang:1.7
 ADD ./bin/dialer /go/bin
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="dialer" \
+      org.opencontainers.image.source="https://github.com/weaveworks/scope/tree/master/extras/dialer" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/extras/example/Makefile
+++ b/extras/example/Makefile
@@ -1,6 +1,7 @@
 CC=gcc
 CFLAGS=-g -lpthread
 BUILD_IN_CONTAINER=true
+GIT_REVISION := $(shell git rev-parse HEAD)
 
 all: .qotd.marker .app.marker .client.marker .searchapp.marker .shout.marker .frontend.marker .frontend-k8s.marker .echo.marker .trace_app.marker
 
@@ -33,7 +34,7 @@ endif
 .echo.marker: echo/*
 .trace_app.marker: trace_app/*
 .%.marker:
-	docker build -t tomwilkie/$(<D) $(<D)/
+	docker build --build-arg=revision=$(GIT_REVISION) -t tomwilkie/$(<D) $(<D)/
 	touch $@
 
 clean:

--- a/extras/example/app/Dockerfile
+++ b/extras/example/app/Dockerfile
@@ -1,8 +1,14 @@
 FROM tatsushid/tinycore-python:2.7
-LABEL maintainer="Weaveworks Inc <help@weave.works>"
 WORKDIR /home/weave
 ADD requirements.txt /home/weave/
 RUN pip install -r /home/weave/requirements.txt
 ADD app.py /home/weave/
 EXPOSE 5000
 ENTRYPOINT ["python", "/home/weave/app.py"]
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="example-app" \
+      org.opencontainers.image.source="https://github.com/weaveworks/scope/tree/master/extras/example/app" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/extras/example/client/Dockerfile
+++ b/extras/example/client/Dockerfile
@@ -1,7 +1,13 @@
 FROM tatsushid/tinycore-python:2.7
-LABEL maintainer="Weaveworks Inc <help@weave.works>"
 WORKDIR /home/weave
 ADD requirements.txt /home/weave/
 RUN pip install -r /home/weave/requirements.txt
 ADD client.py /home/weave/
 ENTRYPOINT ["python", "/home/weave/client.py"]
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="example-client" \
+      org.opencontainers.image.source="https://github.com/weaveworks/scope/tree/master/extras/example/client" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/extras/example/echo/Dockerfile
+++ b/extras/example/echo/Dockerfile
@@ -1,8 +1,14 @@
 FROM tatsushid/tinycore-python:2.7
-LABEL maintainer="Weaveworks Inc <help@weave.works>"
 WORKDIR /home/weave
 ADD requirements.txt /home/weave/
 RUN pip install -r /home/weave/requirements.txt
 ADD echo.py /home/weave/
 EXPOSE 5000
 ENTRYPOINT ["python", "/home/weave/echo.py"]
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="example-echo" \
+      org.opencontainers.image.source="https://github.com/weaveworks/scope/tree/master/extras/example/echo" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/extras/example/frontend-k8s/Dockerfile
+++ b/extras/example/frontend-k8s/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu
-LABEL maintainer="Weaveworks Inc <help@weave.works>"
 RUN apt-get update && \
   apt-get install -y nginx && \
   rm -rf /var/lib/apt/lists/*
@@ -9,3 +8,10 @@ RUN rm /etc/nginx/sites-available/default && \
 COPY default.conf /etc/nginx/conf.d/
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="example-frontend-k8s" \
+      org.opencontainers.image.source="https://github.com/weaveworks/scope/tree/master/extras/example/frontend-k8s" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/extras/example/frontend/Dockerfile
+++ b/extras/example/frontend/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu
-LABEL maintainer="Weaveworks Inc <help@weave.works>"
 RUN apt-get update && \
   apt-get install -y nginx && \
   rm -rf /var/lib/apt/lists/*
@@ -9,3 +8,10 @@ RUN rm /etc/nginx/sites-available/default && \
 COPY default.conf /etc/nginx/conf.d/
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="example-frontend" \
+      org.opencontainers.image.source="https://github.com/weaveworks/scope/tree/master/extras/example/frontend" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/extras/example/qotd/Dockerfile
+++ b/extras/example/qotd/Dockerfile
@@ -1,6 +1,12 @@
 FROM ubuntu
-LABEL maintainer="Weaveworks Inc <help@weave.works>"
 WORKDIR /home/weave
 ADD ./qotd /home/weave/
 EXPOSE 4446
 ENTRYPOINT ["/home/weave/qotd"]
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="example-qotd" \
+      org.opencontainers.image.source="https://github.com/weaveworks/scope/tree/master/extras/example/qotd" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/extras/example/searchapp/Dockerfile
+++ b/extras/example/searchapp/Dockerfile
@@ -1,6 +1,12 @@
 FROM progrium/busybox
-LABEL maintainer="Weaveworks Inc <help@weave.works>"
 WORKDIR /home/weave
 ADD searchapp /home/weave/
 EXPOSE 8080
 ENTRYPOINT ["/home/weave/searchapp"]
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="example-searchapp" \
+      org.opencontainers.image.source="https://github.com/weaveworks/scope/tree/master/extras/example/searchapp" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/extras/example/shout/Dockerfile
+++ b/extras/example/shout/Dockerfile
@@ -1,6 +1,12 @@
 FROM alpine:latest
-LABEL maintainer="Weaveworks Inc <help@weave.works>"
 WORKDIR /home/weave
 ADD shout /home/weave/
 EXPOSE 8090
 ENTRYPOINT ["/home/weave/shout"]
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="example-shout" \
+      org.opencontainers.image.source="https://github.com/weaveworks/scope/tree/master/extras/example/shout" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/extras/example/trace_app/Dockerfile
+++ b/extras/example/trace_app/Dockerfile
@@ -1,8 +1,14 @@
 FROM tatsushid/tinycore-python:2.7
-LABEL maintainer="Weaveworks Inc <help@weave.works>"
 WORKDIR /home/weave
 ADD requirements.txt /home/weave/
 RUN pip install -r /home/weave/requirements.txt
 ADD app.py /home/weave/
 EXPOSE 5000
 ENTRYPOINT ["python", "/home/weave/app.py"]
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="example-trace_app" \
+      org.opencontainers.image.source="https://github.com/weaveworks/scope/tree/master/extras/example/trace_app" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"


### PR DESCRIPTION
Why? What?

- This should ultimately help for image-to-code back references.
- `org.label-schema.*` labels are now deprecated, in favour of `org.opencontainers.image.*` labels.
  See also: https://github.com/opencontainers/image-spec/blob/master/annotations.md#back-compatibility-with-label-schema
- Git revision (`git rev-parse HEAD`) is now injected at `docker build` time.

Testing

```console
$ docker inspect weaveworks/scope
[
    {
        [...]
        "ContainerConfig": {
            [...]
            "Labels": {
                "maintainer": "Weaveworks <help@weave.works>",
                "org.opencontainers.image.revision": "4e58b8302416437f3af8a938ee823b6297bcd50b",
                "org.opencontainers.image.source": "https://github.com/weaveworks/scope",
                "org.opencontainers.image.title": "scope",
                "org.opencontainers.image.vendor": "Weaveworks",
                "works.weave.role": "system"
            }
[...]
```