### PR TITLE
Fix intention of support for fallback protocol and add tests for probe/cri/registry 

### DIFF
--- a/probe/cri/registry.go
+++ b/probe/cri/registry.go
@@ -18,26 +18,32 @@ func dial(addr string, timeout time.Duration) (net.Conn, error) {
 }
 
 func getAddressAndDialer(endpoint string) (string, func(addr string, timeout time.Duration) (net.Conn, error), error) {
-	protocol, addr, err := parseEndpointWithFallbackProtocol(endpoint, unixProtocol)
+	addr, err := parseEndpointWithFallbackProtocol(endpoint, unixProtocol)
 	if err != nil {
 		return "", nil, err
-	}
-	if protocol != unixProtocol {
-		return "", nil, fmt.Errorf("endpoint was not unix socket %v", protocol)
 	}
 
 	return addr, dial, nil
 }
 
-func parseEndpointWithFallbackProtocol(endpoint string, fallbackProtocol string) (protocol string, addr string, err error) {
-	if protocol, addr, err = parseEndpoint(endpoint); err != nil && protocol == "" {
+func parseEndpointWithFallbackProtocol(endpoint string, fallbackProtocol string) (addr string, err error) {
+	var protocol string
+
+	protocol, addr, err = parseEndpoint(endpoint)
+
+	if err != nil {
+		return "", err
+	}
+
+	if protocol == "" {
 		fallbackEndpoint := fallbackProtocol + "://" + endpoint
-		protocol, addr, err = parseEndpoint(fallbackEndpoint)
+		_, addr, err = parseEndpoint(fallbackEndpoint)
+
 		if err != nil {
-			return "", "", err
+			return "", err
 		}
 	}
-	return
+	return addr, err
 }
 
 func parseEndpoint(endpoint string) (string, string, error) {
@@ -47,11 +53,11 @@ func parseEndpoint(endpoint string) (string, string, error) {
 	}
 
 	if u.Scheme == "tcp" {
-		return "tcp", u.Host, nil
+		return "tcp", u.Host, fmt.Errorf("endpoint was not unix socket %v", u.Scheme)
 	} else if u.Scheme == "unix" {
 		return "unix", u.Path, nil
 	} else if u.Scheme == "" {
-		return "", "", fmt.Errorf("Using %q as endpoint is deprecated, please consider using full url format", endpoint)
+		return "", "", nil
 	} else {
 		return u.Scheme, "", fmt.Errorf("protocol %q not supported", u.Scheme)
 	}

--- a/probe/cri/registry_test.go
+++ b/probe/cri/registry_test.go
@@ -7,15 +7,36 @@ import (
 	"github.com/weaveworks/scope/probe/cri"
 )
 
-func TestParseHttpEndpointUrl(t *testing.T) {
-	_, err := cri.NewCRIClient("http://xyz.com")
-
-	assert.Equal(t, "protocol \"http\" not supported", err.Error())
+var nonUnixSocketsTest = []struct {
+	endpoint     string
+	errorMessage string
+}{
+	{"http://xyz.com", "protocol \"http\" not supported"},
+	{"tcp://var/unix.sock", "endpoint was not unix socket tcp"},
+	{"http://[fe80::%31]/", "parse http://[fe80::%31]/: invalid URL escape \"%31\""},
 }
 
-func TestParseTcpEndpointUrl(t *testing.T) {
-	client, err := cri.NewCRIClient("127.0.0.1")
+func TestParseNonUnixEndpointUrl(t *testing.T) {
+	for _, tt := range nonUnixSocketsTest {
+		_, err := cri.NewCRIClient(tt.endpoint)
 
-	assert.Equal(t, nil, err)
-	assert.NotEqual(t, nil, client)
+		assert.Equal(t, tt.errorMessage, err.Error())
+	}
+}
+
+var unixSocketsTest = []string{
+	"127.0.0.1", // tests the fallback endpoint
+	"unix://127.0.0.1",
+	"unix///var/run/dockershim.sock",
+	"var/run/dockershim.sock",
+}
+
+func TestParseUnixEndpointUrl(t *testing.T) {
+	for _, tt := range unixSocketsTest {
+		client, err := cri.NewCRIClient(tt)
+
+		assert.Equal(t, nil, err)
+		assert.NotEqual(t, nil, client)
+	}
+
 }


### PR DESCRIPTION
Hey all 👋,

First of all, thank you for making such a great project! Found it via Hacktoberfest and immediately jumped into the bandwagon for helping out. Love the current organisation/labelling of the issues. Super helpful for us newcomers.

Figured I should get this PR out sooner rather than later to start getting some feedback. While stressing the different code paths with the tests, I noticed there was one case that no matter what I do, I couldn't get an error to bubble up: The case where the scheme is `""`. 

I'm not sure if this is some sort of 🐞 or am I missing something (?), but I ended up refactoring (to the best of my _very_ limited Go knowledge and understanding of the project) some bits to make it so that it complies with what I _think_ the intention was.

From what I read, the assumption was that we don't support URLs were the scheme is not specified but we're supporting them anyways when we use the fallback protocol. The branch is the more natural thing to miss, so I optimised for supporting the case (feedback is very very welcome).

The last commit is _very_ optional, I'm not familiar with Go (in fact, this is my first PR _ever_). I'm happy to take it out if this is not the way we do things in Goland.

As for the tests they cover:

Unhappy path tests try to cover three scenarios

- When the endpoint URL scheme is not explicitly supported e.g. HTTP
- When the endpoint URL scheme is TCP which is also not supported
- When we fail to parse the given URL (to extract the scheme)

The happy path covers two scenarios

- When we specify the supported scheme in the URL which is an unix
socket e.g. `unix///var/run/dockershim.sock`
- When we pass a socket address but fail to specify the scheme but our registry attempts
to use the fallback protocol e.g. `var/run/dockershim.sock`

Solves #3302 