### PR TITLE
app: delete duplicates in report

### DIFF
--- a/probe/docker/container.go
+++ b/probe/docker/container.go
@@ -11,7 +11,6 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 	log "github.com/sirupsen/logrus"
-
 	"github.com/weaveworks/common/mtime"
 	"github.com/weaveworks/scope/report"
 )
@@ -322,9 +321,6 @@ func (c *container) NetworkInfo(localAddrs []net.IP) report.Sets {
 	if len(c.container.NetworkSettings.Ports) > 0 {
 		s = s.Add(ContainerPorts, c.ports(localAddrs))
 	}
-	if len(ipv4s) > 0 {
-		s = s.Add(ContainerIPs, report.MakeStringSet(ipv4s...))
-	}
 	if len(ipsWithScopes) > 0 {
 		s = s.Add(ContainerIPsWithScopes, report.MakeStringSet(ipsWithScopes...))
 	}
@@ -465,7 +461,7 @@ func (c *container) GetNode() report.Node {
 
 // ExtractContainerIPs returns the list of container IPs given a Node from the Container topology.
 func ExtractContainerIPs(nmd report.Node) []string {
-	v, _ := nmd.Sets.Lookup(ContainerIPs)
+	v, _ := nmd.Sets.LookupMask(ContainerIPsWithScopes, `[.]?;(.*)$`, 1)
 	return []string(v)
 }
 

--- a/probe/docker/container_test.go
+++ b/probe/docker/container_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	client "github.com/fsouza/go-dockerclient"
-
 	"github.com/weaveworks/common/mtime"
 	"github.com/weaveworks/scope/probe/docker"
 	"github.com/weaveworks/scope/report"
@@ -108,12 +107,11 @@ func TestContainer(t *testing.T) {
 		want := report.MakeSets().
 			Add("docker_container_ports", report.MakeStringSet("1.2.3.4:80->80/tcp", "81/tcp")).
 			Add("docker_container_networks", nil).
-			Add("docker_container_ips", report.MakeStringSet("1.2.3.4")).
-			Add("docker_container_ips", report.MakeStringSet("5.6.7.8")).
 			Add("docker_container_ips_with_scopes", report.MakeStringSet(";1.2.3.4")).
 			Add("docker_container_ips_with_scopes", report.MakeStringSet(";5.6.7.8")).
 			Add("docker_container_networks", report.MakeStringSet("network1"))
-
+			// Add("docker_container_ips", report.MakeStringSet("1.2.3.4")).
+			// Add("docker_container_ips", report.MakeStringSet("5.6.7.8")).
 		test.Poll(t, 100*time.Millisecond, want, func() interface{} {
 			return c.NetworkInfo([]net.IP{})
 		})

--- a/probe/docker/reporter.go
+++ b/probe/docker/reporter.go
@@ -6,7 +6,6 @@ import (
 
 	humanize "github.com/dustin/go-humanize"
 	docker_client "github.com/fsouza/go-dockerclient"
-
 	"github.com/weaveworks/scope/probe"
 	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/report"
@@ -37,7 +36,7 @@ var (
 		ContainerUptime:       {ID: ContainerUptime, Label: "Uptime", From: report.FromLatest, Priority: 5, Datatype: report.Duration},
 		ContainerRestartCount: {ID: ContainerRestartCount, Label: "Restart #", From: report.FromLatest, Priority: 6},
 		ContainerNetworks:     {ID: ContainerNetworks, Label: "Networks", From: report.FromSets, Priority: 7},
-		ContainerIPs:          {ID: ContainerIPs, Label: "IPs", From: report.FromSets, Priority: 8},
+		ContainerIPs:          {ID: ContainerIPsWithScopes, Label: "IPs", From: report.FromSetsIPScope, Priority: 8},
 		ContainerPorts:        {ID: ContainerPorts, Label: "Ports", From: report.FromSets, Priority: 9},
 		ContainerCreated:      {ID: ContainerCreated, Label: "Created", From: report.FromLatest, Datatype: report.DateTime, Priority: 10},
 		ContainerID:           {ID: ContainerID, Label: "ID", From: report.FromLatest, Truncate: 12, Priority: 11},
@@ -226,7 +225,6 @@ func (r *Reporter) containerTopology(localAddrs []net.IP) report.Topology {
 		if hostIPs, err := getLocalIPs(); err == nil {
 			hostIPsWithScopes := addScopeToIPs(r.hostID, hostIPs)
 			hostNetworkInfo = hostNetworkInfo.
-				Add(ContainerIPs, report.MakeStringSet(hostIPs...)).
 				Add(ContainerIPsWithScopes, report.MakeStringSet(hostIPsWithScopes...))
 		}
 

--- a/render/detailed/summary_test.go
+++ b/render/detailed/summary_test.go
@@ -253,11 +253,11 @@ func TestNodeMetadata(t *testing.T) {
 				docker.LabelPrefix + "label1": "label1value",
 				docker.ContainerStateHuman:    docker.StateRunning,
 			}).WithTopology(report.Container).WithSets(report.MakeSets().
-				Add(docker.ContainerIPs, report.MakeStringSet("10.10.10.0/24", "10.10.10.1/24")),
+				Add(docker.ContainerIPsWithScopes, report.MakeStringSet("10.10.10.0-10.10.10.3;10.10.10.0/24", ";10.10.10.1/24", ";10.10.10.1/24")),
 			),
 			want: []report.MetadataRow{
 				{ID: docker.ContainerStateHuman, Label: "State", Value: "running", Priority: 4},
-				{ID: docker.ContainerIPs, Label: "IPs", Value: "10.10.10.0/24, 10.10.10.1/24", Priority: 8},
+				{ID: docker.ContainerIPsWithScopes, Label: "IPs", Value: "10.10.10.0/24, 10.10.10.1/24", Priority: 8},
 				{ID: docker.ContainerID, Label: "ID", Value: fixture.ClientContainerID, Priority: 11, Truncate: 12},
 			},
 		},

--- a/report/metadata_template.go
+++ b/report/metadata_template.go
@@ -13,9 +13,10 @@ const (
 // FromLatest and friends denote the different fields where metadata can be
 // gathered from.
 const (
-	FromLatest   = "latest"
-	FromSets     = "sets"
-	FromCounters = "counters"
+	FromLatest      = "latest"
+	FromSets        = "sets"
+	FromCounters    = "counters"
+	FromSetsIPScope = "sets_ip_scope"
 )
 
 // MetadataTemplate extracts some metadata rows from a node
@@ -36,6 +37,8 @@ func (t MetadataTemplate) MetadataRow(n Node) (MetadataRow, bool) {
 		from = fromLatest
 	case FromSets:
 		from = fromSets
+	case FromSetsIPScope:
+		from = fromSetsIPScope
 	case FromCounters:
 		from = fromCounters
 	}
@@ -73,6 +76,11 @@ func fromSets(n Node, key string) (string, bool) {
 func fromCounters(n Node, key string) (string, bool) {
 	val, ok := n.Counters.Lookup(key)
 	return strconv.Itoa(val), ok
+}
+
+func fromSetsIPScope(n Node, key string) (string, bool) {
+	val, ok := n.Sets.LookupMask(key, `[.]?;(.*)$`, 1)
+	return strings.Join(val, ", "), ok
 }
 
 // MetadataRow is a row for the metadata table.


### PR DESCRIPTION
this deletes docker_container_ips from reports and keeps only docker_container_ips_with_scopes. IPs are extracted from docker_container_ips_with_scopes when needed.

Fixes #3433 