### PR TITLE
Stop render package depending on probe

### DIFF
--- a/app/api_report.go
+++ b/app/api_report.go
@@ -6,7 +6,6 @@ import (
 
 	"context"
 
-	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -52,8 +51,8 @@ func makeProbeHandler(rep Reporter) CtxHandlerFunc {
 		result := []probeDesc{}
 		for _, n := range rpt.Host.Nodes {
 			id, _ := n.Latest.Lookup(report.ControlProbeID)
-			hostname, _ := n.Latest.Lookup(host.HostName)
-			version, dt, _ := n.Latest.LookupEntry(host.ScopeVersion)
+			hostname, _ := n.Latest.Lookup(report.HostName)
+			version, dt, _ := n.Latest.LookupEntry(report.ScopeVersion)
 			result = append(result, probeDesc{
 				ID:       id,
 				Hostname: hostname,

--- a/probe/docker/container.go
+++ b/probe/docker/container.go
@@ -52,20 +52,8 @@ const (
 	CPUUsageInKernelmode = "docker_cpu_usage_in_kernelmode"
 	CPUSystemCPUUsage    = "docker_cpu_system_cpu_usage"
 
-	LabelPrefix = "docker_label_"
+	LabelPrefix = report.DockerLabelPrefix
 	EnvPrefix   = report.DockerEnvPrefix
-)
-
-// These 'constants' are used for node states.
-// We need to take pointers to them, so they are vars...
-var (
-	StateCreated    = "created"
-	StateDead       = "dead"
-	StateExited     = "exited"
-	StatePaused     = "paused"
-	StateRestarting = "restarting"
-	StateRunning    = "running"
-	StateDeleted    = "deleted"
 )
 
 // StatsGatherer gathers container stats
@@ -479,7 +467,7 @@ func ExtractContainerIPsWithScopes(nmd report.Node) []string {
 // ContainerIsStopped checks if the docker container is in one of our "stopped" states
 func ContainerIsStopped(c Container) bool {
 	state := c.StateString()
-	return (state != StateRunning && state != StateRestarting && state != StatePaused)
+	return (state != report.StateRunning && state != report.StateRestarting && state != report.StatePaused)
 }
 
 // splitImageName returns parts of the full image name (image name, image tag).

--- a/probe/docker/registry.go
+++ b/probe/docker/registry.go
@@ -382,7 +382,7 @@ func (r *registry) deleteContainer(containerID string) {
 func (r *registry) sendDeletedUpdate(containerID string) {
 	node := report.MakeNodeWith(report.MakeContainerNodeID(containerID), map[string]string{
 		ContainerID:    containerID,
-		ContainerState: StateDeleted,
+		ContainerState: report.StateDeleted,
 	})
 	// Trigger anyone watching for updates
 	for _, f := range r.watchers {

--- a/probe/docker/registry_test.go
+++ b/probe/docker/registry_test.go
@@ -57,7 +57,7 @@ func (c *mockContainer) State() string {
 }
 
 func (c *mockContainer) StateString() string {
-	return docker.StateRunning
+	return report.StateRunning
 }
 
 func (c *mockContainer) StartGatheringStats(docker.StatsGatherer) error {

--- a/probe/docker/reporter.go
+++ b/probe/docker/reporter.go
@@ -19,11 +19,11 @@ const (
 	ImageSize        = report.DockerImageSize
 	ImageVirtualSize = report.DockerImageVirtualSize
 	IsInHostNetwork  = report.DockerIsInHostNetwork
-	ImageLabelPrefix = "docker_image_label_"
+	ImageLabelPrefix = report.DockerImageLabelPrefix
 	ImageTableID     = "image_table"
 	ServiceName      = report.DockerServiceName
 	StackNamespace   = report.DockerStackNamespace
-	DefaultNamespace = "No stack"
+	DefaultNamespace = report.DockerDefaultNamespace
 )
 
 // Exposed for testing

--- a/probe/docker/reporter.go
+++ b/probe/docker/reporter.go
@@ -8,7 +8,6 @@ import (
 	docker_client "github.com/fsouza/go-dockerclient"
 
 	"github.com/weaveworks/scope/probe"
-	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -306,7 +305,7 @@ func (r *Reporter) overlayTopology() report.Topology {
 	// Add both local and global networks to the LocalNetworks Set
 	// since we treat container IPs as local
 	node := report.MakeNode(report.MakeOverlayNodeID(report.DockerOverlayPeerPrefix, r.hostID)).WithSets(
-		report.MakeSets().Add(host.LocalNetworks, report.MakeStringSet(subnets...)))
+		report.MakeSets().Add(report.HostLocalNetworks, report.MakeStringSet(subnets...)))
 	t := report.MakeTopology()
 	t.AddNode(node)
 	return t

--- a/probe/docker/reporter_test.go
+++ b/probe/docker/reporter_test.go
@@ -6,7 +6,6 @@ import (
 	client "github.com/fsouza/go-dockerclient"
 
 	"github.com/weaveworks/scope/probe/docker"
-	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -141,7 +140,7 @@ func TestReporter(t *testing.T) {
 		}
 
 		want := "5.6.7.8/24"
-		if have, ok := node.Sets.Lookup(host.LocalNetworks); !ok || len(have) != 1 || have[0] != want {
+		if have, ok := node.Sets.Lookup(report.HostLocalNetworks); !ok || len(have) != 1 || have[0] != want {
 			t.Fatalf("Expected node to have exactly local network %v but found %v", want, have)
 		}
 

--- a/probe/host/reporter.go
+++ b/probe/host/reporter.go
@@ -14,16 +14,16 @@ import (
 
 // Keys for use in Node.Latest.
 const (
-	Timestamp     = "ts"
-	HostName      = "host_name"
-	LocalNetworks = "local_networks"
-	OS            = "os"
-	KernelVersion = "kernel_version"
-	Uptime        = "uptime"
-	Load1         = "load1"
-	CPUUsage      = "host_cpu_usage_percent"
-	MemoryUsage   = "host_mem_usage_bytes"
-	ScopeVersion  = "host_scope_version"
+	Timestamp     = report.Timestamp
+	HostName      = report.HostName
+	LocalNetworks = report.HostLocalNetworks
+	OS            = report.OS
+	KernelVersion = report.KernelVersion
+	Uptime        = report.Uptime
+	Load1         = report.Load1
+	CPUUsage      = report.CPUUsage
+	MemoryUsage   = report.MemoryUsage
+	ScopeVersion  = report.ScopeVersion
 )
 
 // Exposed for testing.

--- a/probe/host/reporter.go
+++ b/probe/host/reporter.go
@@ -21,8 +21,8 @@ const (
 	KernelVersion = report.KernelVersion
 	Uptime        = report.Uptime
 	Load1         = report.Load1
-	CPUUsage      = report.CPUUsage
-	MemoryUsage   = report.MemoryUsage
+	CPUUsage      = report.HostCPUUsage
+	MemoryUsage   = report.HostMemoryUsage
 	ScopeVersion  = report.ScopeVersion
 )
 

--- a/probe/kubernetes/pod.go
+++ b/probe/kubernetes/pod.go
@@ -16,12 +16,6 @@ const (
 	RestartCount    = report.KubernetesRestartCount
 )
 
-// Pod states we handle specially
-const (
-	StateDeleted = "deleted"
-	StateFailed  = "Failed"
-)
-
 // Pod represents a Kubernetes pod
 type Pod interface {
 	Meta

--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"fmt"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -241,19 +240,11 @@ func (r *Reporter) podEvent(e Event, pod Pod) {
 		rpt.Pod.AddNode(
 			report.MakeNodeWith(
 				report.MakePodNodeID(pod.UID()),
-				map[string]string{State: StateDeleted},
+				map[string]string{State: report.StateDeleted},
 			),
 		)
 		r.probe.Publish(rpt)
 	}
-}
-
-// IsPauseImageName indicates whether an image name corresponds to a
-// kubernetes pause container image.
-func IsPauseImageName(imageName string) bool {
-	return strings.Contains(imageName, "google_containers/pause") ||
-		strings.Contains(imageName, "k8s.gcr.io/pause") ||
-		strings.Contains(imageName, "eks/pause")
 }
 
 func isPauseContainer(n report.Node, rpt report.Report) bool {
@@ -270,7 +261,7 @@ func isPauseContainer(n report.Node, rpt report.Report) bool {
 		if !ok {
 			continue
 		}
-		return IsPauseImageName(imageName)
+		return report.IsPauseImageName(imageName)
 	}
 	return false
 }

--- a/probe/overlay/weave.go
+++ b/probe/overlay/weave.go
@@ -10,7 +10,6 @@ import (
 	"github.com/weaveworks/common/backoff"
 	"github.com/weaveworks/scope/common/weave"
 	"github.com/weaveworks/scope/probe/docker"
-	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -249,7 +248,7 @@ func (w *Weave) Report() (report.Report, error) {
 	if w.statusCache.IPAM != nil {
 		r.Overlay.AddNode(
 			report.MakeNode(report.MakeOverlayNodeID(report.WeaveOverlayPeerPrefix, w.statusCache.Router.Name)).
-				WithSet(host.LocalNetworks, report.MakeStringSet(w.statusCache.IPAM.DefaultSubnet)),
+				WithSet(report.HostLocalNetworks, report.MakeStringSet(w.statusCache.IPAM.DefaultSubnet)),
 		)
 	}
 	return r, nil

--- a/probe/overlay/weave.go
+++ b/probe/overlay/weave.go
@@ -15,8 +15,8 @@ import (
 
 // Keys for use in Node
 const (
-	WeavePeerName                          = "weave_peer_name"
-	WeavePeerNickName                      = "weave_peer_nick_name"
+	WeavePeerName                          = report.WeavePeerName
+	WeavePeerNickName                      = report.WeavePeerNickName
 	WeaveDNSHostname                       = "weave_dns_hostname"
 	WeaveMACAddress                        = "weave_mac_address"
 	WeaveVersion                           = "weave_version"

--- a/probe/overlay/weave_test.go
+++ b/probe/overlay/weave_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/weaveworks/scope/probe/docker"
-	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/probe/overlay"
 	"github.com/weaveworks/scope/report"
 	"github.com/weaveworks/scope/test"
@@ -82,7 +81,7 @@ func TestOverlayTopology(t *testing.T) {
 		if peerNick, ok := node.Latest.Lookup(overlay.WeavePeerNickName); !ok || peerNick != weave.MockWeavePeerNickName {
 			t.Errorf("Expected weave peer nickname %q, got %q", weave.MockWeavePeerNickName, peerNick)
 		}
-		if localNetworks, ok := node.Sets.Lookup(host.LocalNetworks); !ok || !reflect.DeepEqual(localNetworks, report.MakeStringSet(weave.MockWeaveDefaultSubnet)) {
+		if localNetworks, ok := node.Sets.Lookup(report.HostLocalNetworks); !ok || !reflect.DeepEqual(localNetworks, report.MakeStringSet(weave.MockWeaveDefaultSubnet)) {
 			t.Errorf("Expected weave node local_networks %q, got %q", report.MakeStringSet(weave.MockWeaveDefaultSubnet), localNetworks)
 		}
 		// The weave proxy container is running

--- a/render/container_test.go
+++ b/render/container_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/weaveworks/common/test"
-	"github.com/weaveworks/scope/probe/docker"
-	"github.com/weaveworks/scope/probe/process"
 	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/scope/render/expected"
 	"github.com/weaveworks/scope/report"
@@ -30,8 +28,8 @@ var (
 func TestMapProcess2Container(t *testing.T) {
 	for _, input := range []testcase{
 		{"empty", report.MakeNode("empty"), true},
-		{"basic process", report.MakeNodeWith("basic", map[string]string{process.PID: "201", docker.ContainerID: "a1b2c3"}), true},
-		{"uncontained", report.MakeNodeWith("uncontained", map[string]string{process.PID: "201", report.HostNodeID: report.MakeHostNodeID("foo")}), true},
+		{"basic process", report.MakeNodeWith("basic", map[string]string{report.PID: "201", report.DockerContainerID: "a1b2c3"}), true},
+		{"uncontained", report.MakeNodeWith("uncontained", map[string]string{report.PID: "201", report.HostNodeID: report.MakeHostNodeID("foo")}), true},
 	} {
 		testMap(t, render.MapProcess2Container, input)
 	}
@@ -66,7 +64,7 @@ func TestContainerFilterRenderer(t *testing.T) {
 	// it is filtered out correctly.
 	input := fixture.Report.Copy()
 	input.Container.Nodes[fixture.ClientContainerNodeID] = input.Container.Nodes[fixture.ClientContainerNodeID].WithLatests(map[string]string{
-		docker.LabelPrefix + "works.weave.role": "system",
+		report.DockerLabelPrefix + "works.weave.role": "system",
 	})
 	have := utils.Prune(render.Render(context.Background(), input, render.ContainerWithImageNameRenderer, filterApplication).Nodes)
 	want := utils.Prune(expected.RenderedContainers.Copy())

--- a/render/detailed/node_test.go
+++ b/render/detailed/node_test.go
@@ -73,7 +73,7 @@ func TestMakeDetailedHostNode(t *testing.T) {
 			},
 			Metrics: []report.MetricRow{
 				{
-					ID:       report.CPUUsage,
+					ID:       report.HostCPUUsage,
 					Label:    "CPU",
 					Format:   "percent",
 					Value:    0.07,
@@ -81,7 +81,7 @@ func TestMakeDetailedHostNode(t *testing.T) {
 					Metric:   &fixture.ClientHostCPUMetric,
 				},
 				{
-					ID:       report.MemoryUsage,
+					ID:       report.HostMemoryUsage,
 					Label:    "Memory",
 					Format:   "filesize",
 					Value:    0.08,

--- a/render/detailed/node_test.go
+++ b/render/detailed/node_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/weaveworks/common/test"
 	"github.com/weaveworks/scope/probe/docker"
-	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/probe/kubernetes"
 	"github.com/weaveworks/scope/probe/process"
 	"github.com/weaveworks/scope/render"
@@ -74,7 +73,7 @@ func TestMakeDetailedHostNode(t *testing.T) {
 			},
 			Metrics: []report.MetricRow{
 				{
-					ID:       host.CPUUsage,
+					ID:       report.CPUUsage,
 					Label:    "CPU",
 					Format:   "percent",
 					Value:    0.07,
@@ -82,7 +81,7 @@ func TestMakeDetailedHostNode(t *testing.T) {
 					Metric:   &fixture.ClientHostCPUMetric,
 				},
 				{
-					ID:       host.MemoryUsage,
+					ID:       report.MemoryUsage,
 					Label:    "Memory",
 					Format:   "filesize",
 					Value:    0.08,
@@ -90,7 +89,7 @@ func TestMakeDetailedHostNode(t *testing.T) {
 					Metric:   &fixture.ClientHostMemoryMetric,
 				},
 				{
-					ID:       host.Load1,
+					ID:       report.Load1,
 					Label:    "Load (1m)",
 					Group:    "load",
 					Value:    0.09,

--- a/render/detailed/summary_test.go
+++ b/render/detailed/summary_test.go
@@ -250,7 +250,7 @@ func TestNodeMetadata(t *testing.T) {
 			node: report.MakeNodeWith(fixture.ClientContainerNodeID, map[string]string{
 				docker.ContainerID:            fixture.ClientContainerID,
 				docker.LabelPrefix + "label1": "label1value",
-				docker.ContainerStateHuman:    docker.StateRunning,
+				docker.ContainerStateHuman:    report.StateRunning,
 			}).WithTopology(report.Container).WithSets(report.MakeSets().
 				Add(docker.ContainerIPs, report.MakeStringSet("10.10.10.0/24", "10.10.10.1/24")),
 			),
@@ -336,7 +336,7 @@ func TestNodeMetrics(t *testing.T) {
 			node: fixture.Report.Host.Nodes[fixture.ClientHostNodeID],
 			want: []report.MetricRow{
 				{
-					ID:       report.CPUUsage,
+					ID:       report.HostCPUUsage,
 					Label:    "CPU",
 					Format:   "percent",
 					Group:    "",
@@ -345,7 +345,7 @@ func TestNodeMetrics(t *testing.T) {
 					Metric:   &fixture.ClientHostCPUMetric,
 				},
 				{
-					ID:       report.MemoryUsage,
+					ID:       report.HostMemoryUsage,
 					Label:    "Memory",
 					Format:   "filesize",
 					Group:    "",
@@ -424,7 +424,7 @@ func TestNodeTables(t *testing.T) {
 			node: report.MakeNodeWith(fixture.ClientContainerNodeID, map[string]string{
 				docker.ContainerID:            fixture.ClientContainerID,
 				docker.LabelPrefix + "label1": "label1value",
-				docker.ContainerState:         docker.StateRunning,
+				docker.ContainerState:         report.StateRunning,
 			}).WithTopology(report.Container).WithSets(report.MakeSets().
 				Add(docker.ContainerIPs, report.MakeStringSet("10.10.10.0/24", "10.10.10.1/24")),
 			),

--- a/render/detailed/summary_test.go
+++ b/render/detailed/summary_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/weaveworks/common/mtime"
 	"github.com/weaveworks/common/test"
 	"github.com/weaveworks/scope/probe/docker"
-	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/probe/process"
 	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/scope/render/detailed"
@@ -173,7 +172,7 @@ func TestMakeNodeSummary(t *testing.T) {
 					Tag:        "",
 				},
 				Metadata: []report.MetadataRow{
-					{ID: host.HostName, Label: "Hostname", Value: fixture.ClientHostName, Priority: 11},
+					{ID: report.HostName, Label: "Hostname", Value: fixture.ClientHostName, Priority: 11},
 				},
 				Adjacency: report.MakeIDList(fixture.ServerHostNodeID),
 			},
@@ -337,7 +336,7 @@ func TestNodeMetrics(t *testing.T) {
 			node: fixture.Report.Host.Nodes[fixture.ClientHostNodeID],
 			want: []report.MetricRow{
 				{
-					ID:       host.CPUUsage,
+					ID:       report.CPUUsage,
 					Label:    "CPU",
 					Format:   "percent",
 					Group:    "",
@@ -346,7 +345,7 @@ func TestNodeMetrics(t *testing.T) {
 					Metric:   &fixture.ClientHostCPUMetric,
 				},
 				{
-					ID:       host.MemoryUsage,
+					ID:       report.MemoryUsage,
 					Label:    "Memory",
 					Format:   "filesize",
 					Group:    "",
@@ -355,7 +354,7 @@ func TestNodeMetrics(t *testing.T) {
 					Metric:   &fixture.ClientHostMemoryMetric,
 				},
 				{
-					ID:       host.Load1,
+					ID:       report.Load1,
 					Label:    "Load (1m)",
 					Group:    "load",
 					Value:    0.09,

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -2,7 +2,6 @@ package expected
 
 import (
 	"github.com/weaveworks/scope/probe/docker"
-	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/probe/kubernetes"
 	"github.com/weaveworks/scope/probe/process"
 	"github.com/weaveworks/scope/render"
@@ -345,7 +344,7 @@ var (
 	RenderedHosts = report.Nodes{
 		fixture.ClientHostNodeID: hostNode(fixture.ClientHostNodeID, fixture.ServerHostNodeID).
 			WithLatests(map[string]string{
-				host.HostName: fixture.ClientHostName,
+				report.HostName: fixture.ClientHostName,
 			}).
 			WithChildren(report.MakeNodeSet(
 				RenderedEndpoints[fixture.Client54001NodeID],

--- a/render/persistentvolume.go
+++ b/render/persistentvolume.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/weaveworks/scope/probe/kubernetes"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -29,9 +28,9 @@ type volumesRenderer struct{}
 func (v volumesRenderer) Render(ctx context.Context, rpt report.Report) Nodes {
 	nodes := make(report.Nodes)
 	for id, n := range rpt.PersistentVolumeClaim.Nodes {
-		volume, _ := n.Latest.Lookup(kubernetes.VolumeName)
+		volume, _ := n.Latest.Lookup(report.KubernetesVolumeName)
 		for _, p := range rpt.PersistentVolume.Nodes {
-			volumeName, _ := p.Latest.Lookup(kubernetes.Name)
+			volumeName, _ := p.Latest.Lookup(report.KubernetesName)
 			if volume == volumeName {
 				n.Adjacency = n.Adjacency.Add(p.ID)
 				n.Children = n.Children.Add(p)
@@ -54,16 +53,16 @@ type podToVolumesRenderer struct{}
 func (v podToVolumesRenderer) Render(ctx context.Context, rpt report.Report) Nodes {
 	nodes := make(report.Nodes)
 	for podID, podNode := range rpt.Pod.Nodes {
-		claimNames, found := podNode.Latest.Lookup(kubernetes.VolumeClaim)
+		claimNames, found := podNode.Latest.Lookup(report.KubernetesVolumeClaim)
 		if !found {
 			continue
 		}
-		podNamespace, _ := podNode.Latest.Lookup(kubernetes.Namespace)
+		podNamespace, _ := podNode.Latest.Lookup(report.KubernetesNamespace)
 		claimNameList := strings.Split(claimNames, report.ScopeDelim)
 		for _, ClaimName := range claimNameList {
 			for _, pvcNode := range rpt.PersistentVolumeClaim.Nodes {
-				pvcName, _ := pvcNode.Latest.Lookup(kubernetes.Name)
-				pvcNamespace, _ := pvcNode.Latest.Lookup(kubernetes.Namespace)
+				pvcName, _ := pvcNode.Latest.Lookup(report.KubernetesName)
+				pvcNamespace, _ := pvcNode.Latest.Lookup(report.KubernetesNamespace)
 				if (pvcName == ClaimName) && (podNamespace == pvcNamespace) {
 					podNode.Adjacency = podNode.Adjacency.Add(pvcNode.ID)
 					podNode.Children = podNode.Children.Add(pvcNode)
@@ -87,9 +86,9 @@ type pvcToStorageClassRenderer struct{}
 func (v pvcToStorageClassRenderer) Render(ctx context.Context, rpt report.Report) Nodes {
 	nodes := make(report.Nodes)
 	for scID, scNode := range rpt.StorageClass.Nodes {
-		storageClass, _ := scNode.Latest.Lookup(kubernetes.Name)
+		storageClass, _ := scNode.Latest.Lookup(report.KubernetesName)
 		for _, pvcNode := range rpt.PersistentVolumeClaim.Nodes {
-			storageClassName, _ := pvcNode.Latest.Lookup(kubernetes.StorageClassName)
+			storageClassName, _ := pvcNode.Latest.Lookup(report.KubernetesStorageClassName)
 			if storageClassName == storageClass {
 				scNode.Adjacency = scNode.Adjacency.Add(pvcNode.ID)
 				scNode.Children = scNode.Children.Add(pvcNode)
@@ -110,9 +109,9 @@ type pvToSnapshotRenderer struct{}
 func (v pvToSnapshotRenderer) Render(ctx context.Context, rpt report.Report) Nodes {
 	nodes := make(report.Nodes)
 	for pvNodeID, p := range rpt.PersistentVolume.Nodes {
-		volumeName, _ := p.Latest.Lookup(kubernetes.Name)
+		volumeName, _ := p.Latest.Lookup(report.KubernetesName)
 		for _, volumeSnapshotNode := range rpt.VolumeSnapshot.Nodes {
-			snapshotPVName, _ := volumeSnapshotNode.Latest.Lookup(kubernetes.VolumeName)
+			snapshotPVName, _ := volumeSnapshotNode.Latest.Lookup(report.KubernetesVolumeName)
 			if volumeName == snapshotPVName {
 				p.Adjacency = p.Adjacency.Add(volumeSnapshotNode.ID)
 				p.Children = p.Children.Add(volumeSnapshotNode)
@@ -134,9 +133,9 @@ type volumeSnapshotRenderer struct{}
 func (v volumeSnapshotRenderer) Render(ctx context.Context, rpt report.Report) Nodes {
 	nodes := make(report.Nodes)
 	for volumeSnapshotID, volumeSnapshotNode := range rpt.VolumeSnapshot.Nodes {
-		snapshotData, _ := volumeSnapshotNode.Latest.Lookup(kubernetes.SnapshotData)
+		snapshotData, _ := volumeSnapshotNode.Latest.Lookup(report.KubernetesSnapshotData)
 		for volumeSnapshotDataID, volumeSnapshotDataNode := range rpt.VolumeSnapshotData.Nodes {
-			snapshotDataName, _ := volumeSnapshotDataNode.Latest.Lookup(kubernetes.Name)
+			snapshotDataName, _ := volumeSnapshotDataNode.Latest.Lookup(report.KubernetesName)
 			if snapshotDataName == snapshotData {
 				volumeSnapshotNode.Adjacency = volumeSnapshotNode.Adjacency.Add(volumeSnapshotDataNode.ID)
 				volumeSnapshotNode.Children = volumeSnapshotNode.Children.Add(volumeSnapshotDataNode)

--- a/render/pod_test.go
+++ b/render/pod_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	"github.com/weaveworks/common/test"
-	"github.com/weaveworks/scope/probe/kubernetes"
 	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/scope/render/expected"
+	"github.com/weaveworks/scope/report"
 	"github.com/weaveworks/scope/test/fixture"
 	"github.com/weaveworks/scope/test/reflect"
 	"github.com/weaveworks/scope/test/utils"
@@ -31,7 +31,7 @@ func TestPodFilterRenderer(t *testing.T) {
 	// it is filtered out correctly.
 	input := fixture.Report.Copy()
 	input.Pod.Nodes[fixture.ClientPodNodeID] = input.Pod.Nodes[fixture.ClientPodNodeID].WithLatests(map[string]string{
-		kubernetes.Namespace: "kube-system",
+		report.KubernetesNamespace: "kube-system",
 	})
 
 	have := utils.Prune(render.Render(context.Background(), input, render.PodRenderer, filterNonKubeSystem).Nodes)
@@ -55,7 +55,7 @@ func TestPodServiceFilterRenderer(t *testing.T) {
 	// it is filtered out correctly.
 	input := fixture.Report.Copy()
 	input.Service.Nodes[fixture.ServiceNodeID] = input.Service.Nodes[fixture.ServiceNodeID].WithLatests(map[string]string{
-		kubernetes.Namespace: "kube-system",
+		report.KubernetesNamespace: "kube-system",
 	})
 
 	have := utils.Prune(render.Render(context.Background(), input, render.PodServiceRenderer, filterNonKubeSystem).Nodes)

--- a/render/process.go
+++ b/render/process.go
@@ -3,8 +3,6 @@ package render
 import (
 	"context"
 
-	"github.com/weaveworks/scope/probe/endpoint"
-	"github.com/weaveworks/scope/probe/process"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -52,7 +50,7 @@ func (e endpoints2Processes) Render(ctx context.Context, rpt report.Report) Node
 	endpoints := SelectEndpoint.Render(ctx, rpt).Nodes
 	return MapEndpoints(
 		func(n report.Node) string {
-			pid, ok := n.Latest.Lookup(process.PID)
+			pid, ok := n.Latest.Lookup(report.PID)
 			if !ok {
 				return ""
 			}
@@ -81,7 +79,7 @@ func hasMoreThanOneConnection(n report.Node, endpoints report.Nodes) bool {
 	firstRealEndpointID := ""
 	for _, endpointID := range n.Adjacency {
 		if ep, ok := endpoints[endpointID]; ok {
-			if copyID, _, ok := ep.Latest.LookupEntry(endpoint.CopyOf); ok {
+			if copyID, _, ok := ep.Latest.LookupEntry(report.CopyOf); ok {
 				endpointID = copyID
 			}
 		}
@@ -94,7 +92,7 @@ func hasMoreThanOneConnection(n report.Node, endpoints report.Nodes) bool {
 	return false
 }
 
-var processNameTopology = MakeGroupNodeTopology(report.Process, process.Name)
+var processNameTopology = MakeGroupNodeTopology(report.Process, report.Name)
 
 // processes2Names maps process Nodes to Nodes for each process name.
 func processes2Names(processes Nodes) Nodes {
@@ -103,7 +101,7 @@ func processes2Names(processes Nodes) Nodes {
 	for _, n := range processes.Nodes {
 		if n.Topology == Pseudo {
 			ret.passThrough(n)
-		} else if name, ok := n.Latest.Lookup(process.Name); ok {
+		} else if name, ok := n.Latest.Lookup(report.Name); ok {
 			ret.addChildAndChildren(n, name, processNameTopology)
 		}
 	}

--- a/render/short_lived_connections_test.go
+++ b/render/short_lived_connections_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/weaveworks/common/mtime"
 
-	"github.com/weaveworks/scope/probe/docker"
 	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/scope/report"
 	"github.com/weaveworks/scope/test/utils"
@@ -66,32 +65,32 @@ var (
 		Container: report.Topology{
 			Nodes: report.Nodes{
 				container1NodeID: report.MakeNodeWith(container1NodeID, map[string]string{
-					docker.ContainerID:   container1ID,
-					docker.ContainerName: container1Name,
-					report.HostNodeID:    serverHostNodeID,
+					report.DockerContainerID:   container1ID,
+					report.DockerContainerName: container1Name,
+					report.HostNodeID:          serverHostNodeID,
 				}).
 					WithSets(report.MakeSets().
-						Add(docker.ContainerIPs, report.MakeStringSet(container1IP)).
-						Add(docker.ContainerIPsWithScopes, report.MakeStringSet(report.MakeAddressNodeID("", container1IP))).
-						Add(docker.ContainerPorts, report.MakeStringSet(fmt.Sprintf("%s:%s->%s/tcp", serverIP, serverPort, serverPort))),
+						Add(report.DockerContainerIPs, report.MakeStringSet(container1IP)).
+						Add(report.DockerContainerIPsWithScopes, report.MakeStringSet(report.MakeAddressNodeID("", container1IP))).
+						Add(report.DockerContainerPorts, report.MakeStringSet(fmt.Sprintf("%s:%s->%s/tcp", serverIP, serverPort, serverPort))),
 					).WithTopology(report.Container),
 				container2NodeID: report.MakeNodeWith(container2NodeID, map[string]string{
-					docker.ContainerID:   container2ID,
-					docker.ContainerName: container2Name,
-					report.HostNodeID:    serverHostNodeID,
+					report.DockerContainerID:   container2ID,
+					report.DockerContainerName: container2Name,
+					report.HostNodeID:          serverHostNodeID,
 				}).
 					WithSets(report.MakeSets().
-						Add(docker.ContainerIPs, report.MakeStringSet(container2IP)).
-						Add(docker.ContainerIPsWithScopes, report.MakeStringSet(report.MakeAddressNodeID("", container2IP))),
+						Add(report.DockerContainerIPs, report.MakeStringSet(container2IP)).
+						Add(report.DockerContainerIPsWithScopes, report.MakeStringSet(report.MakeAddressNodeID("", container2IP))),
 					).WithTopology(report.Container),
 				pauseContainerNodeID: report.MakeNodeWith(pauseContainerNodeID, map[string]string{
-					docker.ContainerID:   pauseContainerID,
-					docker.ContainerName: pauseContainerName,
-					report.HostNodeID:    serverHostNodeID,
+					report.DockerContainerID:   pauseContainerID,
+					report.DockerContainerName: pauseContainerName,
+					report.HostNodeID:          serverHostNodeID,
 				}).
 					WithSets(report.MakeSets().
-						Add(docker.ContainerIPs, report.MakeStringSet(pauseContainerIP)).
-						Add(docker.ContainerIPsWithScopes, report.MakeStringSet(report.MakeAddressNodeID("", pauseContainerIP))),
+						Add(report.DockerContainerIPs, report.MakeStringSet(pauseContainerIP)).
+						Add(report.DockerContainerIPsWithScopes, report.MakeStringSet(report.MakeAddressNodeID("", pauseContainerIP))),
 					).WithTopology(report.Container).WithLatest(report.DoesNotMakeConnections, mtime.Now(), ""),
 			},
 		},

--- a/render/short_lived_connections_test.go
+++ b/render/short_lived_connections_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/weaveworks/common/mtime"
 
 	"github.com/weaveworks/scope/probe/docker"
-	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/scope/report"
 	"github.com/weaveworks/scope/test/utils"
@@ -102,7 +101,7 @@ var (
 					report.HostNodeID: serverHostNodeID,
 				}).
 					WithSets(report.MakeSets().
-						Add(host.LocalNetworks, report.MakeStringSet("192.168.0.0/16")),
+						Add(report.HostLocalNetworks, report.MakeStringSet("192.168.0.0/16")),
 					).WithTopology(report.Host),
 			},
 		},

--- a/render/theinternet.go
+++ b/render/theinternet.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/camlistore/camlistore/pkg/lru"
 
-	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -77,7 +76,7 @@ func LocalNetworks(r report.Report) report.Networks {
 
 	for _, topology := range []report.Topology{r.Host, r.Overlay} {
 		for _, md := range topology.Nodes {
-			nets, _ := md.Sets.Lookup(host.LocalNetworks)
+			nets, _ := md.Sets.Lookup(report.HostLocalNetworks)
 			for _, s := range nets {
 				networks.AddCIDR(s)
 			}

--- a/render/theinternet_test.go
+++ b/render/theinternet_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/weaveworks/common/test"
-	"github.com/weaveworks/scope/probe/host"
 	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/scope/report"
 )
@@ -16,7 +15,7 @@ func TestReportLocalNetworks(t *testing.T) {
 			Nodes: report.Nodes{
 				"nonets": report.MakeNode("nonets"),
 				"foo": report.MakeNode("foo").WithSets(report.MakeSets().
-					Add(host.LocalNetworks, report.MakeStringSet(
+					Add(report.HostLocalNetworks, report.MakeStringSet(
 						"10.0.0.1/8", "192.168.1.1/24", "10.0.0.1/8", "badnet/33")),
 				),
 			},
@@ -24,7 +23,7 @@ func TestReportLocalNetworks(t *testing.T) {
 		Overlay: report.Topology{
 			Nodes: report.Nodes{
 				"router": report.MakeNode("router").WithSets(report.MakeSets().
-					Add(host.LocalNetworks, report.MakeStringSet("10.32.0.1/12")),
+					Add(report.HostLocalNetworks, report.MakeStringSet("10.32.0.1/12")),
 				),
 			},
 		},

--- a/render/weave.go
+++ b/render/weave.go
@@ -1,7 +1,6 @@
 package render
 
 import (
-	"github.com/weaveworks/scope/probe/overlay"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -22,7 +21,7 @@ func MapWeaveIdentity(m report.Node) report.Node {
 
 	var (
 		node        = m
-		nickname, _ = m.Latest.Lookup(overlay.WeavePeerNickName)
+		nickname, _ = m.Latest.Lookup(report.WeavePeerNickName)
 	)
 
 	// Nodes without a host id indicate they are not monitored by Scope

--- a/report/id.go
+++ b/report/id.go
@@ -302,3 +302,11 @@ func IsLoopback(address string) bool {
 	ip := net.ParseIP(address)
 	return ip != nil && ip.IsLoopback()
 }
+
+// IsPauseImageName indicates whether an image name corresponds to a
+// kubernetes pause container image.
+func IsPauseImageName(imageName string) bool {
+	return strings.Contains(imageName, "google_containers/pause") ||
+		strings.Contains(imageName, "k8s.gcr.io/pause") ||
+		strings.Contains(imageName, "eks/pause")
+}

--- a/report/map_keys.go
+++ b/report/map_keys.go
@@ -22,6 +22,7 @@ const (
 	DockerIsInHostNetwork        = "docker_is_in_host_network"
 	DockerServiceName            = "service_name"
 	DockerStackNamespace         = "stack_namespace"
+	DockerDefaultNamespace       = "No stack"
 	DockerStopContainer          = "docker_stop_container"
 	DockerStartContainer         = "docker_start_container"
 	DockerRestartContainer       = "docker_restart_container"
@@ -105,9 +106,12 @@ const (
 	KernelVersion     = "kernel_version"
 	Uptime            = "uptime"
 	Load1             = "load1"
-	CPUUsage          = "host_cpu_usage_percent"
-	MemoryUsage       = "host_mem_usage_bytes"
+	HostCPUUsage      = "host_cpu_usage_percent"
+	HostMemoryUsage   = "host_mem_usage_bytes"
 	ScopeVersion      = "host_scope_version"
+	// probe/overlay/weave
+	WeavePeerName     = "weave_peer_name"
+	WeavePeerNickName = "weave_peer_nick_name"
 )
 
 /* Lookup table to allow msgpack/json decoder to avoid heap allocation
@@ -227,9 +231,12 @@ var commonKeys = map[string]string{
 	KernelVersion:     KernelVersion,
 	Uptime:            Uptime,
 	Load1:             Load1,
-	CPUUsage:          CPUUsage,
-	MemoryUsage:       MemoryUsage,
+	HostCPUUsage:      HostCPUUsage,
+	HostMemoryUsage:   HostMemoryUsage,
 	ScopeVersion:      ScopeVersion,
+
+	WeavePeerName:     WeavePeerName,
+	WeavePeerNickName: WeavePeerNickName,
 }
 
 func lookupCommonKey(b []byte) string {

--- a/report/map_keys.go
+++ b/report/map_keys.go
@@ -97,6 +97,17 @@ const (
 	ECSServiceRunningCount = "ecs_service_running_count"
 	ECSScaleUp             = "ecs_scale_up"
 	ECSScaleDown           = "ecs_scale_down"
+	// probe/host
+	Timestamp         = "ts"
+	HostName          = "host_name"
+	HostLocalNetworks = "local_networks"
+	OS                = "os"
+	KernelVersion     = "kernel_version"
+	Uptime            = "uptime"
+	Load1             = "load1"
+	CPUUsage          = "host_cpu_usage_percent"
+	MemoryUsage       = "host_mem_usage_bytes"
+	ScopeVersion      = "host_scope_version"
 )
 
 /* Lookup table to allow msgpack/json decoder to avoid heap allocation
@@ -208,6 +219,17 @@ var commonKeys = map[string]string{
 	ECSServiceRunningCount: ECSServiceRunningCount,
 	ECSScaleUp:             ECSScaleUp,
 	ECSScaleDown:           ECSScaleDown,
+
+	Timestamp:         Timestamp,
+	HostName:          HostName,
+	HostLocalNetworks: HostLocalNetworks,
+	OS:                OS,
+	KernelVersion:     KernelVersion,
+	Uptime:            Uptime,
+	Load1:             Load1,
+	CPUUsage:          CPUUsage,
+	MemoryUsage:       MemoryUsage,
+	ScopeVersion:      ScopeVersion,
 }
 
 func lookupCommonKey(b []byte) string {

--- a/report/map_values.go
+++ b/report/map_values.go
@@ -1,0 +1,16 @@
+package report
+
+// constants used in node metadata values
+const (
+	DockerLabelPrefix      = "docker_label_"
+	DockerImageLabelPrefix = "docker_image_label_"
+
+	StateCreated    = "created"
+	StateDead       = "dead"
+	StateExited     = "exited"
+	StatePaused     = "paused"
+	StateRestarting = "restarting"
+	StateRunning    = "running"
+	StateDeleted    = "deleted"
+	StateFailed     = "Failed"
+)

--- a/test/fixture/report_fixture.go
+++ b/test/fixture/report_fixture.go
@@ -224,8 +224,8 @@ var (
 						docker.LabelPrefix + "io.kubernetes.pod.uid": ClientPodUID,
 						docker.LabelPrefix + TestLabelKey1:           ApplicationLabelValue1,
 						kubernetes.Namespace:                         KubernetesNamespace,
-						docker.ContainerState:                        docker.StateRunning,
-						docker.ContainerStateHuman:                   docker.StateRunning,
+						docker.ContainerState:                        report.StateRunning,
+						docker.ContainerStateHuman:                   report.StateRunning,
 					}).
 					WithTopology(report.Container).WithParents(report.MakeSets().
 					Add("host", report.MakeStringSet(ClientHostNodeID)).
@@ -241,8 +241,8 @@ var (
 						docker.ContainerID:                                        ServerContainerID,
 						docker.ContainerName:                                      ServerContainerName,
 						docker.ContainerHostname:                                  ServerContainerHostname,
-						docker.ContainerState:                                     docker.StateRunning,
-						docker.ContainerStateHuman:                                docker.StateRunning,
+						docker.ContainerState:                                     report.StateRunning,
+						docker.ContainerStateHuman:                                report.StateRunning,
 						docker.ImageID:                                            ServerContainerImageID,
 						report.HostNodeID:                                         ServerHostNodeID,
 						docker.LabelPrefix + detailed.AmazonECSContainerNameLabel: "server",
@@ -299,9 +299,9 @@ var (
 					WithTopology(report.Host).WithSets(report.MakeSets().
 					Add(report.HostLocalNetworks, report.MakeStringSet("10.10.10.0/24")),
 				).WithMetrics(report.Metrics{
-					report.CPUUsage:    ClientHostCPUMetric,
-					report.MemoryUsage: ClientHostMemoryMetric,
-					report.Load1:       ClientHostLoad1Metric,
+					report.HostCPUUsage:    ClientHostCPUMetric,
+					report.HostMemoryUsage: ClientHostMemoryMetric,
+					report.Load1:           ClientHostLoad1Metric,
 				}),
 				ServerHostNodeID: report.MakeNodeWith(
 
@@ -313,9 +313,9 @@ var (
 					WithTopology(report.Host).WithSets(report.MakeSets().
 					Add(report.HostLocalNetworks, report.MakeStringSet("10.10.10.0/24")),
 				).WithMetrics(report.Metrics{
-					report.CPUUsage:    ServerHostCPUMetric,
-					report.MemoryUsage: ServerHostMemoryMetric,
-					report.Load1:       ServerHostLoad1Metric,
+					report.HostCPUUsage:    ServerHostCPUMetric,
+					report.HostMemoryUsage: ServerHostMemoryMetric,
+					report.Load1:           ServerHostLoad1Metric,
 				}),
 			},
 			MetadataTemplates: host.MetadataTemplates,

--- a/test/fixture/report_fixture.go
+++ b/test/fixture/report_fixture.go
@@ -297,11 +297,11 @@ var (
 						report.HostNodeID: ClientHostNodeID,
 					}).
 					WithTopology(report.Host).WithSets(report.MakeSets().
-					Add(host.LocalNetworks, report.MakeStringSet("10.10.10.0/24")),
+					Add(report.HostLocalNetworks, report.MakeStringSet("10.10.10.0/24")),
 				).WithMetrics(report.Metrics{
-					host.CPUUsage:    ClientHostCPUMetric,
-					host.MemoryUsage: ClientHostMemoryMetric,
-					host.Load1:       ClientHostLoad1Metric,
+					report.CPUUsage:    ClientHostCPUMetric,
+					report.MemoryUsage: ClientHostMemoryMetric,
+					report.Load1:       ClientHostLoad1Metric,
 				}),
 				ServerHostNodeID: report.MakeNodeWith(
 
@@ -311,11 +311,11 @@ var (
 						report.HostNodeID: ServerHostNodeID,
 					}).
 					WithTopology(report.Host).WithSets(report.MakeSets().
-					Add(host.LocalNetworks, report.MakeStringSet("10.10.10.0/24")),
+					Add(report.HostLocalNetworks, report.MakeStringSet("10.10.10.0/24")),
 				).WithMetrics(report.Metrics{
-					host.CPUUsage:    ServerHostCPUMetric,
-					host.MemoryUsage: ServerHostMemoryMetric,
-					host.Load1:       ServerHostLoad1Metric,
+					report.CPUUsage:    ServerHostCPUMetric,
+					report.MemoryUsage: ServerHostMemoryMetric,
+					report.Load1:       ServerHostLoad1Metric,
 				}),
 			},
 			MetadataTemplates: host.MetadataTemplates,


### PR DESCRIPTION
This dependency makes it harder to see the structure of the program, and sometimes complicates compilation.

Mostly just changing the source of strings that are already exported from the `report` package.  A few new strings have to be moved there, plus the function `IsPauseImageName()`.
