### PR TITLE
Run AWS CLI from a container image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,16 +179,16 @@ jobs:
           path: /tmp/artifacts
 
   deploy:
-    <<: *defaults
+    machine:
+      image: circleci/classic:201709-01
+    working_directory: /home/circleci/src/github.com/weaveworks/scope
     environment:
       IMAGES: scope cloud-agent
     steps:
       - checkout
-      - setup_remote_docker
       - attach_workspace:
           at: .
       - run: |
-          pip install awscli
           docker load -i scope.tar
           docker load -i cloud-agent.tar
       - run: |


### PR DESCRIPTION
The change in #3833 to stop installing Python in the build container means we can no longer just `pip install aws-cli`.

Instead, use the official AWS image to run it.

Need to run in 'machine' executor on CircleCI so we can mount volumes into the Docker container.
Note that `setup_remote_docker` spins up a VM anyway, so this is probably more efficient.