### PR TITLE
Remove trailing zeros in large numbers in UI

### DIFF
--- a/client/app/scripts/utils/__tests__/string-utils-test.js
+++ b/client/app/scripts/utils/__tests__/string-utils-test.js
@@ -10,7 +10,7 @@ describe('StringUtils', () => {
     it('it should render 0', () => {
       expect(f(0)).toBe('0.00');
     });
-    
+
     it('it should render get rid of trailing zeros', () => {
       expect(f(2104)).toBe('2.104k');
       expect(f(21100)).toBe('21.1k');

--- a/client/app/scripts/utils/__tests__/string-utils-test.js
+++ b/client/app/scripts/utils/__tests__/string-utils-test.js
@@ -10,6 +10,12 @@ describe('StringUtils', () => {
     it('it should render 0', () => {
       expect(f(0)).toBe('0.00');
     });
+    
+    it('it should render get rid of trailing zeros', () => {
+      expect(f(2104)).toBe('2.104k');
+      expect(f(21100)).toBe('21.1k');
+      expect(f(2120001)).toBe('2.12M');
+    });
   });
 
   describe('longestCommonPrefix', () => {

--- a/client/app/scripts/utils/__tests__/string-utils-test.js
+++ b/client/app/scripts/utils/__tests__/string-utils-test.js
@@ -10,7 +10,6 @@ describe('StringUtils', () => {
     it('it should render 0', () => {
       expect(f(0)).toBe('0.00');
     });
-
     it('it should render get rid of trailing zeros', () => {
       expect(f(2104)).toBe('2.104k');
       expect(f(21100)).toBe('21.1k');

--- a/client/app/scripts/utils/string-utils.js
+++ b/client/app/scripts/utils/string-utils.js
@@ -5,7 +5,7 @@ import { isoFormat } from 'd3-time-format';
 import LCP from 'lcp';
 import moment from 'moment';
 
-const formatLargeValue = d3Format('s');
+const formatLargeValue = d3Format('~s');
 
 
 function renderHtml(text, unit) {


### PR DESCRIPTION
Added ~ option to d3Format which trims trailing zeros across format types.

Fixes #3741