### PR TITLE
change slack channel to '#scope', change wording a little bit, point to mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add custom details or interactions for your hosts, containers and/or processes b
 
 ## <a name="getting-started"></a>Getting started
 
-```
+```console
 sudo curl -L git.io/scope -o /usr/local/bin/scope
 sudo chmod a+x /usr/local/bin/scope
 scope launch
@@ -51,11 +51,11 @@ For instructions on installing Scope on [Kubernetes](https://www.weave.works/doc
 If you have any questions about, feedback for or problems with Scope:
 
 - Read [the Weave Scope docs](https://www.weave.works/docs/scope/latest/introducing/).
-- Invite yourself to the <a href="https://weaveworks.github.io/community-slack/" target="_blank"> #weave-community </a> slack channel.
-- Ask a question on the <a href="https://weave-community.slack.com/messages/general/"> #weave-community</a> slack channel.
-- Join the <a href="https://www.meetup.com/pro/Weave/"> Weave User Group </a> and get invited to online talks, hands-on training and meetups in your area.
-- Send an email to <a href="mailto:weave-users@weave.works">weave-users@weave.works</a>
-- <a href="https://github.com/weaveworks/scope/issues/new">File an issue.</a>
+- Invite yourself to the <a href="https://weaveworks.github.io/community-slack/" target="_blank">Weave community</a> slack.
+- Ask a question on the [#scope](https://weave-community.slack.com/messages/scope/) slack channel.
+- Join the [Weave User Group](https://www.meetup.com/pro/Weave/) and get invited to online talks, hands-on training and meetups in your area.
+- Send an email to [Scope community group](https://groups.google.com/forum/#!forum/scope-community).
+- Join (and read up on) the regular [Scope community meetings](https://docs.google.com/document/d/103_60TuEkfkhz_h2krrPJH8QOx-vRnPpbcCZqrddE1s/edit).
+- [File an issue](https://github.com/weaveworks/scope/issues/new).
 
 Your feedback is always welcome!
-


### PR DESCRIPTION
Changing the slack channel to `#scope`.

I'm pointing to the scope Google group as well. I saw that there's only one message on it. Is it new? Should it be announced somewhere else, so people know where to look?