### PR TITLE
example k8s: add support for PodSecurityPolicy

### DIFF
--- a/examples/k8s/cluster-role.yaml
+++ b/examples/k8s/cluster-role.yaml
@@ -51,3 +51,11 @@ rules:
   verbs:
   - list
   - watch
+- apigroups:
+  - extensions
+  resourcenames:
+  - weave-scope
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/examples/k8s/psp.yaml
+++ b/examples/k8s/psp.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: weave-scope
+spec:
+  privileged: true
+  hostPID: true
+  hostNetwork: true
+  allowedCapabilities:
+  - 'NET_ADMIN'
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - secret
+  - hostPath


### PR DESCRIPTION
This add a psp file with needed right to work on kubernetes.

Fixes https://github.com/weaveworks/scope/issues/3203
Signed-off-by: Julien Garcia Gonzalez <julien@giantswarm.io>