### PR TITLE
Stop pipe operations after EOF

### DIFF
--- a/app/multitenant/consul_pipe_router.go
+++ b/app/multitenant/consul_pipe_router.go
@@ -256,7 +256,7 @@ func (pr *consulPipeRouter) privateAPI() {
 			defer conn.Close()
 
 			end, _ := pipe.Ends()
-			if err := pipe.CopyToWebsocket(end, conn); err != nil && !xfer.IsExpectedWSCloseError(err) {
+			if _, err := pipe.CopyToWebsocket(end, conn); err != nil {
 				log.Errorf("%s: Server bridge connection; Error copying pipe to websocket: %v", key, err)
 			}
 		})
@@ -446,7 +446,7 @@ func (bc *bridgeConnection) loop() {
 		bc.conn = conn
 		bc.mtx.Unlock()
 
-		if err := bc.pipe.CopyToWebsocket(end, conn); err != nil && !xfer.IsExpectedWSCloseError(err) {
+		if _, err := bc.pipe.CopyToWebsocket(end, conn); err != nil {
 			log.Errorf("%s: Client bridge connection; Error copying pipe to websocket: %v", bc.key, err)
 		}
 		conn.Close()

--- a/app/pipes.go
+++ b/app/pipes.go
@@ -67,13 +67,11 @@ func handlePipeWs(pr PipeRouter, end End) CtxHandlerFunc {
 		}
 		defer conn.Close()
 
-		if err := pipe.CopyToWebsocket(endIO, conn); err != nil {
+		if _, err := pipe.CopyToWebsocket(endIO, conn); err != nil {
 			if span := opentracing.SpanFromContext(ctx); span != nil {
 				span.LogKV("error", err.Error())
 			}
-			if !xfer.IsExpectedWSCloseError(err) {
-				log.Errorf("Error copying to pipe %s (%d) websocket: %v", id, end, err)
-			}
+			log.Errorf("Error copying to pipe %s (%d) websocket: %v", id, end, err)
 		}
 	}
 }

--- a/probe/appclient/app_client.go
+++ b/probe/appclient/app_client.go
@@ -374,6 +374,9 @@ func (c *appClient) pipeConnection(id string, pipe xfer.Pipe) (bool, error) {
 
 	_, remote := pipe.Ends()
 	done, err := pipe.CopyToWebsocket(remote, conn)
+	if err == io.EOF {
+		return true, nil
+	}
 	return done, err
 }
 

--- a/probe/appclient/app_client.go
+++ b/probe/appclient/app_client.go
@@ -373,10 +373,8 @@ func (c *appClient) pipeConnection(id string, pipe xfer.Pipe) (bool, error) {
 	defer c.closeConn(id)
 
 	_, remote := pipe.Ends()
-	if err := pipe.CopyToWebsocket(remote, conn); err != nil && !xfer.IsExpectedWSCloseError(err) {
-		return false, err
-	}
-	return false, nil
+	done, err := pipe.CopyToWebsocket(remote, conn)
+	return done, err
 }
 
 func (c *appClient) PipeConnection(id string, pipe xfer.Pipe) {

--- a/probe/docker/controls_test.go
+++ b/probe/docker/controls_test.go
@@ -46,11 +46,11 @@ func TestControls(t *testing.T) {
 
 type mockPipe struct{}
 
-func (mockPipe) Ends() (io.ReadWriter, io.ReadWriter)                { return nil, nil }
-func (mockPipe) CopyToWebsocket(io.ReadWriter, xfer.Websocket) error { return nil }
-func (mockPipe) Close() error                                        { return nil }
-func (mockPipe) Closed() bool                                        { return false }
-func (mockPipe) OnClose(func())                                      {}
+func (mockPipe) Ends() (io.ReadWriter, io.ReadWriter)                        { return nil, nil }
+func (mockPipe) CopyToWebsocket(io.ReadWriter, xfer.Websocket) (bool, error) { return true, nil }
+func (mockPipe) Close() error                                                { return nil }
+func (mockPipe) Closed() bool                                                { return false }
+func (mockPipe) OnClose(func())                                              {}
 
 func TestPipes(t *testing.T) {
 	oldNewPipe := controls.NewPipe


### PR DESCRIPTION
Fixes #3684

Move the check for `IsExpectedWSCloseError()` inside `CopyToWebsocket()` and only do the check on the websocket side.

Previously we were treating EOF on the non-websocket side of the conversation as no-error, meaning that operations like Kubernetes Describe would retry endlessly when finished.
