### PR TITLE
Update Go to 1.17.8; tidy build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: /go/src/github.com/weaveworks/scope
   docker:
-    - image: bboreham/scope-backend-build:go-1-17-8-87988e5a
+    - image: weaveworks/scope-backend-build:go-1-17-8-bcdf2caa
 
 client-defaults: &client-defaults
   working_directory: /home/weave/scope

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: /go/src/github.com/weaveworks/scope
   docker:
-    - image: weaveworks/scope-backend-build:build-updates-1b1c9664
+    - image: bboreham/scope-backend-build:go-1-17-8-87988e5a
 
 client-defaults: &client-defaults
   working_directory: /home/weave/scope

--- a/app/multitenant/collector.go
+++ b/app/multitenant/collector.go
@@ -107,6 +107,7 @@ type pendingEntry struct {
 	older  []*report.Report
 }
 
+// NewLiveCollector makes a new LiveCollector from the supplied config.
 func NewLiveCollector(config LiveCollectorConfig) (app.Collector, error) {
 	c := &liveCollector{
 		cfg: config,

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.2
+FROM golang:1.17.8-buster
 ENV SCOPE_SKIP_UI_ASSETS true
 RUN set -eux; \
    export arch_val="$(dpkg --print-architecture)"; \
@@ -7,22 +7,14 @@ RUN set -eux; \
      apt-get install -y libpcap-dev time file shellcheck git gcc-arm-linux-gnueabihf curl build-essential gcc-s390x-linux-gnu; \
    else \
      apt-get install -y libpcap-dev time file shellcheck git curl build-essential; \
-   fi; \
-   \
+   fi && \
    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN go clean -i net && \
-	go install -tags netgo std && \
-   export arch_val="$(dpkg --print-architecture)"; \
-   if [ "$arch_val" != "ppc64el" ] && [ "$arch_val" != "s390x" ]; then \
-	go install -race -tags netgo std; \
-   fi; \
-    go get -tags netgo \
+RUN go get -tags netgo \
 		github.com/fzipp/gocyclo \
 		golang.org/x/lint/golint \
 		github.com/kisielk/errcheck \
 		github.com/client9/misspell/cmd/misspell && \
-	chmod a+wr --recursive /usr/local/go && \
 	rm -rf /go/pkg/ /go/src/
 
    # Only install shfmt on amd64, as the version v1.3.0 isn't supported for ppc64le

--- a/probe/docker/network_linux.go
+++ b/probe/docker/network_linux.go
@@ -1,4 +1,5 @@
 // withNetNS function requires a fix that first appeared in Go version 1.10
+//go:build go1.10
 // +build go1.10
 
 package docker

--- a/probe/docker/network_others.go
+++ b/probe/docker/network_others.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package docker

--- a/probe/endpoint/connection_tracker.go
+++ b/probe/endpoint/connection_tracker.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package endpoint

--- a/probe/endpoint/conntrack.go
+++ b/probe/endpoint/conntrack.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package endpoint

--- a/probe/endpoint/dns_snooper.go
+++ b/probe/endpoint/dns_snooper.go
@@ -1,3 +1,4 @@
+//go:build (linux && amd64) || (linux && ppc64le)
 // +build linux,amd64 linux,ppc64le
 
 // Build constraint to use this file for amd64 & ppc64le on Linux

--- a/probe/endpoint/dns_snooper_others.go
+++ b/probe/endpoint/dns_snooper_others.go
@@ -1,3 +1,4 @@
+//go:build darwin || arm || arm64 || s390x
 // +build darwin arm arm64 s390x
 
 // Cross-compiling the snooper requires having pcap binaries,

--- a/probe/endpoint/dns_snooper_test.go
+++ b/probe/endpoint/dns_snooper_test.go
@@ -1,3 +1,4 @@
+//go:build (linux && amd64) || (linux && ppc64le)
 // +build linux,amd64 linux,ppc64le
 
 package endpoint

--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package endpoint

--- a/probe/endpoint/ebpf_test.go
+++ b/probe/endpoint/ebpf_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package endpoint

--- a/probe/endpoint/nat.go
+++ b/probe/endpoint/nat.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package endpoint

--- a/probe/endpoint/nat_internal_test.go
+++ b/probe/endpoint/nat_internal_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package endpoint

--- a/probe/endpoint/reporter_linux.go
+++ b/probe/endpoint/reporter_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package endpoint

--- a/probe/endpoint/reporter_other.go
+++ b/probe/endpoint/reporter_other.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package endpoint

--- a/prog/tools.go
+++ b/prog/tools.go
@@ -1,5 +1,6 @@
 // Ensure go mod fetches files needed to build the Docker container;
 // the build constraint ensures this file is ignored
+//go:build tools
 // +build tools
 
 package report

--- a/report/tools.go
+++ b/report/tools.go
@@ -1,5 +1,6 @@
 // Ensure go mod fetches files needed at code generation time;
 // the build constraint ensures this file is ignored
+//go:build tools
 // +build tools
 
 package report


### PR DESCRIPTION
Need to specify `-buster` otherwise libpcap gets unresolved symbols.

Add back a missing `&&` after installing packages; it doesn't make a practical difference but looks more consistent to me.

Stop rebuilding various Go libraries since they are now cached automatically for each different set of tags, and in a different
directory so the ones inside the image aren't actually used.
Compare build on master vs this branch:
```
weaveworks/scope-backend-build      master-a774857b        af5063a2025a     1.54GB
weaveworks/scope-backend-build      go-1-17-8-87988e5a     0bec25faf9c5     1.15GB
```

I have uploaded a copy of the build image to DockerHub at `bboreham/scope-backend-build:go-1-17-8-87988e5a` since I don't have write access to `weaveworks/scope-backend-build`.