### PR TITLE
Add OpenTracing span for report.ReadBinary()

### DIFF
--- a/app/benchmark_internal_test.go
+++ b/app/benchmark_internal_test.go
@@ -30,7 +30,7 @@ func readReportFiles(b *testing.B, path string) []report.Report {
 			if info.IsDir() {
 				return nil
 			}
-			rpt, err := report.MakeFromFile(p)
+			rpt, err := report.MakeFromFile(context.Background(), p)
 			if err != nil {
 				return err
 			}

--- a/app/collector.go
+++ b/app/collector.go
@@ -278,7 +278,7 @@ func NewFileCollector(path string, window time.Duration) (Collector, error) {
 			}
 			timestamps = append(timestamps, t)
 
-			rpt, err := report.MakeFromFile(p)
+			rpt, err := report.MakeFromFile(context.Background(), p)
 			if err != nil {
 				return err
 			}

--- a/app/multitenant/s3_client.go
+++ b/app/multitenant/s3_client.go
@@ -83,7 +83,7 @@ func (store *S3Store) fetchReport(ctx context.Context, key string) (*report.Repo
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return report.MakeFromBinary(resp.Body)
+	return report.MakeFromBinary(ctx, resp.Body)
 }
 
 // StoreReportBytes stores a report.

--- a/app/router.go
+++ b/app/router.go
@@ -140,7 +140,7 @@ func RegisterReportPostHandler(a Adder, router *mux.Router) {
 			return
 		}
 
-		if err := rpt.ReadBinary(reader, gzipped, handle); err != nil {
+		if err := rpt.ReadBinary(ctx, reader, gzipped, handle); err != nil {
 			respondWith(w, http.StatusBadRequest, err)
 			return
 		}

--- a/extras/copyreport/main.go
+++ b/extras/copyreport/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 
@@ -15,7 +16,7 @@ func main() {
 		log.Fatal("usage: copyreport src.(json|msgpack)[.gz] dst.(json|msgpack)[.gz]")
 	}
 
-	rpt, err := report.MakeFromFile(flag.Arg(0))
+	rpt, err := report.MakeFromFile(context.Background(), flag.Arg(0))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/report/marshal_test.go
+++ b/report/marshal_test.go
@@ -1,6 +1,7 @@
 package report_test
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -14,7 +15,7 @@ func TestRoundtrip(t *testing.T) {
 	r1 := report.MakeReport()
 	buf, _ := r1.WriteBinary()
 	bytes := append([]byte{}, buf.Bytes()...) // copy the contents for later
-	r2, err := report.MakeFromBinary(buf)
+	r2, err := report.MakeFromBinary(context.Background(), buf)
 	if err != nil {
 		t.Error(err)
 	}
@@ -71,7 +72,7 @@ func makeTestReport() report.Report {
 func TestBiggerRoundtrip(t *testing.T) {
 	r1 := makeTestReport()
 	buf, _ := r1.WriteBinary()
-	r2, err := report.MakeFromBinary(buf)
+	r2, err := report.MakeFromBinary(context.Background(), buf)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
So we can see the timing and size in Jaeger.

