### PR TITLE
fix CVE-2018-16487 (lodash vulnerability)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -25,7 +25,7 @@
     "immutable": "3.8.2",
     "json-stable-stringify": "1.0.1",
     "lcp": "1.1.0",
-    "lodash": "4.17.10",
+    "lodash": "4.17.11",
     "materialize-css": "0.98.1",
     "moment": "2.21.0",
     "page": "1.7.1",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -5078,9 +5078,9 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4.17.10:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+lodash@4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
 lodash@^3.10.0:
   version "3.10.1"


### PR DESCRIPTION
Update to latest lodash release, c.f.
- https://nvd.nist.gov/vuln/detail/CVE-2018-16487
- https://hackerone.com/reports/380873