### PR TITLE
Optimise Node.WithLatests()

### DIFF
--- a/probe/kubernetes/reporter_test.go
+++ b/probe/kubernetes/reporter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	apiv1 "k8s.io/api/core/v1"
+	apiv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -111,9 +112,10 @@ func newMockClient() *mockClient {
 }
 
 type mockClient struct {
-	pods     []kubernetes.Pod
-	services []kubernetes.Service
-	logs     map[string]io.ReadCloser
+	pods        []kubernetes.Pod
+	services    []kubernetes.Service
+	deployments []kubernetes.Deployment
+	logs        map[string]io.ReadCloser
 }
 
 func (c *mockClient) Stop() {}
@@ -143,6 +145,11 @@ func (c *mockClient) WalkCronJobs(f func(kubernetes.CronJob) error) error {
 	return nil
 }
 func (c *mockClient) WalkDeployments(f func(kubernetes.Deployment) error) error {
+	for _, deployment := range c.deployments {
+		if err := f(deployment); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 func (c *mockClient) WalkNamespaces(f func(kubernetes.NamespaceResource) error) error {
@@ -280,6 +287,39 @@ func TestReporter(t *testing.T) {
 		}
 	}
 
+}
+
+func BenchmarkReporter(b *testing.B) {
+	hr := controls.NewDefaultHandlerRegistry()
+	mockK8s := newMockClient()
+	// Add more dummy data
+	for i := 0; i < 50; i++ {
+		service := apiService1
+		service.ObjectMeta.UID = types.UID(fmt.Sprintf("service%d", i))
+		mockK8s.services = append(mockK8s.services, kubernetes.NewService(&service))
+		pod := apiPod1
+		pod.ObjectMeta.UID = types.UID(fmt.Sprintf("pod%d", i))
+		mockK8s.pods = append(mockK8s.pods, kubernetes.NewPod(&pod))
+		deployment := apiv1beta1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "v1beta1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              fmt.Sprintf("deployment%d", i),
+				UID:               types.UID(fmt.Sprintf("deployment%d", i)),
+				Namespace:         "ping",
+				CreationTimestamp: metav1.Now(),
+			},
+		}
+		mockK8s.deployments = append(mockK8s.deployments, kubernetes.NewDeployment(&deployment))
+	}
+	reporter := kubernetes.NewReporter(mockK8s, nil, "probe-id", "foo", nil, hr, nodeName, 0)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		reporter.Report()
+	}
 }
 
 func TestTagger(t *testing.T) {

--- a/render/container.go
+++ b/render/container.go
@@ -143,11 +143,9 @@ func (r containerWithImageNameRenderer) Render(rpt report.Report) Nodes {
 		imageNameWithoutTag := docker.ImageNameWithoutTag(imageName)
 		imageNodeID := report.MakeContainerImageNodeID(imageNameWithoutTag)
 
-		c = propagateLatest(docker.ImageName, image, c)
-		c = propagateLatest(docker.ImageTag, image, c)
-		c = propagateLatest(docker.ImageSize, image, c)
-		c = propagateLatest(docker.ImageVirtualSize, image, c)
-		c = propagateLatest(docker.ImageLabelPrefix+"works.weave.role", image, c)
+		c.Latest = c.Latest.Propagate(image.Latest, docker.ImageName, docker.ImageTag,
+			docker.ImageSize, docker.ImageVirtualSize, docker.ImageLabelPrefix+"works.weave.role")
+
 		c.Parents = c.Parents.
 			Delete(report.ContainerImage).
 			Add(report.ContainerImage, report.MakeStringSet(imageNodeID))

--- a/render/render.go
+++ b/render/render.go
@@ -115,13 +115,6 @@ func (m Map) Render(rpt report.Report) Nodes {
 	return output.result(input)
 }
 
-func propagateLatest(key string, from, to report.Node) report.Node {
-	if value, timestamp, ok := from.Latest.LookupEntry(key); ok {
-		to.Latest = to.Latest.Set(key, timestamp, value)
-	}
-	return to
-}
-
 // Condition is a predecate over the entire report that can evaluate to true or false.
 type Condition func(report.Report) bool
 

--- a/report/map_helpers.go
+++ b/report/map_helpers.go
@@ -173,3 +173,16 @@ func (m StringLatestMap) addMapEntries(ts time.Time, n map[string]string) String
 	out.fixup()
 	return out
 }
+
+// Propagate a set of latest values from one set to another.
+func (m StringLatestMap) Propagate(from StringLatestMap, keys ...string) StringLatestMap {
+	out := make(StringLatestMap, len(m), len(m)+len(keys))
+	copy(out, m)
+	for _, k := range keys {
+		if v, ts, ok := from.LookupEntry(k); ok {
+			out = append(out, stringLatestEntry{key: k, Value: v, Timestamp: ts})
+		}
+	}
+	out.fixup()
+	return out
+}

--- a/report/map_helpers.go
+++ b/report/map_helpers.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/ugorji/go/codec"
 	"github.com/weaveworks/ps"
@@ -137,4 +138,38 @@ func mapWrite(m ps.Map, encoder *codec.Encoder, encodeValue func(*codec.Encoder,
 		encodeValue(encoder, val)
 	})
 	z.EncSendContainerState(containerMapEnd)
+}
+
+// Now follow helpers for StringLatestMap
+
+// These let us sort a StringLatestMap strings by key
+func (m StringLatestMap) Len() int           { return len(m) }
+func (m StringLatestMap) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
+func (m StringLatestMap) Less(i, j int) bool { return m[i].key < m[j].key }
+
+// sort entries and shuffle down any duplicates
+func (m StringLatestMap) fixup() {
+	sort.Sort(m)
+	for i := 1; i < len(m); {
+		if m[i-1].key == m[i].key {
+			if m[i-1].Timestamp.Before(m[i].Timestamp) {
+				m = append(m[:i-1], m[i:]...)
+			} else {
+				m = append(m[:i], m[i+1:]...)
+			}
+		} else {
+			i++
+		}
+	}
+}
+
+// add several entries at the same timestamp
+func (m StringLatestMap) addMapEntries(ts time.Time, n map[string]string) StringLatestMap {
+	out := make(StringLatestMap, len(m), len(m)+len(n))
+	copy(out, m)
+	for k, v := range n {
+		out = append(out, stringLatestEntry{key: k, Value: v, Timestamp: ts})
+	}
+	out.fixup()
+	return out
 }

