### PR TITLE
Release 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 - Add describe control to all Kubernetes resources [#3589](https://github.com/weaveworks/scope/pull/3589)
 - Show Kubernetes jobs [#3609](https://github.com/weaveworks/scope/pull/3609)
 
-Thanks to everyone who contributed to this release: @Deepak1100, @SaifRehman, @awolde, @bboreham, @bia, @dholbach, @fbarl, @foot, @guyfedwards, @jrryjcksn, @leavest, @n0rig, @najeal @paulmorabito, @qiell, @qurname2, @rade, @satyamz, @shindanim, @tiriplicamihai, @tvvignesh, @xrgy :tada:
+Thanks to everyone who contributed to this release: @Deepak1100, @SaifRehman, @awolde, @bboreham, @bia, @dholbach, @fbarl, @foot, @guyfedwards, @jrryjcksn, @leavest, @n0rig, @najeal, @paulmorabito, @qiell, @qurname2, @rade, @satyamz, @shindanim, @tiriplicamihai, @tvvignesh, @xrgy.
 
-Special thanks to @qiell and @satyamz for implementing both features.
+Special thanks to @qiell and @satyamz for implementing both features!
 
 ### Minor improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,44 @@
+## Release 1.11.0
+
+### Highlights
+
+- Add describe control to all Kubernetes resources [#3589](https://github.com/weaveworks/scope/pull/3589)
+- Show Kubernetes jobs [#3609](https://github.com/weaveworks/scope/pull/3609)
+
+Thanks to everyone who contributed to this release: @Deepak1100, @SaifRehman, @awolde, @bboreham, @bia, @dholbach, @fbarl, @foot, @guyfedwards, @jrryjcksn, @leavest, @n0rig, @najeal @paulmorabito, @qiell, @qurname2, @rade, @satyamz, @shindanim, @tiriplicamihai, @tvvignesh, @xrgy :tada:
+
+Special thanks to @qiell and @satyamz for implementing both features.
+
+### Minor improvements
+
+- Conditional report censoring [#3571](https://github.com/weaveworks/scope/pull/3571)
+- Add a confirmation dialog for deleting a pod [#3572](https://github.com/weaveworks/scope/pull/3572)
+- Add OpenTracing span for report.ReadBinary() [#3598](https://github.com/weaveworks/scope/pull/3598)
+- Add metrics for report size and count per tenant [#3599](https://github.com/weaveworks/scope/pull/3599)
+
+### Bugs and security fixes
+
+- Security fixes in dev dependencies [#3578](https://github.com/weaveworks/scope/pull/3578)
+- Use Time Travel context when downloading raw reports [#3582](https://github.com/weaveworks/scope/pull/3582)
+- Fix bug Chrome 56+ can't prevent default wheel events [#3593](https://github.com/weaveworks/scope/pull/3593)
+- Fix dnssnooper probe for multiple CNAMEs [#3566](https://github.com/weaveworks/scope/pull/3566)
+- Fix build-pkg script [#3587](https://github.com/weaveworks/scope/pull/3587)
+
+### Dependencies updates
+
+- Upgrade to Webpack 4 [#3580](https://github.com/weaveworks/scope/pull/3580)
+- Upgrade client-go version to 10.0.0 [#3588](https://github.com/weaveworks/scope/pull/3588)
+- Upgrade ui-components and some of similar dependencies [#3574](https://github.com/weaveworks/scope/pull/3574)
+- Remove materialize-css JS dep [#3596](https://github.com/weaveworks/scope/pull/3596)
+
+### Documentation and examples
+
+- The path is actually examples/k8s [#3586](https://github.com/weaveworks/scope/pull/3586)
+- Update examples/k8s RBAC permissions [#3595](https://github.com/weaveworks/scope/pull/3595)
+- Update example yamls to probe Kubernetes once per cluster [#3569](https://github.com/weaveworks/scope/pull/3569)
+- Add CPU and memory requests to example Kubernetes manifests [#3570](https://github.com/weaveworks/scope/pull/3570)
+- Extend FAQ with basic auth through environment variables [#3575](https://github.com/weaveworks/scope/pull/3575)
+
 ## Release 1.10.2
 
 This release has a security fix, a few bug-fixes and some other minor

--- a/site/installing.md
+++ b/site/installing.md
@@ -112,7 +112,7 @@ After it’s been launched, open your browser to `http://localhost:4040`.
 **Docker Compose Format Version 1:**
 
     scope:
-      image: weaveworks/scope:1.10.2
+      image: weaveworks/scope:1.11.0
       net: "host"
       pid: "host"
       privileged: true
@@ -128,7 +128,7 @@ After it’s been launched, open your browser to `http://localhost:4040`.
     version: '2'
     services:
       scope:
-        image: weaveworks/scope:1.10.2
+        image: weaveworks/scope:1.11.0
         network_mode: "host"
         pid: "host"
         privileged: true


### PR DESCRIPTION
See [CHANGELOG.md](https://github.com/weaveworks/scope/pull/3610/files#diff-4ac32a78649ca5bdd8e0ba38b7006a1e) for the list of changes.

#### Tested out

- [x] Start a 2 node cluster and leave a UI connected, watch for performance regression
- [ ] Run a Scope cluster on ECS
- [x] Run Scope on https://github.com/microservices-demo/microservices-demo/
- [x] Run Scope on Docker For Mac
- [x] Start and stop Scope in standalone mode
  - [x] Linux
  - [x] docker-machine
- [ ] Connect probes from release candidate to Weave Cloud
  - [ ] Local scope in probe-only mode connects to Weave Cloud and renders correctly
    - [ ] dev
    - [ ] prod
  - [ ] Controls appear for containers and function correctly
    - [x] dev
    - [ ] prod
  - [ ] No new errors in logging or telemetry
    - [ ] dev
    - [ ] prod
- [x] UI integration
  - [x] Hot-reloading `cd client && yarn install && yarn start` and open http://localhost:4042
  - [x] UI under prefix path  `cd client && yarn build && yarn start-production` and open http://localhost:4043/scoped/
  - [x] URL parameters: Run previous release and click around, keep UI open, start new release, reload page
- [x] UI features
  (To test: clone [microservices demo](https://github.com/microservices-demo/microservices-demo) and run `cd deploy/docker-compose && docker-compose up`)
  - [x] General: switch between topologies, see nodes and edges, details panel
  - [x] Zoom and pan, switch between topologies
  - [x] Topology filters: namespaces, system containers, etc.
  - [x] Metrics on canvas, try pinning/unpinning
  - [x] Search
    - [x] by container name
    - [x] by usage `cpu < 2%`
  - [x] Terminal
    - [x] Attach to container to see logs
    - [x] Exec to container and type `ls`
    - [x] Pop out terminal
  - [x] Contrast mode
  - [x] Download report
  - [x] Pause button

#### New issues found

* Contrast mode not persisted properly in the URL #3611 
* Building with `make` puts too strong permissions on client assets #3612
