### PR TITLE
fix: handle errors reported by the conntrack package

### DIFF
--- a/probe/endpoint/conntrack.go
+++ b/probe/endpoint/conntrack.go
@@ -147,6 +147,11 @@ func (c *conntrackWalker) run() {
 			if !ok {
 				return
 			}
+			if f.Err != nil {
+				log.Errorf("conntrack event error: %v", f.Err)
+				stop()
+				return
+			}
 			if c.relevant(f) {
 				c.handleFlow(f)
 			}


### PR DESCRIPTION
In particular, ENOBUFS which indicates data has been dropped.
With this change the collector will restart, thus resynchronising with the OS.

I believe this is the cause of #3645 
