### PR TITLE
fix: report http error if /api call fails

### DIFF
--- a/probe/appclient/app_client.go
+++ b/probe/appclient/app_client.go
@@ -192,6 +192,9 @@ func (c *appClient) Details() (xfer.Details, error) {
 	if err != nil {
 		return result, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return result, fmt.Errorf("Error response from %s: %s", c.url("/api"), resp.Status)
+	}
 	defer resp.Body.Close()
 	if err := codec.NewDecoder(resp.Body, &codec.JsonHandle{}).Decode(&result); err != nil {
 		return result, err


### PR DESCRIPTION
Previously it would try to run the JSON decoder on a string like "404 not found" and report that failing with the message "Error fetching app details: only encoded map or array can be decoded into a struct".

Now it will report the http error, like this:
```
<probe> ERRO: 2019/10/06 17:00:42.290708 Error fetching app details: Error response from http://172.16.0.3:4040//api: 404 Not Found
```

Fixes #3249 