### PR TITLE
feature: allow user to disable plugins via command-line flag

### DIFF
--- a/prog/main.go
+++ b/prog/main.go
@@ -299,7 +299,7 @@ func setupFlags(flags *flags) {
 	flag.DurationVar(&flags.probe.publishInterval, "probe.publish.interval", 3*time.Second, "publish (output) interval")
 	flag.DurationVar(&flags.probe.spyInterval, "probe.spy.interval", time.Second, "spy (scan) interval")
 	flag.IntVar(&flags.probe.ticksPerFullReport, "probe.full-report-every", 3, "publish full report every N times, deltas in between. Make sure N < (app.window / probe.publish.interval)")
-	flag.StringVar(&flags.probe.pluginsRoot, "probe.plugins.root", "/var/run/scope/plugins", "Root directory to search for plugins")
+	flag.StringVar(&flags.probe.pluginsRoot, "probe.plugins.root", "/var/run/scope/plugins", "Root directory to search for plugins (disable plugins if blank)")
 	flag.BoolVar(&flags.probe.noControls, "probe.no-controls", false, "Disable controls (e.g. start/stop containers, terminals, logs ...)")
 	flag.BoolVar(&flags.probe.noCommandLineArguments, "probe.omit.cmd-args", false, "Disable collection of command-line arguments")
 	flag.BoolVar(&flags.probe.noEnvironmentVariables, "probe.omit.env-vars", true, "Disable collection of environment variables")

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -351,21 +351,23 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 		}
 	}
 
-	pluginRegistry, err := plugins.NewRegistry(
-		flags.pluginsRoot,
-		pluginAPIVersion,
-		map[string]string{
-			"probe_id":    probeID,
-			"api_version": pluginAPIVersion,
-		},
-		handlerRegistry,
-		p,
-	)
-	if err != nil {
-		log.Errorf("plugins: problem loading: %v", err)
-	} else {
-		defer pluginRegistry.Close()
-		p.AddReporter(pluginRegistry)
+	if flags.pluginsRoot != "" {
+		pluginRegistry, err := plugins.NewRegistry(
+			flags.pluginsRoot,
+			pluginAPIVersion,
+			map[string]string{
+				"probe_id":    probeID,
+				"api_version": pluginAPIVersion,
+			},
+			handlerRegistry,
+			p,
+		)
+		if err != nil {
+			log.Errorf("plugins: problem loading: %v", err)
+		} else {
+			defer pluginRegistry.Close()
+			p.AddReporter(pluginRegistry)
+		}
 	}
 
 	maybeExportProfileData(flags)


### PR DESCRIPTION
I wanted to do this to get rid of debug-level log messages every few seconds, but it might also be desirable to reduce attack surface.