--- a/report/node.go
+++ b/report/node.go
@@ -73,9 +73,7 @@ func (n Node) After(other Node) bool {
 // WithLatests returns a fresh copy of n, with Metadata m merged in.
 func (n Node) WithLatests(m map[string]string) Node {
 	ts := mtime.Now()
-	for k, v := range m {
-		n.Latest = n.Latest.Set(k, ts, v)
-	}
+	n.Latest = n.Latest.addMapEntries(ts, m)
 	return n
 }
 


### PR DESCRIPTION
This is a different take on solving the same problem as in #3137.  It's not quite as fast but has lower memory usage, and it doesn't have the same readability issue.

Here we make one memory allocation to resize the array, then add the contents of the map, sort to regain the `LatestMap` invariant, then remove any keys which are now duplicated (in normal usage this doesn't happen, but better to be safe. It does happen in at least one test).

Based on profiling some real probes, I wrote a benchmark to mimic typical operation of this code.

Results before (best of 5):
```
BenchmarkReporter 	     500	   2671920 ns/op	  841966 B/op	    9290 allocs/op
```

After:
```
BenchmarkReporter 	     500	   2364309 ns/op	  472526 B/op	    8479 allocs/op
```

~Note the optimisation to `propagateLatests()` in #3137 is not included in this PR.~