### PR TITLE
Remove old 'Controls' field which was replaced two years ago

### DIFF
--- a/report/marshal_test.go
+++ b/report/marshal_test.go
@@ -44,7 +44,6 @@ func makeTestReport() report.Report {
 	r.Endpoint.AddNode(report.MakeNode(";172.20.1.168;41582").
 		WithTopology("endpoint").
 		WithSet("snooped_dns_names", report.MakeStringSet("ip-172-20-1-168.ec2.internal")).
-		WithControls("docker_remove_container").
 		WithLatestActiveControls("docker_pause_container").
 		WithLatest("addr", t1, "127.0.0.1"),
 	)
@@ -57,7 +56,6 @@ func makeTestReport() report.Report {
 	r.Pod.WithShape("heptagon").WithLabel("pod", "pods").
 		AddNode(report.MakeNode("fceef9592ec3cf1a8e1d178fdd0de41a;<pod>").
 			WithTopology("pod").
-			WithControls("kubernetes_delete_pod").
 			WithLatestControls(map[string]report.NodeControlData{"kubernetes_get_logs": {Dead: true}}).
 			WithLatest("host_node_id", t1, "ip-172-20-1-168;<host>"))
 	r.Overlay.WithMetadataTemplates(report.MetadataTemplates{

--- a/report/node.go
+++ b/report/node.go
@@ -15,7 +15,6 @@ type Node struct {
 	Counters       Counters                 `json:"counters,omitempty"`
 	Sets           Sets                     `json:"sets,omitempty"`
 	Adjacency      IDList                   `json:"adjacency,omitempty"`
-	Controls       NodeControls             `json:"controls,omitempty"`
 	LatestControls NodeControlDataLatestMap `json:"latestControls,omitempty"`
 	Latest         StringLatestMap          `json:"latest,omitempty"`
 	Metrics        Metrics                  `json:"metrics,omitempty" deepequal:"nil==empty"`
@@ -30,7 +29,6 @@ func MakeNode(id string) Node {
 		Counters:       MakeCounters(),
 		Sets:           MakeSets(),
 		Adjacency:      MakeIDList(),
-		Controls:       MakeNodeControls(),
 		LatestControls: MakeNodeControlDataLatestMap(),
 		Latest:         MakeStringLatestMap(),
 		Metrics:        Metrics{},
@@ -120,12 +118,6 @@ func (n Node) WithAdjacent(a ...string) Node {
 	return n
 }
 
-// WithControls returns a fresh copy of n, with cs added to Controls.
-func (n Node) WithControls(cs ...string) Node {
-	n.Controls = n.Controls.Add(cs...)
-	return n
-}
-
 // WithLatestActiveControls returns a fresh copy of n, with active controls cs added to LatestControls.
 func (n Node) WithLatestActiveControls(cs ...string) Node {
 	lcs := map[string]NodeControlData{}
@@ -199,7 +191,6 @@ func (n Node) Merge(other Node) Node {
 		Counters:       n.Counters.Merge(other.Counters),
 		Sets:           n.Sets.Merge(other.Sets),
 		Adjacency:      n.Adjacency.Merge(other.Adjacency),
-		Controls:       n.Controls.Merge(other.Controls),
 		LatestControls: n.LatestControls.Merge(other.LatestControls),
 		Latest:         n.Latest.Merge(other.Latest),
 		Metrics:        n.Metrics.Merge(other.Metrics),

--- a/report/report.go
+++ b/report/report.go
@@ -419,43 +419,8 @@ func (r Report) Validate() error {
 
 // Upgrade returns a new report based on a report received from the old probe.
 //
-// This for now creates node's LatestControls from Controls.
 func (r Report) Upgrade() Report {
-	return r.upgradeLatestControls().upgradePodNodes().upgradeNamespaces().upgradeDNSRecords()
-}
-
-func (r Report) upgradeLatestControls() Report {
-	needUpgrade := false
-	r.WalkTopologies(func(topology *Topology) {
-		for _, node := range topology.Nodes {
-			if node.LatestControls.Size() == 0 && len(node.Controls.Controls) > 0 {
-				needUpgrade = true
-			}
-		}
-	})
-
-	if !needUpgrade {
-		return r
-	}
-
-	cp := r.Copy()
-	ncd := NodeControlData{
-		Dead: false,
-	}
-	cp.WalkTopologies(func(topology *Topology) {
-		n := Nodes{}
-		for name, node := range topology.Nodes {
-			if node.LatestControls.Size() == 0 && len(node.Controls.Controls) > 0 {
-				for _, control := range node.Controls.Controls {
-					node.LatestControls = node.LatestControls.Set(control, node.Controls.Timestamp, ncd)
-				}
-			}
-			n[name] = node
-		}
-		topology.Nodes = n
-	})
-
-	return cp
+	return r.upgradePodNodes().upgradeNamespaces().upgradeDNSRecords()
 }
 
 func (r Report) upgradePodNodes() Report {

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -82,14 +82,8 @@ func TestReportUpgrade(t *testing.T) {
 	namespaceID := report.MakeNamespaceNodeID(namespaceName)
 	podNode := report.MakeNode("foo").
 		WithLatests(map[string]string{report.KubernetesNamespace: namespaceName}).
-		WithControls("alive").
 		WithParents(report.MakeSets().Add(report.ReplicaSet, report.MakeStringSet("bar")))
-	controls := map[string]report.NodeControlData{
-		"alive": {
-			Dead: false,
-		},
-	}
-	expectedPodNode := podNode.PruneParents().WithParents(parentsWithDeployment).WithLatestControls(controls)
+	expectedPodNode := podNode.PruneParents().WithParents(parentsWithDeployment)
 	rpt := report.MakeReport()
 	rpt.ReplicaSet.AddNode(rsNode)
 	rpt.Pod.AddNode(podNode)


### PR DESCRIPTION
This saves memory and CPU time encoding and decoding.

We assume that no probes two years old are still running, and we don't need to reconstruct the data for saved historical reports because controls are not relevant to historical nodes.

Before (best of 5):
```
BenchmarkReportUnmarshal-2   	       1	1115642386 ns/op	180600552 B/op	 2451487 allocs/op
BenchmarkReportMerge-2   	       5	 319579062 ns/op	63458179 B/op	  474721 allocs/op
```

After:
```
BenchmarkReportUnmarshal-2   	       1	1017682911 ns/op	174734200 B/op	 2451483 allocs/op
BenchmarkReportMerge-2   	       5	 284404766 ns/op	61683891 B/op	  474442 allocs/op
```