### PR TITLE
Separate API endpoint namespace from URL path part

### DIFF
--- a/client/app/scripts/utils/web-api-utils.js
+++ b/client/app/scripts/utils/web-api-utils.js
@@ -87,11 +87,13 @@ export function basePathSlash(urlPath) {
   return `${basePath(urlPath)}/`;
 }
 
+// TODO: This helper should probably be passed by the 'user' of Scope,
+// i.e. in this case Weave Cloud, rather than being hardcoded here.
 export function getApiPath(pathname = window.location.pathname) {
   if (process.env.SCOPE_API_PREFIX) {
-    // Flip the current namespaces and instanceName args to match Weave Cloud routes.
-    const [, instanceName, namespace] = pathname.split('/');
-    return basePath(`${process.env.SCOPE_API_PREFIX}/${namespace}/${instanceName}`);
+    // Extract the instance name (pathname in WC context is of format '/:orgId/explore').
+    const orgId = pathname.split('/')[1];
+    return basePath(`${process.env.SCOPE_API_PREFIX}/app/${orgId}`);
   }
 
   return basePath(pathname);


### PR DESCRIPTION
Prerequisite for https://github.com/weaveworks/service-ui/issues/1457.

**Note:** These changes only affect Scope in Weave Cloud (nothing about the standalone should have changed).
