### PR TITLE
Only mount plugins directory if it exists

### DIFF
--- a/integration/315_ebpf_restart_test.sh
+++ b/integration/315_ebpf_restart_test.sh
@@ -20,7 +20,7 @@ has_container "$HOST1" nginx
 has_container "$HOST1" client
 has_connection containers "$HOST1" client nginx
 
-docker_on "$HOST1" exec weavescope sh -c "echo stop > /var/run/scope/debug-bpf"
+docker_on "$HOST1" exec weavescope sh -c "mkdir /var/run/scope && echo stop > /var/run/scope/debug-bpf"
 sleep 5
 
 server_on "$HOST1" "nginx2"

--- a/scope
+++ b/scope
@@ -155,26 +155,22 @@ check_not_running() {
     esac
 }
 
-create_plugins_dir() {
-    # Docker for Mac (as of beta18) looks for this path on VM first, and when it doesn't
-    # find it there, it assumes the user referes to the path on Mac OS. Firstly, in most
-    # cases user won't have /var/run/scope/plugins on their Mac OS filesystem, and
-    # secondly Docker for Mac would have to be configured to share this path. The result
-    # of this "feature" is an error message: "The path /var/run/scope/plugins
-    # is not shared from OS X and does not belong to the system."
-    # In any case, creating /var/run/scope/plugins on Mac OS would not work, as domain
-    # sockets do not cross VM boundaries. We need this directory to exits on the VM.
-    docker run $USERNS_HOST --rm --entrypoint=/bin/sh \
+check_plugins_dir() {
+    # If plugins dir exists for Docker containers then we will mount it
+    # (the context for Docker might be different to that for this script, e.g. when using Docker for Mac)
+    if docker run $USERNS_HOST --rm --entrypoint=/bin/sh \
         -v /var/run:/var/run \
-        "$SCOPE_IMAGE" -c "mkdir -p /var/run/scope/plugins"
+        "$SCOPE_IMAGE" -c "test -d /var/run/scope/plugins"; then
+        PLUGINS_DIR_EXISTS=true
+    fi
 }
 
 docker_args() {
     echo --privileged $USERNS_HOST --net=host --pid=host \
         -v /var/run/docker.sock:/var/run/docker.sock \
-        -v /var/run/scope/plugins:/var/run/scope/plugins \
         -v /sys/kernel/debug:/sys/kernel/debug \
         -e CHECKPOINT_DISABLE
+    [ -n "${PLUGINS_DIR_EXISTS:-}" ] && echo -v /var/run/scope/plugins:/var/run/scope/plugins
 }
 
 launch_command() {
@@ -262,8 +258,9 @@ case "$COMMAND" in
         ;;
 
     launch)
+        dry_run "$@"
+        check_plugins_dir
         if check_docker_for_mac; then
-            create_plugins_dir
             if check_probe_only; then
                 launch "$@"
                 exit
@@ -273,7 +270,6 @@ case "$COMMAND" in
             # access to host ports of the VM.
             # - https://github.com/weaveworks/scope/issues/1411
             # - https://forums.docker.com/t/ports-in-host-network-namespace-are-not-accessible/10789
-            dry_run "$@"
             if check_listen_address_arg; then
                 echo "--app.http.address argument not supported on Docker for Mac" >&2
                 exit 1
@@ -290,7 +286,6 @@ case "$COMMAND" in
             print_app_endpoints "localhost"
             exit
         fi
-        dry_run "$@"
         launch "$@"
         if ! check_probe_only; then
             if check_listen_address_arg; then

--- a/scope
+++ b/scope
@@ -282,7 +282,7 @@ case "$COMMAND" in
             app_ip=$(docker inspect -f '{{.NetworkSettings.IPAddress}}' "${CONTAINER}")
             docker rm -f "$SCOPE_CONTAINER_NAME" >/dev/null 2>&1 || true
             # shellcheck disable=SC2091
-            CONTAINER=$($(launch_command --no-app "$@" "${app_ip}:4040"))
+            CONTAINER=$($(launch_command) --no-app "$@" "${app_ip}:4040")
             print_app_endpoints "localhost"
             exit
         fi


### PR DESCRIPTION
This gets over a problem with Docker for Mac where `/var/run` is read-only.
Now, anyone wishing to use Scope plugins will have to ensure that directory (where the sockets used to communicate between Scope and plugins live) exists.

I'm not clear whether it is ever possible under Docker for Mac to create the `/var/run/scope/plugins` directory the code is looking for, or whether it will be necessary to parameterise the code.

Also fix the Mac probe launch command - paren in wrong place meant it was running the app and not getting any extra args
