### PR TITLE
Probe: remove backwards-compatibility code when publishing reports

### DIFF
--- a/probe/probe.go
+++ b/probe/probe.go
@@ -200,7 +200,7 @@ ForLoop:
 		}
 	}
 
-	if err := p.publisher.Publish(rpt.BackwardCompatible()); err != nil {
+	if err := p.publisher.Publish(rpt); err != nil {
 		log.Infof("publish: %v", err)
 	}
 }

--- a/report/report.go
+++ b/report/report.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/weaveworks/common/mtime"
 	"github.com/weaveworks/scope/common/xfer"
 )
 
@@ -501,34 +500,6 @@ func (r Report) upgradeDNSRecords() Report {
 	}
 	r.DNS = dns
 	return r
-}
-
-// BackwardCompatible returns a new backward-compatible report.
-//
-// This for now creates node's Controls from LatestControls.
-func (r Report) BackwardCompatible() Report {
-	now := mtime.Now()
-	cp := r.Copy()
-	cp.WalkTopologies(func(topology *Topology) {
-		n := Nodes{}
-		for name, node := range topology.Nodes {
-			var controls []string
-			node.LatestControls.ForEach(func(k string, _ time.Time, v NodeControlData) {
-				if !v.Dead {
-					controls = append(controls, k)
-				}
-			})
-			if len(controls) > 0 {
-				node.Controls = NodeControls{
-					Timestamp: now,
-					Controls:  MakeStringSet(controls...),
-				}
-			}
-			n[name] = node
-		}
-		topology.Nodes = n
-	})
-	return cp
 }
 
 // Sampling describes how the packet data sources for this report were

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -72,29 +72,6 @@ func TestNode(t *testing.T) {
 	}
 }
 
-func TestReportBackwardCompatibility(t *testing.T) {
-	mtime.NowForce(time.Now())
-	defer mtime.NowReset()
-	rpt := report.MakeReport()
-	controls := map[string]report.NodeControlData{
-		"dead": {
-			Dead: true,
-		},
-		"alive": {
-			Dead: false,
-		},
-	}
-	node := report.MakeNode("foo").WithLatestControls(controls)
-	expectedNode := node.WithControls("alive")
-	rpt.Pod.AddNode(node)
-	expected := report.MakeReport()
-	expected.Pod.AddNode(expectedNode)
-	got := rpt.BackwardCompatible()
-	if !s_reflect.DeepEqual(expected, got) {
-		t.Error(test.Diff(expected, got))
-	}
-}
-
 func TestReportUpgrade(t *testing.T) {
 	mtime.NowForce(time.Now())
 	defer mtime.NowReset()


### PR DESCRIPTION
Removed to reduce CPU and memory usage in probes.

This code was added [in August 2016](https://github.com/weaveworks/scope/pull/1682) so that newer probes could be used with older apps. Since then we have adopted the stance that new apps will accept reports from old probes but not vice-versa, on a version change.