### PR TITLE
Update alpine base image to 3.13

### DIFF
--- a/docker/Dockerfile.cloud-agent
+++ b/docker/Dockerfile.cloud-agent
@@ -1,4 +1,4 @@
-FROM alpine:3.11.3
+FROM alpine:3.11.8
 WORKDIR /home/weave
 RUN apk add --no-cache bash conntrack-tools iproute2 util-linux curl
 COPY ./scope /home/weave/

--- a/docker/Dockerfile.cloud-agent
+++ b/docker/Dockerfile.cloud-agent
@@ -1,6 +1,6 @@
-FROM alpine:3.13
+FROM alpine:3.13.2
 WORKDIR /home/weave
-RUN apk add --no-cache bash conntrack-tools iproute2 util-linux curl
+RUN apk add --no-cache bash conntrack-tools iproute2 util-linux curl libpcap-dev
 COPY ./scope /home/weave/
 ENTRYPOINT ["/home/weave/scope", "--mode=probe", "--no-app", "--probe.docker=true"]
 

--- a/docker/Dockerfile.cloud-agent
+++ b/docker/Dockerfile.cloud-agent
@@ -1,6 +1,6 @@
 FROM alpine:3.13.2
 WORKDIR /home/weave
-RUN apk add --no-cache bash conntrack-tools iproute2 util-linux curl libpcap-dev
+RUN apk add --no-cache bash conntrack-tools iproute2 util-linux curl bcc-tools libpcap-dev
 COPY ./scope /home/weave/
 ENTRYPOINT ["/home/weave/scope", "--mode=probe", "--no-app", "--probe.docker=true"]
 

--- a/docker/Dockerfile.cloud-agent
+++ b/docker/Dockerfile.cloud-agent
@@ -1,4 +1,4 @@
-FROM alpine:3.11.8
+FROM alpine:3.13
 WORKDIR /home/weave
 RUN apk add --no-cache bash conntrack-tools iproute2 util-linux curl
 COPY ./scope /home/weave/

--- a/docker/Dockerfile.cloud-agent
+++ b/docker/Dockerfile.cloud-agent
@@ -1,6 +1,6 @@
 FROM alpine:3.13.2
 WORKDIR /home/weave
-RUN apk add --no-cache bash conntrack-tools iproute2 util-linux curl bcc-tools libpcap-dev
+RUN apk add --no-cache bash conntrack-tools iproute2 util-linux curl
 COPY ./scope /home/weave/
 ENTRYPOINT ["/home/weave/scope", "--mode=probe", "--no-app", "--probe.docker=true"]
 


### PR DESCRIPTION
Update alpine 3.11 to latest patch version.

It would make more sense at this point to update to 3.13, let me know if you want make to make the change. 

Change log for 3.11.8: https://alpinelinux.org/posts/Alpine-3.10.6-3.11.8-3.12.4-released.html