### PR TITLE
Pass a logger to middleware.Log

### DIFF
--- a/prog/app.go
+++ b/prog/app.go
@@ -282,9 +282,11 @@ func appMain(flags appFlags) {
 	capabilities := map[string]bool{
 		xfer.HistoricReportsCapability: collector.HasHistoricReports(),
 	}
+	logger := logging.Logrus(log.StandardLogger())
 	handler := router(collector, controlRouter, pipeRouter, flags.externalUI, capabilities, flags.metricsGraphURL)
 	if flags.logHTTP {
 		handler = middleware.Log{
+			Log:               logger,
 			LogRequestHeaders: flags.logHTTPHeaders,
 		}.Wrap(handler)
 	}
@@ -309,7 +311,7 @@ func appMain(flags appFlags) {
 
 	// block until INT/TERM
 	signals.SignalHandlerLoop(
-		logging.Logrus(log.StandardLogger()),
+		logger,
 		stopper{
 			Server:      server,
 			StopTimeout: flags.stopTimeout,


### PR DESCRIPTION
Should fix:
```
2018/07/23 20:29:49 http: panic serving 10.244.204.241:34716: runtime error: invalid memory address or nil pointer dereference
goroutine 1169 [running]:
net/http.(*conn).serve.func1(0xc420739a40)
/usr/local/go/src/net/http/server.go:1726 +0xd0
panic(0x17d5200, 0x2a7f5e0)
/usr/local/go/src/runtime/panic.go:502 +0x229
github.com/weaveworks/scope/vendor/github.com/weaveworks/common/middleware.Log.Wrap.func1(0x1dc60e0, 0xc4215e7a40, 0xc4202cee00)
/go/src/github.com/weaveworks/scope/vendor/github.com/weaveworks/common/middleware/logging.go:40 +0x3c7
[...]
```
caused by an update of dependencies and that change http://github.com/weaveworks/common/pull/96/files#diff-34ebe92b41e559320767523ef0557f71R15