### PR TITLE
fix (integration tests): replace localhost with 127.0.0.1 

### DIFF
--- a/integration/312_container_to_container_edge_same_netns_test.sh
+++ b/integration/312_container_to_container_edge_same_netns_test.sh
@@ -7,7 +7,7 @@ start_suite "Test short lived connection between containers in same network name
 
 scope_on "$HOST1" launch
 docker_on "$HOST1" run -d --name nginx nginx
-docker_on "$HOST1" run -d --net=container:nginx --name client albanc/dialer /go/bin/dialer connectshortlived localhost:80
+docker_on "$HOST1" run -d --net=container:nginx --name client albanc/dialer /go/bin/dialer connectshortlived 127.0.0.1:80
 
 wait_for_containers "$HOST1" 60 nginx client
 


### PR DESCRIPTION
Continuing the tradition of #2103 and #2554. 

This was causing [integration test failures](https://circleci.com/gh/weaveworks/scope/15424) because the container was connecting to `::1` and Scope ignores ipv6 connections. 
