### PR TITLE
Fixed the sidebar namespaces hover effect at last-child

### DIFF
--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -1329,17 +1329,20 @@ a {
     overflow: hidden;
     max-height: 27px;
     transition: max-height 0.5s 0s $base-ease;
-    &:hover {
-      height: auto;
-      max-height: calc((13px * 1.5 + 3px + 3px) * 8); // expand to display 8 rows
-      overflow: auto;
-      transition: max-height 0.5s 0s $base-ease;
-    }
+
     .topology-option-action {
       flex: 1 1 auto;
       text-align: center;
     }
   }
+  
+    &:last-child :hover {
+    height: auto;
+    max-height: calc((13px * 1.5 + 3px + 3px) * 8); // expand to display 8 rows
+    overflow: auto;
+    transition: max-height 0.5s 0s $base-ease;
+  } 
+
   font-size: $font-size-small;
 
   &-action {


### PR DESCRIPTION
Fixes #3555 
Applied the hover effect to the last child to fix the other above sidebar nodes to remain constant and to improve experience through all the browsers. 

Signed-off-by: A V RAHUL  a.v.rahul11@gmail.com