### PR TITLE
multitenant: scan container command-lines as well as process

### DIFF
--- a/app/multitenant/billing_emitter.go
+++ b/app/multitenant/billing_emitter.go
@@ -1,6 +1,7 @@
 package multitenant
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"flag"
@@ -9,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"context"
 	log "github.com/sirupsen/logrus"
 	billing "github.com/weaveworks/billing-client"
 

--- a/app/multitenant/billing_emitter.go
+++ b/app/multitenant/billing_emitter.go
@@ -139,10 +139,19 @@ func (e *BillingEmitter) reportInterval(r report.Report) time.Duration {
 		return r.Window
 	}
 	var inter string
-	for _, c := range r.Process.Nodes {
-		if cmd, ok := c.Latest.Lookup(report.Cmdline); ok {
+	for _, c := range r.Container.Nodes {
+		if cmd, ok := c.Latest.Lookup(report.DockerContainerCommand); ok {
 			if inter = intervalFromCommand(cmd); inter != "" {
 				break
+			}
+		}
+	}
+	if inter == "" { // not found in containers: look in processes
+		for _, c := range r.Process.Nodes {
+			if cmd, ok := c.Latest.Lookup(report.Cmdline); ok {
+				if inter = intervalFromCommand(cmd); inter != "" {
+					break
+				}
 			}
 		}
 	}

--- a/app/multitenant/billing_emitter.go
+++ b/app/multitenant/billing_emitter.go
@@ -119,6 +119,19 @@ func (e *BillingEmitter) Add(ctx context.Context, rep report.Report, buf []byte)
 	return e.Collector.Add(ctx, rep, buf)
 }
 
+func intervalFromCommand(cmd string) string {
+	if strings.Contains(cmd, "scope") &&
+		strings.Contains(cmd, "probe.publish.interval") {
+		cmds := strings.SplitAfter(cmd, "probe.publish.interval")
+		aft := strings.Split(cmds[1], " ")
+		if aft[0] == "" {
+			return aft[1]
+		}
+		return aft[0][1:]
+	}
+	return ""
+}
+
 // reportInterval tries to find the custom report interval of this report. If
 // it is malformed, or not set, it returns zero.
 func (e *BillingEmitter) reportInterval(r report.Report) time.Duration {
@@ -127,20 +140,10 @@ func (e *BillingEmitter) reportInterval(r report.Report) time.Duration {
 	}
 	var inter string
 	for _, c := range r.Process.Nodes {
-		cmd, ok := c.Latest.Lookup("cmdline")
-		if !ok {
-			continue
-		}
-		if strings.Contains(cmd, "scope") &&
-			strings.Contains(cmd, "probe.publish.interval") {
-			cmds := strings.SplitAfter(cmd, "probe.publish.interval")
-			aft := strings.Split(cmds[1], " ")
-			if aft[0] == "" {
-				inter = aft[1]
-			} else {
-				inter = aft[0][1:]
+		if cmd, ok := c.Latest.Lookup(report.Cmdline); ok {
+			if inter = intervalFromCommand(cmd); inter != "" {
+				break
 			}
-
 		}
 	}
 	if inter == "" {

--- a/app/multitenant/billing_emitter_test.go
+++ b/app/multitenant/billing_emitter_test.go
@@ -1,0 +1,25 @@
+package multitenant
+
+import "testing"
+
+func Test_intervalFromCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{cmd: "/home/weave/scope --mode=probe --probe-only --probe.kubernetes=true --probe.spy.interval=3s --probe.publish.interval=5s --probe.processes=false --probe.conntrack=false --probe.ebpf.connections=false --probe.docker.bridge=docker0 --probe.docker=true https://redacted@cloud.weave.works.", want: "5s", name: "seconds"},
+		{cmd: "/home/weave/scope --mode=probe --probe-only --probe.kubernetes=true --probe.spy.interval=3s --probe.publish.interval 5s --probe.processes=false --probe.conntrack=false --probe.ebpf.connections=false --probe.docker.bridge=docker0 --probe.docker=true https://redacted@cloud.weave.works.", want: "5s", name: "space"},
+		{cmd: "/home/weave/scope --mode=probe --no-app --probe.docker=true --probe.kubernetes.role=host --weave=false --probe.publish.interval=4500ms --probe.spy.interval=2s --probe.http.listen=:4041 --probe.conntrack.buffersize=4194304 https://redacted@cloud.weave.works scope.weave.svc.cluster.local:80", want: "4500ms", name: "miliseconds"},
+		{cmd: "/home/weave/scope --mode=probe --no-app --probe.docker=true --probe.kubernetes.role=host --weave=false --probe.spy.interval=2s --probe.http.listen=:4041 --probe.conntrack.buffersize=4194304 https://redacted@cloud.weave.works scope.weave.svc.cluster.local:80", want: "", name: "notset"},
+		{cmd: "/bin/prometheus --config.file=/etc/prometheus/prometheus.yml --web.listen-address=:8080 --storage.tsdb.retention.time=2h --web.enable-lifecycle", want: "", name: "notscope"},
+		{cmd: "", want: "", name: "blank"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := intervalFromCommand(tt.cmd); got != tt.want {
+				t.Errorf("intervalFromCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In most cases there will be fewer containers than processes, so we can get the answer faster.
Also this works in the case where process-scanning has been turned off.
