### PR TITLE
Change URL resolution to accomodate Weave Cloud paths

### DIFF
--- a/client/app/scripts/utils/__tests__/web-api-utils-test.js
+++ b/client/app/scripts/utils/__tests__/web-api-utils-test.js
@@ -57,7 +57,8 @@ describe('WebApiUtils', () => {
     });
     it('returns the correct url when running as a component', () => {
       process.env.SCOPE_API_PREFIX = '/api';
-      expect(getApiPath('/app/proud-cloud-77')).toEqual('/api/app/proud-cloud-77');
+      // instance ID first to match Weave Cloud routes
+      expect(getApiPath('/proud-cloud-77/app')).toEqual('/api/app/proud-cloud-77');
     });
     it('returns the correct url from an arbitrary path', () => {
       expect(getApiPath('/demo/')).toEqual('/demo');
@@ -83,7 +84,7 @@ describe('WebApiUtils', () => {
     });
     it('returns the correct url when running as a component', () => {
       process.env.SCOPE_API_PREFIX = '/api';
-      expect(getWebsocketUrl(host, '/app/proud-cloud-77')).toEqual(`ws://${host}/api/app/proud-cloud-77`);
+      expect(getWebsocketUrl(host, '/proud-cloud-77/app')).toEqual(`ws://${host}/api/app/proud-cloud-77`);
     });
     it('returns the correct url from an arbitrary path', () => {
       expect(getWebsocketUrl(host, '/demo/')).toEqual(`ws://${host}/demo`);

--- a/client/app/scripts/utils/web-api-utils.js
+++ b/client/app/scripts/utils/web-api-utils.js
@@ -48,7 +48,6 @@ let createWebsocketAt = null;
 let firstMessageOnWebsocketAt = null;
 let continuePolling = true;
 
-
 export function buildUrlQuery(params = makeMap(), state) {
   // Attach the time travel timestamp to every request to the backend.
   params = params.set('timestamp', state.get('pausedAt'));
@@ -90,7 +89,9 @@ export function basePathSlash(urlPath) {
 
 export function getApiPath(pathname = window.location.pathname) {
   if (process.env.SCOPE_API_PREFIX) {
-    return basePath(`${process.env.SCOPE_API_PREFIX}${pathname}`);
+    // Flip the current namespaces and instanceName args to match Weave Cloud routes.
+    const [, instanceName, namespace] = pathname.split('/');
+    return basePath(`${process.env.SCOPE_API_PREFIX}/${namespace}/${instanceName}`);
   }
 
   return basePath(pathname);
@@ -104,7 +105,7 @@ function topologiesUrl(state) {
 
 export function getWebsocketUrl(host = window.location.host, pathname = window.location.pathname) {
   const wsProto = window.location.protocol === 'https:' ? 'wss' : 'ws';
-  return `${wsProto}://${host}${process.env.SCOPE_API_PREFIX || ''}${basePath(pathname)}`;
+  return `${wsProto}://${host}${getApiPath(pathname)}`;
 }
 
 function buildWebsocketUrl(topologyUrl, topologyOptions = makeMap(), state) {


### PR DESCRIPTION
Part of https://github.com/weaveworks/service-ui/issues/2391

Makes Weave Cloud Explore work with the new URL schema defined in https://github.com/weaveworks/service-ui/issues/2391.

I will wait to merge this until the other repo is ready for these changes.