### PR TITLE
Fix the CRI volumeMount name in the example manifest

### DIFF
--- a/examples/cri/ds.yaml
+++ b/examples/cri/ds.yaml
@@ -39,7 +39,7 @@ spec:
           securityContext:
             privileged: true
           volumeMounts:
-            - name: crio-socket
+            - name: cri-socket
               mountPath: /var/run/crio/crio.sock
             - name: scope-plugins
               mountPath: /var/run/scope/plugins


### PR DESCRIPTION
volumeMounts need to refer to an existing volume name to be successfully
mounted. cri-socket is the defined volume name.