### PR TITLE
Sleep to stop TestRegistryDelete() failing

### DIFF
--- a/probe/docker/registry_test.go
+++ b/probe/docker/registry_test.go
@@ -470,7 +470,7 @@ func TestRegistryDelete(t *testing.T) {
 	setupStubs(mdc, func() {
 		registry := testRegistry()
 		defer registry.Stop()
-		runtime.Gosched()
+		time.Sleep(time.Millisecond * 100) // Allow for goroutines to get started
 
 		// Collect all the events.
 		mtx := sync.Mutex{}


### PR DESCRIPTION
Fixes #3209

Not very purist, but it seems to work.
