### PR TITLE
(fix): Mount plugin volume to weave-scope-cluster-agent resource

### DIFF
--- a/examples/k8s/probe-deploy.yaml
+++ b/examples/k8s/probe-deploy.yaml
@@ -41,4 +41,11 @@ spec:
             requests:
               cpu: 100m
               memory: 100Mi
+          volumeMounts:
+            - name: scope-plugins
+              mountPath: /var/run/scope/plugins
       serviceAccountName: weave-scope
+      volumes:
+        - name: scope-plugins
+          hostPath:
+            path: /var/run/scope/plugins


### PR DESCRIPTION
- Mount the plugin volume to deployment

Fixes https://github.com/weaveworks/scope/issues/3667