### PR TITLE
Render: add ContainerName into output node when rendering processes

### DIFF
--- a/render/process.go
+++ b/render/process.go
@@ -44,7 +44,7 @@ func (r processWithContainerNameRenderer) Render(rpt report.Report) Nodes {
 		if !ok {
 			continue
 		}
-		propagateLatest(docker.ContainerName, container, p)
+		p = propagateLatest(docker.ContainerName, container, p)
 		outputs[id] = p
 	}
 	return Nodes{Nodes: outputs, Filtered: processes.Filtered}


### PR DESCRIPTION
This was a bug - we spend eight lines fetching the name, then didn't assign the new node into the variable.

Extracted from #3137 
