### PR TITLE
Slow down DNS poll interval

### DIFF
--- a/probe/appclient/resolver.go
+++ b/probe/appclient/resolver.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	dnsPollInterval = 10 * time.Second
+	dnsPollInterval = 5 * time.Minute
 )
 
 // fastStartTicker is a ticker that 'ramps up' from 1 sec to duration.


### PR DESCRIPTION
There's no reason to expect anyone is changing their DNS that fast, and the probe queries all endpoints every time it polls so slowing down will reduce effort.