### PR TITLE
handle IP addresses in binary rather than strings

### DIFF
--- a/probe/endpoint/connection_tracker.go
+++ b/probe/endpoint/connection_tracker.go
@@ -190,7 +190,7 @@ func (t *connectionTracker) performEbpfTrack(rpt *report.Report, hostNodeID stri
 	return nil
 }
 
-func (t *connectionTracker) addConnection(rpt *report.Report, incoming bool, ft fourTuple, namespaceID uint64, extraFromNode, extraToNode map[string]string) {
+func (t *connectionTracker) addConnection(rpt *report.Report, incoming bool, ft fourTuple, namespaceID uint32, extraFromNode, extraToNode map[string]string) {
 	if incoming {
 		ft = reverse(ft)
 		extraFromNode, extraToNode = extraToNode, extraFromNode
@@ -207,7 +207,7 @@ func (t *connectionTracker) addConnection(rpt *report.Report, incoming bool, ft 
 	t.addDNS(rpt, toAddr.String())
 }
 
-func (t *connectionTracker) makeEndpointNode(namespaceID uint64, addr net.IP, port uint16, extra map[string]string) report.Node {
+func (t *connectionTracker) makeEndpointNode(namespaceID uint32, addr net.IP, port uint16, extra map[string]string) report.Node {
 	node := report.MakeNodeWith(report.MakeEndpointNodeIDB(t.conf.HostID, namespaceID, addr, port), nil)
 	if extra != nil {
 		node = node.WithLatests(extra)
@@ -240,7 +240,7 @@ func (t *connectionTracker) Stop() error {
 	return nil
 }
 
-func connectionTuple(conn *procspy.Connection, seenTuples map[string]fourTuple) (fourTuple, uint64, bool) {
+func connectionTuple(conn *procspy.Connection, seenTuples map[string]fourTuple) (fourTuple, uint32, bool) {
 	tuple := makeFourTuple(conn.LocalAddress, conn.RemoteAddress, conn.LocalPort, conn.RemotePort)
 
 	// If we've already seen this connection, we should know the direction

--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -25,7 +25,7 @@ import (
 // An ebpfConnection represents a TCP connection
 type ebpfConnection struct {
 	tuple            fourTuple
-	networkNamespace uint64
+	networkNamespace uint32
 	incoming         bool
 	pid              int
 }
@@ -173,7 +173,7 @@ func (t *EbpfTracker) TCPEventV4(e tracer.TcpV4) {
 		t.handleFdInstall(e.Type, int(e.Pid), int(e.Fd))
 	} else {
 		tuple := makeFourTuple(e.SAddr, e.DAddr, e.SPort, e.DPort)
-		t.handleConnection(e.Type, tuple, int(e.Pid), uint64(e.NetNS))
+		t.handleConnection(e.Type, tuple, int(e.Pid), e.NetNS)
 	}
 }
 
@@ -198,7 +198,7 @@ func (t *EbpfTracker) LostV6(count uint64) {
 	// TODO: IPv6 not supported in Scope
 }
 
-func tupleFromPidFd(pid int, fd int) (tuple fourTuple, netns uint64, ok bool) {
+func tupleFromPidFd(pid int, fd int) (tuple fourTuple, netns uint32, ok bool) {
 	// read /proc/$pid/ns/net
 	//
 	// probe/endpoint/procspy/proc_linux.go supports Linux < 3.8 but we
@@ -268,7 +268,7 @@ func (t *EbpfTracker) handleFdInstall(ev tracer.EventType, pid int, fd int) {
 	}
 }
 
-func (t *EbpfTracker) handleConnection(ev tracer.EventType, tuple fourTuple, pid int, networkNamespace uint64) {
+func (t *EbpfTracker) handleConnection(ev tracer.EventType, tuple fourTuple, pid int, networkNamespace uint32) {
 	t.Lock()
 	defer t.Unlock()
 

--- a/probe/endpoint/ebpf_test.go
+++ b/probe/endpoint/ebpf_test.go
@@ -5,7 +5,6 @@ package endpoint
 import (
 	"net"
 	"reflect"
-	"strconv"
 	"testing"
 	"time"
 
@@ -27,8 +26,10 @@ func TestHandleConnection(t *testing.T) {
 	var (
 		ServerPid  uint32 = 42
 		ClientPid  uint32 = 43
-		ServerIP          = net.IP("127.0.0.1")
-		ClientIP          = net.IP("127.0.0.2")
+		ServerAddr        = [net.IPv4len]byte{127, 0, 0, 1}
+		ServerIP          = net.IP(ServerAddr[:])
+		ClientAddr        = [net.IPv4len]byte{127, 0, 0, 2}
+		ClientIP          = net.IP(ClientAddr[:])
 		ServerPort uint16 = 12345
 		ClientPort uint16 = 6789
 		NetNS      uint32 = 123456789
@@ -47,12 +48,12 @@ func TestHandleConnection(t *testing.T) {
 
 		IPv4ConnectEbpfConnection = ebpfConnection{
 			tuple: fourTuple{
-				fromAddr: ClientIP.String(),
-				toAddr:   ServerIP.String(),
+				fromAddr: ClientAddr,
+				toAddr:   ServerAddr,
 				fromPort: ClientPort,
 				toPort:   ServerPort,
 			},
-			networkNamespace: strconv.Itoa(int(NetNS)),
+			networkNamespace: uint64(NetNS),
 			incoming:         false,
 			pid:              int(ClientPid),
 		}
@@ -83,12 +84,12 @@ func TestHandleConnection(t *testing.T) {
 
 		IPv4AcceptEbpfConnection = ebpfConnection{
 			tuple: fourTuple{
-				fromAddr: ServerIP.String(),
-				toAddr:   ClientIP.String(),
+				fromAddr: ServerAddr,
+				toAddr:   ClientAddr,
 				fromPort: ServerPort,
 				toPort:   ClientPort,
 			},
-			networkNamespace: strconv.Itoa(int(NetNS)),
+			networkNamespace: uint64(NetNS),
 			incoming:         true,
 			pid:              int(ServerPid),
 		}
@@ -108,15 +109,15 @@ func TestHandleConnection(t *testing.T) {
 
 	mockEbpfTracker := newMockEbpfTracker()
 
-	tuple := fourTuple{IPv4ConnectEvent.SAddr.String(), IPv4ConnectEvent.DAddr.String(), uint16(IPv4ConnectEvent.SPort), uint16(IPv4ConnectEvent.DPort)}
-	mockEbpfTracker.handleConnection(IPv4ConnectEvent.Type, tuple, int(IPv4ConnectEvent.Pid), strconv.FormatUint(uint64(IPv4ConnectEvent.NetNS), 10))
+	tuple := fourTuple{ClientAddr, ServerAddr, uint16(IPv4ConnectEvent.SPort), uint16(IPv4ConnectEvent.DPort)}
+	mockEbpfTracker.handleConnection(IPv4ConnectEvent.Type, tuple, int(IPv4ConnectEvent.Pid), uint64(NetNS))
 	if !reflect.DeepEqual(mockEbpfTracker.openConnections[tuple], IPv4ConnectEbpfConnection) {
 		t.Errorf("Connection mismatch connect event\nTarget connection:%v\nParsed connection:%v",
 			IPv4ConnectEbpfConnection, mockEbpfTracker.openConnections[tuple])
 	}
 
-	tuple = fourTuple{IPv4ConnectCloseEvent.SAddr.String(), IPv4ConnectCloseEvent.DAddr.String(), uint16(IPv4ConnectCloseEvent.SPort), uint16(IPv4ConnectCloseEvent.DPort)}
-	mockEbpfTracker.handleConnection(IPv4ConnectCloseEvent.Type, tuple, int(IPv4ConnectCloseEvent.Pid), strconv.FormatUint(uint64(IPv4ConnectCloseEvent.NetNS), 10))
+	tuple = fourTuple{ClientAddr, ServerAddr, uint16(IPv4ConnectCloseEvent.SPort), uint16(IPv4ConnectCloseEvent.DPort)}
+	mockEbpfTracker.handleConnection(IPv4ConnectCloseEvent.Type, tuple, int(IPv4ConnectCloseEvent.Pid), uint64(NetNS))
 	if len(mockEbpfTracker.openConnections) != 0 {
 		t.Errorf("Connection mismatch close event\nConnection to close:%v",
 			mockEbpfTracker.openConnections[tuple])
@@ -124,15 +125,15 @@ func TestHandleConnection(t *testing.T) {
 
 	mockEbpfTracker = newMockEbpfTracker()
 
-	tuple = fourTuple{IPv4AcceptEvent.SAddr.String(), IPv4AcceptEvent.DAddr.String(), uint16(IPv4AcceptEvent.SPort), uint16(IPv4AcceptEvent.DPort)}
-	mockEbpfTracker.handleConnection(IPv4AcceptEvent.Type, tuple, int(IPv4AcceptEvent.Pid), strconv.FormatUint(uint64(IPv4AcceptEvent.NetNS), 10))
+	tuple = fourTuple{ServerAddr, ClientAddr, uint16(IPv4AcceptEvent.SPort), uint16(IPv4AcceptEvent.DPort)}
+	mockEbpfTracker.handleConnection(IPv4AcceptEvent.Type, tuple, int(IPv4AcceptEvent.Pid), uint64(NetNS))
 	if !reflect.DeepEqual(mockEbpfTracker.openConnections[tuple], IPv4AcceptEbpfConnection) {
 		t.Errorf("Connection mismatch connect event\nTarget connection:%v\nParsed connection:%v",
 			IPv4AcceptEbpfConnection, mockEbpfTracker.openConnections[tuple])
 	}
 
-	tuple = fourTuple{IPv4AcceptCloseEvent.SAddr.String(), IPv4AcceptCloseEvent.DAddr.String(), uint16(IPv4AcceptCloseEvent.SPort), uint16(IPv4AcceptCloseEvent.DPort)}
-	mockEbpfTracker.handleConnection(IPv4AcceptCloseEvent.Type, tuple, int(IPv4AcceptCloseEvent.Pid), strconv.FormatUint(uint64(IPv4AcceptCloseEvent.NetNS), 10))
+	tuple = fourTuple{ServerAddr, ClientAddr, uint16(IPv4AcceptCloseEvent.SPort), uint16(IPv4AcceptCloseEvent.DPort)}
+	mockEbpfTracker.handleConnection(IPv4AcceptCloseEvent.Type, tuple, int(IPv4AcceptCloseEvent.Pid), uint64(NetNS))
 
 	if len(mockEbpfTracker.openConnections) != 0 {
 		t.Errorf("Connection mismatch close event\nConnection to close:%v",
@@ -142,32 +143,21 @@ func TestHandleConnection(t *testing.T) {
 
 func TestWalkConnections(t *testing.T) {
 	var (
-		cnt         int
-		activeTuple = fourTuple{
-			fromAddr: "",
-			toAddr:   "",
-			fromPort: 0,
-			toPort:   0,
-		}
-
-		inactiveTuple = fourTuple{
-			fromAddr: "",
-			toAddr:   "",
-			fromPort: 0,
-			toPort:   0,
-		}
+		cnt           int
+		activeTuple   = fourTuple{}
+		inactiveTuple = fourTuple{}
 	)
 	mockEbpfTracker := newMockEbpfTracker()
 	mockEbpfTracker.openConnections[activeTuple] = ebpfConnection{
 		tuple:            activeTuple,
-		networkNamespace: "12345",
+		networkNamespace: 12345,
 		incoming:         true,
 		pid:              0,
 	}
 	mockEbpfTracker.closedConnections = append(mockEbpfTracker.closedConnections,
 		ebpfConnection{
 			tuple:            inactiveTuple,
-			networkNamespace: "12345",
+			networkNamespace: 12345,
 			incoming:         false,
 			pid:              0,
 		})
@@ -183,8 +173,8 @@ func TestInvalidTimeStampDead(t *testing.T) {
 	var (
 		cnt        int
 		ClientPid  uint32 = 43
-		ServerIP          = net.IP("127.0.0.1")
-		ClientIP          = net.IP("127.0.0.2")
+		ServerIP          = net.ParseIP("127.0.0.1")
+		ClientIP          = net.ParseIP("127.0.0.2")
 		ServerPort uint16 = 12345
 		ClientPort uint16 = 6789
 		NetNS      uint32 = 123456789

--- a/probe/endpoint/ebpf_test.go
+++ b/probe/endpoint/ebpf_test.go
@@ -53,7 +53,7 @@ func TestHandleConnection(t *testing.T) {
 				fromPort: ClientPort,
 				toPort:   ServerPort,
 			},
-			networkNamespace: uint64(NetNS),
+			networkNamespace: NetNS,
 			incoming:         false,
 			pid:              int(ClientPid),
 		}
@@ -89,7 +89,7 @@ func TestHandleConnection(t *testing.T) {
 				fromPort: ServerPort,
 				toPort:   ClientPort,
 			},
-			networkNamespace: uint64(NetNS),
+			networkNamespace: NetNS,
 			incoming:         true,
 			pid:              int(ServerPid),
 		}
@@ -110,14 +110,14 @@ func TestHandleConnection(t *testing.T) {
 	mockEbpfTracker := newMockEbpfTracker()
 
 	tuple := fourTuple{ClientAddr, ServerAddr, uint16(IPv4ConnectEvent.SPort), uint16(IPv4ConnectEvent.DPort)}
-	mockEbpfTracker.handleConnection(IPv4ConnectEvent.Type, tuple, int(IPv4ConnectEvent.Pid), uint64(NetNS))
+	mockEbpfTracker.handleConnection(IPv4ConnectEvent.Type, tuple, int(IPv4ConnectEvent.Pid), NetNS)
 	if !reflect.DeepEqual(mockEbpfTracker.openConnections[tuple], IPv4ConnectEbpfConnection) {
 		t.Errorf("Connection mismatch connect event\nTarget connection:%v\nParsed connection:%v",
 			IPv4ConnectEbpfConnection, mockEbpfTracker.openConnections[tuple])
 	}
 
 	tuple = fourTuple{ClientAddr, ServerAddr, uint16(IPv4ConnectCloseEvent.SPort), uint16(IPv4ConnectCloseEvent.DPort)}
-	mockEbpfTracker.handleConnection(IPv4ConnectCloseEvent.Type, tuple, int(IPv4ConnectCloseEvent.Pid), uint64(NetNS))
+	mockEbpfTracker.handleConnection(IPv4ConnectCloseEvent.Type, tuple, int(IPv4ConnectCloseEvent.Pid), NetNS)
 	if len(mockEbpfTracker.openConnections) != 0 {
 		t.Errorf("Connection mismatch close event\nConnection to close:%v",
 			mockEbpfTracker.openConnections[tuple])
@@ -126,14 +126,14 @@ func TestHandleConnection(t *testing.T) {
 	mockEbpfTracker = newMockEbpfTracker()
 
 	tuple = fourTuple{ServerAddr, ClientAddr, uint16(IPv4AcceptEvent.SPort), uint16(IPv4AcceptEvent.DPort)}
-	mockEbpfTracker.handleConnection(IPv4AcceptEvent.Type, tuple, int(IPv4AcceptEvent.Pid), uint64(NetNS))
+	mockEbpfTracker.handleConnection(IPv4AcceptEvent.Type, tuple, int(IPv4AcceptEvent.Pid), NetNS)
 	if !reflect.DeepEqual(mockEbpfTracker.openConnections[tuple], IPv4AcceptEbpfConnection) {
 		t.Errorf("Connection mismatch connect event\nTarget connection:%v\nParsed connection:%v",
 			IPv4AcceptEbpfConnection, mockEbpfTracker.openConnections[tuple])
 	}
 
 	tuple = fourTuple{ServerAddr, ClientAddr, uint16(IPv4AcceptCloseEvent.SPort), uint16(IPv4AcceptCloseEvent.DPort)}
-	mockEbpfTracker.handleConnection(IPv4AcceptCloseEvent.Type, tuple, int(IPv4AcceptCloseEvent.Pid), uint64(NetNS))
+	mockEbpfTracker.handleConnection(IPv4AcceptCloseEvent.Type, tuple, int(IPv4AcceptCloseEvent.Pid), NetNS)
 
 	if len(mockEbpfTracker.openConnections) != 0 {
 		t.Errorf("Connection mismatch close event\nConnection to close:%v",

--- a/probe/endpoint/four_tuple.go
+++ b/probe/endpoint/four_tuple.go
@@ -23,7 +23,7 @@ func makeFourTuple(fromAddr, toAddr net.IP, fromPort, toPort uint16) fourTuple {
 }
 
 func (t fourTuple) String() string {
-	return fmt.Sprintf("%s:%d-%s:%d", t.fromAddr, t.fromPort, t.toAddr, t.toPort)
+	return fmt.Sprintf("%s:%d-%s:%d", net.IP(t.fromAddr[:]), t.fromPort, net.IP(t.toAddr[:]), t.toPort)
 }
 
 // key is a sortable direction-independent key for tuples, used to look up a

--- a/probe/endpoint/four_tuple.go
+++ b/probe/endpoint/four_tuple.go
@@ -2,6 +2,7 @@ package endpoint
 
 import (
 	"fmt"
+	"net"
 	"sort"
 	"strings"
 )
@@ -10,8 +11,15 @@ import (
 // active tells whether the connection belongs to an activeFlow (see
 // conntrack.go)
 type fourTuple struct {
-	fromAddr, toAddr string
+	fromAddr, toAddr [net.IPv4len]byte
 	fromPort, toPort uint16
+}
+
+func makeFourTuple(fromAddr, toAddr net.IP, fromPort, toPort uint16) fourTuple {
+	tuple := fourTuple{fromPort: fromPort, toPort: toPort}
+	copy(tuple.fromAddr[:], fromAddr.To4())
+	copy(tuple.toAddr[:], toAddr.To4())
+	return tuple
 }
 
 func (t fourTuple) String() string {

--- a/probe/endpoint/nat.go
+++ b/probe/endpoint/nat.go
@@ -4,7 +4,6 @@ package endpoint
 
 import (
 	"net"
-	"strconv"
 
 	"github.com/typetypetype/conntrack"
 
@@ -57,10 +56,8 @@ func (n natMapper) applyNAT(rpt report.Report, scope string) {
 	n.flowWalker.walkFlows(func(f conntrack.Conn, _ bool) {
 		mapping := toMapping(f)
 
-		realEndpointPort := strconv.Itoa(int(mapping.originalPort))
-		copyEndpointPort := strconv.Itoa(int(mapping.rewrittenPort))
-		realEndpointID := report.MakeEndpointNodeID(scope, "", mapping.originalIP.String(), realEndpointPort)
-		copyEndpointID := report.MakeEndpointNodeID(scope, "", mapping.rewrittenIP.String(), copyEndpointPort)
+		realEndpointID := report.MakeEndpointNodeIDB(scope, 0, mapping.originalIP, mapping.originalPort)
+		copyEndpointID := report.MakeEndpointNodeIDB(scope, 0, mapping.rewrittenIP, mapping.rewrittenPort)
 
 		node, ok := rpt.Endpoint.Nodes[realEndpointID]
 		if !ok {

--- a/probe/endpoint/procspy/spy.go
+++ b/probe/endpoint/procspy/spy.go
@@ -30,7 +30,7 @@ type Connection struct {
 type Proc struct {
 	PID            uint
 	Name           string
-	NetNamespaceID uint64
+	NetNamespaceID uint32
 }
 
 // ConnIter is returned by Connections().

--- a/report/id.go
+++ b/report/id.go
@@ -35,10 +35,10 @@ func MakeEndpointNodeID(hostID, namespaceID, address, port string) string {
 }
 
 // MakeEndpointNodeIDB produces an endpoint node ID from its composite parts in binary, not strings.
-func MakeEndpointNodeIDB(hostID string, namespaceID uint64, addressIP net.IP, port uint16) string {
+func MakeEndpointNodeIDB(hostID string, namespaceID uint32, addressIP net.IP, port uint16) string {
 	namespace := ""
 	if namespaceID > 0 {
-		namespace = strconv.FormatUint(namespaceID, 10)
+		namespace = strconv.FormatUint(uint64(namespaceID), 10)
 	}
 	return makeAddressID(hostID, namespace, addressIP.String(), addressIP) + ScopeDelim + strconv.Itoa(int(port))
 }

--- a/report/id.go
+++ b/report/id.go
@@ -36,7 +36,10 @@ func MakeEndpointNodeID(hostID, namespaceID, address, port string) string {
 
 // MakeEndpointNodeIDB produces an endpoint node ID from its composite parts in binary, not strings.
 func MakeEndpointNodeIDB(hostID string, namespaceID uint64, addressIP net.IP, port uint16) string {
-	namespace := strconv.FormatUint(namespaceID, 10)
+	namespace := ""
+	if namespaceID > 0 {
+		namespace = strconv.FormatUint(namespaceID, 10)
+	}
 	return makeAddressID(hostID, namespace, addressIP.String(), addressIP) + ScopeDelim + strconv.Itoa(int(port))
 }
 


### PR DESCRIPTION
This is more compact, and in some cases the code was converting to a string then parsing back to an IP address again so we save effort by deferring the conversion.

