### PR TITLE
Update example yamls to probe Kubernetes once per cluster

### DIFF
--- a/examples/k8s/ds.yaml
+++ b/examples/k8s/ds.yaml
@@ -25,17 +25,12 @@ spec:
       containers:
         - name: scope-agent
           args:
-            - '--no-app'
+            - '--mode=probe'
+            - '--probe-only'
+            - '--probe.kubernetes.role=host'
             - '--probe.docker.bridge=docker0'
             - '--probe.docker=true'
-            - '--probe.kubernetes=true'
             - 'weave-scope-app.weave.svc.cluster.local:80'
-          env:
-            - name: KUBERNETES_NODENAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: spec.nodeName
           image: weaveworks/scope:1.10.2
           imagePullPolicy: IfNotPresent
           securityContext:
@@ -50,7 +45,6 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: true
-      serviceAccountName: weave-scope
       tolerations:
         - effect: NoSchedule
           operator: Exists

--- a/examples/k8s/probe-deploy.yaml
+++ b/examples/k8s/probe-deploy.yaml
@@ -1,0 +1,44 @@
+# borrowed from https://cloud.weave.works/k8s/scope.yaml?k8s-version=1.9.3
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: weave-scope-cluster-agent
+  labels:
+    name: weave-scope-cluster-agent
+    app: weave-scope
+    weave-cloud-component: scope
+    weave-scope-component: cluster-agent
+  namespace: weave
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: weave-scope-cluster-agent
+      app: weave-scope
+      weave-cloud-component: scope
+      weave-scope-component: cluster-agent
+  revisionHistoryLimit: 2
+  template:
+    metadata:
+      labels:
+        name: weave-scope-cluster-agent
+        app: weave-scope
+        weave-cloud-component: scope
+        weave-scope-component: cluster-agent
+    spec:
+      containers:
+        - name: scope-cluster-agent
+          args:
+            - '--mode=probe'
+            - '--probe-only'
+            - '--probe.kubernetes.role=cluster'
+            - 'weave-scope-app.weave.svc.cluster.local.:80'
+          command:
+            - /home/weave/scope
+          image: 'docker.io/weaveworks/scope:1.10.2'
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+      serviceAccountName: weave-scope


### PR DESCRIPTION
We stop the per-host probes talking to Kubernetes and run an extra Deployment with one more probe process to collect all information for the cluster, which is less resource-intensive overall.

This feature was added at #3274

(I haven't tried this exact config on a cluster yet; publishing for visibility and if someone else wants to test it)