### PR TITLE
perf(probe): add 'omitempty' tag to Topology.Nodes

### DIFF
--- a/probe/appclient/app_client_internal_test.go
+++ b/probe/appclient/app_client_internal_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +15,7 @@ import (
 	"github.com/weaveworks/common/test"
 	"github.com/weaveworks/scope/common/xfer"
 	"github.com/weaveworks/scope/report"
+	"github.com/weaveworks/scope/test/reflect"
 )
 
 func dummyServer(t *testing.T, expectedToken, expectedID string, expectedVersion string, expectedReport report.Report, done chan struct{}) *httptest.Server {
@@ -69,14 +69,6 @@ func TestAppClientPublish(t *testing.T) {
 		rpt     = report.MakeReport()
 		done    = make(chan struct{}, 10)
 	)
-
-	// marshalling->unmarshaling is not idempotent due to `json:"omitempty"`
-	// tags, transforming empty slices into nils. So, we make DeepEqual
-	// happy by setting empty `json:"omitempty"` entries to nil
-	rpt.WalkTopologies(func(to *report.Topology) {
-		*to = report.MakeTopology()
-		to.Controls = nil
-	})
 
 	s := dummyServer(t, token, id, version, rpt, done)
 	defer s.Close()

--- a/probe/probe_internal_test.go
+++ b/probe/probe_internal_test.go
@@ -68,13 +68,6 @@ func TestProbe(t *testing.T) {
 	want := report.MakeReport()
 	node := report.MakeNodeWith("a", map[string]string{"b": "c"})
 
-	// marshalling->unmarshaling is not idempotent due to `json:"omitempty"`
-	// tags, transforming empty slices into nils. So, we make DeepEqual
-	// happy by setting empty `json:"omitempty"` entries to nil
-	node.Metrics = nil
-	want.WalkTopologies(func(t *report.Topology) {
-		t.Controls = nil
-	})
 	want.Endpoint.AddNode(node)
 
 	pub := mockPublisher{make(chan report.Report, 10)}

--- a/report/topology.go
+++ b/report/topology.go
@@ -13,7 +13,7 @@ type Topology struct {
 	Tag               string            `json:"tag,omitempty"`
 	Label             string            `json:"label,omitempty"`
 	LabelPlural       string            `json:"label_plural,omitempty"`
-	Nodes             Nodes             `json:"nodes"`
+	Nodes             Nodes             `json:"nodes,omitempty" deepequal:"nil==empty"`
 	Controls          Controls          `json:"controls,omitempty" deepequal:"nil==empty"`
 	MetadataTemplates MetadataTemplates `json:"metadata_templates,omitempty"`
 	MetricTemplates   MetricTemplates   `json:"metric_templates,omitempty"`


### PR DESCRIPTION
So we save space writing out empty topologies, which we see more often after #3677.  Very small impact overall.

Need to fix up `app_client_internal_test.go` to use Scope's `test/reflect` package that understands empty==nil, so now it doesn't need a previous workaround.

Remove a similar workaround in `probe_internal_test.go` that isn't necessary since it's already using that package.