### PR TITLE
Probe: Rate-limit report publishing

### DIFF
--- a/probe/probe.go
+++ b/probe/probe.go
@@ -83,7 +83,7 @@ func New(
 		spyInterval:     spyInterval,
 		publishInterval: publishInterval,
 		publisher:       publisher,
-		rateLimiter:     rate.NewLimiter(rate.Every(publishInterval)*10, 1),
+		rateLimiter:     rate.NewLimiter(rate.Every(publishInterval/100), 1),
 		noControls:      noControls,
 		quit:            make(chan struct{}),
 		spiedReports:    make(chan report.Report, spiedReportBufferSize),


### PR DESCRIPTION
Fixes #3150 

Rate-limit report publishing so that, if many shortcut reports are produced in quick succession, they will tend to get merged together before sending.

Also expand the queue size for shortcut reports, to avoid holding up the producer so much.

The behaviour of the Go rate-limiter with a burst size of 1 is that it will let 1 report go through immediately, then the next one will wait until the time specified (300ms by default).  If nothing happens for more than 300ms the next report will go immediately, and so on.