### PR TITLE
Fix golint import path

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,7 +19,7 @@ RUN go clean -i net && \
    fi; \
     go get -tags netgo \
 		github.com/fzipp/gocyclo \
-		github.com/golang/lint/golint \
+		golang.org/x/lint/golint \
 		github.com/kisielk/errcheck \
 		github.com/fatih/hclfmt \
 		github.com/mjibson/esc \

--- a/tools/build/golang/Dockerfile
+++ b/tools/build/golang/Dockerfile
@@ -30,7 +30,7 @@ RUN go get -tags netgo \
 		github.com/gogo/protobuf/gogoproto \
 		github.com/gogo/protobuf/protoc-gen-gogoslick \
 		github.com/golang/dep/... \
-		github.com/golang/lint/golint \
+		golang.org/x/lint/golint \
 		github.com/golang/protobuf/protoc-gen-go \
 		github.com/kisielk/errcheck \
 		github.com/mjibson/esc \


### PR DESCRIPTION
golint path was changed on February 2018. Since Oct 11 2018, the package
started enforcing it.

This change updates the path for golint to match the new version.

Fixes #3388 

Refers to golang/lint/issues/415