### PR TITLE
Remove obsolete dependency github.com/fatih/hclfmt

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,7 +21,6 @@ RUN go clean -i net && \
 		github.com/fzipp/gocyclo \
 		golang.org/x/lint/golint \
 		github.com/kisielk/errcheck \
-		github.com/fatih/hclfmt \
 		github.com/mjibson/esc \
 		github.com/client9/misspell/cmd/misspell && \
 	chmod a+wr --recursive /usr/local/go && \

--- a/tools/build/golang/Dockerfile
+++ b/tools/build/golang/Dockerfile
@@ -28,7 +28,6 @@ RUN go clean -i net && \
 RUN go get -tags netgo \
 		github.com/FiloSottile/gvt \
 		github.com/client9/misspell/cmd/misspell \
-		github.com/fatih/hclfmt \
 		github.com/fzipp/gocyclo \
 		github.com/gogo/protobuf/gogoproto \
 		github.com/gogo/protobuf/protoc-gen-gogoslick \


### PR DESCRIPTION
github.com/fatih/hclfmt was archived. Technically there is a possibility to fork (or used another forked version) to executle hclfmt.

But it leads to another issues - problems with importing https://github.com/hashicorp/hcl/hcl/printers. HCL was released in version 2 so that the file structure was changes.
I do not see any way to install it in changed Makefile. Go installs does not support pining to given tags so that always the newest version is installed.

For now, the impact on build process should be minimal. it is used only in ./tools/lint/lint() method. I was able to execute it locally without executing hclfmt.