### PR TITLE
Add Filip Barl as maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,4 @@
 Alfonso Acosta <fons@syntacticsugar.consulting> (@2opremio)
+Filip Barl <filip@weave.works> (@fbarl)
 Bryan Boreham <bryan@weave.works> (@bboreham)
 Satyam Zode <satyam.zode@openebs.io> (@satyamz)


### PR DESCRIPTION
@fbarl has made 137 PRs on Scope, which easily justifies his position as a maintainer.

CC @2opremio and @satyamz as other current maintainers
