### PR TITLE
Docs: improve the warning about opening Scope to the Internet

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ If you would like to see your name added, let us know on Slack, or send a PR ple
 
 ## <a name="getting-started"></a>Getting Started
 
+Ensure your computer is behind a firewall that blocks port 4040 then,
+
 ```console
 sudo curl -L git.io/scope -o /usr/local/bin/scope
 sudo chmod a+x /usr/local/bin/scope

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you would like to see your name added, let us know on Slack, or send a PR ple
 
 ## <a name="getting-started"></a>Getting Started
 
-Ensure your computer is behind a firewall that blocks port 4040 then,
+**Ensure your computer is behind a firewall that blocks port 4040** then,
 
 ```console
 sudo curl -L git.io/scope -o /usr/local/bin/scope

--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ scope launch
 ```
 
 This script downloads and runs a recent Scope image from Docker Hub.
-Now, open your web browser to **http://localhost:4040**. (If you're using
-boot2docker, replace localhost with the output of `boot2docker ip`.)
+Now, open your web browser to **http://localhost:4040**.
 
 For instructions on installing Scope on [Kubernetes](https://www.weave.works/docs/scope/latest/installing/#k8s), [DCOS](https://www.weave.works/docs/scope/latest/installing/#dcos), or [ECS](https://www.weave.works/docs/scope/latest/installing/#ecs), see [the docs](https://www.weave.works/docs/scope/latest/introducing/).
 

--- a/site/installing.md
+++ b/site/installing.md
@@ -168,6 +168,11 @@ Allowable parameters for the launcher URL:
 
 The URL is: http://localhost:4040.
 
+>**Note:** Do not expose the Scope service to the Internet, e.g. by
+   changing the type to NodePort or LoadBalancer. Scope allows anyone
+   with access to the user interface control over your hosts and
+   containers.
+
 ### Kubernetes (local clone)
 
 A simple way to get Scope running in a Kubernetes setting is to

--- a/site/plugins.md
+++ b/site/plugins.md
@@ -34,7 +34,7 @@ Official Weave Scope plugins can be found at [Weaveworks Plugins](https://github
 	* Number of HTTP requests per seconds.
 	* Number of HTTP responses code per second (per code).
 
->**Note:** The HTTP Statistics plugin requires a [recent kernel version with ebpf support](https://github.com/iovisor/bcc/blob/master/INSTALL.md#kernel-configuration) and it will not compile on [dlite](https://github.com/nlf/dlite) or on boot2docker hosts.
+>**Note:** The HTTP Statistics plugin requires a [recent kernel version with ebpf support](https://github.com/iovisor/bcc/blob/master/INSTALL.md#kernel-configuration) and it will not compile on [dlite](https://github.com/nlf/dlite) hosts.
 
 * [Traffic Control](https://github.com/weaveworks-plugins/scope-traffic-control): This plugin allows you to modify latency and packet loss for a specific container via controls from the container's detailed view in the Scope user interface.
 


### PR DESCRIPTION
Trying to improve the situation at #3624 and #2814 

Also drive-by removal of `boot2docker` since it's ancient history and complicates the instructions.