### PR TITLE
fix(probe/ebpf): feed initial connections synchronously on restart

### DIFF
--- a/probe/endpoint/connection_tracker.go
+++ b/probe/endpoint/connection_tracker.go
@@ -86,7 +86,7 @@ func (t *connectionTracker) ReportConnections(rpt *report.Report) {
 			log.Warnf("ebpf tracker died, restarting it")
 			err := t.ebpfTracker.restart()
 			if err == nil {
-				go t.getInitialState()
+				t.getInitialState()
 				t.performEbpfTrack(rpt, hostNodeID)
 				return
 			}


### PR DESCRIPTION
Fixes #3711 

If we run `getInitialState()` async there is some chance we will see another ebpf failure and call `useProcfs()` before `getInitialState()` gets to the last line, whereupon it will crash on nil pointer.

Also it seems pointless to call `performEbpfTrack()` without waiting for something to feed in, so I suspect this is what the original author had in mind.

It will slow down this one `Report()` on machines with a lot of processes or connections, but `EbpfTracker` restart is supposed to be a rare event.