### PR TITLE
Security ypgrade to Alpine:1.11.0

### DIFF
--- a/docker/Dockerfile.cloud-agent
+++ b/docker/Dockerfile.cloud-agent
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.9
 WORKDIR /home/weave
 RUN apk add --no-cache bash conntrack-tools iproute2 util-linux curl
 COPY ./scope /home/weave/


### PR DESCRIPTION
Container scanning tools are reporting 6 CVEs due to an older version of Alpine. 
 
| Vulnerability | Package | Fix |
|-|-|-|
| CVE-2019-14697 | musl-utils-1.1.18-r3   | 1.1.18-r4 |
| CVE-2019-14697 | musl-1.1.18-r3         | 1.1.18-r4 |
| CVE-2019-5482  | libcurl-7.61.1-r2      | 7.61.1-r3 |
| CVE-2019-5481  | libcurl-7.61.1-r2      | 7.61.1-r3 |
| CVE-2019-5482  | curl-7.61.1-r2         | 7.61.1-r3 |
| CVE-2019-5481  | curl-7.61.1-r2         | 7.61.1-r3 |