### PR TITLE
Update alpine base image to 3.11.3

### DIFF
--- a/docker/Dockerfile.cloud-agent
+++ b/docker/Dockerfile.cloud-agent
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.11.3
 WORKDIR /home/weave
 RUN apk add --no-cache bash conntrack-tools iproute2 util-linux curl
 COPY ./scope /home/weave/


### PR DESCRIPTION
Note I'm pinning the minor version here, otherwise it can vary depending on what's on your machine when you build.

Replaces #3767