### PR TITLE
Probe: fix message to name the correct flag

### DIFF
--- a/prog/probe.go
+++ b/prog/probe.go
@@ -100,7 +100,7 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 	defer log.Info("probe exiting")
 
 	if flags.spyProcs && os.Getegid() != 0 {
-		log.Warn("--probe.process=true, but that requires root to find everything")
+		log.Warn("--probe.proc.spy=true, but that requires root to find everything")
 	}
 
 	rand.Seed(time.Now().UnixNano())


### PR DESCRIPTION
Fixes the incorrect log message reported at #3151 