### PR TITLE
fix: remove unused metric SpyDuration

### DIFF
--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -1,9 +1,6 @@
 package endpoint
 
 import (
-	"time"
-
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaveworks/scope/probe/endpoint/procspy"
 	"github.com/weaveworks/scope/probe/process"
 	"github.com/weaveworks/scope/report"
@@ -30,18 +27,6 @@ type ReporterConfig struct {
 	Scanner      procspy.ConnectionScanner
 	DNSSnooper   *DNSSnooper
 }
-
-// SpyDuration is an exported prometheus metric
-var SpyDuration = prometheus.NewSummaryVec(
-	prometheus.SummaryOpts{
-		Namespace: "scope",
-		Subsystem: "probe",
-		Name:      "spy_duration_seconds",
-		Help:      "Time in seconds spent spying on active connections.",
-		MaxAge:    10 * time.Second, // like statsd
-	},
-	[]string{},
-)
 
 // Name of this reporter, for metrics gathering
 func (Reporter) Name() string { return "Endpoint" }

--- a/probe/endpoint/reporter_linux.go
+++ b/probe/endpoint/reporter_linux.go
@@ -3,8 +3,6 @@
 package endpoint
 
 import (
-	"time"
-
 	"github.com/weaveworks/scope/report"
 )
 
@@ -39,10 +37,6 @@ func (r *Reporter) Stop() {
 
 // Report implements Reporter.
 func (r *Reporter) Report() (report.Report, error) {
-	defer func(begin time.Time) {
-		SpyDuration.WithLabelValues().Observe(time.Since(begin).Seconds())
-	}(time.Now())
-
 	rpt := report.MakeReport()
 
 	r.connectionTracker.ReportConnections(&rpt)


### PR DESCRIPTION
The call to register this metric was removed in #633 over three years ago.
If it isn't registered then nobody can see the values.
The measurement is duplicated by metrics added in #658.