### PR TITLE
fix: merging active controls on host

### DIFF
--- a/report/node.go
+++ b/report/node.go
@@ -218,6 +218,12 @@ func (n Node) Merge(other Node) Node {
 		panic("Cannot merge nodes with different topology types: " + topology + " != " + other.Topology)
 	}
 
+	// Special case to merge controls from two different probes.
+	// Do this first, then the value we want will be picked as newest by n.Latest.Merge().
+	if topology == Host {
+		n = n.MergeActiveControls(other)
+	}
+
 	newNode := Node{
 		ID:        id,
 		Topology:  topology,
@@ -227,11 +233,6 @@ func (n Node) Merge(other Node) Node {
 		Metrics:   n.Metrics.Merge(other.Metrics),
 		Parents:   n.Parents.Merge(other.Parents),
 		Children:  n.Children.Merge(other.Children),
-	}
-
-	// Special case to merge controls from two different probes.
-	if topology == Host {
-		newNode = newNode.MergeActiveControls(other)
 	}
 
 	return newNode

--- a/report/node_test.go
+++ b/report/node_test.go
@@ -182,24 +182,24 @@ func TestCounters(t *testing.T) {
 	}
 }
 
-func TestActiveControls(t *testing.T) {
+func TestMergeActiveControls(t *testing.T) {
 	mtime.NowForce(time.Now())
 	defer mtime.NowReset()
 
 	controls1 := []string{"bar", "foo"}
-	node1 := report.MakeNode("node1").WithLatestActiveControls(controls1...)
+	node1 := report.MakeNode("node1").WithTopology(report.Host).WithLatestActiveControls(controls1...)
 	assert.Equal(t, controls1, node1.ActiveControls())
-	assert.Equal(t, controls1, sorted(node1.MergeActiveControls(node1).ActiveControls()))
+	assert.Equal(t, controls1, sorted(node1.Merge(node1).ActiveControls()))
 
-	node2 := report.MakeNode("node2")
-	assert.Equal(t, controls1, node1.MergeActiveControls(node2).ActiveControls())
-	assert.Equal(t, controls1, node2.MergeActiveControls(node1).ActiveControls())
+	node2 := report.MakeNode("node2") // has no active controls
+	assert.Equal(t, controls1, node1.Merge(node2).ActiveControls())
+	assert.Equal(t, controls1, node2.Merge(node1).ActiveControls())
 
 	controls2 := []string{"bar", "bor"}
 	controls3 := []string{"bar", "bor", "foo"}
 	node3 := report.MakeNode("node1").WithLatestActiveControls(controls2...)
-	assert.Equal(t, controls3, sorted(node1.MergeActiveControls(node3).ActiveControls()))
-	assert.Equal(t, controls3, sorted(node3.MergeActiveControls(node1).ActiveControls()))
+	assert.Equal(t, controls3, sorted(node1.Merge(node3).ActiveControls()))
+	assert.Equal(t, controls3, sorted(node3.Merge(node1).ActiveControls()))
 }
 
 func sorted(s []string) []string {


### PR DESCRIPTION
Need to do the special-case merge before `n.Latest.Merge()`, otherwise it picks just one set of controls.

Also modified the test to call `Merge()` where the problem happened.