### PR TITLE
Fix accidental rename of DNS to 'nodes'

### DIFF
--- a/report/report.go
+++ b/report/report.go
@@ -188,7 +188,9 @@ type Report struct {
 	// Job represent all Kubernetes Job on hosts running probes.
 	Job Topology
 
-	DNS DNSRecords `json:"nodes,omitempty" deepequal:"nil==empty"`
+	DNS DNSRecords `json:"DNS,omitempty" deepequal:"nil==empty"`
+	// For release 1.11.6, probes accidentally sent DNS records labeled "nodes".
+	BugDNS DNSRecords `json:"nodes,omitempty"`
 
 	// Sampling data for this report.
 	Sampling Sampling
@@ -544,6 +546,11 @@ func (r Report) upgradeNamespaces() Report {
 }
 
 func (r Report) upgradeDNSRecords() Report {
+	// For release 1.11.6, probes accidentally sent DNS records labeled "nodes".
+	if len(r.BugDNS) > 0 {
+		r.DNS = r.BugDNS
+		r.BugDNS = nil
+	}
 	if len(r.DNS) > 0 {
 		return r
 	}

--- a/report/report.go
+++ b/report/report.go
@@ -189,7 +189,7 @@ type Report struct {
 	Job Topology
 
 	DNS DNSRecords `json:"DNS,omitempty" deepequal:"nil==empty"`
-	// For release 1.11.6, probes accidentally sent DNS records labeled "nodes".
+	// Backwards-compatibility for an accident in commit 951629a / release 1.11.6.
 	BugDNS DNSRecords `json:"nodes,omitempty"`
 
 	// Sampling data for this report.
@@ -547,6 +547,7 @@ func (r Report) upgradeNamespaces() Report {
 
 func (r Report) upgradeDNSRecords() Report {
 	// For release 1.11.6, probes accidentally sent DNS records labeled "nodes".
+	// Translate the incorrect version here. Accident was in commit 951629a.
 	if len(r.BugDNS) > 0 {
 		r.DNS = r.BugDNS
 		r.BugDNS = nil


### PR DESCRIPTION
In commit 951629af292a (part of #3677) the `DNS` field was accidentally renamed in serialised data to `nodes`.  Put it back, and also add a field to fix up data coming from a probe with that fault.

🤦‍♂ 