### PR TITLE
Multitenant mode: fetch live data from collectors

### DIFF
--- a/app/api_report.go
+++ b/app/api_report.go
@@ -19,7 +19,7 @@ func makeRawReportHandler(rep Reporter) CtxHandlerFunc {
 			return
 		}
 		censorCfg := report.GetCensorConfigFromRequest(r)
-		respondWith(ctx, w, http.StatusOK, report.CensorRawReport(rawReport, censorCfg))
+		respondWithReport(ctx, w, r, report.CensorRawReport(rawReport, censorCfg))
 	}
 }
 

--- a/app/multitenant/aws_collector.go
+++ b/app/multitenant/aws_collector.go
@@ -156,6 +156,9 @@ type awsCollector struct {
 	nats        *nats.Conn
 	waitersLock sync.Mutex
 	waiters     map[watchKey]*nats.Subscription
+
+	collectors   []string
+	lastResolved time.Time
 }
 
 // Shortcut reports:

--- a/app/multitenant/aws_collector.go
+++ b/app/multitenant/aws_collector.go
@@ -142,6 +142,7 @@ type AWSCollectorConfig struct {
 	MemcacheClient *MemcacheClient
 	Window         time.Duration
 	MaxTopNodes    int
+	CollectorAddr  string
 }
 
 // if StoreInterval is set, reports are merged into here and held until flushed to store

--- a/app/multitenant/aws_collector.go
+++ b/app/multitenant/aws_collector.go
@@ -564,6 +564,10 @@ func (c *awsCollector) HasReports(ctx context.Context, timestamp time.Time) (boo
 	if err != nil {
 		return false, err
 	}
+	if time.Since(timestamp) < c.cfg.Window {
+		has, err := c.hasReportsFromLive(ctx, userid)
+		return has, err
+	}
 	start := timestamp.Add(-c.cfg.Window)
 	reportKeys, err := c.getReportKeys(ctx, userid, start, timestamp)
 	return len(reportKeys) > 0, err

--- a/app/multitenant/aws_collector.go
+++ b/app/multitenant/aws_collector.go
@@ -200,7 +200,7 @@ func NewAWSCollector(config AWSCollectorConfig) (AWSCollector, error) {
 	}
 
 	// If given a StoreInterval we will be storing periodically; if not we only answer queries
-	if config.StoreInterval != 0 {
+	if c.isCollector() {
 		c.ticker = time.NewTicker(config.StoreInterval)
 		go c.flushLoop()
 	}

--- a/app/multitenant/collector.go
+++ b/app/multitenant/collector.go
@@ -1,0 +1,34 @@
+package multitenant
+
+// Collect reports from probes per-tenant, and supply them to queriers on demand
+
+import (
+	"sync"
+
+	"context"
+
+	"github.com/weaveworks/scope/report"
+)
+
+// if StoreInterval is set, reports are merged into here and held until flushed to store
+type pendingEntry struct {
+	sync.Mutex
+	report *report.Report
+}
+
+// We are building up a report in memory; merge into that and it will be saved shortly
+// NOTE: may retain a reference to rep; must not be used by caller after this.
+func (c *awsCollector) addToLive(ctx context.Context, userid string, rep report.Report) {
+	entry := &pendingEntry{}
+	if e, found := c.pending.LoadOrStore(userid, entry); found {
+		entry = e.(*pendingEntry)
+	}
+	entry.Lock()
+	if entry.report == nil {
+		entry.report = &rep
+	} else {
+		entry.report.UnsafeMerge(rep)
+	}
+	entry.Unlock()
+}
+

--- a/app/multitenant/collector.go
+++ b/app/multitenant/collector.go
@@ -3,10 +3,19 @@ package multitenant
 // Collect reports from probes per-tenant, and supply them to queriers on demand
 
 import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
 	"sync"
 
 	"context"
 
+	"github.com/opentracing-contrib/go-stdlib/nethttp"
+	opentracing "github.com/opentracing/opentracing-go"
+	log "github.com/sirupsen/logrus"
+	"github.com/weaveworks/common/user"
 	"github.com/weaveworks/scope/report"
 )
 
@@ -14,6 +23,7 @@ import (
 type pendingEntry struct {
 	sync.Mutex
 	report *report.Report
+	older  []*report.Report
 }
 
 // We are building up a report in memory; merge into that and it will be saved shortly
@@ -32,3 +42,93 @@ func (c *awsCollector) addToLive(ctx context.Context, userid string, rep report.
 	entry.Unlock()
 }
 
+func (c *awsCollector) reportsFromLive(ctx context.Context, userid string) ([]report.Report, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "reportsFromLive")
+	defer span.Finish()
+	if c.cfg.StoreInterval != 0 {
+		// We are a collector
+		e, found := c.pending.Load(userid)
+		if !found {
+			return nil, nil
+		}
+		entry := e.(*pendingEntry)
+		entry.Lock()
+		ret := make([]report.Report, 0, len(entry.older)+1)
+		if entry.report != nil {
+			ret = append(ret, entry.report.Copy()) // Copy contents because this report is being unsafe-merged to
+		}
+		for _, v := range entry.older {
+			if v != nil {
+				ret = append(ret, *v) // no copy because older reports are immutable
+			}
+		}
+		entry.Unlock()
+		return ret, nil
+	}
+
+	// We are a querier: fetch the most up-to-date reports from collectors
+	// TODO: resolve c.collectorAddress periodically instead of every time we make a call
+	addrs := resolve(c.cfg.CollectorAddr)
+	ret := make([]report.Report, 0, len(addrs))
+	// make a call to each collector and fetch its data for this userid
+	// TODO: do them in parallel
+	for _, addr := range addrs {
+		body, err := oneCall(ctx, addr, "/api/report", userid)
+		if err != nil {
+			log.Warnf("error calling '%s': %v", addr, err)
+			continue
+		}
+		rpt, err := report.MakeFromBinary(ctx, body, false, true)
+		body.Close()
+		if err != nil {
+			log.Warnf("error decoding: %v", err)
+			continue
+		}
+		ret = append(ret, *rpt)
+	}
+
+	return ret, nil
+}
+
+func resolve(name string) []string {
+	_, addrs, err := net.LookupSRV("", "", name)
+	if err != nil {
+		log.Warnf("Cannot resolve '%s': %v", name, err)
+		return []string{}
+	}
+	endpoints := make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		port := strconv.Itoa(int(addr.Port))
+		endpoints = append(endpoints, net.JoinHostPort(addr.Target, port))
+	}
+	return endpoints
+}
+
+func oneCall(ctx context.Context, endpoint, path, userid string) (io.ReadCloser, error) {
+	fullPath := "http://" + endpoint + path
+	req, err := http.NewRequest("GET", fullPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error making request %s: %w", fullPath, err)
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set(user.OrgIDHeaderName, userid)
+	req.Header.Set("Accept", "application/msgpack")
+	req.Header.Set("Accept-Encoding", "identity") // disable compression
+	if parentSpan := opentracing.SpanFromContext(ctx); parentSpan != nil {
+		var ht *nethttp.Tracer
+		req, ht = nethttp.TraceRequest(parentSpan.Tracer(), req, nethttp.OperationName("Collector Fetch"))
+		defer ht.Finish()
+	}
+	client := &http.Client{Transport: &nethttp.Transport{}}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error getting %s: %w", fullPath, err)
+	}
+	if res.StatusCode != http.StatusOK {
+		content, _ := io.ReadAll(res.Body)
+		res.Body.Close()
+		return nil, fmt.Errorf("error from collector: %s (%s)", res.Status, string(content))
+	}
+
+	return res.Body, nil
+}

