### PR TITLE
Include the node control's id as an attr on the node control button

### DIFF
--- a/client/app/scripts/components/node-details/node-details-control-button.js
+++ b/client/app/scripts/components/node-details/node-details-control-button.js
@@ -12,14 +12,14 @@ class NodeDetailsControlButton extends React.Component {
   }
 
   render() {
-    const { icon, human } = this.props.control;
+    const { icon, id, human } = this.props.control;
     const className = classNames('tour-step-anchor node-control-button', icon, {
       // Old Agent / plugins don't include the 'fa ' prefix, so provide it if they don't.
       fa: icon.startsWith('fa-'),
       'node-control-button-pending': this.props.pending
     });
     return (
-      <i className={className} title={human} onClick={this.handleClick} />
+      <i className={className} data-id={id} title={human} onClick={this.handleClick} />
     );
   }
 


### PR DESCRIPTION
- To allow easy CSS selection of a particular button. We might want to
  hide it in some cases or give it a different color etc.