### PR TITLE
Add CPU and memory requests to example Kubernetes manifests

### DIFF
--- a/examples/k8s/deploy.yaml
+++ b/examples/k8s/deploy.yaml
@@ -33,3 +33,7 @@ spec:
           ports:
             - containerPort: 4040
               protocol: TCP
+          resources:
+            requests:
+              cpu: 200m
+              memory: 200Mi

--- a/examples/k8s/ds.yaml
+++ b/examples/k8s/ds.yaml
@@ -38,6 +38,10 @@ spec:
                   fieldPath: spec.nodeName
           image: weaveworks/scope:1.10.2
           imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION
If you don't specify, the default is typically 0 which (a) gives the Kubernetes scheduler a false idea of expected usage and (b) makes the Linux scheduler penalise Scope processes under contention.

For best results adjust the figures here after observing actual usage on your cluster.