### PR TITLE
multitenant query: don't drop topologies so much

### DIFF
--- a/app/multitenant/aws_collector.go
+++ b/app/multitenant/aws_collector.go
@@ -113,6 +113,7 @@ func registerAWSCollectorMetrics() {
 	prometheus.MustRegister(reportSizeHistogram)
 	prometheus.MustRegister(reportsPerUser)
 	prometheus.MustRegister(reportSizePerUser)
+	prometheus.MustRegister(topologiesDropped)
 	prometheus.MustRegister(natsRequests)
 	flushDuration.Register()
 }

--- a/app/multitenant/aws_collector.go
+++ b/app/multitenant/aws_collector.go
@@ -450,8 +450,12 @@ func (c *awsCollector) getReports(ctx context.Context, userid string, reportKeys
 // process a report from a probe which may be at an older version or overloaded
 func (c *awsCollector) massageReport(userid string, report report.Report) report.Report {
 	if c.cfg.MaxTopNodes > 0 {
+		max := c.cfg.MaxTopNodes
+		if len(report.Host.Nodes) > 1 {
+			max = max * len(report.Host.Nodes) // higher limit for merged reports
+		}
 		var dropped []string
-		report, dropped = report.DropTopologiesOver(c.cfg.MaxTopNodes)
+		report, dropped = report.DropTopologiesOver(max)
 		for _, name := range dropped {
 			topologiesDropped.WithLabelValues(userid, name).Inc()
 		}


### PR DESCRIPTION
We have a limit of (by default) 10,000 nodes per topology, but when a report has been merged from several probes it's much more likely to hit this limit.  Apply a heuristic to use a higher limit.

Also fix the metric that was supposed to show problems like this, but wasn't registered.
