### PR TITLE
use Labels to filter out application groups(pods) and add OOMKilled count for API

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -85,23 +85,23 @@ func namespaceFilters(namespaces []string, noneLabel string) APITopologyOptionGr
 // labelFilters generates a label selector option group based on the given labels
 func labelFilters(labels []string, noneLabel string) APITopologyOptionGroup {
 	options := APITopologyOptionGroup{ID: "label", Default: "", SelectType: "union", NoneLabel: noneLabel}
-	new_labels := []string{}
+	newLabels := []string{}
 	for _, name := range labels {
 		found := false
-		if len(new_labels) > 0 {
-			for _, new_name := range new_labels {
-				if name == new_name {
+		if len(newLabels) > 0 {
+			for _, newName := range newLabels {
+				if name == newName {
 					found = true
 					break
 				}
 			}
 		}
 		if !found {
-			new_labels = append(new_labels, name)
+			newLabels = append(newLabels, name)
 		}
 	}
 
-	for _, label := range new_labels {
+	for _, label := range newLabels {
 		options.Options = append(options.Options, APITopologyOption{
 			Value: label, Label: label, filter: render.IsLabel(label), filterPseudo: false,
 		})

--- a/client/app/styles/_base.scss
+++ b/client/app/styles/_base.scss
@@ -1326,8 +1326,9 @@ a {
   &-wrapper {
     display: inline-flex;
     flex-wrap: wrap;
-    overflow: hidden;
-    max-height: 27px;
+    overflow: scroll;
+    height: auto;
+    max-height: calc((13px * 1.5 + 3px + 3px) * 3); // expand to display 8 rows
     transition: max-height 0.5s 0s $base-ease;
 
     .topology-option-action {
@@ -1335,13 +1336,15 @@ a {
       text-align: center;
     }
   }
-  
-    &:last-child :hover {
+
+/*
+  &:last-child :hover {
     height: auto;
     max-height: calc((13px * 1.5 + 3px + 3px) * 8); // expand to display 8 rows
     overflow: auto;
     transition: max-height 0.5s 0s $base-ease;
-  } 
+  }
+  */
 
   font-size: $font-size-small;
 

--- a/probe/kubernetes/client.go
+++ b/probe/kubernetes/client.go
@@ -15,7 +15,9 @@ import (
 	snapshotv1 "github.com/openebs/k8s-snapshot-client/snapshot/pkg/apis/volumesnapshot/v1"
 	snapshot "github.com/openebs/k8s-snapshot-client/snapshot/pkg/client/clientset/versioned"
 	"github.com/pborman/uuid"
+	dto "github.com/prometheus/client_model/go"
 	log "github.com/sirupsen/logrus"
+	"github.com/weaveworks/scope/report"
 	apiappsv1 "k8s.io/api/apps/v1"
 	apiappsv1beta1 "k8s.io/api/apps/v1beta1"
 	apibatchv1 "k8s.io/api/batch/v1"
@@ -38,8 +40,6 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	kubectldescribe "k8s.io/kubernetes/pkg/kubectl/describe"
 	kubectl "k8s.io/kubernetes/pkg/kubectl/describe/versioned"
-	"github.com/weaveworks/scope/report"
-	dto "github.com/prometheus/client_model/go"
 )
 
 // Client keeps track of running kubernetes pods and services
@@ -105,8 +105,8 @@ type client struct {
 	volumeSnapshotStore        cache.Store
 	volumeSnapshotDataStore    cache.Store
 
-	podWatchesMutex sync.Mutex
-	podWatches      []func(Event, Pod)
+	podWatchesMutex     sync.Mutex
+	podWatches          []func(Event, Pod)
 	oomKilledFinishedAt metav1.Time
 }
 
@@ -125,7 +125,6 @@ type ClientConfig struct {
 	User                 string
 	Username             string
 }
-
 
 // NewClient returns a usable Client. Don't forget to Stop it.
 func NewClient(config ClientConfig) (Client, error) {
@@ -337,7 +336,7 @@ func (c *client) WalkPods(f func(Pod) error) error {
 				log.Infof("[WalkPods] pod Status.ContainerStatuses[%d].LastTerminationState.Terminated.Reason: %+v\n", i, state.LastTerminationState.Terminated.Reason)
 
 				var reason string = state.LastTerminationState.Terminated.Reason
-				if (strings.Contains(reason, OOMKilledReason)) {
+				if strings.Contains(reason, OOMKilledReason) {
 					startedAt := state.LastTerminationState.Terminated.StartedAt
 					finishedAt := state.LastTerminationState.Terminated.FinishedAt
 					RestartCount := state.RestartCount

--- a/probe/kubernetes/meta.go
+++ b/probe/kubernetes/meta.go
@@ -10,13 +10,13 @@ import (
 
 // These constants are keys used in node metadata
 const (
-	Name            = report.KubernetesName
-	Namespace       = report.KubernetesNamespace
-	Created         = report.KubernetesCreated
-	LabelPrefix     = "kubernetes_labels_"
-	VolumeClaimName = report.KubernetesVolumeClaim
+	Name                = report.KubernetesName
+	Namespace           = report.KubernetesNamespace
+	Created             = report.KubernetesCreated
+	LabelPrefix         = "kubernetes_labels_"
+	VolumeClaimName     = report.KubernetesVolumeClaim
 	OOMKilledCountLabel = "oomkilled_count"
-	OOMKilledCount      =  LabelPrefix + OOMKilledCountLabel
+	OOMKilledCount      = LabelPrefix + OOMKilledCountLabel
 	OOMKilledReason     = "OOMKilled"
 )
 

--- a/probe/kubernetes/meta.go
+++ b/probe/kubernetes/meta.go
@@ -15,6 +15,9 @@ const (
 	Created         = report.KubernetesCreated
 	LabelPrefix     = "kubernetes_labels_"
 	VolumeClaimName = report.KubernetesVolumeClaim
+	OOMKilledCountLabel = "oomkilled_count"
+	OOMKilledCount      =  LabelPrefix + OOMKilledCountLabel
+	OOMKilledReason     = "OOMKilled"
 )
 
 // Meta represents a metadata information about a Kubernetes object

--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -46,6 +46,7 @@ var (
 		Namespace:        {ID: Namespace, Label: "Namespace", From: report.FromLatest, Priority: 5},
 		Created:          {ID: Created, Label: "Created", From: report.FromLatest, Datatype: report.DateTime, Priority: 6},
 		RestartCount:     {ID: RestartCount, Label: "Restart #", From: report.FromLatest, Priority: 7},
+		OOMKilledCount:   {ID: OOMKilledCount, Label: "OOMKilled #", From: report.FromOOMKilled, Priority: 8},
 	}
 
 	PodMetricTemplates = docker.ContainerMetricTemplates

--- a/prog/main.go
+++ b/prog/main.go
@@ -14,6 +14,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/prometheus/client_golang/prometheus"
 	billing "github.com/weaveworks/billing-client"
 	"github.com/weaveworks/scope/app"
 	"github.com/weaveworks/scope/app/multitenant"
@@ -22,9 +23,8 @@ import (
 	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/probe/kubernetes"
 	"github.com/weaveworks/scope/render"
-	"github.com/weaveworks/weave/common"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaveworks/scope/report"
+	"github.com/weaveworks/weave/common"
 )
 
 var (

--- a/prog/main.go
+++ b/prog/main.go
@@ -23,6 +23,8 @@ import (
 	"github.com/weaveworks/scope/probe/kubernetes"
 	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/weave/common"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/weaveworks/scope/report"
 )
 
 var (
@@ -397,6 +399,9 @@ func setupFlags(flags *flags) {
 }
 
 func main() {
+	// register OOMKilled counter
+	prometheus.MustRegister(report.OOMKilledCounter)
+
 	flags := flags{}
 	setupFlags(&flags)
 	flags.app.BillingEmitterConfig.RegisterFlags(flag.CommandLine)

--- a/render/filters.go
+++ b/render/filters.go
@@ -310,6 +310,26 @@ func IsNamespace(namespace string) FilterFunc {
 	}
 }
 
+// IsLabel checks if the node is a pod/service containing the specified label
+func IsLabel(label string) FilterFunc {
+	return func(n report.Node) bool {
+		tryKeys := []string{"kubernetes_labels_app", "kubernetes_labels_deployment", "kubernetes_labels_deploymentconfig", "kubernetes_labels_template", "kubernetes_labels_type", "kubernetes_labels_k8s-app", "kubernetes_labels_openshift.io/component", kubernetes.Namespace, docker.LabelPrefix + k8sNamespaceLabel, docker.StackNamespace, docker.LabelPrefix + swarmNamespaceLabel}
+
+		gotLabel := ""
+		for _, key := range tryKeys {
+			if value, ok := n.Latest.Lookup(key); ok {
+				gotLabel = value
+				break
+			}
+		}
+		// Special case for docker
+		if label == docker.DefaultNamespace && gotLabel == "" {
+			return true
+		}
+		return label == gotLabel
+	}
+}
+
 // IsTopology checks if the node is from a particular report topology
 func IsTopology(topology string) FilterFunc {
 	return func(n report.Node) bool {

--- a/report/metadata_template.go
+++ b/report/metadata_template.go
@@ -16,6 +16,7 @@ const (
 	FromLatest   = "latest"
 	FromSets     = "sets"
 	FromCounters = "counters"
+	FromOOMKilled = "oomkilled"
 )
 
 // MetadataTemplate extracts some metadata rows from a node
@@ -38,6 +39,8 @@ func (t MetadataTemplate) MetadataRow(n Node) (MetadataRow, bool) {
 		from = fromSets
 	case FromCounters:
 		from = fromCounters
+	case FromOOMKilled:
+		from = fromOOMKilled
 	}
 	if val, ok := from(n, t.ID); ok {
 		return MetadataRow{
@@ -62,6 +65,10 @@ func fromDefault(n Node, key string) (string, bool) {
 }
 
 func fromLatest(n Node, key string) (string, bool) {
+	return n.Latest.Lookup(key)
+}
+
+func fromOOMKilled(n Node, key string) (string, bool) {
 	return n.Latest.Lookup(key)
 }
 

--- a/report/metadata_template.go
+++ b/report/metadata_template.go
@@ -13,9 +13,9 @@ const (
 // FromLatest and friends denote the different fields where metadata can be
 // gathered from.
 const (
-	FromLatest   = "latest"
-	FromSets     = "sets"
-	FromCounters = "counters"
+	FromLatest    = "latest"
+	FromSets      = "sets"
+	FromCounters  = "counters"
 	FromOOMKilled = "oomkilled"
 )
 

--- a/report/report.go
+++ b/report/report.go
@@ -6,16 +6,17 @@ import (
 	"strings"
 	"time"
 
-	"github.com/weaveworks/scope/common/xfer"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/weaveworks/scope/common/xfer"
 )
 
 var (
+	// OOMKilledCounter is to count OOMKilled status of a pod
 	OOMKilledCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "scope",
-			Name: "oom_killed_count",
-			Help: "Number of OOMKilled count of a pod",
+			Name:      "oom_killed_count",
+			Help:      "Number of OOMKilled count of a pod",
 		},
 		[]string{"namespace", "app", "pod"},
 	)

--- a/report/report.go
+++ b/report/report.go
@@ -7,6 +7,18 @@ import (
 	"time"
 
 	"github.com/weaveworks/scope/common/xfer"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	OOMKilledCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "scope",
+			Name: "oom_killed_count",
+			Help: "Number of OOMKilled count of a pod",
+		},
+		[]string{"namespace", "app", "pod"},
+	)
 )
 
 // Names of the various topologies.

--- a/vendor/k8s.io/client-go/listers/core/v1/pod.go
+++ b/vendor/k8s.io/client-go/listers/core/v1/pod.go
@@ -49,6 +49,7 @@ func (s *podLister) List(selector labels.Selector) (ret []*v1.Pod, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Pod))
 	})
+
 	return ret, err
 }
 


### PR DESCRIPTION
[scope][GUI] use Labels to filter out application groups(pods)
[scope][prometheus] Add OOMKilled count to prometheus exporter.
[scope][API] get OOMKilled count from prometheus exporter and add OOMKilled count to metadata of a pod.