### PR TITLE
[fix] [make] update ui build to avoid yarn build fail after make.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ $(SCOPE_UI_TOOLCHAIN_UPTODATE): client/yarn.lock $(SCOPE_UI_BUILD_UPTODATE)
 			-v $(shell pwd)/client:/home/weave/scope/client \
 			-v $(shell pwd)/$(SCOPE_UI_TOOLCHAIN):/home/weave/scope/client/node_modules \
 			-w /home/weave/scope/client \
+			-u $(shell id -u ${USER}):$(shell id -g ${USER}) \
 			$(SCOPE_UI_BUILD_IMAGE) yarn install; \
 	fi
 	touch $(SCOPE_UI_TOOLCHAIN_UPTODATE)
@@ -165,6 +166,7 @@ client/build/index.html: $(shell find client/app -type f) $(SCOPE_UI_TOOLCHAIN_U
 			-v $(shell pwd)/client:/home/weave/scope/client \
 			-v $(shell pwd)/$(SCOPE_UI_TOOLCHAIN):/home/weave/scope/client/node_modules \
 			-w /home/weave/scope/client \
+			-u $(shell id -u ${USER}):$(shell id -g ${USER}) \
 			$(SCOPE_UI_BUILD_IMAGE) yarn run build; \
 	fi
 
@@ -176,6 +178,7 @@ client/build-external/index.html: $(shell find client/app -type f) $(SCOPE_UI_TO
 			-v $(shell pwd)/client:/home/weave/scope/client \
 			-v $(shell pwd)/$(SCOPE_UI_TOOLCHAIN):/home/weave/scope/client/node_modules \
 			-w /home/weave/scope/client \
+			-u $(shell id -u ${USER}):$(shell id -g ${USER}) \
 			$(SCOPE_UI_BUILD_IMAGE) yarn run build-external; \
 	fi
 
@@ -185,6 +188,7 @@ client-test: $(shell find client/app/scripts -type f) $(SCOPE_UI_TOOLCHAIN_UPTOD
 		-v $(shell pwd)/client:/home/weave/scope/client \
 		-v $(shell pwd)/$(SCOPE_UI_TOOLCHAIN):/home/weave/scope/client/node_modules \
 		-w /home/weave/scope/client \
+		-u $(id -u ${USER}):$(id -g ${USER}) \
 		$(SCOPE_UI_BUILD_IMAGE) yarn test
 
 client-lint: $(SCOPE_UI_TOOLCHAIN_UPTODATE)
@@ -193,6 +197,7 @@ client-lint: $(SCOPE_UI_TOOLCHAIN_UPTODATE)
 		-v $(shell pwd)/client:/home/weave/scope/client \
 		-v $(shell pwd)/$(SCOPE_UI_TOOLCHAIN):/home/weave/scope/client/node_modules \
 		-w /home/weave/scope/client \
+		-u $(shell id -u ${USER}):$(shell id -g ${USER}) \
 		$(SCOPE_UI_BUILD_IMAGE) yarn run lint
 
 client-start: $(SCOPE_UI_TOOLCHAIN_UPTODATE)
@@ -202,6 +207,7 @@ client-start: $(SCOPE_UI_TOOLCHAIN_UPTODATE)
 		-v $(shell pwd)/$(SCOPE_UI_TOOLCHAIN):/home/weave/scope/client/node_modules \
 		-e WEBPACK_SERVER_HOST \
 		-w /home/weave/scope/client \
+		-u $(shell id -u ${USER}):$(shell id -g ${USER}) \
 		$(SCOPE_UI_BUILD_IMAGE) yarn start
 
 client/bundle/weave-scope.tgz: $(shell find client/app -type f) $(SCOPE_UI_TOOLCHAIN_UPTODATE)
@@ -211,6 +217,7 @@ client/bundle/weave-scope.tgz: $(shell find client/app -type f) $(SCOPE_UI_TOOLC
 		-v $(shell pwd)/$(SCOPE_UI_TOOLCHAIN):/home/weave/scope/client/node_modules \
 		-v $(shell pwd)/tmp:/home/weave/tmp \
 		-w /home/weave/scope/client \
+		-u $(shell id -u ${USER}):$(shell id -g ${USER}) \
 		$(SCOPE_UI_BUILD_IMAGE) yarn run bundle
 
 else


### PR DESCRIPTION
We are building ui-dist in make using docker image of nodejs after building dist it put those dist in build or build-external folder. These folders are created by docker run under root user. After make if we try to build it locally by yarn build it tries to delete build folder from `$USER` user thats why we are getting permission error.

```bash
shovan@probot:~/Desktop/workspace/src/github.com/weaveworks/scope/client$ ls -l
total 420
drwxr-xr-x    7 shovan shovan   4096 Jun 12 15:46 app
drwxr-xr-x    2 root   root     4096 Jun 13 00:42 build
drwxr-xr-x    2 root   root     4096 Jun 13 00:37 build-external
-rw-r--r--    1 shovan shovan    608 Jun 12 15:46 Dockerfile
drwxr-xr-x 1016 shovan shovan  36864 Jun 13 00:36 node_modules
-rw-r--r--    1 shovan shovan   4642 Jun 13 00:29 package.json
-rw-r--r--    1 shovan shovan   1764 Jun 12 15:46 README.md
-rw-r--r--    1 shovan shovan   2623 Jun 12 15:46 server.js
drwxr-xr-x    5 shovan shovan   4096 Jun 12 16:14 test
-rw-r--r--    1 shovan shovan   4239 Jun 12 15:46 webpack.local.config.js
-rw-r--r--    1 shovan shovan   3856 Jun 13 00:27 webpack.production.config.js
-rw-r--r--    1 shovan shovan 334991 Jun 12 15:46 yarn.lock
```

Fixes #3612

Signed-off-by: Shovan Maity <shovan.cse91@gmail.com>