### PR TITLE
Don't return blank addresses for pods

### DIFF
--- a/render/pod.go
+++ b/render/pod.go
@@ -116,7 +116,7 @@ func MapPod2IP(m report.Node) []string {
 	}
 
 	ip, ok := m.Latest.Lookup(kubernetes.IP)
-	if !ok {
+	if !ok || ip == "" {
 		return nil
 	}
 	return []string{report.MakeScopedEndpointNodeID("", ip, "")}


### PR DESCRIPTION
A small performance improvement - instead of creating an entry in a map which doesn't match anything, just skip a pod with a blank IP.

This was sitting as part of #3089 which we're not going to merge.

