### PR TITLE
Defer metrics registration until we need it

### DIFF
--- a/app/multitenant/aws_collector.go
+++ b/app/multitenant/aws_collector.go
@@ -76,7 +76,7 @@ var (
 	}, []string{"method", "status_code"})
 )
 
-func init() {
+func registerAWSCollectorMetrics() {
 	prometheus.MustRegister(dynamoRequestDuration)
 	prometheus.MustRegister(dynamoConsumedCapacity)
 	prometheus.MustRegister(dynamoValueSize)
@@ -85,6 +85,8 @@ func init() {
 	prometheus.MustRegister(reportSizeHistogram)
 	prometheus.MustRegister(natsRequests)
 }
+
+var registerAWSCollectorMetricsOnce sync.Once
 
 // AWSCollector is a Collector which can also CreateTables
 type AWSCollector interface {
@@ -137,6 +139,7 @@ type watchKey struct {
 // NewAWSCollector the elastic reaper of souls
 // https://github.com/aws/aws-sdk-go/wiki/common-examples
 func NewAWSCollector(config AWSCollectorConfig) (AWSCollector, error) {
+	registerAWSCollectorMetricsOnce.Do(registerAWSCollectorMetrics)
 	var nc *nats.Conn
 	if config.NatsHost != "" {
 		var err error

--- a/app/multitenant/memcache_client.go
+++ b/app/multitenant/memcache_client.go
@@ -39,11 +39,13 @@ var (
 	}, []string{"method", "status_code"})
 )
 
-func init() {
+func registerMemcacheClientMetrics() {
 	prometheus.MustRegister(memcacheRequests)
 	prometheus.MustRegister(memcacheHits)
 	prometheus.MustRegister(memcacheRequestDuration)
 }
+
+var registerMemcacheClientMetricsOnce sync.Once
 
 // MemcacheClient is a memcache client that gets its server list from SRV
 // records, and periodically updates that ServerList.
@@ -72,6 +74,7 @@ type MemcacheConfig struct {
 // NewMemcacheClient creates a new MemcacheClient that gets its server list
 // from SRV and updates the server list on a regular basis.
 func NewMemcacheClient(config MemcacheConfig) *MemcacheClient {
+	registerMemcacheClientMetricsOnce.Do(registerMemcacheClientMetrics)
 	var servers memcache.ServerList
 	client := memcache.NewFromSelector(&servers)
 	client.Timeout = config.Timeout

--- a/app/multitenant/s3_client.go
+++ b/app/multitenant/s3_client.go
@@ -2,6 +2,7 @@ package multitenant
 
 import (
 	"bytes"
+	"sync"
 
 	"context"
 	"github.com/aws/aws-sdk-go/aws"
@@ -28,12 +29,15 @@ type S3Store struct {
 	bucketName string
 }
 
-func init() {
+func registerS3ClientMetrics() {
 	prometheus.MustRegister(s3RequestDuration)
 }
 
+var registerS3ClientMetricsOnce sync.Once
+
 // NewS3Client creates a new S3 client.
 func NewS3Client(config *aws.Config, bucketName string) S3Store {
+	registerS3ClientMetricsOnce.Do(registerS3ClientMetrics)
 	return S3Store{
 		s3:         s3.New(session.New(config)),
 		bucketName: bucketName,

--- a/app/multitenant/sqs_control_router.go
+++ b/app/multitenant/sqs_control_router.go
@@ -30,9 +30,11 @@ var (
 	}, []string{"method", "status_code"})
 )
 
-func init() {
+func registerSQSMetrics() {
 	prometheus.MustRegister(sqsRequestDuration)
 }
+
+var registerSQSMetricsOnce sync.Once
 
 // sqsControlRouter:
 // Creates a queue for every probe that connects to it, and a queue for
@@ -64,6 +66,7 @@ type sqsResponseMessage struct {
 
 // NewSQSControlRouter the harbinger of death
 func NewSQSControlRouter(config *aws.Config, userIDer UserIDer, prefix string, rpcTimeout time.Duration) app.ControlRouter {
+	registerSQSMetricsOnce.Do(registerSQSMetrics)
 	result := &sqsControlRouter{
 		service:          sqs.New(session.New(config)),
 		responseQueueURL: nil,


### PR DESCRIPTION
This avoids app-specific metrics appearing in the probe.