### PR TITLE
Correct api.getFluxImages usage

### DIFF
--- a/client/app/scripts/actions/app-actions.js
+++ b/client/app/scripts/actions/app-actions.js
@@ -854,7 +854,7 @@ export function getImagesForService(orgId, serviceId) {
     });
 
     // Use the fluxv2 api
-    api.getFluxImages(orgId, serviceId, 2)
+    api.getFluxImages(orgId, serviceId)
       .then((services) => {
         dispatch({
           type: ActionTypes.RECEIVE_SERVICE_IMAGES,


### PR DESCRIPTION
`api.getFluxImages` takes 3 parameters: `getFluxImages(id, serviceId = null, containerFields = [])` with a recent change adding the containerFields parameter.

The 3rd parameter (`2`) passed to `api.getFluxImages` has been incorrect for a while now.

Fixes https://github.com/weaveworks/service-ui/issues/2749