### PR TITLE
refactor(logs): Add reporter name to error logs.

### DIFF
--- a/probe/probe.go
+++ b/probe/probe.go
@@ -148,7 +148,7 @@ func (p *Probe) tick() {
 		err := ticker.Tick()
 		metrics.MeasureSince([]string{ticker.Name(), "ticker"}, t)
 		if err != nil {
-			log.Errorf("error doing ticker: %v", err)
+			log.Errorf("Error doing ticker: %v", err)
 		}
 	}
 }
@@ -165,7 +165,7 @@ func (p *Probe) report() report.Report {
 			}
 			metrics.MeasureSince([]string{rep.Name(), "reporter"}, t)
 			if err != nil {
-				log.Errorf("error generating report: %v", err)
+				log.Errorf("Error generating %s report: %v", rep.Name(), err)
 				newReport = report.MakeReport() // empty is OK to merge
 			}
 			reports <- newReport
@@ -190,7 +190,7 @@ func (p *Probe) tag(r report.Report) report.Report {
 		}
 		metrics.MeasureSince([]string{tagger.Name(), "tagger"}, t)
 		if err != nil {
-			log.Errorf("error applying tagger: %v", err)
+			log.Errorf("Error applying tagger: %v", err)
 		}
 	}
 	return r
@@ -213,7 +213,7 @@ ForLoop:
 		})
 	}
 	if err := p.publisher.Publish(rpt); err != nil {
-		log.Infof("publish: %v", err)
+		log.Infof("Publish: %v", err)
 	}
 }
 


### PR DESCRIPTION
1. Adding reporter name to logs improves tracing of error.
2. Capitalize first letter of error log.

Fixes https://github.com/weaveworks/scope/issues/3306

Signed-off-by: Prince Rachit Sinha <prince.rachit@mayadata.io>