### PR TITLE
Fix for ImagePullBackOff error when running the k8s example

### DIFF
--- a/extras/example/k8s/elasticsearch-deployment.yaml
+++ b/extras/example/k8s/elasticsearch-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: elasticsearch
-        image: elasticsearch
+        image: elasticsearch:7.4.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9200


### PR DESCRIPTION
Fix for the issue #3401 