### PR TITLE
fix(probe): Avoid ebpf events out of order by adding offset to time

### DIFF
--- a/vendor/github.com/weaveworks/tcptracer-bpf/pkg/tracer/event.go
+++ b/vendor/github.com/weaveworks/tcptracer-bpf/pkg/tracer/event.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package tracer
 
 import (
@@ -37,9 +39,15 @@ func tcpV4ToGo(data *[]byte) (ret TcpV4) {
 	return
 }
 
+// Offset added to all timestamps, to hold back events so they are less
+// likely to be reported out of order. Value is in nanoseconds.
+var (
+	TimestampOffset uint64 = 100000
+)
+
 func tcpV4Timestamp(data *[]byte) uint64 {
 	eventC := (*C.struct_tcp_ipv4_event_t)(unsafe.Pointer(&(*data)[0]))
-	return uint64(eventC.timestamp)
+	return uint64(eventC.timestamp) + TimestampOffset
 }
 
 func tcpV6ToGo(data *[]byte) (ret TcpV6) {
@@ -72,5 +80,5 @@ func tcpV6ToGo(data *[]byte) (ret TcpV6) {
 
 func tcpV6Timestamp(data *[]byte) uint64 {
 	eventC := (*C.struct_tcp_ipv6_event_t)(unsafe.Pointer(&(*data)[0]))
-	return uint64(eventC.timestamp)
+	return uint64(eventC.timestamp) + TimestampOffset
 }

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -2037,7 +2037,7 @@
 			"importpath": "github.com/weaveworks/tcptracer-bpf",
 			"repository": "https://github.com/weaveworks/tcptracer-bpf",
 			"vcs": "git",
-			"revision": "6dca783d10f7ba0c8fe707e5e210a8d3114af4c0",
+			"revision": "cd53e7c84baca8cc63cb689185b93a14b0169848",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
Fixes #2827

Needs the [upstream PR](https://github.com/weaveworks/tcptracer-bpf/pull/67) to be merged then vendor that change here.

The idea is described at https://github.com/iovisor/gobpf/issues/42#issuecomment-508500065 but no response in that repo so I'm making the change in a weaveworks-controlled repo.