### PR TITLE
Add rules in cluster role for k8s storage components

### DIFF
--- a/examples/k8s/cluster-role.yaml
+++ b/examples/k8s/cluster-role.yaml
@@ -15,6 +15,8 @@ rules:
   - replicationcontrollers
   - services
   - nodes
+  - persistentvolumes
+  - persistentvolumeclaims
   verbs:
   - list
   - watch
@@ -39,6 +41,13 @@ rules:
   - daemonsets
   - deployments
   - replicasets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
   verbs:
   - list
   - watch


### PR DESCRIPTION
This will add rules to cluster role for k8s storage components.
These RBAC permissions are required for scope to fetch details about PV, PVC, SC
resources.

Signed-off-by: Satyam Zode <satyamzode@gmail.com>