### PR TITLE
Undo changes made in the 'tools' subtree

### DIFF
--- a/tools/socks/Dockerfile
+++ b/tools/socks/Dockerfile
@@ -1,5 +1,5 @@
 FROM gliderlabs/alpine
-LABEL maintainer="Weaveworks Inc <help@weave.works>"
+MAINTAINER Weaveworks Inc <help@weave.works>
 WORKDIR /
 COPY proxy /
 EXPOSE 8000

--- a/tools/socks/main.go
+++ b/tools/socks/main.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"text/template"
 
-	"context"
 	socks5 "github.com/armon/go-socks5"
 	"github.com/weaveworks/common/mflag"
 	"github.com/weaveworks/common/mflagext"
+	"golang.org/x/net/context"
 )
 
 type pacFileParameters struct {


### PR DESCRIPTION
The `tools` directory is vendor'd in from https://github.com/weaveworks/build-tools so must not be changed here.

Since the changes were made in two different commits nearly a year apart I am simply hand-undoing them and then we can fix upstream.
