### PR TITLE
Stop filterUnconnected() modifying its input

### DIFF
--- a/render/filters.go
+++ b/render/filters.go
@@ -158,10 +158,10 @@ func connected(nodes report.Nodes) map[string]struct{} {
 // and outgoing internet node. These are typically artifacts of
 // imperfect connection tracking, e.g. when VIPs and NAT traversal are
 // in use.
-func filterInternetAdjacencies(nodes report.Nodes) report.Nodes {
+func filterInternetAdjacencies(nodes report.Nodes) {
 	incomingInternet, ok := nodes[IncomingInternetID]
 	if !ok {
-		return nodes
+		return
 	}
 	newAdjacency := report.MakeIDList()
 	for _, dstID := range incomingInternet.Adjacency {
@@ -170,9 +170,7 @@ func filterInternetAdjacencies(nodes report.Nodes) report.Nodes {
 		}
 	}
 	incomingInternet.Adjacency = newAdjacency
-	output := nodes.Copy()
-	output[IncomingInternetID] = incomingInternet
-	return output
+	nodes[IncomingInternetID] = incomingInternet
 }
 
 // ColorConnected colors nodes with the IsConnectedMark key if they
@@ -197,7 +195,8 @@ type filterUnconnected struct {
 
 // Transform implements Transformer
 func (f filterUnconnected) Transform(input Nodes) Nodes {
-	output := filterInternetAdjacencies(input.Nodes)
+	output := input.Nodes.Copy()
+	filterInternetAdjacencies(output)
 	connected := connected(output)
 	filtered := input.Filtered
 	for id, node := range output {


### PR DESCRIPTION
Helper function `filterInternetAdjacencies()` would sometimes copy and sometimes not copy the input, which can lead to concurrent reads and writes as seen in #3219.

Changed to always copy, before calling.

I found this by eyeballing; this is the only case I could see where the input `.Nodes` can be modified.