### PR TITLE
[WIP] Add the message and reason fields for pods

### DIFF
--- a/client/app/scripts/charts/nodes-grid.js
+++ b/client/app/scripts/charts/nodes-grid.js
@@ -18,7 +18,7 @@ import { getNodeColor } from '../utils/color-utils';
 
 
 const IGNORED_COLUMNS = ['docker_container_ports', 'docker_container_id', 'docker_image_id',
-  'docker_container_command', 'docker_container_networks'];
+  'docker_container_command', 'docker_container_networks', 'kubernetes_reason', 'kubernetes_message'];
 
 
 const Icon = styled.span`

--- a/client/app/scripts/components/node-details/node-details-info.js
+++ b/client/app/scripts/components/node-details/node-details-info.js
@@ -41,6 +41,9 @@ class NodeDetailsInfo extends React.Component {
       <div className="node-details-info">
         {rows.map((field) => {
           const { value, title } = formatDataType(field, timestamp);
+          if (field.hideIfEmpty && value === '') {
+            return null;
+          }
           return (
             <div className="node-details-info-field" key={field.id}>
               <div className="node-details-info-field-label truncate" title={field.label}>

--- a/probe/kubernetes/pod.go
+++ b/probe/kubernetes/pod.go
@@ -88,10 +88,12 @@ func (p *pod) VolumeClaimName() string {
 
 func (p *pod) GetNode(probeID string) report.Node {
 	latests := map[string]string{
-		State: p.State(),
-		IP:    p.Status.PodIP,
+		State:                 p.State(),
+		IP:                    p.Status.PodIP,
 		report.ControlProbeID: probeID,
 		RestartCount:          strconv.FormatUint(uint64(p.RestartCount()), 10),
+		Reason:                p.Status.Reason,
+		Message:               p.Status.Message,
 	}
 
 	if p.VolumeClaimName() != "" {

--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -30,6 +30,7 @@ const (
 	AccessModes        = report.KubernetesAccessModes
 	ReclaimPolicy      = report.KubernetesReclaimPolicy
 	Status             = report.KubernetesStatus
+	Reason             = report.KubernetesReason
 	Message            = report.KubernetesMessage
 	VolumeName         = report.KubernetesVolumeName
 	Provisioner        = report.KubernetesProvisioner
@@ -45,6 +46,8 @@ var (
 		Namespace:        {ID: Namespace, Label: "Namespace", From: report.FromLatest, Priority: 5},
 		Created:          {ID: Created, Label: "Created", From: report.FromLatest, Datatype: report.DateTime, Priority: 6},
 		RestartCount:     {ID: RestartCount, Label: "Restart #", From: report.FromLatest, Priority: 7},
+		Reason:           {ID: Reason, Label: "Reason", From: report.FromLatest, Priority: 8, HideIfEmpty: true},
+		Message:          {ID: Message, Label: "Message", From: report.FromLatest, Priority: 9, HideIfEmpty: true},
 	}
 
 	PodMetricTemplates = docker.ContainerMetricTemplates

--- a/report/map_keys.go
+++ b/report/map_keys.go
@@ -77,6 +77,7 @@ const (
 	KubernetesAccessModes          = "kubernetes_access_modes"
 	KubernetesReclaimPolicy        = "kubernetes_reclaim_policy"
 	KubernetesStatus               = "kubernetes_status"
+	KubernetesReason               = "kubernetes_reason"
 	KubernetesMessage              = "kubernetes_message"
 	KubernetesVolumeName           = "kubernetes_volume_name"
 	KubernetesProvisioner          = "kubernetes_provisioner"

--- a/report/metadata_template.go
+++ b/report/metadata_template.go
@@ -20,12 +20,13 @@ const (
 
 // MetadataTemplate extracts some metadata rows from a node
 type MetadataTemplate struct {
-	ID       string  `json:"id"`
-	Label    string  `json:"label,omitempty"`    // Human-readable descriptor for this row
-	Truncate int     `json:"truncate,omitempty"` // If > 0, truncate the value to this length.
-	Datatype string  `json:"dataType,omitempty"`
-	Priority float64 `json:"priority,omitempty"`
-	From     string  `json:"from,omitempty"` // Defines how to get the value from a report node
+	ID          string  `json:"id"`
+	Label       string  `json:"label,omitempty"`    // Human-readable descriptor for this row
+	Truncate    int     `json:"truncate,omitempty"` // If > 0, truncate the value to this length.
+	Datatype    string  `json:"dataType,omitempty"`
+	Priority    float64 `json:"priority,omitempty"`
+	From        string  `json:"from,omitempty"`        // Defines how to get the value from a report node
+	HideIfEmpty bool    `json:"hideIfEmpty,omitempty"` // If the value is empty, omit showing the row.
 }
 
 // MetadataRow returns the row for a node
@@ -41,12 +42,13 @@ func (t MetadataTemplate) MetadataRow(n Node) (MetadataRow, bool) {
 	}
 	if val, ok := from(n, t.ID); ok {
 		return MetadataRow{
-			ID:       t.ID,
-			Label:    t.Label,
-			Value:    val,
-			Truncate: t.Truncate,
-			Datatype: t.Datatype,
-			Priority: t.Priority,
+			ID:          t.ID,
+			Label:       t.Label,
+			Value:       val,
+			Truncate:    t.Truncate,
+			Datatype:    t.Datatype,
+			Priority:    t.Priority,
+			HideIfEmpty: t.HideIfEmpty,
 		}, true
 	}
 	return MetadataRow{}, false
@@ -77,12 +79,13 @@ func fromCounters(n Node, key string) (string, bool) {
 
 // MetadataRow is a row for the metadata table.
 type MetadataRow struct {
-	ID       string  `json:"id"`
-	Label    string  `json:"label"`
-	Value    string  `json:"value"`
-	Priority float64 `json:"priority,omitempty"`
-	Datatype string  `json:"dataType,omitempty"`
-	Truncate int     `json:"truncate,omitempty"`
+	ID          string  `json:"id"`
+	Label       string  `json:"label"`
+	Value       string  `json:"value"`
+	Priority    float64 `json:"priority,omitempty"`
+	Datatype    string  `json:"dataType,omitempty"`
+	Truncate    int     `json:"truncate,omitempty"`
+	HideIfEmpty bool    `json:"hideIfEmpty,omitempty"`
 }
 
 // MetadataTemplates is a mergeable set of metadata templates


### PR DESCRIPTION
Fixes #2989
I think I've got a viable PR for this issue. 🙂

The only problem is that the new reason and message fields always show, even if they are blank. I was trying to figure out how to optionally show these if the status was an unhealthy or blank, but there didn't seem to be an easy way. A possible idea that came to my mind was to add another field to the report.MetadataTemplate struct to indicate to the frontend to hide if it is the zero value.

What do you think about this?