### PR TITLE
perf(probe): publish delta reports to reduce data size

### DIFF
--- a/extras/generate_latest_map
+++ b/extras/generate_latest_map
@@ -230,6 +230,19 @@ function generate_latest_map() {
         return true
     }
 
+    // EqualIgnoringTimestamps returns true if all keys and values are the same.
+    func (m ${latest_map_type}) EqualIgnoringTimestamps(n ${latest_map_type}) bool {
+        if m.Size() != n.Size() {
+            return false
+        }
+        for i := range m {
+            if m[i].key != n[i].key || m[i].Value != n[i].Value {
+                return false
+            }
+        }
+        return true
+    }
+
     // CodecEncodeSelf implements codec.Selfer.
     // Duplicates the output for a built-in map without generating an
     // intermediate copy of the data structure, to save time.  Note this

--- a/probe/probe_internal_test.go
+++ b/probe/probe_internal_test.go
@@ -16,7 +16,7 @@ func TestApply(t *testing.T) {
 		endpointNode   = report.MakeNodeWith(endpointNodeID, map[string]string{"5": "6"})
 	)
 
-	p := New(0, 0, nil, false)
+	p := New(0, 0, nil, 1, false)
 	p.AddTagger(NewTopologyTagger())
 
 	r := report.MakeReport()
