### PR TITLE
feature(app): Add a debugging summary function, exposed via http

### DIFF
--- a/app/collector.go
+++ b/app/collector.go
@@ -31,6 +31,7 @@ type Reporter interface {
 	Report(context.Context, time.Time) (report.Report, error)
 	HasReports(context.Context, time.Time) (bool, error)
 	HasHistoricReports() bool
+	AdminSummary(context.Context, time.Time) (string, error)
 	WaitOn(context.Context, chan struct{})
 	UnWait(context.Context, chan struct{})
 }
@@ -172,6 +173,20 @@ func (c *collector) HasHistoricReports() bool {
 	return false
 }
 
+// AdminSummary returns a string with some internal information about
+// the report, which may be useful to troubleshoot.
+func (c *collector) AdminSummary(ctx context.Context, timestamp time.Time) (string, error) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	var b strings.Builder
+	for i := range c.reports {
+		fmt.Fprintf(&b, "%v: ", c.timestamps[i].Format(time.StampMilli))
+		b.WriteString(c.reports[i].Summary())
+		b.WriteByte('\n')
+	}
+	return b.String(), nil
+}
+
 // remove reports older than the app.window
 func (c *collector) clean() {
 	var (
@@ -238,6 +253,10 @@ func (c StaticCollector) HasReports(context.Context, time.Time) (bool, error) {
 // older than now-app.window.
 func (c StaticCollector) HasHistoricReports() bool {
 	return false
+}
+
+func (c StaticCollector) AdminSummary(ctx context.Context, timestamp time.Time) (string, error) {
+	return "not implemented", nil
 }
 
 // Add adds a report to the collector's internal state. It implements Adder.

--- a/app/collector.go
+++ b/app/collector.go
@@ -255,6 +255,7 @@ func (c StaticCollector) HasHistoricReports() bool {
 	return false
 }
 
+// AdminSummary implements Reporter
 func (c StaticCollector) AdminSummary(ctx context.Context, timestamp time.Time) (string, error) {
 	return "not implemented", nil
 }

--- a/app/multitenant/aws_collector.go
+++ b/app/multitenant/aws_collector.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -442,6 +443,34 @@ func (c *awsCollector) HasReports(ctx context.Context, timestamp time.Time) (boo
 
 func (c *awsCollector) HasHistoricReports() bool {
 	return true
+}
+
+// AdminSummary returns a string with some internal information about
+// the report, which may be useful to troubleshoot.
+func (c *awsCollector) AdminSummary(ctx context.Context, timestamp time.Time) (string, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "awsCollector.Report")
+	defer span.Finish()
+	userid, err := c.cfg.UserIDer(ctx)
+	if err != nil {
+		return "", err
+	}
+	end := timestamp
+	start := end.Add(-c.cfg.Window)
+	reportKeys, err := c.getReportKeys(ctx, userid, start, end)
+	if err != nil {
+		return "", err
+	}
+	reports, err := c.reportsForKeysInRange(ctx, reportKeys, start.UnixNano(), end.UnixNano())
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	for i := range reports {
+		// TODO: print the key - note reports may be in a different order from reportKeys
+		b.WriteString(reports[i].Summary())
+		b.WriteByte('\n')
+	}
+	return b.String(), nil
 }
 
 // calculateDynamoKeys generates the row & column keys for Dynamo.

--- a/app/router.go
+++ b/app/router.go
@@ -159,6 +159,18 @@ func RegisterReportPostHandler(a Adder, router *mux.Router) {
 	}))
 }
 
