### PR TITLE
Update Go to 1.13.9

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.0
+FROM golang:1.13.9
 ENV SCOPE_SKIP_UI_ASSETS true
 RUN set -eux; \
    export arch_val="$(dpkg --print-architecture)"; \


### PR DESCRIPTION
I figured before making Scope release 1.13 I should update Go to the latest patch release.

Will look at moving to Go 1.14 after release.
