### PR TITLE
Remove weaveutil and weave from Dockerfile.cloud-agent

### DIFF
--- a/docker/Dockerfile.cloud-agent
+++ b/docker/Dockerfile.cloud-agent
@@ -2,7 +2,6 @@ FROM alpine:3.7
 WORKDIR /home/weave
 RUN apk add --update bash conntrack-tools iproute2 util-linux curl && \
 	rm -rf /var/cache/apk/*
-ADD ./weave ./weaveutil /usr/bin/
 COPY ./scope /home/weave/
 ENTRYPOINT ["/home/weave/scope", "--mode=probe", "--no-app", "--probe.docker=true"]
 

--- a/docker/Dockerfile.scope
+++ b/docker/Dockerfile.scope
@@ -2,6 +2,7 @@ FROM weaveworks/cloud-agent
 RUN apk add --update runit && \
 	rm -rf /var/cache/apk/*
 ADD ./demo.json /
+ADD ./weave ./weaveutil /usr/bin/
 COPY ./runsvinit ./entrypoint.sh /home/weave/
 COPY ./run-app /etc/service/app/run
 COPY ./run-probe /etc/service/probe/run


### PR DESCRIPTION
- Moves the `weave` and `weaveutil` from `Dockerfile.cloud-agent` to
  `Dockerfile.scope`
- Fixes #3341 

