### PR TITLE
Discard pod updates for other nodes

### DIFF
--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -193,6 +193,10 @@ func (r *Reporter) Stop() {
 func (Reporter) Name() string { return "K8s" }
 
 func (r *Reporter) podEvent(e Event, pod Pod) {
+	// filter out non-local pods, if we have been given a node name to report on
+	if r.nodeName != "" && pod.NodeName() != r.nodeName {
+		return
+	}
 	switch e {
 	case ADD:
 		rpt := report.MakeReport()


### PR DESCRIPTION
We were filtering pods to those on the local node already, for regular reports, so we should also filter events that come in asynchronously.

Problem noted at https://github.com/weaveworks/scope/issues/3150#issuecomment-429563114