### PR TITLE
#3302: Absolute basic UT

### DIFF
--- a/probe/cri/registry_test.go
+++ b/probe/cri/registry_test.go
@@ -3,25 +3,19 @@ package cri_test
 import (
 	"testing"
 
+	"github.com/bmizerany/assert"
 	"github.com/weaveworks/scope/probe/cri"
 )
 
 func TestParseHttpEndpointUrl(t *testing.T) {
 	_, err := cri.NewCRIClient("http://xyz.com")
 
-	if err == nil {
-		t.Fatal("Should not create client with Http protocol")
-	}
+	assert.Equal(t, "protocol \"http\" not supported", err.Error())
 }
 
 func TestParseTcpEndpointUrl(t *testing.T) {
 	client, err := cri.NewCRIClient("127.0.0.1")
 
-	if err != nil {
-		t.Fatal("Should have created service client")
-	}
-
-	if client == nil {
-		t.Fatal("Should have created service client")
-	}
+	assert.Equal(t, nil, err)
+	assert.NotEqual(t, nil, client)
 }

--- a/probe/cri/registry_test.go
+++ b/probe/cri/registry_test.go
@@ -1,0 +1,27 @@
+package cri_test
+
+import (
+	"testing"
+
+	"github.com/weaveworks/scope/probe/cri"
+)
+
+func TestParseHttpEndpointUrl(t *testing.T) {
+	_, err := cri.NewCRIClient("http://xyz.com")
+
+	if err == nil {
+		t.Fatal("Should not create client with Http protocol")
+	}
+}
+
+func TestParseTcpEndpointUrl(t *testing.T) {
+	client, err := cri.NewCRIClient("127.0.0.1")
+
+	if err != nil {
+		t.Fatal("Should have created service client")
+	}
+
+	if client == nil {
+		t.Fatal("Should have created service client")
+	}
+}


### PR DESCRIPTION
tests: Adding Unit tests

Some work on adding unit tests for `probe/cri`. This PR adds absolute basic unit tests.

Partially fixes https://github.com/weaveworks/scope/issues/3302


P.S: I'm a beginner to Go. Open to listening for things I can do better.