### PR TITLE
Remove ProcessWithContainerNameRenderer, it wasn't working

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -197,7 +197,7 @@ func MakeRegistry() *Registry {
 	registry.Add(
 		APITopologyDesc{
 			id:          processesID,
-			renderer:    render.ProcessWithContainerNameRenderer,
+			renderer:    render.ConnectedProcessRenderer,
 			Name:        "Processes",
 			Rank:        1,
 			Options:     unconnectedFilter,

--- a/render/benchmark_test.go
+++ b/render/benchmark_test.go
@@ -19,8 +19,8 @@ var (
 
 func BenchmarkEndpointRender(b *testing.B) { benchmarkRender(b, render.EndpointRenderer) }
 func BenchmarkProcessRender(b *testing.B)  { benchmarkRender(b, render.ProcessRenderer) }
-func BenchmarkProcessWithContainerNameRender(b *testing.B) {
-	benchmarkRender(b, render.ProcessWithContainerNameRenderer)
+func BenchmarkConnectedProcessRender(b *testing.B) {
+	benchmarkRender(b, render.ConnectedProcessRenderer)
 }
 func BenchmarkProcessNameRender(b *testing.B) { benchmarkRender(b, render.ProcessNameRenderer) }
 func BenchmarkContainerRender(b *testing.B)   { benchmarkRender(b, render.ContainerRenderer) }


### PR DESCRIPTION
Followup from #3212 

`ProcessWithContainerNameRenderer` wasn't working due missing a variable update (see #3212 ) so we decided to simply remove it, since nobody noticed and presumably nobody cares.