### PR TITLE
Fix dnssnooper probe for multiple CNAMEs.

### DIFF
--- a/probe/endpoint/dns_snooper.go
+++ b/probe/endpoint/dns_snooper.go
@@ -250,15 +250,14 @@ func (s *DNSSnooper) processDNSMessage(dns *layers.DNS) {
 		domainQueried = question.Name
 		records       = append(dns.Answers, dns.Additionals...)
 		ips           = map[string]struct{}{}
-		alias         []byte
+		aliases       = [][]byte{}
 	)
 
-	// Traverse records for a CNAME first since the DNS RFCs don't seem to guarantee it
-	// appearing before its A-records
+	// Traverse all the CNAME records and the get the aliases. There are cases when the A record is for only one of the
+	// aliases. We traverse CNAME records first because there is no guarantee that the A records will be the first ones
 	for _, record := range records {
-		if record.Type == layers.DNSTypeCNAME && record.Class == layers.DNSClassIN && bytes.Equal(domainQueried, record.Name) {
-			alias = record.CNAME
-			break
+		if record.Type == layers.DNSTypeCNAME && record.Class == layers.DNSClassIN {
+			aliases = append(aliases, record.CNAME)
 		}
 	}
 
@@ -267,8 +266,15 @@ func (s *DNSSnooper) processDNSMessage(dns *layers.DNS) {
 		if record.Type != layers.DNSTypeA || record.Class != layers.DNSClassIN {
 			continue
 		}
-		if bytes.Equal(domainQueried, record.Name) || (alias != nil && bytes.Equal(alias, record.Name)) {
+		if bytes.Equal(domainQueried, record.Name) {
 			ips[record.IP.String()] = struct{}{}
+			continue
+		}
+		for _, alias := range aliases {
+			if bytes.Equal(alias, record.Name) {
+				ips[record.IP.String()] = struct{}{}
+				continue
+			}
 		}
 	}
 

--- a/probe/endpoint/dns_snooper.go
+++ b/probe/endpoint/dns_snooper.go
@@ -273,7 +273,7 @@ func (s *DNSSnooper) processDNSMessage(dns *layers.DNS) {
 		for _, alias := range aliases {
 			if bytes.Equal(alias, record.Name) {
 				ips[record.IP.String()] = struct{}{}
-				continue
+				break
 			}
 		}
 	}

--- a/probe/endpoint/dns_snooper_test.go
+++ b/probe/endpoint/dns_snooper_test.go
@@ -20,19 +20,19 @@ func TestProcessDNSMessageMultipleCNAME(t *testing.T) {
 
 	ipAddressCNAME := "127.0.0.1"
 	answers := []layers.DNSResourceRecord{
-		layers.DNSResourceRecord{
+		{
 			Name:  []byte("api.dummy.com"),
 			CNAME: []byte("api.dummy.com"),
 			Type:  layers.DNSTypeCNAME,
 			Class: layers.DNSClassIN,
 		},
-		layers.DNSResourceRecord{
+		{
 			Name:  []byte("star.c10r.dummy.com"),
 			CNAME: []byte("star.c10r.dummy.com"),
 			Type:  layers.DNSTypeCNAME,
 			Class: layers.DNSClassIN,
 		},
-		layers.DNSResourceRecord{
+		{
 			Name:  []byte("star.c10r.dummy.com"),
 			Type:  layers.DNSTypeA,
 			Class: layers.DNSClassIN,

--- a/probe/endpoint/dns_snooper_test.go
+++ b/probe/endpoint/dns_snooper_test.go
@@ -1,4 +1,5 @@
 // +build linux,amd64 linux,ppc64le
+
 package endpoint
 
 import (

--- a/probe/endpoint/dns_snooper_test.go
+++ b/probe/endpoint/dns_snooper_test.go
@@ -1,0 +1,74 @@
+// +build linux,amd64 linux,ppc64le
+package endpoint
+
+import (
+	"net"
+	"testing"
+
+	"github.com/google/gopacket/layers"
+)
+
+func TestprocessDNSMessageMultipleCNAME(t *testing.T) {
+	domain := "dummy.com"
+	question := layers.DNSQuestion{
+		Name: []byte(domain),
+		Type: layers.DNSTypeA,
+	}
+
+	ipAddressCNAME := "127.0.0.1"
+	ipAddress := "127.0.1.1"
+	answers := []layers.DNSResourceRecord{
+		layers.DNSResourceRecord{
+			Name:  []byte("api.dummy.com"),
+			Type:  layers.DNSTypeCNAME,
+			Class: layers.DNSClassIN,
+		},
+		layers.DNSResourceRecord{
+			Name:  []byte("star.c10r.dummy.com"),
+			Type:  layers.DNSTypeCNAME,
+			Class: layers.DNSClassIN,
+		},
+		layers.DNSResourceRecord{
+			Name:  []byte("dummy.com"),
+			Type:  layers.DNSTypeA,
+			Class: layers.DNSClassIN,
+			IP:    net.ParseIP(ipAddress),
+		},
+		layers.DNSResourceRecord{
+			Name:  []byte("star.c10r.dummy.com"),
+			Type:  layers.DNSTypeA,
+			Class: layers.DNSClassIN,
+			IP:    net.ParseIP(ipAddressCNAME),
+		},
+	}
+
+	dns := layers.DNS{
+		ResponseCode: layers.DNSResponseCodeNoErr,
+		Questions:    []layers.DNSQuestion{question},
+		Answers:      answers,
+	}
+
+	snooper := &DNSSnooper{}
+
+	snooper.processDNSMessage(&dns)
+
+	existingDomains, err := snooper.reverseDNSCache.Get(ipAddressCNAME)
+
+	if err != nil {
+		t.Errorf("A domain should have been inserted for the given CNAME IP:%v", err)
+	}
+
+	if _, ok := existingDomains.(map[string]struct{})[domain]; !ok {
+		t.Errorf("Domain %s should have been inserted", domain)
+	}
+
+	existingDomains, err = snooper.reverseDNSCache.Get(ipAddress)
+
+	if err != nil {
+		t.Errorf("A domain should have been inserted for the given IP:%v", err)
+	}
+
+	if _, ok := existingDomains.(map[string]struct{})[domain]; !ok {
+		t.Errorf("Domain %s should have been inserted", domain)
+	}
+}


### PR DESCRIPTION
Hello,
Playing with scope I noticed a bug where the dns snooper does not identify some external hosts. Digging a bit deeper I found the faulty pattern - if there are multiple CNAMEs in a record but only one of it has a corresponding A address then the match will not be done. Here's an example:

```
100.x.x.x.domain > 100.y.y.y.54637: 34745 3/0/0 graph.facebook.com. CNAME api.facebook.com., api.facebook.com. CNAME star.c10r.facebook.com., star.c10r.facebook.com. A 31.13.66.4 (174)
```

For this frame the outbound calls from my service to `graph.facebook.com.` where never caught.

The fix I considered goes through all the CNAME records and builds a list of aliases. Let me know what you think.

P.S. Scope is awesome, thanks for building it!