### PR TITLE
fix(github): give all code owners equal weight

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,4 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*	@bboreham
-*	@fbarl
-*	@satyamz
-*	@qiell
+*	@bboreham @fbarl @satyamz @qiell


### PR DESCRIPTION
The [docs](https://help.github.com/en/articles/about-code-owners) say the format is pattern followed by one or more owners.
What we had previously was multiple patterns all the same, so it takes the last one.
