### PR TITLE
Don't look for blank volume claims when rendering

### DIFF
--- a/render/persistentvolume.go
+++ b/render/persistentvolume.go
@@ -53,7 +53,10 @@ type podToVolumesRenderer struct{}
 func (v podToVolumesRenderer) Render(ctx context.Context, rpt report.Report) Nodes {
 	nodes := make(report.Nodes)
 	for podID, podNode := range rpt.Pod.Nodes {
-		ClaimName, _ := podNode.Latest.Lookup(kubernetes.VolumeClaim)
+		ClaimName, found := podNode.Latest.Lookup(kubernetes.VolumeClaim)
+		if !found {
+			continue
+		}
 		for _, pvcNode := range rpt.PersistentVolumeClaim.Nodes {
 			pvcName, _ := pvcNode.Latest.Lookup(kubernetes.Name)
 			if pvcName == ClaimName {


### PR DESCRIPTION
If a pod has no VolumeClaim set, just move on to the next pod.
Eliminates small waste of time.
