### PR TITLE
Remove -e flag from docker login

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ jobs:
           docker load -i cloud-agent.tar
       - run: |
           test -z "${DOCKER_USER}" && exit 0
-          docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+          docker login -u $DOCKER_USER -p $DOCKER_PASS
           for IMAGE in $IMAGES; do
               test "${DOCKER_ORGANIZATION:-$DOCKER_USER}" = "weaveworks" || docker tag weaveworks/$IMAGE:latest ${DOCKER_ORGANIZATION:-$DOCKER_USER}/$IMAGE:latest
               docker tag weaveworks/$IMAGE:latest ${DOCKER_ORGANIZATION:-$DOCKER_USER}/$IMAGE:$(./tools/image-tag)


### PR DESCRIPTION
- Builds are failing because CI is not able to login to docker
because -e (email) flag is deprecated.

Signed-off-by: Akash Srivastava <akashsrivastava4927@gmail.com>