### PR TITLE
Updating cluster-role.yaml to fix rbac

### DIFF
--- a/examples/cri/cluster-role.yaml
+++ b/examples/cri/cluster-role.yaml
@@ -15,6 +15,7 @@ rules:
   - replicationcontrollers
   - services
   - nodes
+  - namespaces
   verbs:
   - list
   - watch

--- a/examples/k8s/cluster-role.yaml
+++ b/examples/k8s/cluster-role.yaml
@@ -16,6 +16,7 @@ rules:
   - replicationcontrollers
   - services
   - nodes
+  - namespaces
   - persistentvolumes
   - persistentvolumeclaims
   verbs:


### PR DESCRIPTION
This PR is intended to fix the issue mentioned in [this](https://github.com/weaveworks/scope/issues/3805#issuecomment-652585371) comment.

**Issue:** The serviceaccount - weave-scope don't have permission to list resource "namespaces" in API group "" at the cluster scope.

**Fix:** Have updated the cluster role to include listing of `namespaces` resource.