### PR TITLE
Fix build-pkg script

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -3,7 +3,7 @@
     [
       "@babel/preset-env",
       {
-        "modules": false
+        "modules": "commonjs"
       }
     ],
     "@babel/preset-react"


### PR DESCRIPTION
Follow-up to #3580.

This change makes babel in `build-pkg` script fully transform the JS files to make them more compatible when imported from Weave Cloud.