+// RegisterAdminRoutes registers routes for admin calls with a http mux.
+func RegisterAdminRoutes(router *mux.Router, reporter Reporter) {
+	get := router.Methods("GET").Subrouter()
+	get.Handle("/admin/summary", requestContextDecorator(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		summary, err := reporter.AdminSummary(ctx, time.Now())
+		if err != nil {
+			respondWith(w, http.StatusBadRequest, err)
+		}
+		fmt.Fprintln(w, summary)
+	}))
+}
+
 var newVersion = struct {
 	sync.Mutex
 	*xfer.NewVersionInfo

--- a/prog/app.go
+++ b/prog/app.go
@@ -67,6 +67,7 @@ func router(collector app.Collector, controlRouter app.ControlRouter, pipeRouter
 	app.RegisterControlRoutes(router, controlRouter)
 	app.RegisterPipeRoutes(router, pipeRouter)
 	app.RegisterTopologyRoutes(router, app.WebReporter{Reporter: collector, MetricsGraphURL: metricsGraphURL}, capabilities)
+	app.RegisterAdminRoutes(router, collector)
 
 	uiHandler := http.FileServer(GetFS(externalUI))
 	router.PathPrefix("/ui").Name("static").Handler(

--- a/report/report.go
+++ b/report/report.go
@@ -559,6 +559,26 @@ func (r Report) upgradeDNSRecords() Report {
 	return r
 }
 
+func (r Report) Summary() string {
+	ret := ""
+	if len(r.Host.Nodes) == 1 {
+		for k, _ := range r.Host.Nodes {
+			ret = k + ":"
+		}
+	}
+	count := 0
+	r.WalkNamedTopologies(func(n string, t *Topology) {
+		if len(t.Nodes) > 0 {
+			count++
+			if count > 1 {
+				ret = ret + ", "
+			}
+			ret = ret + fmt.Sprintf("%s:%d", n, len(t.Nodes))
+		}
+	})
+	return ret
+}
+
 // Sampling describes how the packet data sources for this report were
 // sampled. It can be used to calculate effective sample rates. We can't
 // just put the rate here, because that can't be accurately merged. Counts

--- a/report/report.go
+++ b/report/report.go
@@ -559,10 +559,11 @@ func (r Report) upgradeDNSRecords() Report {
 	return r
 }
 
+// Summary returns a human-readable string summarising the contents, for diagnostic purposes
 func (r Report) Summary() string {
 	ret := ""
 	if len(r.Host.Nodes) == 1 {
-		for k, _ := range r.Host.Nodes {
+		for k := range r.Host.Nodes {
 			ret = k + ":"
 		}
 	}

--- a/report/report.go
+++ b/report/report.go
@@ -564,7 +564,7 @@ func (r Report) Summary() string {
 	ret := ""
 	if len(r.Host.Nodes) == 1 {
 		for k := range r.Host.Nodes {
-			ret = k + ":"
+			ret = k + ": "
 		}
 	}
 	count := 0

--- a/site/faq.md
+++ b/site/faq.md
@@ -65,6 +65,12 @@ Scope doesn't support LDAP right now.
 
 OSS Scope reports aren't persistent and the probe keeps the last 15 seconds of metrics in memory.
 
+## Admin Endpoints
+
+Scope exposes the following http endpoints that can be used for troubleshooting:
+
+- `/admin/summary` - lists the reports being used by the app, with counts of each node type (containers, processes, etc.).
+
 ## API Endpoints
 
 Scope exposes the following endpoints that can be used by external monitoring services.


### PR DESCRIPTION
When someone says they have a performance problem, the first thing I want to know is whether Scope is reporting 26,000 processes on a node, or similar.  It's awkward to do that via the raw reports, so I wrote this summarising function you can call via URL `/admin/summary`

Example output:
```
pod:183, service:81, deployment:87, daemon_set:8, stateful_set:2, cron_job:5, namespace:14, persistent_volume:3, persistent_volume_claim:4, storage_class:1
ip-172-20-2-197;<host>:endpoint:992, process:369, container:101, container_image:41, host:1, overlay:1
ip-172-20-1-59;<host>:endpoint:266, process:250, container:43, container_image:15, host:1, overlay:1
ip-172-20-3-247;<host>:endpoint:891, process:383, container:107, container_image:43, host:1, overlay:1
```