### PR TITLE
Add more rbac permissions in the 'apps' group

### DIFF
--- a/examples/k8s/cluster-role.yaml
+++ b/examples/k8s/cluster-role.yaml
@@ -33,6 +33,7 @@ rules:
   resources:
   - deployments
   - statefulsets
+  - daemonsets
   verbs:
   - get
   - list
@@ -62,6 +63,13 @@ rules:
   resources:
   - deployments/scale
   verbs:
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments/scale
+  verbs:
+  - get
   - update
 - apiGroups:
   - storage.k8s.io


### PR DESCRIPTION
Apparently `daemonset` was missed in the update from `v1beta1` to `v1`; also we need `get` and `update` on `deployments/scale`.

(I am a bit confused why nobody has pointed this out before)
