### PR TITLE
Fixes sending the default topologyOptions to the /api

### DIFF
--- a/client/app/scripts/reducers/root.js
+++ b/client/app/scripts/reducers/root.js
@@ -688,7 +688,8 @@ export function rootReducer(state = initialState, action) {
         pinnedMetricType: action.state.pinnedMetricType,
       });
       if (action.state.topologyOptions) {
-        state = state.set('topologyOptions', fromJS(action.state.topologyOptions));
+        const options = getDefaultTopologyOptions(state).mergeDeep(action.state.topologyOptions);
+        state = state.set('topologyOptions', options);
       }
       if (action.state.topologyViewMode) {
         state = state.set('topologyViewMode', action.state.topologyViewMode);


### PR DESCRIPTION
- Which fails sometimes as we overwrite them whatever we find in the
  url state. Url state is not complete anymore so this doesn't work

Test with:
```
cd $WEAVE/scope/client
mkdir tmp
yarn bundle
cd $WEAVE/service-ui/client
yarn add $WEAVE/scope/client/tmp/weave-scope.tgz
SERVICE_HOST=frontend.dev.weave.works yarn start
```