### PR TITLE
Report a subset of connections from/to the same endpoint

### DIFF
--- a/integration/321_many_connections_2_test.sh
+++ b/integration/321_many_connections_2_test.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+# shellcheck disable=SC1091
+. ./config.sh
+
+start_suite "Test short lived connections between containers on different hosts"
+
+weave_on "$HOST1" launch "$HOST1" "$HOST2"
+weave_on "$HOST2" launch "$HOST1" "$HOST2"
+
+scope_on "$HOST1" launch
+scope_on "$HOST2" launch
+
+server_on "$HOST1"
+client_on "$HOST2"
+
+sleep 30 # need to allow the scopes to poll dns, resolve the other app ids, and send them reports
+
+check() {
+    has_container "$1" nginx
+    has_container "$1" client
+    has_connection containers "$1" client nginx
+}
+
+check "$HOST1"
+check "$HOST2"
+
+scope_end_suite

--- a/probe/endpoint/connection_tracker.go
+++ b/probe/endpoint/connection_tracker.go
@@ -172,8 +172,8 @@ func feedEBPFInitialState(conf ReporterConfig, ebpfTracker *EbpfTracker) {
 }
 
 func (t *connectionTracker) performEbpfTrack(rpt *report.Report, hostNodeID string) error {
-	t.ebpfTracker.walkConnections(func(e ebpfConnection) {
-		t.addConnection(rpt, hostNodeID, uint(e.pid), e.incoming, e.tuple, e.networkNamespace)
+	t.ebpfTracker.walkConnections(func(key ebpfKey, e ebpfDetail) {
+		t.addConnection(rpt, hostNodeID, uint(e.pid), e.incoming, key.fourTuple, key.networkNamespace)
 	})
 	return nil
 }

--- a/probe/endpoint/connection_tracker_test.go
+++ b/probe/endpoint/connection_tracker_test.go
@@ -1,0 +1,112 @@
+package endpoint
+
+import (
+	"testing"
+)
+
+// mapPortToPids collects info about connections between specific
+// address pairs and destination port.
+
+// a set of connections from a single pid to a destination off-box (pid is zero)
+func fakeConnectionsOffBox(count int, fromPid uint32, startPort uint16) mapPortToPids {
+	ret := make(mapPortToPids, count)
+	for i := 0; i < count; i++ {
+		ret[uint16(i)+startPort] = pidPair{fromPid: fromPid, toPid: 0}
+	}
+	return ret
+}
+
+// a set of connections to a single pid from a destination off-box (pid is zero)
+func fakeConnectionsFromOffBox(count int, toPid uint32, startPort uint16) mapPortToPids {
+	ret := make(mapPortToPids, count)
+	for i := 0; i < count; i++ {
+		ret[uint16(i)+startPort] = pidPair{fromPid: 0, toPid: toPid}
+	}
+	return ret
+}
+
+// a set of connections from a range of pids and a range of ports between two pids
+func fakeConnections(count int, fromPid, toPid uint32, startPort uint16) mapPortToPids {
+	ret := make(mapPortToPids, count)
+	for i := 0; i < count; i++ {
+		ret[uint16(i)+startPort] = pidPair{fromPid: fromPid, toPid: toPid}
+	}
+	return ret
+}
+
+// union N existing sets
+func concatMapPortToPids(maps ...mapPortToPids) mapPortToPids {
+	ret := make(mapPortToPids)
+	for _, m := range maps {
+		for port, pair := range m {
+			ret[port] = pair
+		}
+	}
+	return ret
+}
+
+func TestConnectionThinning(t *testing.T) {
+	for _, d := range []struct {
+		name string
+		m    mapPortToPids
+		expC int
+	}{
+		{
+			name: "0 ports",
+			m:    mapPortToPids{},
+			expC: 0,
+		},
+		{
+			name: "5 connections off-box",
+			m:    fakeConnectionsOffBox(5, 1000, 30000),
+			expC: 5, // 5 is too few to thin down
+		},
+		{
+			name: "50 connections off-box",
+			m:    fakeConnectionsOffBox(50, 1000, 30000),
+			expC: 5, // 50 connections should be thinned down
+		},
+		{
+			name: "50 connections from off-box",
+			m:    fakeConnectionsFromOffBox(50, 1000, 30000),
+			expC: 5, // 50 connections should be thinned down
+		},
+		{
+			name: "5 connections from pid 1000 to 2000",
+			m:    fakeConnections(5, 1000, 2000, 30000),
+			expC: 5, // 5 is too few to thin down
+		},
+		{
+			name: "50 connections from pid 1000 to 2000",
+			m:    fakeConnections(50, 1000, 2000, 30000),
+			expC: 5, // 50 connections should be thinned down
+		},
+		{
+			name: "connections both ways",
+			m: concatMapPortToPids(
+				fakeConnections(50, 1000, 2000, 30000),
+				fakeConnections(50, 2000, 1000, 40000)),
+			expC: 100, // no thinning because in both directions
+		},
+		{
+			name: "connections to two different pids",
+			m: concatMapPortToPids(
+				fakeConnections(50, 1000, 2000, 30000),
+				fakeConnections(50, 1000, 3000, 40000)),
+			expC: 100, // no thinning because two different pids
+		},
+		{
+			name: "connections from off-box and on-box",
+			m:    concatMapPortToPids(fakeConnectionsFromOffBox(50, 1000, 30000), fakeConnections(50, 2000, 1000, 40000)),
+			expC: 100, // no thinning because pid and no-pid
+		},
+	} {
+		t.Run(d.name, func(t *testing.T) {
+			filter, count := makeFilter(d.m)
+			_ = filter
+			if d.expC != count {
+				t.Errorf("expected count %d, got %d", d.expC, count)
+			}
+		})
+	}
+}

--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -323,6 +323,9 @@ func (t *EbpfTracker) walkConnections(f func(ebpfConnection)) {
 func (t *EbpfTracker) feedInitialConnections(conns procspy.ConnIter, seenTuples map[string]fourTuple, processesWaitingInAccept []int, hostNodeID string) {
 	t.Lock()
 	for conn := conns.Next(); conn != nil; conn = conns.Next() {
+		if conn.Proc.PID == 0 {
+			continue // no point in tracking a connection which we can't associate to a process
+		}
 		tuple, namespaceID, incoming := connectionTuple(conn, seenTuples)
 		if _, ok := t.closedDuringInit[tuple]; !ok {
 			if _, ok := t.openConnections[tuple]; !ok {

--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -329,6 +329,8 @@ func (t *EbpfTracker) feedInitialConnections(conns procspy.ConnIter, seenTuples 
 		tuple, namespaceID, incoming := connectionTuple(conn, seenTuples)
 		if _, ok := t.closedDuringInit[tuple]; !ok {
 			if _, ok := t.openConnections[tuple]; !ok {
+				log.Debugf("initialConnection([%v], in=%v, pid=%v, netNS=%v)",
+					tuple, incoming, conn.Proc.PID, namespaceID)
 				t.openConnections[tuple] = ebpfConnection{
 					incoming:         incoming,
 					tuple:            tuple,

--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"regexp"
 	"strconv"
@@ -22,12 +23,31 @@ import (
 	"github.com/weaveworks/tcptracer-bpf/pkg/tracer"
 )
 
-// An ebpfConnection represents a TCP connection
-type ebpfConnection struct {
-	tuple            fourTuple
+// Open connections are held by four-tuple, and loopback addresses (e.g. 127.0.0.1)
+// are scoped by network namespace.  We only need one namespace: either
+// just one from or to address is loopback, or both are in the same namespace.
+type ebpfKey struct {
+	fourTuple
 	networkNamespace uint32
-	incoming         bool
-	pid              int
+}
+
+func makeKey(tuple fourTuple, namespace uint32) ebpfKey {
+	ret := ebpfKey{fourTuple: tuple}
+	if net.IP(tuple.fromAddr[:]).IsLoopback() || net.IP(tuple.toAddr[:]).IsLoopback() {
+		ret.networkNamespace = namespace
+	}
+	return ret
+}
+
+// For each connection we also record which direction it was opened in, and the pid of the 'from' end.
+type ebpfDetail struct {
+	incoming bool
+	pid      uint32 // zero if unknown
+}
+
+type ebpfClosedConnection struct {
+	key ebpfKey
+	ebpfDetail
 }
 
 // EbpfTracker contains the sets of open and closed TCP connections.
@@ -51,9 +71,9 @@ type EbpfTracker struct {
 	//   $ echo stop | sudo tee /proc/$(pidof scope-probe)/root/var/run/scope/debug-bpf
 	debugBPF bool
 
-	openConnections   map[fourTuple]ebpfConnection
-	closedConnections []ebpfConnection
-	closedDuringInit  map[fourTuple]struct{}
+	openConnections   map[ebpfKey]ebpfDetail
+	closedConnections []ebpfClosedConnection
+	closedDuringInit  map[ebpfKey]struct{}
 }
 
 // releaseRegex should match all possible variations of a common Linux
@@ -263,11 +283,9 @@ func (t *EbpfTracker) handleFdInstall(ev tracer.EventType, pid int, fd int) {
 	t.Lock()
 	defer t.Unlock()
 
-	t.openConnections[tuple] = ebpfConnection{
-		incoming:         true,
-		tuple:            tuple,
-		pid:              pid,
-		networkNamespace: netns,
+	t.openConnections[makeKey(tuple, netns)] = ebpfDetail{
+		incoming: true,
+		pid:      uint32(pid),
 	}
 }
 
@@ -278,28 +296,25 @@ func (t *EbpfTracker) handleConnection(ev tracer.EventType, tuple fourTuple, pid
 	log.Debugf("handleConnection(%v, [%v:%v --> %v:%v], pid=%v, netNS=%v)",
 		ev, tuple.fromAddr, tuple.fromPort, tuple.toAddr, tuple.toPort, pid, networkNamespace)
 
+	key := makeKey(tuple, networkNamespace)
 	switch ev {
 	case tracer.EventConnect:
-		t.openConnections[tuple] = ebpfConnection{
-			incoming:         false,
-			tuple:            tuple,
-			pid:              pid,
-			networkNamespace: networkNamespace,
+		t.openConnections[key] = ebpfDetail{
+			incoming: false,
+			pid:      uint32(pid),
 		}
 	case tracer.EventAccept:
-		t.openConnections[tuple] = ebpfConnection{
-			incoming:         true,
-			tuple:            tuple,
-			pid:              pid,
-			networkNamespace: networkNamespace,
+		t.openConnections[key] = ebpfDetail{
+			incoming: true,
+			pid:      uint32(pid),
 		}
 	case tracer.EventClose:
 		if !t.ready {
-			t.closedDuringInit[tuple] = struct{}{}
+			t.closedDuringInit[key] = struct{}{}
 		}
-		if deadConn, ok := t.openConnections[tuple]; ok {
-			delete(t.openConnections, tuple)
-			t.closedConnections = append(t.closedConnections, deadConn)
+		if deadConn, ok := t.openConnections[key]; ok {
+			delete(t.openConnections, key)
+			t.closedConnections = append(t.closedConnections, ebpfClosedConnection{key: key, ebpfDetail: deadConn})
 		} else {
 			log.Debugf("EbpfTracker: unmatched close event: %s pid=%d netns=%v", tuple, pid, networkNamespace)
 		}
@@ -310,15 +325,15 @@ func (t *EbpfTracker) handleConnection(ev tracer.EventType, tuple fourTuple, pid
 
 // walkConnections calls f with all open connections and connections that have come and gone
 // since the last call to walkConnections
-func (t *EbpfTracker) walkConnections(f func(ebpfConnection)) {
+func (t *EbpfTracker) walkConnections(f func(ebpfKey, ebpfDetail)) {
 	t.Lock()
 	defer t.Unlock()
 
-	for _, connection := range t.openConnections {
-		f(connection)
+	for tuple, detail := range t.openConnections {
+		f(tuple, detail)
 	}
 	for _, connection := range t.closedConnections {
-		f(connection)
+		f(connection.key, connection.ebpfDetail)
 	}
 	t.closedConnections = t.closedConnections[:0]
 }
@@ -330,15 +345,14 @@ func (t *EbpfTracker) feedInitialConnections(conns procspy.ConnIter, seenTuples 
 			continue // no point in tracking a connection which we can't associate to a process
 		}
 		tuple, namespaceID, incoming := connectionTuple(conn, seenTuples)
-		if _, ok := t.closedDuringInit[tuple]; !ok {
-			if _, ok := t.openConnections[tuple]; !ok {
+		key := makeKey(tuple, namespaceID)
+		if _, ok := t.closedDuringInit[key]; !ok {
+			if _, ok := t.openConnections[key]; !ok {
 				log.Debugf("initialConnection([%v], in=%v, pid=%v, netNS=%v)",
 					tuple, incoming, conn.Proc.PID, namespaceID)
-				t.openConnections[tuple] = ebpfConnection{
-					incoming:         incoming,
-					tuple:            tuple,
-					pid:              int(conn.Proc.PID),
-					networkNamespace: namespaceID,
+				t.openConnections[key] = ebpfDetail{
+					incoming: incoming,
+					pid:      uint32(conn.Proc.PID),
 				}
 			}
 		}
@@ -389,9 +403,9 @@ func (t *EbpfTracker) restart() error {
 	t.dead = false
 	t.ready = false
 
-	t.openConnections = map[fourTuple]ebpfConnection{}
-	t.closedDuringInit = map[fourTuple]struct{}{}
-	t.closedConnections = []ebpfConnection{}
+	t.openConnections = map[ebpfKey]ebpfDetail{}
+	t.closedDuringInit = map[ebpfKey]struct{}{}
+	t.closedConnections = []ebpfClosedConnection{}
 
 	tracer, err := tracer.NewTracer(t)
 	if err != nil {

--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -247,6 +247,9 @@ func tupleFromPidFd(pid int, fd int) (tuple fourTuple, netns uint32, ok bool) {
 	return fourTuple{}, 0, false
 }
 
+// this callback exists to close a hole whereby we don't get a kprobe
+// for tcp_accept if accept was called before the probe started.
+// It's fairly safe to assume all such connections are incoming, but not 100%
 func (t *EbpfTracker) handleFdInstall(ev tracer.EventType, pid int, fd int) {
 	if !process.IsProcInAccept("/proc", strconv.Itoa(pid)) {
 		t.tracer.RemoveFdInstallWatcher(uint32(pid))

--- a/render/detailed/connections.go
+++ b/render/detailed/connections.go
@@ -101,8 +101,15 @@ func (c *connectionCounters) add(dns report.DNSRecords, outgoing bool, localNode
 		return
 	}
 
+	count := 1
+	if countStr, _, ok := srcEndpoint.Latest.LookupEntry(report.ConnectionCount); ok {
+		if i, err := strconv.Atoi(countStr); err == nil {
+			count = i
+		}
+	}
+
 	c.counted[connectionID] = struct{}{}
-	c.counts[conn]++
+	c.counts[conn] += count
 }
 
 func internetAddr(dns report.DNSRecords, node report.Node, ep report.Node) (string, bool) {

--- a/report/map_keys.go
+++ b/report/map_keys.go
@@ -6,6 +6,8 @@ const (
 	ReverseDNSNames = "reverse_dns_names"
 	SnoopedDNSNames = "snooped_dns_names"
 	CopyOf          = "copy_of"
+	ConnectionCount = "conn_count"
+
 	// probe/process
 	PID     = "pid"
 	Name    = "name" // also used by probe/docker


### PR DESCRIPTION
Fixes #3584 

The app will only show one line, regardless of how many connections we have, so reduce the number we send to save bandwidth and rendering time. Include a note of how many connections were elided in the report, so the app can still show the same number in the detail window.

I've only done this for the ebpf collector for now.  

We collect the details by "triple" of (source address, destination address, destination port), recording what we know about the source or destination pid, then where there are more than 5 connections going to the same endpoint, all for the same process, we thin them down using a modulus.

Inspired by the discussion at https://github.com/weaveworks/scope/pull/3452#pullrequestreview-179371870

Note this is a (minor) breaking change in the protocol: older apps will show an incorrect connection count.