@@ -72,7 +72,7 @@ func TestProbe(t *testing.T) {
 
 	pub := mockPublisher{make(chan report.Report, 10)}
 
-	p := New(10*time.Millisecond, 100*time.Millisecond, pub, false)
+	p := New(10*time.Millisecond, 100*time.Millisecond, pub, 1, false)
 	p.AddReporter(mockReporter{want})
 	p.Start()
 	defer p.Stop()

--- a/prog/main.go
+++ b/prog/main.go
@@ -298,7 +298,7 @@ func setupFlags(flags *flags) {
 	flag.StringVar(&flags.probe.httpListen, "probe.http.listen", "", "listen address for HTTP profiling and instrumentation server")
 	flag.DurationVar(&flags.probe.publishInterval, "probe.publish.interval", 3*time.Second, "publish (output) interval")
 	flag.DurationVar(&flags.probe.spyInterval, "probe.spy.interval", time.Second, "spy (scan) interval")
-	flag.IntVar(&flags.probe.ticksPerFullReport, "probe.full-report-every", 3, "publish full report every N times, deltas in between")
+	flag.IntVar(&flags.probe.ticksPerFullReport, "probe.full-report-every", 3, "publish full report every N times, deltas in between. Make sure N < (app.window / probe.publish.interval)")
 	flag.StringVar(&flags.probe.pluginsRoot, "probe.plugins.root", "/var/run/scope/plugins", "Root directory to search for plugins")
 	flag.BoolVar(&flags.probe.noControls, "probe.no-controls", false, "Disable controls (e.g. start/stop containers, terminals, logs ...)")
 	flag.BoolVar(&flags.probe.noCommandLineArguments, "probe.omit.cmd-args", false, "Disable collection of command-line arguments")

--- a/prog/main.go
+++ b/prog/main.go
@@ -100,6 +100,7 @@ type probeFlags struct {
 	token                  string
 	httpListen             string
 	publishInterval        time.Duration
+	ticksPerFullReport     int
 	spyInterval            time.Duration
 	pluginsRoot            string
 	insecure               bool
@@ -297,6 +298,7 @@ func setupFlags(flags *flags) {
 	flag.StringVar(&flags.probe.httpListen, "probe.http.listen", "", "listen address for HTTP profiling and instrumentation server")
 	flag.DurationVar(&flags.probe.publishInterval, "probe.publish.interval", 3*time.Second, "publish (output) interval")
 	flag.DurationVar(&flags.probe.spyInterval, "probe.spy.interval", time.Second, "spy (scan) interval")
+	flag.IntVar(&flags.probe.ticksPerFullReport, "probe.full-report-every", 3, "publish full report every N times, deltas in between")
 	flag.StringVar(&flags.probe.pluginsRoot, "probe.plugins.root", "/var/run/scope/plugins", "Root directory to search for plugins")
 	flag.BoolVar(&flags.probe.noControls, "probe.no-controls", false, "Disable controls (e.g. start/stop containers, terminals, logs ...)")
 	flag.BoolVar(&flags.probe.noCommandLineArguments, "probe.omit.cmd-args", false, "Disable collection of command-line arguments")

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -240,7 +240,7 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 		clients = multiClients
 	}
 
-	p := probe.New(flags.spyInterval, flags.publishInterval, clients, flags.noControls)
+	p := probe.New(flags.spyInterval, flags.publishInterval, clients, flags.ticksPerFullReport, flags.noControls)
 	p.AddTagger(probe.NewTopologyTagger())
 	var processCache *process.CachingWalker
 

--- a/report/id_list.go
+++ b/report/id_list.go
@@ -27,6 +27,11 @@ func (a IDList) Merge(b IDList) IDList {
 	return IDList(merged)
 }
 
+// Equal returns true if a and b have the same contents
+func (a IDList) Equal(b IDList) bool {
+	return StringSet(a).Equal(StringSet(b))
+}
+
 // Contains returns true if id is in the list.
 func (a IDList) Contains(id string) bool {
 	return StringSet(a).Contains(id)

--- a/report/latest_map_generated.go
+++ b/report/latest_map_generated.go
@@ -198,6 +198,19 @@ func (m StringLatestMap) DeepEqual(n StringLatestMap) bool {
 	return true
 }
 
+// EqualIgnoringTimestamps returns true if all keys and values are the same.
+func (m StringLatestMap) EqualIgnoringTimestamps(n StringLatestMap) bool {
+	if m.Size() != n.Size() {
+		return false
+	}
+	for i := range m {
+		if m[i].key != n[i].key || m[i].Value != n[i].Value {
+			return false
+		}
+	}
+	return true
+}
+
 // CodecEncodeSelf implements codec.Selfer.
 // Duplicates the output for a built-in map without generating an
 // intermediate copy of the data structure, to save time.  Note this
@@ -444,6 +457,19 @@ func (m NodeControlDataLatestMap) DeepEqual(n NodeControlDataLatestMap) bool {
 	}
 	for i := range m {
 		if m[i].key != n[i].key || !m[i].Equal(&n[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// EqualIgnoringTimestamps returns true if all keys and values are the same.
+func (m NodeControlDataLatestMap) EqualIgnoringTimestamps(n NodeControlDataLatestMap) bool {
+	if m.Size() != n.Size() {
+		return false
+	}
+	for i := range m {
+		if m[i].key != n[i].key || m[i].Value != n[i].Value {
 			return false
 		}
 	}

--- a/report/report.go
+++ b/report/report.go
@@ -351,6 +351,16 @@ func (r *Report) UnsafeMerge(other Report) {
 	})
 }
 
+// UnsafeUnMerge removes any information from r that would be added by merging other.
+// The original is modified.
+func (r *Report) UnsafeUnMerge(other Report) {
+	// TODO: DNS, Sampling, Plugins
+	r.Window = r.Window - other.Window
+	r.WalkPairedTopologies(&other, func(ourTopology, theirTopology *Topology) {
+		ourTopology.UnsafeUnMerge(*theirTopology)
+	})
+}
+
 // WalkTopologies iterates through the Topologies of the report,
 // potentially modifying them
 func (r *Report) WalkTopologies(f func(*Topology)) {

--- a/report/report.go
+++ b/report/report.go
@@ -188,7 +188,7 @@ type Report struct {
 	// Job represent all Kubernetes Job on hosts running probes.
 	Job Topology
 
-	DNS DNSRecords
+	DNS DNSRecords `json:"nodes,omitempty" deepequal:"nil==empty"`
 
 	// Sampling data for this report.
 	Sampling Sampling

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -98,3 +98,41 @@ func TestReportUpgrade(t *testing.T) {
 		t.Error(test.Diff(expected, got))
 	}
 }
+
+func TestReportUnMerge(t *testing.T) {
+	n1 := report.MakeNodeWith("foo", map[string]string{"foo": "bar"})
+	r1 := makeTestReport()
+	r2 := r1.Copy()
+	r2.Container.AddNode(n1)
+	// r2 should be the same as r1 with just the foo-bar node added
+	r2.UnsafeUnMerge(r1)
+	// Now r2 should have everything removed except that one node, and its ID
+	expected := report.Report{
+		ID: r2.ID,
+		Container: report.Topology{
+			Nodes: report.Nodes{
+				"foo": n1,
+			},
+		},
+	}
+
+	// Now test report with two nodes unmerged on report with one
+	r1.Container.AddNode(n1)
+	r2 = r1.Copy()
+	n2 := report.MakeNodeWith("foo2", map[string]string{"ping": "pong"})
+	r2.Container.AddNode(n2)
+	// r2 should be the same as r1 with one extra node
+	r2.UnsafeUnMerge(r1)
+	expected = report.Report{
+		ID: r2.ID,
+		Container: report.Topology{
+			Nodes: report.Nodes{
+				"foo2": n2,
+			},
+		},
+	}
+
+	if !s_reflect.DeepEqual(expected, r2) {
+		t.Error(test.Diff(expected, r2))
+	}
+}


### PR DESCRIPTION
Similar to video compression which uses key-frames and differences between them: every N publishes we send a full report, but inbetween we only send what has changed.

Fairly simple approach in the probe - hold on to the last full report, and for the deltas remove anything that would be merged in from the full report.

On the receiving side in the app it already merges a set of reports together to produce the final output for rendering, so provided N is smaller than that set we don't need to do anything different.

Deltas don't need to represent nodes that have disappeared - an earlier full node will have that node so it would be merged into the final output anyway.

Results from a small test showed around 40% drop in bytes/second sent by probes - process and container metrics are still updated on every publish.
CPU usage in the app dropped about 35%.
Probes memory and CPU was about the same as before - most of the effort goes into collecting the data not publishing it.