### PR TITLE
Disable CRI probe by default

### DIFF
--- a/prog/main.go
+++ b/prog/main.go
@@ -308,7 +308,7 @@ func setupFlags(flags *flags) {
 	flag.StringVar(&flags.probe.dockerBridge, "probe.docker.bridge", "docker0", "the docker bridge name")
 
 	// CRI
-	flag.BoolVar(&flags.probe.criEnabled, "probe.cri", true, "collect CRI-related attributes for processes")
+	flag.BoolVar(&flags.probe.criEnabled, "probe.cri", false, "collect CRI-related attributes for processes")
 	flag.StringVar(&flags.probe.criEndpoint, "probe.cri.endpoint", "unix///var/run/dockershim.sock", "The endpoint to connect to the CRI")
 
 	// K8s


### PR DESCRIPTION
This was enabled by default but we want it to be disabled instead, just
like with the docker probe.
