### PR TITLE
Fixes "45undefined" in node memory overlay

### DIFF
--- a/client/app/scripts/utils/string-utils.js
+++ b/client/app/scripts/utils/string-utils.js
@@ -32,7 +32,7 @@ function makeFormatters(renderFn) {
   const formatters = {
     filesize(value) {
       const obj = filesize(value, {output: 'object', round: 1});
-      return renderFn(obj.value, obj.suffix);
+      return renderFn(obj.value, obj.symbol);
     },
 
     integer(value) {


### PR DESCRIPTION
- Should be "45MB"
- Seems like the filesize lib subtley changed their API

Fixes #3672