### PR TITLE
Rename :orgId to :instanceId in metrics graph url

### DIFF
--- a/client/app/scripts/components/cloud-link.js
+++ b/client/app/scripts/components/cloud-link.js
@@ -9,7 +9,7 @@ import CloudFeature from './cloud-feature';
  * that is comprised of Weave Cloud related pieces.
  *
  * We support here relative links with a leading `/` that rewrite
- * the browser url as well as cloud-related placeholders (:orgId).
+ * the browser url as well as cloud-related placeholders (:instanceId).
  *
  * If no `url` is given, only the children is rendered (no anchor).
  *
@@ -50,8 +50,8 @@ class LinkWrapper extends React.Component {
 
   buildHref(url) {
     const { params } = this.props;
-    if (!url || !params || !params.orgId) return url;
-    return url.replace(/:orgid/gi, encodeURIComponent(this.props.params.orgId));
+    if (!url || !params || !params.instanceId) return url;
+    return url.replace(/:instanceid/gi, encodeURIComponent(params.instanceId));
   }
 
   render() {

--- a/client/app/scripts/components/node-details/__tests__/node-details-health-link-item-test.js
+++ b/client/app/scripts/components/node-details/__tests__/node-details-health-link-item-test.js
@@ -15,7 +15,7 @@ describe('NodeDetailsHealthLinkItem', () => {
     });
 
     it('appends as json for cloud link', () => {
-      const url = appendTime('/prom/:orgid/notebook/new/%7B%22cells%22%3A%5B%7B%22queries%22%3A%5B%22go_goroutines%22%5D%7D%5D%7D', time);
+      const url = appendTime('/prom/:instanceid/notebook/new/%7B%22cells%22%3A%5B%7B%22queries%22%3A%5B%22go_goroutines%22%5D%7D%5D%7D', time);
       expect(url).toContain(timeUnix);
 
       const payload = JSON.parse(decodeURIComponent(url.substr(url.indexOf('new/') + 4)));

--- a/client/app/scripts/utils/web-api-utils.js
+++ b/client/app/scripts/utils/web-api-utils.js
@@ -91,9 +91,9 @@ export function basePathSlash(urlPath) {
 // i.e. in this case Weave Cloud, rather than being hardcoded here.
 export function getApiPath(pathname = window.location.pathname) {
   if (process.env.SCOPE_API_PREFIX) {
-    // Extract the instance name (pathname in WC context is of format '/:orgId/explore').
-    const orgId = pathname.split('/')[1];
-    return basePath(`${process.env.SCOPE_API_PREFIX}/app/${orgId}`);
+    // Extract the instance name (pathname in WC context is of format '/:instanceId/explore').
+    const instanceId = pathname.split('/')[1];
+    return basePath(`${process.env.SCOPE_API_PREFIX}/app/${instanceId}`);
   }
 
   return basePath(pathname);

--- a/prog/main.go
+++ b/prog/main.go
@@ -387,7 +387,7 @@ func setupFlags(flags *flags) {
 	flag.IntVar(&flags.app.memcachedCompressionLevel, "app.memcached.compression", gzip.DefaultCompression, "How much to compress reports stored in memcached.")
 	flag.StringVar(&flags.app.userIDHeader, "app.userid.header", "", "HTTP header to use as userid")
 	flag.BoolVar(&flags.app.externalUI, "app.externalUI", false, "Point to externally hosted static UI assets")
-	flag.StringVar(&flags.app.metricsGraphURL, "app.metrics-graph", "", "Enable extended metrics graph by providing a templated URL (supports :orgID and :query). Example: --app.metric-graph=/prom/:orgID/notebook/new")
+	flag.StringVar(&flags.app.metricsGraphURL, "app.metrics-graph", "", "Enable extended metrics graph by providing a templated URL (supports :instanceID and :query). Example: --app.metrics-graph=/prom/:instanceID/notebook/new")
 	flag.StringVar(&flags.app.serviceName, "app.service-name", "app", "The name for this service which should be reported in instrumentation")
 
 	flag.IntVar(&flags.app.blockProfileRate, "app.block.profile.rate", 0, "If more than 0, enable block profiling. The profiler aims to sample an average of one blocking event per rate nanoseconds spent blocked.")

--- a/render/detailed/links_test.go
+++ b/render/detailed/links_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	sampleMetricsGraphURL = "/prom/:orgID/notebook/new"
+	sampleMetricsGraphURL = "/prom/:instanceID/notebook/new"
 )
 
 var (


### PR DESCRIPTION
- Renames placeholders `:orgId` to `:instanceId` in
  `--app.metrics-graph`
- Adjusts frontend client to use the provided instanceId by its host
  application (Weave Cloud)