### PR TITLE
Don't quote RELEASE_ARGS which may contain two arguments

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -144,7 +144,7 @@ draft() {
     fi
 
     echo "== Creating GitHub release $RELEASE_ARGS $RELEASE_NAME $VERSION"
-    github-release release "$RELEASE_ARGS" \
+    github-release release $RELEASE_ARGS \
         --user "$GITHUB_USER" \
         --repo scope \
         --tag "$LATEST_TAG" \


### PR DESCRIPTION
If it is `--draft --pre-release` then we need to pass that unquoted so it is seen as two arguments.