### PR TITLE
kubernetes: detect more 'pause' containers

### DIFF
--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -248,6 +248,10 @@ func (r *Reporter) podEvent(e Event, pod Pod) {
 }
 
 func isPauseContainer(n report.Node, rpt report.Report) bool {
+	k8sContainerType, _ := n.Latest.Lookup(report.DockerLabelPrefix + "io.kubernetes.docker.type")
+	if k8sContainerType == "podsandbox" { // this label is added by dockershim
+		return true
+	}
 	containerImageIDs, ok := n.Parents.Lookup(report.ContainerImage)
 	if !ok {
 		return false

--- a/render/filters.go
+++ b/render/filters.go
@@ -245,6 +245,10 @@ func IsApplication(n report.Node) bool {
 	if _, ok := systemImagePrefixes[imagePrefix]; ok || report.IsPauseImageName(imagePrefix) {
 		return false
 	}
+	k8sContainerType, _ := n.Latest.Lookup(report.DockerLabelPrefix + "io.kubernetes.docker.type")
+	if k8sContainerType == "podsandbox" { // another way to detect "pause container"
+		return false
+	}
 	roleLabel, _ := n.Latest.Lookup(report.DockerLabelPrefix + "works.weave.role")
 	if roleLabel == "system" {
 		return false


### PR DESCRIPTION
Dockershim has added a label `io.kubernetes.docker.type` for at least four years, where the pause container is of type `podsandbox`.  This should be more reliable than trying to keep up with everyone's name for the pause container.

I don't like the way we do this in two places (one probe, one app), but it seemed a bit complicated to unwind that right now.

I left in the old name-based code just in case; I don't think it is necessary any more.