### PR TITLE
Fixed example for PodSecurityPolicy inside examples/k8s/psp.yaml

### DIFF
--- a/examples/k8s/psp.yaml
+++ b/examples/k8s/psp.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: weave-scope


### PR DESCRIPTION
With reference to blog from [Kubernetes](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)

**PodSecurityPolicy** (in the **extensions/v1beta1** API group)

Migrate to use the **policy/v1beta1** API, available since v1.10. Existing persisted data can be retrieved/updated via the policy/v1beta1 API.

This PR fixes this.