### PR TITLE
Add adjacency between Pod and PVC when claim name and namespace are same

### DIFF
--- a/render/persistentvolume.go
+++ b/render/persistentvolume.go
@@ -57,9 +57,11 @@ func (v podToVolumesRenderer) Render(ctx context.Context, rpt report.Report) Nod
 		if !found {
 			continue
 		}
+		podNamespace, _ := podNode.Latest.Lookup(kubernetes.Namespace)
 		for _, pvcNode := range rpt.PersistentVolumeClaim.Nodes {
 			pvcName, _ := pvcNode.Latest.Lookup(kubernetes.Name)
-			if pvcName == ClaimName {
+			pvcNamespace, _ := pvcNode.Latest.Lookup(kubernetes.Namespace)
+			if (pvcName == ClaimName) && (podNamespace == pvcNamespace) {
 				podNode.Adjacency = podNode.Adjacency.Add(pvcNode.ID)
 				podNode.Children = podNode.Children.Add(pvcNode)
 			}


### PR DESCRIPTION
- Name of the PVC can be the same in different namespaces, in this
scenario an application pod is connected to multiple PVC.
![screenshot from 2018-12-07 22-46-05](https://user-images.githubusercontent.com/22732158/49686917-9493b200-fb21-11e8-88ed-8f84fc875ee3.png)

- Add adjacency between Pod and PVC when `claim name` and `namespace` are same.

Signed-off-by: Akash Srivastava <akash.srivastava@openebs.io>