### PR TITLE
rename 'storagesheet' to 'sheet'

### DIFF
--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -19,7 +19,7 @@ var (
 	cloud          = "cloud"
 	cylinder       = "cylinder"
 	dottedcylinder = "dottedcylinder"
-	storagesheet   = "storagesheet"
+	storagesheet   = "sheet"
 
 	// Helper to make a report.node with some common options
 	node = func(topology string) func(id string, adjacent ...string) report.Node {

--- a/report/report.go
+++ b/report/report.go
@@ -43,7 +43,7 @@ const (
 	Cloud          = "cloud"
 	Cylinder       = "cylinder"
 	DottedCylinder = "dottedcylinder"
-	StorageSheet   = "storagesheet"
+	StorageSheet   = "sheet"
 
 	// Used when counting the number of containers
 	ContainersKey = "containers"


### PR DESCRIPTION
the client now expects a node shape of `sheet` not `storagesheet`
update report.go to reflect this.

fixes #3322