### PR TITLE
fix (multitenant collector): Use consistent report timestamp

### DIFF
--- a/app/collector.go
+++ b/app/collector.go
@@ -348,6 +348,7 @@ func replay(a Adder, timestamps []time.Time, reports []report.Report) {
 	due := time.Now()
 	for {
 		for i, r := range reports {
+			r.TS = due
 			a.Add(nil, r, nil)
 			due = due.Add(delays[i])
 			delay := due.Sub(time.Now())

--- a/app/multitenant/aws_collector.go
+++ b/app/multitenant/aws_collector.go
@@ -538,7 +538,7 @@ func (c *awsCollector) Add(ctx context.Context, rep report.Report, buf []byte) e
 	}
 
 	// first, put the report on s3
-	rowKey, colKey := calculateDynamoKeys(userid, time.Now())
+	rowKey, colKey := calculateDynamoKeys(userid, rep.TS)
 	reportKey, err := calculateReportKey(rowKey, colKey)
 	if err != nil {
 		return err

--- a/app/multitenant/billing_emitter.go
+++ b/app/multitenant/billing_emitter.go
@@ -59,7 +59,7 @@ func (e *BillingEmitter) Add(ctx context.Context, rep report.Report, buf []byte)
 		// proceeding.
 		return err
 	}
-	rowKey, colKey := calculateDynamoKeys(userID, now)
+	rowKey, colKey := calculateDynamoKeys(userID, rep.TS)
 
 	interval := e.reportInterval(rep)
 	// Cache the last-known value of interval for this user, and use

--- a/app/router.go
+++ b/app/router.go
@@ -148,6 +148,10 @@ func RegisterReportPostHandler(a Adder, router *mux.Router) {
 			buf, _ = rpt.WriteBinary()
 		}
 
+		// If it didn't come in with a timestamp, give it one now
+		if rpt.TS.IsZero() {
+			rpt.TS = time.Now().UTC()
+		}
 		if err := a.Add(ctx, *rpt, buf.Bytes()); err != nil {
 			log.Errorf("Error Adding report: %v", err)
 			respondWith(w, http.StatusInternalServerError, err)


### PR DESCRIPTION
Previously the code called `time.Now()` in two different places so the timestamps didn't match. 
Now we use the timestamp of the report itself.

Add the collector's local time to the report if it didn't have one.
