### PR TITLE
Move to Kubernetes 'v1' APIs

### DIFF
--- a/extras/example/k8s/app-deployment.yaml
+++ b/extras/example/k8s/app-deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      name: app
   template:
     metadata:
       labels:

--- a/extras/example/k8s/client-deployment.yaml
+++ b/extras/example/k8s/client-deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: client
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: client
   template:
     metadata:
       labels:

--- a/extras/example/k8s/echo-deployment.yaml
+++ b/extras/example/k8s/echo-deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: echo
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: echo
   template:
     metadata:
       labels:

--- a/extras/example/k8s/elasticsearch-deployment.yaml
+++ b/extras/example/k8s/elasticsearch-deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: elasticsearch
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: elasticsearch
   template:
     metadata:
       labels:

--- a/extras/example/k8s/frontend-deployment.yaml
+++ b/extras/example/k8s/frontend-deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      name: frontend
   template:
     metadata:
       labels:

--- a/extras/example/k8s/qotd-deployment.yaml
+++ b/extras/example/k8s/qotd-deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: qotd
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: qotd
   template:
     metadata:
       labels:

--- a/extras/example/k8s/redis-deployment.yaml
+++ b/extras/example/k8s/redis-deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: redis
   template:
     metadata:
       labels:

--- a/extras/example/k8s/search-deployment.yaml
+++ b/extras/example/k8s/search-deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: search
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: search
   template:
     metadata:
       labels:

--- a/probe/kubernetes/daemonset.go
+++ b/probe/kubernetes/daemonset.go
@@ -3,7 +3,7 @@ package kubernetes
 import (
 	"fmt"
 
-	apiv1beta1 "k8s.io/api/extensions/v1beta1"
+	apiv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -23,12 +23,12 @@ type DaemonSet interface {
 }
 
 type daemonSet struct {
-	*apiv1beta1.DaemonSet
+	*apiv1.DaemonSet
 	Meta
 }
 
 // NewDaemonSet creates a new daemonset
-func NewDaemonSet(d *apiv1beta1.DaemonSet) DaemonSet {
+func NewDaemonSet(d *apiv1.DaemonSet) DaemonSet {
 	return &daemonSet{
 		DaemonSet: d,
 		Meta:      meta{d.ObjectMeta},

--- a/probe/kubernetes/deployment.go
+++ b/probe/kubernetes/deployment.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/weaveworks/scope/report"
 
+	apiappsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
-	apiv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -27,13 +27,13 @@ type Deployment interface {
 }
 
 type deployment struct {
-	*apiv1beta1.Deployment
+	*apiappsv1.Deployment
 	Meta
 	Node *apiv1.Node
 }
 
 // NewDeployment creates a new Deployment
-func NewDeployment(d *apiv1beta1.Deployment) Deployment {
+func NewDeployment(d *apiappsv1.Deployment) Deployment {
 	return &deployment{Deployment: d, Meta: meta{d.ObjectMeta}}
 }
 

--- a/probe/kubernetes/reporter_test.go
+++ b/probe/kubernetes/reporter_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
-	apiv1beta1 "k8s.io/api/extensions/v1beta1"
 	k8smeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -323,10 +323,10 @@ func BenchmarkReporter(b *testing.B) {
 		pod := apiPod1
 		pod.ObjectMeta.UID = types.UID(fmt.Sprintf("pod%d", i))
 		mockK8s.pods = append(mockK8s.pods, kubernetes.NewPod(&pod))
-		deployment := apiv1beta1.Deployment{
+		deployment := appsv1.Deployment{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Deployment",
-				APIVersion: "v1beta1",
+				APIVersion: "v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              fmt.Sprintf("deployment%d", i),

--- a/probe/kubernetes/statefulset.go
+++ b/probe/kubernetes/statefulset.go
@@ -3,7 +3,7 @@ package kubernetes
 import (
 	"fmt"
 
-	"k8s.io/api/apps/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -18,12 +18,12 @@ type StatefulSet interface {
 }
 
 type statefulSet struct {
-	*v1beta1.StatefulSet
+	*appsv1.StatefulSet
 	Meta
 }
 
 // NewStatefulSet creates a new statefulset
-func NewStatefulSet(s *v1beta1.StatefulSet) StatefulSet {
+func NewStatefulSet(s *appsv1.StatefulSet) StatefulSet {
 	return &statefulSet{
 		StatefulSet: s,
 		Meta:        meta{s.ObjectMeta},
@@ -48,9 +48,7 @@ func (s *statefulSet) GetNode(probeID string) report.Node {
 		DesiredReplicas:       fmt.Sprint(desiredReplicas),
 		Replicas:              fmt.Sprint(s.Status.Replicas),
 		report.ControlProbeID: probeID,
-	}
-	if s.Status.ObservedGeneration != nil {
-		latests[ObservedGeneration] = fmt.Sprint(*s.Status.ObservedGeneration)
+		ObservedGeneration:    fmt.Sprint(s.Status.ObservedGeneration),
 	}
 	return s.MetaNode(report.MakeStatefulSetNodeID(s.UID())).
 		WithLatests(latests).


### PR DESCRIPTION
The latest Kubernetes release, 1.16, no longer serves the v1beta1 APIs by default.

Scope will no longer work with Kubernetes 1.8 and below.
