### PR TITLE
Enable Kubernetes objects to be reported just once in a cluster

### DIFF
--- a/probe/host/tagger.go
+++ b/probe/host/tagger.go
@@ -30,7 +30,8 @@ func (t Tagger) Tag(r report.Report) (report.Report, error) {
 
 	// Explicitly don't tag Endpoints, Addresses and Overlay nodes - These topologies include pseudo nodes,
 	// and as such do their own host tagging.
-	for _, topology := range []report.Topology{r.Process, r.Container, r.ContainerImage, r.Host, r.Pod} {
+	// Don't tag Pods so they can be reported centrally.
+	for _, topology := range []report.Topology{r.Process, r.Container, r.ContainerImage, r.Host} {
 		for _, node := range topology.Nodes {
 			topology.ReplaceNode(node.WithLatests(metadata).WithParent(report.Host, t.hostNodeID))
 		}

--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -238,8 +238,15 @@ func isPauseContainer(n report.Node, rpt report.Report) bool {
 	return false
 }
 
+// Tagger adds pod parents to container nodes.
+type Tagger struct {
+}
+
+// Name of this tagger, for metrics gathering
+func (Tagger) Name() string { return "K8s" }
+
 // Tag adds pod parents to container nodes.
-func (r *Reporter) Tag(rpt report.Report) (report.Report, error) {
+func (r *Tagger) Tag(rpt report.Report) (report.Report, error) {
 	for id, n := range rpt.Container.Nodes {
 		uid, ok := n.Latest.Lookup(docker.LabelPrefix + "io.kubernetes.pod.uid")
 		if !ok {

--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -561,7 +561,7 @@ func (r *Reporter) podTopology(services []Service, deployments []Deployment, dae
 	}
 
 	var localPodUIDs map[string]struct{}
-	if r.nodeName == "" {
+	if r.nodeName == "" && r.kubeletPort != 0 {
 		// We don't know the node name: fall back to obtaining the local pods from kubelet
 		var err error
 		localPodUIDs, err = GetLocalPodUIDs(fmt.Sprintf("127.0.0.1:%d", r.kubeletPort))

--- a/probe/kubernetes/reporter_test.go
+++ b/probe/kubernetes/reporter_test.go
@@ -328,8 +328,7 @@ func TestTagger(t *testing.T) {
 		docker.LabelPrefix + "io.kubernetes.pod.uid": "123456",
 	}))
 
-	hr := controls.NewDefaultHandlerRegistry()
-	rpt, err := kubernetes.NewReporter(newMockClient(), nil, "", "", nil, hr, "", 0).Tag(rpt)
+	rpt, err := (&kubernetes.Tagger{}).Tag(rpt)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/prog/main.go
+++ b/prog/main.go
@@ -330,7 +330,7 @@ func setupFlags(flags *flags) {
 	flag.StringVar(&flags.probe.kubernetesClientConfig.User, "probe.kubernetes.user", "", "The name of the kubeconfig user to use")
 	flag.StringVar(&flags.probe.kubernetesClientConfig.Username, "probe.kubernetes.username", "", "Username for basic authentication to the API server")
 	flag.StringVar(&flags.probe.kubernetesNodeName, "probe.kubernetes.node-name", "", "Name of this node, for filtering pods")
-	flag.UintVar(&flags.probe.kubernetesKubeletPort, "probe.kubernetes.kubelet-port", 10255, "Node-local TCP port for contacting kubelet")
+	flag.UintVar(&flags.probe.kubernetesKubeletPort, "probe.kubernetes.kubelet-port", 10255, "Node-local TCP port for contacting kubelet (zero to disable)")
 
 	// AWS ECS
 	flag.BoolVar(&flags.probe.ecsEnabled, "probe.ecs", false, "Collect ecs-related attributes for containers on this node")

--- a/prog/main.go
+++ b/prog/main.go
@@ -124,6 +124,7 @@ type probeFlags struct {
 	criEndpoint string
 
 	kubernetesEnabled      bool
+	kubernetesTagOnly      bool
 	kubernetesNodeName     string
 	kubernetesClientConfig kubernetes.ClientConfig
 	kubernetesKubeletPort  uint
@@ -314,6 +315,7 @@ func setupFlags(flags *flags) {
 
 	// K8s
 	flag.BoolVar(&flags.probe.kubernetesEnabled, "probe.kubernetes", false, "collect kubernetes-related attributes for containers")
+	flag.BoolVar(&flags.probe.kubernetesTagOnly, "probe.kubernetes-tag", false, "tag containers with kubernetes parents")
 	flag.StringVar(&flags.probe.kubernetesClientConfig.Server, "probe.kubernetes.api", "", "The address and port of the Kubernetes API server (deprecated in favor of equivalent probe.kubernetes.server)")
 	flag.StringVar(&flags.probe.kubernetesClientConfig.CertificateAuthority, "probe.kubernetes.certificate-authority", "", "Path to a cert. file for the certificate authority")
 	flag.StringVar(&flags.probe.kubernetesClientConfig.ClientCertificate, "probe.kubernetes.client-certificate", "", "Path to a client certificate file for TLS")

--- a/prog/main.go
+++ b/prog/main.go
@@ -124,7 +124,7 @@ type probeFlags struct {
 	criEndpoint string
 
 	kubernetesEnabled      bool
-	kubernetesTagOnly      bool
+	kubernetesRole         string
 	kubernetesNodeName     string
 	kubernetesClientConfig kubernetes.ClientConfig
 	kubernetesKubeletPort  uint
@@ -315,7 +315,7 @@ func setupFlags(flags *flags) {
 
 	// K8s
 	flag.BoolVar(&flags.probe.kubernetesEnabled, "probe.kubernetes", false, "collect kubernetes-related attributes for containers")
-	flag.BoolVar(&flags.probe.kubernetesTagOnly, "probe.kubernetes-tag", false, "tag containers with kubernetes parents")
+	flag.StringVar(&flags.probe.kubernetesRole, "probe.kubernetes.role", "", "host, cluster or blank for everything")
 	flag.StringVar(&flags.probe.kubernetesClientConfig.Server, "probe.kubernetes.api", "", "The address and port of the Kubernetes API server (deprecated in favor of equivalent probe.kubernetes.server)")
 	flag.StringVar(&flags.probe.kubernetesClientConfig.CertificateAuthority, "probe.kubernetes.certificate-authority", "", "Path to a cert. file for the certificate authority")
 	flag.StringVar(&flags.probe.kubernetesClientConfig.ClientCertificate, "probe.kubernetes.client-certificate", "", "Path to a client certificate file for TLS")

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -273,7 +273,7 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 			reporter := kubernetes.NewReporter(client, clients, probeID, hostID, p, handlerRegistry, flags.kubernetesNodeName, flags.kubernetesKubeletPort)
 			defer reporter.Stop()
 			p.AddReporter(reporter)
-			p.AddTagger(reporter)
+			p.AddTagger(&kubernetes.Tagger{})
 		} else {
 			log.Errorf("Kubernetes: failed to start client: %v", err)
 			log.Errorf("Kubernetes: make sure to run Scope inside a POD with a service account or provide valid probe.kubernetes.* flags")

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -233,7 +233,7 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 	if flags.dockerEnabled {
 		// Don't add the bridge in Kubernetes since container IPs are global and
 		// shouldn't be scoped
-		if !flags.kubernetesEnabled {
+		if flags.dockerBridge != "" && !flags.kubernetesEnabled {
 			if err := report.AddLocalBridge(flags.dockerBridge); err != nil {
 				log.Errorf("Docker: problem with bridge %s: %v", flags.dockerBridge, err)
 			}

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -273,11 +273,14 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 			reporter := kubernetes.NewReporter(client, clients, probeID, hostID, p, handlerRegistry, flags.kubernetesNodeName, flags.kubernetesKubeletPort)
 			defer reporter.Stop()
 			p.AddReporter(reporter)
-			p.AddTagger(&kubernetes.Tagger{})
 		} else {
 			log.Errorf("Kubernetes: failed to start client: %v", err)
 			log.Errorf("Kubernetes: make sure to run Scope inside a POD with a service account or provide valid probe.kubernetes.* flags")
 		}
+	}
+
+	if flags.kubernetesEnabled || flags.kubernetesTagOnly {
+		p.AddTagger(&kubernetes.Tagger{})
 	}
 
 	if flags.ecsEnabled {

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -41,6 +41,9 @@ import (
 const (
 	versionCheckPeriod = 6 * time.Hour
 	defaultServiceHost = "https://cloud.weave.works.:443"
+
+	kubernetesRoleHost    = "host"
+	kubernetesRoleCluster = "cluster"
 )
 
 var (
@@ -230,6 +233,17 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 	defer endpointReporter.Stop()
 	p.AddReporter(endpointReporter)
 
+	switch flags.kubernetesRole {
+	case "": // nothing special
+	case kubernetesRoleHost:
+		flags.kubernetesEnabled = true
+	case kubernetesRoleCluster:
+		flags.kubernetesKubeletPort = 0
+		flags.kubernetesEnabled = true
+	default:
+		log.Warnf("unrecognized --probe.kubernetes.role: %s", flags.kubernetesRole)
+	}
+
 	if flags.dockerEnabled {
 		// Don't add the bridge in Kubernetes since container IPs are global and
 		// shouldn't be scoped
@@ -267,7 +281,7 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 		}
 	}
 
-	if flags.kubernetesEnabled {
+	if flags.kubernetesEnabled && flags.kubernetesRole != kubernetesRoleHost {
 		if client, err := kubernetes.NewClient(flags.kubernetesClientConfig); err == nil {
 			defer client.Stop()
 			reporter := kubernetes.NewReporter(client, clients, probeID, hostID, p, handlerRegistry, flags.kubernetesNodeName, flags.kubernetesKubeletPort)
@@ -279,7 +293,7 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 		}
 	}
 
-	if flags.kubernetesEnabled || flags.kubernetesTagOnly {
+	if flags.kubernetesEnabled {
 		p.AddTagger(&kubernetes.Tagger{})
 	}
 


### PR DESCRIPTION
This set of changes allows you to configure the probe on each node with Kubernetes probing disabled, and run one extra probe with Kubernetes enabled and processes, containers, etc., disabled. This is quite simple to arrange with one DaemonSet and one Deployment.

Benefits:
 * less impact on the Kubernetes api-server
 * less work on each node gathering and reporting the data in each probe
 * less work in the app to merge N copies of identical nodes
 * less network traffic to send them to the app.  
Disappointingly the CPU-usage benefit wasn't huge when I tried it in our staging cluster, but I didn't spend long looking at why.

It has one disruptive change: pods never get tagged with a host-id.  The rendering code is changed to find this on a container node. When reporting Kubernetes on just one node in the cluster, it doesn't know what hostID has been given to any other nodes.

Alternatives considered to the above change:
 * Add the Kubernetes node-name to each host node, then have the renderer match them up.
 * use Kubernetes node-name instead of OS-supplied hostname as the host ID. This seems like a better idea, but is a more disruptive change if people are used to seeing a certain format on the screen. Maybe we can separate the internal ID from the on-screen presentation?
