### PR TITLE
[Power Support] Enable weaveworks scope on Power.

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,14 +1,30 @@
-FROM golang:1.10.2-stretch
+FROM golang:1.10.2
 ENV SCOPE_SKIP_UI_ASSETS true
-RUN apt-get update && \
-	apt-get install -y libpcap-dev time file shellcheck git gcc-arm-linux-gnueabihf curl build-essential python-pip && \
-	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN set -eux; \
+   export arch_val="$(dpkg --print-architecture)"; \
+   apt-get update && \
+   if [ "$arch_val" = "amd64" ]; then \
+     apt-get install -y libpcap-dev python-requests time file shellcheck git gcc-arm-linux-gnueabihf curl build-essential python-pip; \
+   else \
+     apt-get install -y libpcap-dev python-requests time file shellcheck git curl build-essential python-pip; \
+   fi; \
+   \
+   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 RUN go clean -i net && \
 	go install -tags netgo std && \
-	go install -race -tags netgo std
-RUN curl -fsSL -o shfmt https://github.com/mvdan/sh/releases/download/v1.3.0/shfmt_v1.3.0_linux_amd64 && \
-    chmod +x shfmt && \
-    mv shfmt /usr/bin
+   export arch_val="$(dpkg --print-architecture)"; \
+   if [ "$arch_val" != "ppc64el" ]; then \
+	go install -race -tags netgo std; \
+   fi;
+RUN export arch_val="$(dpkg --print-architecture)"; \
+   if [ "$arch_val" = "amd64" ]; then \
+     curl -fsSL -o shfmt https://github.com/mvdan/sh/releases/download/v1.3.0/shfmt_v1.3.0_linux_amd64 && \
+     chmod +x shfmt && \
+     mv shfmt /usr/bin; \
+   fi;
+   # Skipped installing shfmt, as the version v1.3.0 isn't supported for ppc64le
+   # and the later version of shfmt doesn't work with the application well
 RUN go get -tags netgo \
 		github.com/fzipp/gocyclo \
 		github.com/golang/lint/golint \

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.4.0
+FROM node:8.11
 WORKDIR /home/weave
 COPY package.json yarn.lock /home/weave/
 ENV NPM_CONFIG_LOGLEVEL=warn NPM_CONFIG_PROGRESS=false

--- a/docker/Dockerfile.cloud-agent
+++ b/docker/Dockerfile.cloud-agent
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.7
 WORKDIR /home/weave
 RUN apk add --update bash conntrack-tools iproute2 util-linux curl && \
 	rm -rf /var/cache/apk/*

--- a/probe/endpoint/dns_snooper.go
+++ b/probe/endpoint/dns_snooper.go
@@ -1,3 +1,7 @@
+// +build linux,amd64 linux,ppc64le
+
+// Build constraint to use this file for amd64 & ppc64le on Linux
+
 package endpoint
 
 import (

--- a/probe/process/walker_linux_test.go
+++ b/probe/process/walker_linux_test.go
@@ -1,6 +1,7 @@
 package process_test
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -79,9 +80,11 @@ var mockFS = fs.Dir("",
 func TestWalker(t *testing.T) {
 	fs_hook.Mock(mockFS)
 	defer fs_hook.Restore()
+	var pageSize uint64
+	pageSize = (uint64)(os.Getpagesize() * 2)
 
 	want := map[int]process.Process{
-		3: {PID: 3, PPID: 2, Name: "curl", Cmdline: "curl google.com", Threads: 1, RSSBytes: 8192, RSSBytesLimit: 2048, OpenFilesCount: 3, OpenFilesLimit: 32768},
+		3: {PID: 3, PPID: 2, Name: "curl", Cmdline: "curl google.com", Threads: 1, RSSBytes: pageSize, RSSBytesLimit: 2048, OpenFilesCount: 3, OpenFilesLimit: 32768},
 		2: {PID: 2, PPID: 1, Name: "bash", Cmdline: "bash", Threads: 1, OpenFilesCount: 2},
 		4: {PID: 4, PPID: 3, Name: "apache", Cmdline: "apache", Threads: 1, OpenFilesCount: 1},
 		1: {PID: 1, PPID: 0, Name: "init", Cmdline: "init", Threads: 1, OpenFilesCount: 0},


### PR DESCRIPTION

Observed this particular test  was failing on ppc64le architecture. Added the test failure log below, 
  walker_linux_test.go:97:
```                --- want
                +++ have
                @@ -32,7 +32,7 @@
                   Cmdline: (string) (len=15) "curl google.com",
                   Threads: (int) 1,
                   Jiffies: (uint64) 0,
                -  RSSBytes: (uint64) 8192,
                +  RSSBytes: (uint64) 131072,
                   RSSBytesLimit: (uint64) 2048,
                   OpenFilesCount: (int) 3,
                   OpenFilesLimit: (uint64) 32768,
```
Hence modified the value for RSSBytes to accept variable value which is computed based on pageSize instead of hard-coded values, as suggested by Adam Harrison over slack channel. 

I have verified this patch on x86 setup as well and all the tests pass there.  Please provide your comments/suggestions on this. 
Thanks,
Meghali 