### PR TITLE
import missing terminal.scss in contrast.scss

### DIFF
--- a/client/app/styles/contrast.scss
+++ b/client/app/styles/contrast.scss
@@ -1,3 +1,4 @@
 @import "variables";
 @import "contrast-overrides";
 @import "base";
+@import "terminal";


### PR DESCRIPTION
import terminal.scss in contrast.scss which is missing currently and causing the terminal styling in contrast mode.

Before:
<img width="372" alt="screen shot 2018-09-14 at 12 09 19 pm" src="https://user-images.githubusercontent.com/18216179/45542920-dbc71b00-b830-11e8-9fe4-a9362fb80855.png">

After:
<img width="520" alt="screen shot 2018-09-14 at 3 03 03 pm" src="https://user-images.githubusercontent.com/18216179/45542937-e71a4680-b830-11e8-9ed0-33f3b9e96ef7.png">

fixes: #3346 