--- a/app/multitenant/collector.go
+++ b/app/multitenant/collector.go
@@ -42,11 +42,14 @@ func (c *awsCollector) addToLive(ctx context.Context, userid string, rep report.
 	entry.Unlock()
 }
 
+func (c *awsCollector) isCollector() bool {
+	return c.cfg.StoreInterval != 0
+}
+
 func (c *awsCollector) reportsFromLive(ctx context.Context, userid string) ([]report.Report, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "reportsFromLive")
 	defer span.Finish()
-	if c.cfg.StoreInterval != 0 {
-		// We are a collector
+	if c.isCollector() {
 		e, found := c.pending.Load(userid)
 		if !found {
 			return nil, nil

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/nats-io/nuid v0.0.0-20160402145409-a5152d67cf63 // indirect
 	github.com/opencontainers/runc v1.0.0-rc5 // indirect
 	github.com/openebs/k8s-snapshot-client v0.0.0-20180831100134-a6506305fb16
+	github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/paypal/ionet v0.0.0-20130919195445-ed0aaebc5417
 	github.com/pborman/uuid v0.0.0-20150824212802-cccd189d45f7

--- a/prog/app.go
+++ b/prog/app.go
@@ -90,7 +90,7 @@ func router(collector app.Collector, controlRouter app.ControlRouter, pipeRouter
 }
 
 func collectorFactory(userIDer multitenant.UserIDer, collectorURL, s3URL string, storeInterval time.Duration, natsHostname string,
-	memcacheConfig multitenant.MemcacheConfig, window time.Duration, maxTopNodes int, createTables bool) (app.Collector, error) {
+	memcacheConfig multitenant.MemcacheConfig, window time.Duration, maxTopNodes int, createTables bool, collectorAddr string) (app.Collector, error) {
 	if collectorURL == "local" {
 		return app.NewCollector(window), nil
 	}
@@ -134,6 +134,7 @@ func collectorFactory(userIDer multitenant.UserIDer, collectorURL, s3URL string,
 				MemcacheClient: memcacheClient,
 				Window:         window,
 				MaxTopNodes:    maxTopNodes,
+				CollectorAddr:  collectorAddr,
 			},
 		)
 		if err != nil {
@@ -248,7 +249,7 @@ func appMain(flags appFlags) {
 			Service:          flags.memcachedService,
 			CompressionLevel: flags.memcachedCompressionLevel,
 		},
-		flags.window, flags.maxTopNodes, flags.awsCreateTables)
+		flags.window, flags.maxTopNodes, flags.awsCreateTables, flags.collectorAddr)
 	if err != nil {
 		log.Fatalf("Error creating collector: %v", err)
 		return

--- a/prog/main.go
+++ b/prog/main.go
@@ -162,7 +162,8 @@ type appFlags struct {
 	containerName  string
 	dockerEndpoint string
 
-	collectorURL              string
+	collectorURL              string // how collector talks to backing store (or "local" if none)
+	collectorAddr             string // how to find collectors if deployed as microservices
 	s3URL                     string
 	storeInterval             time.Duration
 	controlRouterURL          string
@@ -376,6 +377,7 @@ func setupFlags(flags *flags) {
 	flag.Var(&flags.containerLabelFilterFlagsExclude, "app.container-label-filter-exclude", "Add container label-based view filter that excludes containers with the given label, specified as title:label. Multiple flags are accepted. Example: --app.container-label-filter-exclude='Database Containers:role=db'")
 
 	flag.StringVar(&flags.app.collectorURL, "app.collector", "local", "Collector to use (local, dynamodb, or file/directory)")
+	flag.StringVar(&flags.app.collectorAddr, "app.collector-addr", "", "Address to look up collectors when deployed as microservices")
 	flag.StringVar(&flags.app.s3URL, "app.collector.s3", "local", "S3 URL to use (when collector is dynamodb)")
 	flag.DurationVar(&flags.app.storeInterval, "app.collector.store-interval", 0, "How often to store merged incoming reports. If 0, reports are stored unmerged as they arrive.")
 	flag.StringVar(&flags.app.controlRouterURL, "app.control.router", "local", "Control router to use (local or sqs)")

--- a/report/marshal.go
+++ b/report/marshal.go
@@ -102,10 +102,6 @@ func MakeFromBinary(ctx context.Context, r io.Reader, gzipped bool, msgpack bool
 	if err != nil {
 		return nil, err
 	}
-	rep := MakeReport()
-	if err := codec.NewDecoderBytes(buf.Bytes(), codecHandle(msgpack)).Decode(&rep); err != nil {
-		return nil, err
-	}
 	log.Debugf(
 		"Received report sizes: compressed %d bytes, uncompressed %d bytes (%.2f%%)",
 		compressedSize,
@@ -113,6 +109,10 @@ func MakeFromBinary(ctx context.Context, r io.Reader, gzipped bool, msgpack bool
 		float32(compressedSize)/float32(uncompressedSize)*100,
 	)
 	span.LogFields(otlog.Uint64("compressedSize", compressedSize), otlog.Int64("uncompressedSize", uncompressedSize))
+	rep := MakeReport()
+	if err := codec.NewDecoderBytes(buf.Bytes(), codecHandle(msgpack)).Decode(&rep); err != nil {
+		return nil, err
+	}
 	return &rep, nil
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -293,6 +293,7 @@ github.com/openebs/k8s-snapshot-client/snapshot/pkg/client/clientset/versioned
 github.com/openebs/k8s-snapshot-client/snapshot/pkg/client/clientset/versioned/scheme
 github.com/openebs/k8s-snapshot-client/snapshot/pkg/client/clientset/versioned/typed/volumesnapshot/v1
 # github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9
+## explicit
 github.com/opentracing-contrib/go-stdlib/nethttp
 # github.com/opentracing/opentracing-go v1.1.0
 ## explicit


### PR DESCRIPTION
Fixes #3783 

Collectors hold recent reports in memory; when querier needs 'live' data, it fetches it from collectors instead of from the long-term store.

This means queriers get more up-to-date data, by the store-frequency collector was using (e.g. 2 seconds), and we can slow down that frequency to spend less on S3/DynamoDB.

Included in this change: multitenant collector now always saves async - removed support for saving all reports immediately to store.