### PR TITLE
Add s390x support

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,7 +14,7 @@ RUN set -eux; \
 RUN go clean -i net && \
 	go install -tags netgo std && \
    export arch_val="$(dpkg --print-architecture)"; \
-   if [ "$arch_val" != "ppc64el" ]; then \
+   if [ "$arch_val" != "ppc64el" ] && [ "$arch_val" != "s390x" ]; then \
 	go install -race -tags netgo std; \
    fi; \
     go get -tags netgo \
@@ -43,6 +43,8 @@ RUN export arch_val="$(dpkg --print-architecture)"; \
         curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKERVERSION}.tgz; \
     elif [ "$arch_val" = "ppc64el" ]; then \
         curl -fsSLO https://download.docker.com/linux/static/stable/ppc64le/docker-${DOCKERVERSION}.tgz; \
+    elif [ "$arch_val" = "s390x" ]; then \
+        curl -fsSLO https://download.docker.com/linux/static/stable/s390x/docker-${DOCKERVERSION}.tgz; \
     else \
         echo "No Docker client found for architecture $(arch_val)." && \
         exit 1; \

--- a/probe/endpoint/dns_snooper_others.go
+++ b/probe/endpoint/dns_snooper_others.go
@@ -1,4 +1,4 @@
-// +build darwin arm arm64
+// +build darwin arm arm64 s390x
 
 // Cross-compiling the snooper requires having pcap binaries,
 // let's disable it for now.


### PR DESCRIPTION
This PR adds support for s390x architecture. 

Changes implemented:
1) Skipped `go install -race -tags netgo std;` in backend/Dockerfile as ` -race ` flag is not supported on s390x.
2) Added docker binary link for s390x arch in backend/Dockerfile
3) Added s390x in `probe/endpoint/dns_snooper_others.go`  as the make command failed for s390x arch with `undefined: DNSSnooper` error.