### PR TITLE
Add a dot to make DNS names absolute

### DIFF
--- a/examples/cri/ds.yaml
+++ b/examples/cri/ds.yaml
@@ -27,7 +27,7 @@ spec:
             - '--probe.kubernetes=true'
             - '--probe.cri=true'
             - '--probe.cri.endpoint=unix:///var/run/crio/crio.sock'
-            - 'weave-scope-app.weave.svc.cluster.local:80'
+            - 'weave-scope-app.weave.svc.cluster.local.:80'
           env:
             - name: KUBERNETES_NODENAME
               valueFrom:

--- a/examples/k8s/ds.yaml
+++ b/examples/k8s/ds.yaml
@@ -30,7 +30,7 @@ spec:
             - '--probe.kubernetes.role=host'
             - '--probe.docker.bridge=docker0'
             - '--probe.docker=true'
-            - 'weave-scope-app.weave.svc.cluster.local:80'
+            - 'weave-scope-app.weave.svc.cluster.local.:80'
           image: weaveworks/scope:1.10.2
           imagePullPolicy: IfNotPresent
           resources:


### PR DESCRIPTION
Fixes #3544 (at least the part that I could find to fix)

Kubernetes sets up a lengthy DNS search path, so any names are looked up multiple times. Adding a dot at the end tells the DNS resolver the name is absolute, and should not be tried against the search path.

This will reduce pointless DNS lookups.