### PR TITLE
ebpf: update check for known faulty Ubuntu kernels

### DIFF
--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -106,8 +106,7 @@ func isKernelSupported() error {
 			// not "119-ish", so allow it.
 			return nil
 		}
-		// TODO: give the check an upper limit once the bug is fixed
-		if major == 4 && minor == 4 && abiNumber >= 119 {
+		if major == 4 && minor == 4 && abiNumber >= 119 && abiNumber < 127 {
 			// https://github.com/weaveworks/scope/issues/3131
 			// https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1763454
 			return fmt.Errorf("got Ubuntu kernel %s with known bug", release)

--- a/probe/endpoint/ebpf_test.go
+++ b/probe/endpoint/ebpf_test.go
@@ -274,6 +274,11 @@ func TestIsKernelSupported(t *testing.T) {
 			false,
 		},
 		{
+			"4.4.0-127-generic",
+			"#153-Ubuntu SMP Sat May 19 10:58:46 UTC 2018",
+			true,
+		},
+		{
 			"4.4.0-116-generic",
 			"#140-Ubuntu SMP Mon Feb 12 21:23:04 UTC 2018",
 			true,


### PR DESCRIPTION
With c75700fe04251b6d93240fb36ec423ed22b5d59d we added code to detect
Ubuntu Xenial kernels with a regression in the eBPF subsystem in order
to gently fallback to procfs scanning on such systems (and not crash the
host system by running eBPF code).

With the latest kernel update for Ubuntu Xenial, the bug was fixed:

https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1763454

Therefore we can update the added check with an upper limit and make
sure that eBPF connection tracking only is disabled on kernels within
the range having the bug.

xref: https://github.com/weaveworks/scope/issues/3131