### PR TITLE
Clean up Dockerfiles

### DIFF
--- a/docker/Dockerfile.cloud-agent
+++ b/docker/Dockerfile.cloud-agent
@@ -1,7 +1,6 @@
 FROM alpine:3.7
 WORKDIR /home/weave
-RUN apk add --update bash conntrack-tools iproute2 util-linux curl && \
-	rm -rf /var/cache/apk/*
+RUN apk add --no-cache bash conntrack-tools iproute2 util-linux curl
 COPY ./scope /home/weave/
 ENTRYPOINT ["/home/weave/scope", "--mode=probe", "--no-app", "--probe.docker=true"]
 

--- a/docker/Dockerfile.scope
+++ b/docker/Dockerfile.scope
@@ -1,8 +1,7 @@
 FROM weaveworks/cloud-agent
-RUN apk add --update runit && \
-	rm -rf /var/cache/apk/*
-ADD ./demo.json /
-ADD ./weave ./weaveutil /usr/bin/
+RUN apk add --no-cache runit
+COPY ./demo.json /
+COPY ./weave ./weaveutil /usr/bin/
 COPY ./runsvinit ./entrypoint.sh /home/weave/
 COPY ./run-app /etc/service/app/run
 COPY ./run-probe /etc/service/probe/run


### PR DESCRIPTION
Changed `--update` & removing the apk cache to using the `--no-cache` flag, which just installs the newest version of the packages without caching any information.

Changed `ADD` to `COPY`, because they are not archives, which have to be unpacked after adding them. In general it is not encouraged to use `ADD` for just copying files into the image, because of the overloaded functionality of `ADD`.