### PR TITLE
Show deployments in Time Travel

### DIFF
--- a/client/app/scripts/actions/app-actions.js
+++ b/client/app/scripts/actions/app-actions.js
@@ -870,6 +870,12 @@ export function getImagesForService(orgId, serviceId) {
   };
 }
 
+export function getFluxHistory(...params) {
+  return (dispatch, getState, { actions }) => (
+    dispatch(actions.getFluxHistory(...params))
+  );
+}
+
 export function setMonitorState(monitor) {
   return {
     type: ActionTypes.MONITOR_STATE,

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -212,6 +212,11 @@ a {
   pointer-events: none;
   width: 100%;
 
+  .time-travel-wrapper {
+    position: relative;
+    z-index: $layer-front;
+  }
+
   .selectors {
     display: flex;
     position: relative;

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -208,25 +208,19 @@ a {
 }
 
 .header {
+  z-index: $layer-front;
   padding: 15px 10px 0;
   pointer-events: none;
+  position: relative;
   width: 100%;
-
-  .time-travel-wrapper {
-    position: relative;
-    z-index: $layer-front;
-  }
 
   .selectors {
     display: flex;
     position: relative;
 
     > * {
-      z-index: $layer-front;
       flex: 1 1;
     }
-
-    .time-control { z-index: $layer-modal; }
 
     .logo {
       margin: -16px 0 0 8px;

--- a/client/package.json
+++ b/client/package.json
@@ -44,7 +44,7 @@
     "reselect": "3.0.1",
     "reselect-map": "1.0.3",
     "styled-components": "2.2.4",
-    "weaveworks-ui-components": "0.4.82",
+    "weaveworks-ui-components": "0.4.95",
     "whatwg-fetch": "2.0.3",
     "xterm": "3.3.0"
   },

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8345,9 +8345,9 @@ wd@^0.4.0:
     underscore.string "~3.0.3"
     vargs "~0.1.0"
 
-weaveworks-ui-components@0.4.82:
-  version "0.4.82"
-  resolved "https://registry.yarnpkg.com/weaveworks-ui-components/-/weaveworks-ui-components-0.4.82.tgz#c09cd529f59d553e2a3d426413e4f59f7e23d6d2"
+weaveworks-ui-components@0.4.95:
+  version "0.4.95"
+  resolved "https://registry.yarnpkg.com/weaveworks-ui-components/-/weaveworks-ui-components-0.4.95.tgz#6f80f8e00e4fcef06033cadc377588bc3ed443fa"
   dependencies:
     classnames "2.2.5"
     d3-drag "1.2.1"


### PR DESCRIPTION
Resolves https://github.com/weaveworks/service-ui/issues/2614 (affects only Scope in Weave Cloud).

Reuses a lot of code from `<TimeTravelWrapper />` in Service UI - @foot and I had a discussion about converging those two, but that's a separate issue.

##### Other changes

* Bump `ui-components` `v0.4.82` -> `v0.4.95`
* Use `z-index: $layer-front` on the whole header
