### PR TITLE
chore: fix typos in debugging format strings

### DIFF
--- a/app/api_topology.go
+++ b/app/api_topology.go
@@ -181,11 +181,11 @@ func (wc *websocketState) update(ctx context.Context) error {
 		otlog.String("timestamp", reportTimestamp.String()))
 	re, err := wc.rep.Report(ctx, reportTimestamp)
 	if err != nil {
-		return errors.Wrapf(err, "Error generating report: %v")
+		return errors.Wrap(err, "Error generating report")
 	}
 	renderer, filter, err := topologyRegistry.RendererForTopology(wc.topologyID, wc.values, re)
 	if err != nil {
-		return errors.Wrapf(err, "Error generating report: %v")
+		return errors.Wrap(err, "Error generating report")
 	}
 
 	newTopo := detailed.CensorNodeSummaries(
@@ -201,7 +201,7 @@ func (wc *websocketState) update(ctx context.Context) error {
 
 	if err := wc.conn.WriteJSON(diff); err != nil {
 		if !xfer.IsExpectedWSCloseError(err) {
-			return errors.Wrapf(err, "cannot serialize topology diff: %s")
+			return errors.Wrap(err, "cannot serialize topology diff")
 		}
 	}
 	return nil

--- a/probe/awsecs/reporter.go
+++ b/probe/awsecs/reporter.go
@@ -78,7 +78,7 @@ func GetLabelInfo(rpt report.Report) map[string]map[string]*TaskLabelInfo {
 
 		task.ContainerIDs = append(task.ContainerIDs, nodeID)
 	}
-	log.Debug("Got ECS container info: %v", results)
+	log.Debugf("Got ECS container info: %v", results)
 	return results
 }
 


### PR DESCRIPTION
Not sure why these slipped past the lint tools we currently use.