### PR TITLE
UI Build: stop deleting static ui files when building external ui

### DIFF
--- a/client/webpack.production.config.js
+++ b/client/webpack.production.config.js
@@ -48,7 +48,7 @@ module.exports = {
   },
 
   plugins: [
-    new CleanWebpackPlugin(['build']),
+    new CleanWebpackPlugin([OUTPUT_PATH]),
     new webpack.DefinePlugin(GLOBALS),
     new webpack.optimize.CommonsChunkPlugin({ name: 'vendors', filename: 'vendors.js' }),
     new webpack.optimize.OccurrenceOrderPlugin(true),


### PR DESCRIPTION
This can cause an empty static UI if things build in an unfortunate order.

Fixes #3438 
